### PR TITLE
fix: setup wizard storage + login provider buttons v0.2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.2.8] - 2026-03-17
+
+### Fixed
+
+- fix: auto-save storage configuration after successful connection test so test + save are one action (#29)
+- fix: hide Azure AD login button when provider is not configured, eliminating the confusing error on click (#30)
+- fix: rename "Sign in with OIDC" button to "Sign in with SSO" for environment-agnostic labelling (#30)
+
+---
+
 ## [0.2.7] - 2026-03-17
 
 ### Fixed

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -22,6 +22,17 @@ const LoginPage: React.FC = () => {
   // during any `vite build` regardless of --mode. Check MODE instead, which
   // correctly reflects the --mode argument (e.g. 'development').
   const isDev = import.meta.env.MODE === 'development';
+  const [azureADAvailable, setAzureADAvailable] = React.useState<boolean>(false);
+
+  React.useEffect(() => {
+    fetch('/api/v1/auth/login?provider=azuread', { method: 'GET', redirect: 'manual' })
+      .then(res => {
+        setAzureADAvailable(res.type === 'opaqueredirect' || res.status === 0);
+      })
+      .catch(() => {
+        setAzureADAvailable(false);
+      });
+  }, []);
 
   const handleDevLogin = async () => {
     // Call the dev login endpoint to get a JWT (no hardcoded keys)
@@ -134,30 +145,34 @@ const LoginPage: React.FC = () => {
               onClick={handleOIDCLogin}
               sx={{ py: 1.5 }}
             >
-              Sign in with OIDC
+              Sign in with SSO
             </Button>
 
-            <Divider>
-              <Typography variant="body2" color="text.secondary">
-                OR
-              </Typography>
-            </Divider>
+            {azureADAvailable && (
+              <>
+                <Divider>
+                  <Typography variant="body2" color="text.secondary">
+                    OR
+                  </Typography>
+                </Divider>
 
-            <Button
-              variant="contained"
-              size="large"
-              fullWidth
-              onClick={handleAzureADLogin}
-              sx={{ 
-                py: 1.5,
-                backgroundColor: '#0078d4',
-                '&:hover': {
-                  backgroundColor: '#106ebe',
-                },
-              }}
-            >
-              Sign in with Azure AD
-            </Button>
+                <Button
+                  variant="contained"
+                  size="large"
+                  fullWidth
+                  onClick={handleAzureADLogin}
+                  sx={{
+                    py: 1.5,
+                    backgroundColor: '#0078d4',
+                    '&:hover': {
+                      backgroundColor: '#106ebe',
+                    },
+                  }}
+                >
+                  Sign in with Azure AD
+                </Button>
+              </>
+            )}
           </Stack>
 
           <Box sx={{ mt: 3, textAlign: 'center' }}>

--- a/frontend/src/pages/SetupWizardPage.tsx
+++ b/frontend/src/pages/SetupWizardPage.tsx
@@ -177,7 +177,7 @@ const SetupWizardPage: React.FC = () => {
     }
   };
 
-  // Step 2: Test Storage
+  // Step 2: Test Storage (auto-saves on success so test + save are one action)
   const handleTestStorage = async () => {
     try {
       setStorageTesting(true);
@@ -187,6 +187,8 @@ const SetupWizardPage: React.FC = () => {
       setStorageTestResult(result);
       if (!result.success) {
         setError(result.message);
+      } else {
+        await handleSaveStorage();
       }
     } catch (err: any) {
       setError(err.response?.data?.error || 'Storage test failed');


### PR DESCRIPTION
Fixes #29, #30

## Changes
- Auto-save storage config after successful test (test + save are now one action)
- Hide Azure AD button when `TFR_AUTH_AZURE_AD_ENABLED=false` via probe at page mount
- Rename "Sign in with OIDC" → "Sign in with SSO" for environment-agnostic labelling