### PR TITLE
fix: correct usage examples for mirrored providers and modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- fix: mirrored provider usage example now shows upstream source (e.g. `hashicorp/aws`) with `>=major.minor` version constraint instead of registry hostname (#14)
+- fix: module usage example now shows `>=major.minor` version constraint and removes placeholder comment (#14)
+
 ---
 
 ## [0.2.2] - 2026-03-05

--- a/frontend/src/pages/ModuleDetailPage.tsx
+++ b/frontend/src/pages/ModuleDetailPage.tsx
@@ -323,11 +323,12 @@ const ModuleDetailPage: React.FC = () => {
   const getTerraformExample = () => {
     if (!module || !selectedVersion) return '';
 
+    const v = selectedVersion.version;
+    const majorMinor = v.split('.').slice(0, 2).join('.');
+
     return `module "${name}" {
   source  = "${REGISTRY_HOST}/${namespace}/${name}/${system}"
-  version = "${selectedVersion.version}"
-
-  # Add your module variables here
+  version = ">=${majorMinor}"
 }`;
   };
 

--- a/frontend/src/pages/ProviderDetailPage.tsx
+++ b/frontend/src/pages/ProviderDetailPage.tsx
@@ -217,6 +217,24 @@ const ProviderDetailPage: React.FC = () => {
   const getTerraformExample = () => {
     if (!provider || !selectedVersion) return '';
 
+    const v = selectedVersion.version;
+    const majorMinor = v.split('.').slice(0, 2).join('.');
+
+    // Mirrored providers use the upstream source (e.g. hashicorp/aws) because
+    // Terraform resolves the mirror transparently via CLI network mirror config.
+    if (provider.source) {
+      return `terraform {
+  required_version = ">= 1.0.0"
+
+  required_providers {
+    ${name} = {
+      source  = "${namespace}/${name}"
+      version = ">=${majorMinor}"
+    }
+  }
+}`;
+    }
+
     return `terraform {
   required_providers {
     ${name} = {


### PR DESCRIPTION
Closes #14

## Summary

- **ProviderDetailPage**: mirrored providers now show upstream source (e.g. `hashicorp/aws`) with `required_version >= 1.0.0` and `>=major.minor` version constraint. Non-mirrored providers keep the `registry.local/...` format with exact version.
- **ModuleDetailPage**: version constraint changed from exact (`1.0.0`) to `>=major.minor` (`>=1.0`), placeholder comment removed.

## Changelog
- fix: mirrored provider usage example shows upstream source with `>=major.minor` version constraint
- fix: module usage example shows `>=major.minor` version constraint, remove placeholder comment