### PR TITLE
fix: set TFR_SERVER_PUBLIC_URL so E2E logout test redirects to frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.2.9] - 2026-03-17
+
+### Fixed
+
+- fix: set TFR_SERVER_PUBLIC_URL in E2E test compose so logout redirects to the nginx-fronted SPA instead of the raw backend port
+
+---
+
 ## [0.2.8] - 2026-03-17
 
 ### Fixed

--- a/deployments/docker-compose.test.yml
+++ b/deployments/docker-compose.test.yml
@@ -37,6 +37,11 @@ services:
       - TFR_JWT_SECRET=test-jwt-secret-for-e2e-only-not-for-production
       # ENCRYPTION_KEY required for SCM integration — fixed 32-byte value for test only
       - ENCRYPTION_KEY=00000000000000000000000000000000
+      # PUBLIC_URL tells the backend the browser-facing address for OAuth callbacks and
+      # post-logout redirects.  Without this, deriveFrontendURL falls back to the internal
+      # base_url (http://localhost:8080) so logout would redirect to the raw backend instead
+      # of the nginx-fronted SPA that Playwright is testing against.
+      - TFR_SERVER_PUBLIC_URL=https://localhost:3000
     ports:
       - "8080:8080"
     depends_on:


### PR DESCRIPTION
## Summary

- `deriveFrontendURL` in the backend falls back to `cfg.Server.BaseURL` (`http://localhost:8080`) when no public URL or OIDC redirect URL is configured
- In the E2E test compose the backend was reachable at `http://localhost:8080` directly, so logout redirected the browser to the raw backend instead of the nginx-fronted SPA at `https://localhost:3000`
- Playwright's `waitForURL(url => url.pathname === '/')` timed out because it never landed on the frontend

Fixes the `logout returns user to home page` E2E test.

## Test plan

- [ ] E2E `logout returns user to home page` passes with `TFR_SERVER_PUBLIC_URL=https://localhost:3000` set