### PR TITLE
fix: correct OpenTofu default upstream URL in Add Mirror modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- admin/terraform-mirror: corrected OpenTofu default upstream URL from `https://releases.opentofu.org` to `https://github.com/opentofu/opentofu` (#1)
+
 ---
 
 ## [0.1.0] - 2026-03-04

--- a/frontend/src/pages/admin/TerraformMirrorPage.tsx
+++ b/frontend/src/pages/admin/TerraformMirrorPage.tsx
@@ -320,7 +320,7 @@ const ConfigCard: React.FC<{
 
 const TOOL_DEFAULT_URLS: Record<string, string> = {
   terraform: 'https://releases.hashicorp.com',
-  opentofu: 'https://releases.opentofu.org',
+  opentofu: 'https://github.com/opentofu/opentofu',
 };
 
 /** Returns the canonical upstream URL for a known tool, or '' for custom. */


### PR DESCRIPTION
Closes #1

## Summary

- Corrects the hardcoded OpenTofu upstream URL in `TOOL_DEFAULT_URLS` from `https://releases.opentofu.org` to `https://github.com/opentofu/opentofu`
- Updates `CHANGELOG.md` under `[Unreleased]`

## Test plan

- [ ] Navigate to **Admin → Terraform Mirror**
- [ ] Click **Add Mirror**
- [ ] Switch the **Tool** dropdown to **OpenTofu**
- [ ] Confirm **Upstream URL** auto-populates to `https://github.com/opentofu/opentofu`