### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+---
+
+## [0.2.0] - 2026-03-05
+
 ### Fixed
 
 - admin/terraform-mirror: corrected OpenTofu default upstream URL from `https://releases.opentofu.org` to `https://github.com/opentofu/opentofu` (#1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - admin/terraform-mirror: corrected OpenTofu default upstream URL from `https://releases.opentofu.org` to `https://github.com/opentofu/opentofu` (#1)
+- nginx: add `Permissions-Policy` security header to `nginx.conf` and `nginx-ecs.conf.template` (#3)
+- nginx: add extended proxy timeouts (600s) for long-running mirror sync operations (#3)
+
+### Changed
+
+- docker-compose: add `name: terraform-registry` project name for deterministic container naming (#3)
+- docker-compose.oidc: add `terraform-state-manager` Keycloak realm and `shared-keycloak` external network for shared local development (#3)
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- admin/terraform-mirror: corrected OpenTofu default upstream URL from `https://releases.opentofu.org` to `https://github.com/opentofu/opentofu` (#1)
+
 ---
 
 ## [0.1.0] - 2026-03-04

--- a/deployments/docker-compose.oidc.yml
+++ b/deployments/docker-compose.oidc.yml
@@ -4,20 +4,31 @@
 #   docker compose -f docker-compose.yml -f docker-compose.oidc.yml up -d
 #
 # This overlay:
-#   1. Adds a Keycloak service pre-configured with a "terraform-registry" realm,
-#      an OIDC client, and 7 test users (all password: TestPass123!)
+#   1. Adds a Keycloak service pre-configured with two realms:
+#        - "terraform-registry"      (registry users)
+#        - "terraform-state-manager" (state manager users, for shared local dev)
+#      All test users have password: TestPass123!
 #   2. Reconfigures the backend to use Keycloak for OIDC authentication
 #   3. Disables DEV_MODE so the real OIDC flow is exercised
+#   4. Attaches Keycloak to the "shared-keycloak" external network so the
+#      state manager stack can reach it without spinning up its own Keycloak.
 #
 # Keycloak admin console: http://keycloak:8180/admin  (admin / admin)
-# Realm OIDC discovery:   http://keycloak:8180/realms/terraform-registry/.well-known/openid-configuration
+# Registry realm discovery:      http://keycloak:8180/realms/terraform-registry/.well-known/openid-configuration
+# State manager realm discovery: http://keycloak:8180/realms/terraform-state-manager/.well-known/openid-configuration
 #
 # HOSTS FILE REQUIRED: Add this line to C:\Windows\System32\drivers\etc\hosts
 #   127.0.0.1  registry.local keycloak
 #
-# Test users (password for all: TestPass123!):
+# NETWORK SETUP REQUIRED (once):
+#   docker network create shared-keycloak
+#
+# Registry test users (password for all: TestPass123!):
 #   admin.user   alice.dev   bob.ops   carol.qa
 #   dave.readonly   eve.viewer   frank.test
+#
+# State manager test users (password for all: TestPass123!):
+#   admin.user   alice.analyst   bob.operator   carol.viewer
 
 services:
   keycloak:
@@ -46,6 +57,7 @@ services:
       KC_HOSTNAME_PORT: "8180"
     volumes:
       - ./keycloak/realm-export.json:/opt/keycloak/data/import/realm-export.json:ro
+      - ./keycloak/tsm-realm-export.json:/opt/keycloak/data/import/tsm-realm-export.json:ro
     ports:
       - "8180:8180"
       - "9000:9000"
@@ -63,6 +75,7 @@ services:
       start_period: 90s
     networks:
       - registry-network
+      - shared-keycloak
     restart: unless-stopped
 
   backend:
@@ -114,3 +127,10 @@ services:
     networks:
       - registry-network
     restart: "no"
+
+networks:
+  # External network shared with the state manager stack so its backend
+  # can reach this Keycloak container via the "keycloak" hostname.
+  # Create once with: docker network create shared-keycloak
+  shared-keycloak:
+    external: true

--- a/deployments/docker-compose.yml
+++ b/deployments/docker-compose.yml
@@ -1,3 +1,4 @@
+name: terraform-registry
 
 services:
   # PostgreSQL Database
@@ -87,7 +88,15 @@ services:
     volumes:
       - storage_data:/app/storage
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/health"]
+      test:
+        [
+          "CMD",
+          "wget",
+          "--no-verbose",
+          "--tries=1",
+          "--spider",
+          "http://localhost:8080/health",
+        ]
       interval: 30s
       timeout: 3s
       retries: 3

--- a/deployments/keycloak/tsm-realm-export.json
+++ b/deployments/keycloak/tsm-realm-export.json
@@ -1,0 +1,172 @@
+{
+  "realm": "terraform-state-manager",
+  "enabled": true,
+  "displayName": "Terraform State Manager",
+  "sslRequired": "none",
+  "registrationAllowed": false,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "resetPasswordAllowed": true,
+  "editUsernameAllowed": false,
+  "bruteForceProtected": false,
+  "clients": [
+    {
+      "clientId": "terraform-state-manager",
+      "name": "Terraform State Manager",
+      "description": "Terraform State Manager OIDC client",
+      "enabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "terraform-state-manager-secret",
+      "redirectUris": [
+        "http://localhost:3001/*",
+        "http://localhost:8081/*"
+      ],
+      "webOrigins": [
+        "http://localhost:3001",
+        "http://localhost:8081"
+      ],
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "authorizationServicesEnabled": false,
+      "fullScopeAllowed": true,
+      "attributes": {
+        "post.logout.redirect.uris": "http://localhost:3001/*"
+      },
+      "protocolMappers": [
+        {
+          "name": "email",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "email",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "email",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "name": "full name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-full-name-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "name": "given name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "firstName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "given_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "name": "family name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "lastName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "family_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "name": "username",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "preferred_username",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "username": "admin.user",
+      "email": "admin@example.com",
+      "firstName": "Admin",
+      "lastName": "User",
+      "enabled": true,
+      "emailVerified": true,
+      "credentials": [
+        {
+          "type": "password",
+          "value": "TestPass123!",
+          "temporary": false
+        }
+      ]
+    },
+    {
+      "username": "alice.analyst",
+      "email": "alice@example.com",
+      "firstName": "Alice",
+      "lastName": "Analyst",
+      "enabled": true,
+      "emailVerified": true,
+      "credentials": [
+        {
+          "type": "password",
+          "value": "TestPass123!",
+          "temporary": false
+        }
+      ]
+    },
+    {
+      "username": "bob.operator",
+      "email": "bob@example.com",
+      "firstName": "Bob",
+      "lastName": "Operator",
+      "enabled": true,
+      "emailVerified": true,
+      "credentials": [
+        {
+          "type": "password",
+          "value": "TestPass123!",
+          "temporary": false
+        }
+      ]
+    },
+    {
+      "username": "carol.viewer",
+      "email": "carol@example.com",
+      "firstName": "Carol",
+      "lastName": "Viewer",
+      "enabled": true,
+      "emailVerified": true,
+      "credentials": [
+        {
+          "type": "password",
+          "value": "TestPass123!",
+          "temporary": false
+        }
+      ]
+    }
+  ]
+}

--- a/frontend/nginx-ecs.conf.template
+++ b/frontend/nginx-ecs.conf.template
@@ -28,6 +28,7 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none';" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
 
     # Upload size limit (matches backend: 100MB modules, 500MB providers)
     client_max_body_size 500m;

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -22,6 +22,7 @@ server {
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     # CSP: allow scripts from self + jsdelivr (ReDoc CDN); unsafe-inline required for MUI/Emotion CSS-in-JS
     add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none';" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
 
     # Upload size limit (matches backend: 100MB modules, 500MB providers)
     client_max_body_size 500m;
@@ -32,6 +33,17 @@ server {
     }
 
     # Proxy API requests to backend (plain HTTP — backend has no TLS)
+    # Mirror sync operations can take several minutes to download provider binaries.
+    location ~* ^/api/v1/admin/mirrors/[^/]+/sync$ {
+        proxy_pass http://backend:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 600s;
+        proxy_send_timeout 600s;
+    }
+
     location /api/ {
         proxy_pass http://backend:8080;
         proxy_set_header Host $host;

--- a/frontend/src/pages/admin/TerraformMirrorPage.tsx
+++ b/frontend/src/pages/admin/TerraformMirrorPage.tsx
@@ -320,7 +320,7 @@ const ConfigCard: React.FC<{
 
 const TOOL_DEFAULT_URLS: Record<string, string> = {
   terraform: 'https://releases.hashicorp.com',
-  opentofu: 'https://releases.opentofu.org',
+  opentofu: 'https://github.com/opentofu/opentofu',
 };
 
 /** Returns the canonical upstream URL for a known tool, or '' for custom. */


### PR DESCRIPTION
## Summary

Release v0.2.0 — merges all changes accumulated on `development` since v0.1.0.

## What's in this release

### Bug fixes (PR #2, closes #1)
- **#2** Fix OpenTofu default upstream URL in Add Mirror modal (was `releases.opentofu.org`, now `github.com/opentofu/opentofu`)

### nginx and deployment improvements (PR #4, closes #3)
- Add `Permissions-Policy` security header to `nginx.conf` and `nginx-ecs.conf.template`
- Add extended proxy timeouts (600s) for mirror sync endpoint in `nginx.conf`
- Add `name: terraform-registry` project label to `docker-compose.yml`
- Add `terraform-state-manager` Keycloak realm and `shared-keycloak` external network to `docker-compose.oidc.yml`

### Release prep
- Update `CHANGELOG.md` with all entries for `[0.2.0]`