### PR TITLE
fix: redirect nginx pid to /tmp to survive Kubernetes tmpfs /var/run mount

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -74,7 +74,7 @@ RUN mkdir -p /var/cache/nginx/client_temp \
              /var/cache/nginx/scgi_temp && \
     chown -R 101:101 /var/cache/nginx && \
     chown -R 101:101 /var/log/nginx && \
-    touch /var/run/nginx.pid && chown 101:101 /var/run/nginx.pid
+    sed -i 's|pid\s*/var/run/nginx.pid;|pid /tmp/nginx.pid;|' /etc/nginx/nginx.conf
 
 # Expose ports
 EXPOSE 80 443


### PR DESCRIPTION
## Summary

- Changes nginx pid location from `/var/run/nginx.pid` to `/tmp/nginx.pid`
- Kubernetes mounts `/var/run` as a fresh tmpfs at container start, wiping any files created at build time — nginx running as uid 101 can't create files in the root-owned tmpfs

## Changelog

### Fixed
- fix: redirect nginx pid file to /tmp so container starts in AKS without root access to /var/run (#27)

## Test plan
- [ ] CI passes
- [ ] Frontend pod starts without `Permission denied` on nginx.pid