### PR TITLE
docs: fix markdown structure in CONTRIBUTING.md and e2e/README.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- docs: expand CONTRIBUTING.md table of contents, update Node.js prerequisite from 18+ to 20+, fix table alignment (#6)
+- docs: fix markdown heading structure in e2e/README.md (#6)
+
 ---
 
 ## [0.2.0] - 2026-03-05

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,14 +4,23 @@ Thank you for your interest in contributing to the frontend UI and E2E test suit
 
 ## Table of Contents
 
-- [Code of Conduct](#code-of-conduct)
-- [Getting Started](#getting-started)
-- [Development Workflow](#development-workflow)
-- [Frontend (TypeScript) Standards](#frontend-typescript-standards)
-- [Testing Requirements](#testing-requirements)
-- [Pull Request Process](#pull-request-process)
-- [Reporting Security Vulnerabilities](#reporting-security-vulnerabilities)
-- [Documentation](#documentation)
+- [Contributing to Terraform Registry — Frontend](#contributing-to-terraform-registry-%E2%80%94-frontend)
+  - [Table of Contents](#table-of-contents)
+  - [Code of Conduct](#code-of-conduct)
+  - [Getting Started](#getting-started)
+    - [Prerequisites](#prerequisites)
+    - [Fork and Clone](#fork-and-clone)
+    - [Local Setup](#local-setup)
+  - [Development Workflow](#development-workflow)
+    - [Branch Naming](#branch-naming)
+    - [Commit Messages](#commit-messages)
+  - [Frontend (TypeScript) Standards](#frontend-(typescript)-standards)
+    - [Linting](#linting)
+    - [Conventions](#conventions)
+  - [Testing Requirements](#testing-requirements)
+  - [Pull Request Process](#pull-request-process)
+  - [Reporting Security Vulnerabilities](#reporting-security-vulnerabilities)
+  - [Documentation](#documentation)
 
 ---
 
@@ -25,7 +34,7 @@ This project expects all participants to interact with each other professionally
 
 ### Prerequisites
 
-- Node.js 18+ and npm
+- Node.js 20+ and npm
 - Docker and Docker Compose (for running the backend during development)
 
 ### Fork and Clone
@@ -64,7 +73,7 @@ Alternatively, set up the backend manually — see [terraform-registry-backend](
 ### Branch Naming
 
 | Type | Pattern | Example |
-|------|---------|---------|
+| ---- | ------- | ------- |
 | Feature | `feat/short-description` | `feat/mirror-status-page` |
 | Bug fix | `fix/issue-description` | `fix/api-key-expiry-display` |
 | Documentation | `docs/topic` | `docs/e2e-setup` |

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,7 +1,7 @@
 <!-- E2E Test README -->
 # Playwright E2E — Developer Notes
 
-Prerequisites
+## Prerequisites
 
 - Node 20+ and npm
 - npx available
@@ -9,7 +9,7 @@ Prerequisites
 - Backend and frontend reachable at the `baseURL` configured in `e2e/playwright.config.ts` (default <https://localhost:3000>)
 - For dev login fixture, run backend with `DEV_MODE=true` so the dev login endpoint is available.
 
-Common commands (from repo root)
+## Common Commands (from repo root)
 
 ```powershell
 cd e2e
@@ -19,17 +19,17 @@ npx playwright test --workers=1 --retries=0 --reporter=list
 npx playwright show-report
 ```
 
-Running tests locally
+## Running Tests Locally
 
 - Start backend in DEV_MODE and frontend (or use `deployments/docker-compose.test.yml` to bring up all services).
 - Make sure TLS configuration matches `playwright.config.ts` or set `ignoreHTTPSErrors: true` in config.
 - Use `--workers=1` for determinism and `--reporter=json` to capture machine-readable results.
 
-Debugging
+## Debugging
 
 - For failing tests, run with `npx playwright show-trace <trace.zip>` to inspect network and DOM.
 - Playwright artifacts (videos, traces, screenshots) are written to `e2e/test-results/` by default.
 
-Notes
+## Notes
 
 - E2E fixtures assume dev login is available (see `e2e/fixtures/auth.ts`). If you need an alternative auth setup, update the fixture or configure an OAuth test client.


### PR DESCRIPTION
Closes #6

## Summary

- `CONTRIBUTING.md` — expand table of contents with nested links, update Node.js prerequisite from 18+ to 20+, fix markdown table alignment
- `e2e/README.md` — fix markdown headings (add proper `##` prefixes for section structure)