### PR TITLE
fix: derive REGISTRY_HOST from window.location so sources include port

### DIFF
--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -1,8 +1,9 @@
 // Configuration for the Terraform Registry frontend
 
-// The hostname where the registry backend is accessible for Terraform CLI
-// This is used in usage examples shown to users
-export const REGISTRY_HOST = 'registry.local';
+// The hostname (including port when non-standard) where the registry is
+// accessible for Terraform CLI. Derived from the browser URL so usage
+// examples always match the actual deployment.
+export const REGISTRY_HOST = window.location.host;
 
-// Full URL for the registry backend (HTTPS on port 443)
-export const REGISTRY_URL = `https://${REGISTRY_HOST}`;
+// Full base URL for the registry backend, matching the current protocol.
+export const REGISTRY_URL = window.location.origin;


### PR DESCRIPTION
Closes #17

## Summary

`REGISTRY_HOST` was hardcoded to `registry.local`, so module and non-mirrored provider usage examples omitted the port (e.g. showed `registry.local/...` instead of `registry.local:3000/...`).

Now derived from `window.location.host` / `window.location.origin` so examples always reflect the actual deployment host and port.

## Changelog
- fix: derive REGISTRY_HOST from window.location so usage examples include port when non-standard