### PR TITLE
fix: pre-create nginx temp dirs to avoid CHOWN capability at runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.2.5] - 2026-03-17
+
+### Fixed
+
+- fix: add `terraform_binary` and `file` to audit log resource type filter (#23)
+
+### Docs
+
+- docs: add UAT local build validation step to release workflow (#21)
+
+---
+
 ## [0.2.4] - 2026-03-05
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,9 +78,22 @@ When a release is called for:
    git push origin development
    ```
 
-3. Merge `development` → `main` via PR (step 7 above).
+3. **UAT — local build validation** before merging to `main`:
 
-4. **After the PR is merged**, tag the commit that landed on `main` and push the tag:
+   ```bash
+   cd deployments
+   docker compose -f docker-compose.yml -f docker-compose.oidc.yml build --no-cache frontend
+   docker compose -f docker-compose.yml -f docker-compose.oidc.yml up -d
+   ```
+
+   Open the frontend in a browser and verify it loads, pages render, and usage examples
+   display correctly. If the full stack is running, run a quick `terraform init` against a
+   mirrored provider and a module to confirm downloads work end-to-end. **Do not merge to
+   `main` until the local build passes.**
+
+4. Merge `development` → `main` via PR (step 7 above).
+
+5. **After the PR is merged**, tag the commit that landed on `main` and push the tag:
 
    ```bash
    git fetch origin

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -64,6 +64,18 @@ RUN apk add --no-cache openssl && \
     -addext 'subjectAltName=DNS:localhost,DNS:registry.local,IP:127.0.0.1' && \
     chmod 600 /etc/nginx/certs/server.key
 
+# Pre-create nginx temp dirs owned by the nginx user (uid 101) so the
+# container can run without the CHOWN capability (dropped by the Helm chart
+# security context for AKS hardened namespaces).
+RUN mkdir -p /var/cache/nginx/client_temp \
+             /var/cache/nginx/proxy_temp \
+             /var/cache/nginx/fastcgi_temp \
+             /var/cache/nginx/uwsgi_temp \
+             /var/cache/nginx/scgi_temp && \
+    chown -R 101:101 /var/cache/nginx && \
+    chown -R 101:101 /var/log/nginx && \
+    touch /var/run/nginx.pid && chown 101:101 /var/run/nginx.pid
+
 # Expose ports
 EXPOSE 80 443
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -57,11 +57,11 @@ RUN chmod +x /docker-entrypoint-custom.sh
 RUN apk add --no-cache openssl && \
     mkdir -p /etc/nginx/certs && \
     openssl req -x509 -newkey rsa:2048 \
-      -keyout /etc/nginx/certs/server.key \
-      -out /etc/nginx/certs/server.crt \
-      -days 365 -nodes \
-      -subj '/CN=localhost' \
-      -addext 'subjectAltName=DNS:localhost,DNS:registry.local,IP:127.0.0.1' && \
+    -keyout /etc/nginx/certs/server.key \
+    -out /etc/nginx/certs/server.crt \
+    -days 365 -nodes \
+    -subj '/CN=localhost' \
+    -addext 'subjectAltName=DNS:localhost,DNS:registry.local,IP:127.0.0.1' && \
     chmod 600 /etc/nginx/certs/server.key
 
 # Expose ports

--- a/frontend/src/pages/ModuleDetailPage.tsx
+++ b/frontend/src/pages/ModuleDetailPage.tsx
@@ -383,8 +383,8 @@ const ModuleDetailPage: React.FC = () => {
               <ArrowBack />
             </IconButton>
             <Typography variant="h4" component="h1">
-            {name}
-          </Typography>
+              {name}
+            </Typography>
           </Stack>
           {canManage && (
             <Button
@@ -683,10 +683,10 @@ const ModuleDetailPage: React.FC = () => {
                                   event.state === 'succeeded'
                                     ? 'success'
                                     : event.state === 'failed'
-                                    ? 'error'
-                                    : event.state === 'processing'
-                                    ? 'info'
-                                    : 'default'
+                                      ? 'error'
+                                      : event.state === 'processing'
+                                        ? 'info'
+                                        : 'default'
                                 }
                               />
                               <Typography variant="body2">

--- a/frontend/src/pages/ProviderDetailPage.tsx
+++ b/frontend/src/pages/ProviderDetailPage.tsx
@@ -50,7 +50,7 @@ const ProviderDetailPage: React.FC = () => {
   const navigate = useNavigate();
   const { isAuthenticated, allowedScopes } = useAuth();
   const canManage = isAuthenticated && (allowedScopes.includes('admin') || allowedScopes.includes('providers:write'));
-  
+
   // Use 'type' as the name for display
   const name = type;
 
@@ -97,11 +97,11 @@ const ProviderDetailPage: React.FC = () => {
       }
 
       setProvider(matchingProvider);
-      
+
       // Backend returns { versions: [...] } directly
       const versions = versionsData.versions || [];
       setVersions(versions);
-      
+
       if (versions.length > 0) {
         setSelectedVersion(versions[0]);
       }
@@ -115,7 +115,7 @@ const ProviderDetailPage: React.FC = () => {
 
   const handleCopySource = () => {
     if (!provider || !selectedVersion) return;
-    
+
     const source = `${namespace}/${name}`;
     navigator.clipboard.writeText(source);
     setCopiedSource(true);
@@ -293,25 +293,25 @@ provider "${name}" {
 
       {/* Header */}
       <Box sx={{ mb: 4 }}>
-          <Stack direction="row" alignItems="center" justifyContent="space-between" spacing={2} sx={{ mb: 2 }}>
-            <Stack direction="row" alignItems="center" spacing={2}>
-              <IconButton onClick={() => navigate('/providers')}>
-                <ArrowBack />
-              </IconButton>
-              <Typography variant="h4" component="h1">
-                {name}
-              </Typography>
-            </Stack>
-            {canManage && !provider.source && (
-              <Button
-                variant="contained"
-                startIcon={<Add />}
-                onClick={handlePublishNewVersion}
-              >
-                Publish New Version
-              </Button>
-            )}
+        <Stack direction="row" alignItems="center" justifyContent="space-between" spacing={2} sx={{ mb: 2 }}>
+          <Stack direction="row" alignItems="center" spacing={2}>
+            <IconButton onClick={() => navigate('/providers')}>
+              <ArrowBack />
+            </IconButton>
+            <Typography variant="h4" component="h1">
+              {name}
+            </Typography>
           </Stack>
+          {canManage && !provider.source && (
+            <Button
+              variant="contained"
+              startIcon={<Add />}
+              onClick={handlePublishNewVersion}
+            >
+              Publish New Version
+            </Button>
+          )}
+        </Stack>
         <Typography variant="body1" color="text.secondary" gutterBottom>
           {provider.description || 'No description available'}
         </Typography>

--- a/frontend/src/pages/admin/AuditLogPage.tsx
+++ b/frontend/src/pages/admin/AuditLogPage.tsx
@@ -34,6 +34,8 @@ const RESOURCE_TYPES = [
   { value: '', label: 'All Resource Types' },
   { value: 'module', label: 'Module' },
   { value: 'provider', label: 'Provider' },
+  { value: 'terraform_binary', label: 'Terraform Binary' },
+  { value: 'file', label: 'File' },
   { value: 'user', label: 'User' },
   { value: 'mirror', label: 'Mirror' },
   { value: 'api_key', label: 'API Key' },


### PR DESCRIPTION
## Summary

- Pre-create nginx temp dirs (`client_temp`, `proxy_temp`, etc.) with ownership `101:101` (nginx user) at image build time
- Fixes CrashLoopBackOff on AKS where the Helm chart drops the CHOWN Linux capability

## Changelog

### Fixed
- fix: pre-create nginx temp dirs so container starts without CHOWN capability on AKS (#25)

## Test plan
- [ ] CI passes
- [ ] Frontend pod starts without CrashLoopBackOff on AKS