### PR TITLE
fix: add terraform_binary and file to audit log resource type filter

### DIFF
--- a/frontend/src/pages/admin/AuditLogPage.tsx
+++ b/frontend/src/pages/admin/AuditLogPage.tsx
@@ -34,6 +34,8 @@ const RESOURCE_TYPES = [
   { value: '', label: 'All Resource Types' },
   { value: 'module', label: 'Module' },
   { value: 'provider', label: 'Provider' },
+  { value: 'terraform_binary', label: 'Terraform Binary' },
+  { value: 'file', label: 'File' },
   { value: 'user', label: 'User' },
   { value: 'mirror', label: 'Mirror' },
   { value: 'api_key', label: 'API Key' },


### PR DESCRIPTION
Closes #22

## Bug

`AuditLogPage.tsx` `RESOURCE_TYPES` was missing two values written by download handlers:

| Value | Handler |
|---|---|
| `terraform_binary` | `terraform_binaries/binaries.go` |
| `file` | `modules/serve.go` |

These records appeared in the unfiltered audit log view but had no corresponding filter option.

## Fix

Added both entries to `RESOURCE_TYPES` between `Provider` and `User` to keep download-related types grouped together.

## Changelog
- fix: add terraform_binary and file to audit log resource type filter (#22)