### PR TITLE
fix: add Content-Type header to nginx API proxy responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- fix: add explicit `Content-Type: application/json` header to nginx API proxy responses in `nginx.conf` and `nginx-ecs.conf.template` (#7)
+
 ### Changed
 
 - docs: expand CONTRIBUTING.md table of contents, update Node.js prerequisite from 18+ to 20+, fix table alignment (#6)

--- a/frontend/nginx-ecs.conf.template
+++ b/frontend/nginx-ecs.conf.template
@@ -76,6 +76,7 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        add_header Content-Type "application/json" always;
     }
 
     location /health {

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -95,6 +95,7 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        add_header Content-Type "application/json" always;
     }
 
     # Health and readiness pass-through


### PR DESCRIPTION
Closes #7

## Summary

Add explicit `Content-Type: application/json` response header to the nginx API reverse proxy location blocks. Without this header, some clients and Terraform CLI versions may fail to parse registry API responses correctly.

Affected files:
- `frontend/nginx.conf`
- `frontend/nginx-ecs.conf.template`