### PR TITLE
chore: release v0.2.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.2.9] - 2026-03-17
+
+### Fixed
+
+- fix: set TFR_SERVER_PUBLIC_URL in E2E test compose so logout redirects to the nginx-fronted SPA instead of the raw backend port
+
+---
+
 ## [0.2.8] - 2026-03-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.2.10] - 2026-03-22
+
+### Added
+
+- feat: provider documentation tab — ProviderDetailPage gains a Documentation tab with a collapsible sidebar (grouped by subcategory → resource type) and inline markdown rendering; docs are fetched from the backend proxy and displayed without leaving the app
+- feat: shared MarkdownRenderer component — extracted from ModuleDetailPage for reuse across provider docs and module readme rendering
+- feat: Overview tab enhancements — GitHub Repository and Changelog buttons replace the external documentation link; info cards sidebar carried through to the Documentation tab
+
+---
+
 ## [0.2.9] - 2026-03-17
 
 ### Fixed

--- a/deployments/docker-compose.test.yml
+++ b/deployments/docker-compose.test.yml
@@ -48,7 +48,15 @@ services:
       postgres:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/health"]
+      test:
+        [
+          "CMD",
+          "wget",
+          "--no-verbose",
+          "--tries=1",
+          "--spider",
+          "http://localhost:8080/health",
+        ]
       interval: 5s
       timeout: 3s
       retries: 10
@@ -62,14 +70,15 @@ services:
       - ./create-dev-admin-user.sql:/create-dev-admin-user.sql:ro
     environment:
       PGPASSWORD: registry
-    entrypoint: [
-      "psql",
-      "--host=postgres",
-      "--port=5432",
-      "--username=registry",
-      "--dbname=terraform_registry",
-      "--file=/create-dev-admin-user.sql"
-    ]
+    entrypoint:
+      [
+        "psql",
+        "--host=postgres",
+        "--port=5432",
+        "--username=registry",
+        "--dbname=terraform_registry",
+        "--file=/create-dev-admin-user.sql",
+      ]
     depends_on:
       backend:
         condition: service_healthy

--- a/deployments/docker-compose.test.yml
+++ b/deployments/docker-compose.test.yml
@@ -37,6 +37,11 @@ services:
       - TFR_JWT_SECRET=test-jwt-secret-for-e2e-only-not-for-production
       # ENCRYPTION_KEY required for SCM integration — fixed 32-byte value for test only
       - ENCRYPTION_KEY=00000000000000000000000000000000
+      # PUBLIC_URL tells the backend the browser-facing address for OAuth callbacks and
+      # post-logout redirects.  Without this, deriveFrontendURL falls back to the internal
+      # base_url (http://localhost:8080) so logout would redirect to the raw backend instead
+      # of the nginx-fronted SPA that Playwright is testing against.
+      - TFR_SERVER_PUBLIC_URL=https://localhost:3000
     ports:
       - "8080:8080"
     depends_on:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "terraform-registry-frontend",
-  "version": "1.5.0",
+  "version": "1.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "terraform-registry-frontend",
-      "version": "1.5.0",
+      "version": "1.7.1",
       "dependencies": {
         "@emotion/react": "^11.11.3",
         "@emotion/styled": "^11.11.0",

--- a/frontend/src/components/MarkdownRenderer.tsx
+++ b/frontend/src/components/MarkdownRenderer.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { Box } from '@mui/material';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import rehypeSanitize from 'rehype-sanitize';
+
+interface MarkdownRendererProps {
+  children: string;
+}
+
+const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ children }) => (
+  <Box
+    sx={(theme) => ({
+      '& h1': { fontSize: '2rem', fontWeight: 600, mt: 2, mb: 1 },
+      '& h2': { fontSize: '1.5rem', fontWeight: 600, mt: 2, mb: 1 },
+      '& h3': { fontSize: '1.25rem', fontWeight: 600, mt: 2, mb: 1 },
+      '& p': { mb: 2 },
+      '& code': {
+        backgroundColor: theme.palette.mode === 'dark' ? '#2d2d2d' : '#f5f5f5',
+        color: theme.palette.mode === 'dark' ? '#e6e6e6' : '#1e1e1e',
+        padding: '2px 6px',
+        borderRadius: '4px',
+        fontFamily: 'monospace',
+        fontSize: '0.875rem',
+      },
+      '& pre': {
+        backgroundColor: theme.palette.mode === 'dark' ? '#2d2d2d' : '#f5f5f5',
+        color: theme.palette.mode === 'dark' ? '#e6e6e6' : '#1e1e1e',
+        padding: 2,
+        borderRadius: 1,
+        overflow: 'auto',
+      },
+      '& pre code': {
+        backgroundColor: 'transparent',
+        padding: 0,
+      },
+      '& ul, & ol': { pl: 3, mb: 2 },
+      '& li': { mb: 1 },
+      '& table': { borderCollapse: 'collapse', width: '100%', mb: 2 },
+      '& th, & td': {
+        border: theme.palette.mode === 'dark' ? '1px solid #444' : '1px solid #ddd',
+        padding: '8px 12px',
+        textAlign: 'left',
+      },
+      '& th': {
+        backgroundColor: theme.palette.mode === 'dark' ? '#2d2d2d' : '#f5f5f5',
+        fontWeight: 600,
+      },
+    })}
+  >
+    <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeSanitize]}>
+      {children}
+    </ReactMarkdown>
+  </Box>
+);
+
+export default MarkdownRenderer;

--- a/frontend/src/components/ProviderDocContent.tsx
+++ b/frontend/src/components/ProviderDocContent.tsx
@@ -1,0 +1,81 @@
+import React, { useEffect, useState } from 'react';
+import { Box, CircularProgress, Alert } from '@mui/material';
+import MarkdownRenderer from './MarkdownRenderer';
+import api from '../services/api';
+
+interface ProviderDocContentProps {
+  namespace: string;
+  type: string;
+  version: string;
+  category: string;
+  slug: string;
+}
+
+function stripFrontmatter(content: string): string {
+  if (!content.startsWith('---')) return content;
+  const end = content.indexOf('\n---', 3);
+  if (end === -1) return content;
+  return content.slice(end + 4).trimStart();
+}
+
+const ProviderDocContent: React.FC<ProviderDocContentProps> = ({
+  namespace,
+  type,
+  version,
+  category,
+  slug,
+}) => {
+  const [content, setContent] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    setContent(null);
+
+    api
+      .getProviderDocContent(namespace, type, version, category, slug)
+      .then((data) => {
+        if (!cancelled) {
+          setContent(stripFrontmatter(data.content));
+          setLoading(false);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setError('Failed to load documentation.');
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [namespace, type, version, category, slug]);
+
+  if (loading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', pt: 4 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (error) {
+    return (
+      <Box sx={{ pt: 2, pb: 4, pl: 2, pr: 5 }}>
+        <Alert severity="error">{error}</Alert>
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ p: 2 }}>
+      <MarkdownRenderer>{content ?? ''}</MarkdownRenderer>
+    </Box>
+  );
+};
+
+export default ProviderDocContent;

--- a/frontend/src/components/ProviderDocsSidebar.tsx
+++ b/frontend/src/components/ProviderDocsSidebar.tsx
@@ -1,0 +1,367 @@
+import React, { useState, useMemo, useEffect } from 'react';
+import {
+  Box,
+  List,
+  ListItemButton,
+  ListItemText,
+  Typography,
+  TextField,
+  Collapse,
+  InputAdornment,
+} from '@mui/material';
+import Search from '@mui/icons-material/Search';
+import ChevronRight from '@mui/icons-material/ChevronRight';
+import { ProviderDocEntry } from '../types';
+
+const FLAT_CATEGORY_ORDER = ['guides', 'functions', 'actions'];
+const FLAT_CATEGORY_LABELS: Record<string, string> = {
+  guides: 'Guides',
+  functions: 'Functions',
+  actions: 'Actions',
+};
+
+const SUBCAT_CATEGORIES = ['resources', 'data-sources', 'ephemeral-resources', 'list-resources'];
+const SUBCAT_CATEGORY_LABELS: Record<string, string> = {
+  resources: 'Resources',
+  'data-sources': 'Data Sources',
+  'ephemeral-resources': 'Ephemeral Resources',
+  'list-resources': 'List Resources',
+};
+
+interface ProviderDocsSidebarProps {
+  providerName: string;
+  docs: ProviderDocEntry[];
+  selectedCategory?: string;
+  selectedSlug?: string;
+  onSelect: (category: string, slug: string) => void;
+  loading: boolean;
+}
+
+const sidebarFont = '"Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif';
+
+// Chevron that rotates 90° when expanded
+const Chevron: React.FC<{ expanded: boolean }> = ({ expanded }) => (
+  <ChevronRight
+    fontSize="small"
+    sx={{
+      flexShrink: 0,
+      color: 'text.disabled',
+      transform: expanded ? 'rotate(90deg)' : 'rotate(0deg)',
+      transition: 'transform 150ms ease',
+      fontSize: '1rem',
+    }}
+  />
+);
+
+const ProviderDocsSidebar: React.FC<ProviderDocsSidebarProps> = ({
+  providerName,
+  docs,
+  selectedCategory,
+  selectedSlug,
+  onSelect,
+  loading,
+}) => {
+  const [filter, setFilter] = useState('');
+  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
+  const [expandedSubGroups, setExpandedSubGroups] = useState<Set<string>>(new Set());
+
+  const filteredDocs = useMemo(() => {
+    if (!filter.trim()) return docs;
+    const q = filter.toLowerCase();
+    return docs.filter(
+      (d) =>
+        d.title.toLowerCase().includes(q) ||
+        d.slug.toLowerCase().includes(q) ||
+        (d.subcategory && d.subcategory.toLowerCase().includes(q))
+    );
+  }, [docs, filter]);
+
+  const organized = useMemo(() => {
+    const byCategory = new Map<string, ProviderDocEntry[]>();
+    for (const doc of filteredDocs) {
+      if (!byCategory.has(doc.category)) byCategory.set(doc.category, []);
+      byCategory.get(doc.category)!.push(doc);
+    }
+
+    const flatSections = FLAT_CATEGORY_ORDER
+      .filter((cat) => byCategory.has(cat))
+      .map((cat) => ({ cat, docs: byCategory.get(cat)! }));
+
+    const subcatMap = new Map<string, Map<string, ProviderDocEntry[]>>();
+    for (const cat of SUBCAT_CATEGORIES) {
+      for (const doc of byCategory.get(cat) ?? []) {
+        const sub = doc.subcategory ?? '';
+        if (!subcatMap.has(sub)) subcatMap.set(sub, new Map());
+        const catMap = subcatMap.get(sub)!;
+        if (!catMap.has(cat)) catMap.set(cat, []);
+        catMap.get(cat)!.push(doc);
+      }
+    }
+
+    const subcategories = new Map<string, Map<string, ProviderDocEntry[]>>(
+      [...subcatMap.entries()].sort(([a], [b]) => {
+        if (a === '' && b === '') return 0;
+        if (a === '') return 1;
+        if (b === '') return -1;
+        return a.localeCompare(b);
+      })
+    );
+
+    return { overview: byCategory.get('overview') ?? [], flatSections, subcategories };
+  }, [filteredDocs]);
+
+  // Auto-expand the group containing the selected doc
+  useEffect(() => {
+    if (!selectedCategory || !selectedSlug) return;
+    if (FLAT_CATEGORY_ORDER.includes(selectedCategory)) {
+      setExpandedGroups((prev) => new Set([...prev, selectedCategory]));
+    } else if (SUBCAT_CATEGORIES.includes(selectedCategory)) {
+      const doc = docs.find((d) => d.category === selectedCategory && d.slug === selectedSlug);
+      if (doc) {
+        const sub = doc.subcategory ?? '';
+        setExpandedGroups((prev) => new Set([...prev, sub]));
+        setExpandedSubGroups((prev) => new Set([...prev, `${sub}::${selectedCategory}`]));
+      }
+    }
+  }, [selectedCategory, selectedSlug, docs]);
+
+  const toggleGroup = (key: string) => {
+    setExpandedGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key); else next.add(key);
+      return next;
+    });
+  };
+
+  const toggleSubGroup = (key: string) => {
+    setExpandedSubGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key); else next.add(key);
+      return next;
+    });
+  };
+
+  const effectiveGroups = useMemo(() => {
+    if (!filter.trim()) return expandedGroups;
+    const all = new Set<string>();
+    for (const { cat } of organized.flatSections) all.add(cat);
+    for (const sub of organized.subcategories.keys()) all.add(sub);
+    return all;
+  }, [filter, organized, expandedGroups]);
+
+  const effectiveSubGroups = useMemo(() => {
+    if (!filter.trim()) return expandedSubGroups;
+    const all = new Set<string>();
+    for (const [sub, catMap] of organized.subcategories.entries()) {
+      for (const cat of catMap.keys()) all.add(`${sub}::${cat}`);
+    }
+    return all;
+  }, [filter, organized, expandedSubGroups]);
+
+  if (loading) {
+    return (
+      <Box sx={{ p: 2, fontFamily: sidebarFont }}>
+        <Typography variant="body2" color="text.secondary">Loading documentation...</Typography>
+      </Box>
+    );
+  }
+
+  if (docs.length === 0) {
+    return (
+      <Box sx={{ p: 2, fontFamily: sidebarFont }}>
+        <Typography variant="body2" color="text.secondary">No documentation available for this provider.</Typography>
+      </Box>
+    );
+  }
+
+  const isSelected = (cat: string, slug: string) => selectedCategory === cat && selectedSlug === slug;
+
+  const docItemSx = (selected: boolean, indent: number) => ({
+    pl: `${indent * 12}px`,
+    py: '4px',
+    fontFamily: sidebarFont,
+    borderLeft: selected ? '3px solid' : '3px solid transparent',
+    borderColor: selected ? 'primary.main' : 'transparent',
+    borderRadius: 0,
+    '&:hover': {
+      borderLeft: '3px solid',
+      borderColor: selected ? 'primary.main' : 'divider',
+      backgroundColor: 'action.hover',
+    },
+    '&.Mui-selected': {
+      backgroundColor: 'action.selected',
+      '&:hover': { backgroundColor: 'action.selected' },
+    },
+  });
+
+  const groupHeaderSx = (indent: number) => ({
+    pl: `${indent * 12}px`,
+    py: '5px',
+    borderLeft: '3px solid transparent',
+    borderRadius: 0,
+    fontFamily: sidebarFont,
+    '&:hover': {
+      borderLeft: '3px solid',
+      borderColor: 'divider',
+      backgroundColor: 'action.hover',
+    },
+  });
+
+  const renderDocItem = (doc: ProviderDocEntry, indent: number, displayName?: string) => {
+    const selected = isSelected(doc.category, doc.slug);
+    return (
+      <ListItemButton
+        key={doc.id}
+        selected={selected}
+        onClick={() => onSelect(doc.category, doc.slug)}
+        disableRipple
+        sx={docItemSx(selected, indent)}
+      >
+        <ListItemText
+          primary={
+            <Typography
+              sx={{
+                fontFamily: sidebarFont,
+                fontSize: '0.8125rem',
+                fontWeight: selected ? 600 : 400,
+                wordBreak: 'break-word',
+                whiteSpace: 'normal',
+                color: selected ? 'primary.main' : 'text.primary',
+              }}
+            >
+              {displayName ?? doc.title}
+            </Typography>
+          }
+        />
+      </ListItemButton>
+    );
+  };
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', fontFamily: sidebarFont }}>
+      <Box sx={{ p: 1, pb: 0.5 }}>
+        <TextField
+          size="small"
+          fullWidth
+          placeholder="Filter docs..."
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <Search fontSize="small" />
+              </InputAdornment>
+            ),
+            sx: { fontFamily: sidebarFont, fontSize: '0.875rem' },
+          }}
+        />
+      </Box>
+
+      <Box sx={{ overflowY: 'auto', flex: 1, pt: 0.5 }}>
+        {/* Overview docs — show provider name for index doc, title for others */}
+        <List dense disablePadding>
+          {organized.overview.map((doc) =>
+            renderDocItem(
+              doc,
+              2,
+              doc.slug === 'index' ? providerName : doc.title
+            )
+          )}
+        </List>
+
+        {/* Flat sections: Guides, Functions, Actions */}
+        {organized.flatSections.map(({ cat, docs: catDocs }) => {
+          const expanded = effectiveGroups.has(cat);
+          return (
+            <Box key={cat}>
+              <ListItemButton dense disableRipple onClick={() => toggleGroup(cat)} sx={groupHeaderSx(2)}>
+                <Chevron expanded={expanded} />
+                <ListItemText
+                  sx={{ ml: 0.5 }}
+                  primary={
+                    <Typography sx={{ fontFamily: sidebarFont, fontSize: '0.875rem', fontWeight: expanded ? 600 : 400 }}>
+                      {FLAT_CATEGORY_LABELS[cat]}
+                    </Typography>
+                  }
+                />
+              </ListItemButton>
+              <Collapse in={expanded} timeout="auto" unmountOnExit>
+                <List dense disablePadding>
+                  {catDocs.map((doc) => renderDocItem(doc, 3))}
+                </List>
+              </Collapse>
+            </Box>
+          );
+        })}
+
+        {/* Subcategory groups */}
+        {[...organized.subcategories.entries()].map(([sub, catMap]) => {
+          const subLabel = sub || 'Other';
+          const isGroupExpanded = effectiveGroups.has(sub);
+          const totalCount = [...catMap.values()].reduce((n, a) => n + a.length, 0);
+
+          return (
+            <Box key={sub || '__other__'}>
+              <ListItemButton dense disableRipple onClick={() => toggleGroup(sub)} sx={groupHeaderSx(2)}>
+                <Chevron expanded={isGroupExpanded} />
+                <ListItemText
+                  sx={{ ml: 0.5 }}
+                  primary={
+                    <Typography sx={{ fontFamily: sidebarFont, fontSize: '0.875rem', fontWeight: isGroupExpanded ? 600 : 400 }}>
+                      {subLabel}
+                      {!filter && (
+                        <Typography component="span" sx={{ fontFamily: sidebarFont, fontSize: '0.75rem', color: 'text.disabled', ml: 0.5 }}>
+                          ({totalCount})
+                        </Typography>
+                      )}
+                    </Typography>
+                  }
+                />
+              </ListItemButton>
+
+              <Collapse in={isGroupExpanded} timeout="auto" unmountOnExit>
+                {catMap.size === 1
+                  ? [...catMap.values()].map((entries) => (
+                      <List dense disablePadding key="only">
+                        {entries.map((doc) => renderDocItem(doc, 3))}
+                      </List>
+                    ))
+                  : [...catMap.entries()]
+                      .sort(([a], [b]) => SUBCAT_CATEGORIES.indexOf(a) - SUBCAT_CATEGORIES.indexOf(b))
+                      .map(([cat, entries]) => {
+                        const subGroupKey = `${sub}::${cat}`;
+                        const isSubExpanded = effectiveSubGroups.has(subGroupKey);
+                        return (
+                          <Box key={cat}>
+                            <ListItemButton dense disableRipple onClick={() => toggleSubGroup(subGroupKey)} sx={groupHeaderSx(3)}>
+                              <Chevron expanded={isSubExpanded} />
+                              <ListItemText
+                                sx={{ ml: 0.5 }}
+                                primary={
+                                  <Typography sx={{ fontFamily: sidebarFont, fontSize: '0.8125rem', fontWeight: isSubExpanded ? 600 : 400, color: 'text.secondary' }}>
+                                    {SUBCAT_CATEGORY_LABELS[cat]}
+                                    <Typography component="span" sx={{ fontFamily: sidebarFont, fontSize: '0.75rem', color: 'text.disabled', ml: 0.5 }}>
+                                      ({entries.length})
+                                    </Typography>
+                                  </Typography>
+                                }
+                              />
+                            </ListItemButton>
+                            <Collapse in={isSubExpanded} timeout="auto" unmountOnExit>
+                              <List dense disablePadding>
+                                {entries.map((doc) => renderDocItem(doc, 4))}
+                              </List>
+                            </Collapse>
+                          </Box>
+                        );
+                      })}
+              </Collapse>
+            </Box>
+          );
+        })}
+      </Box>
+    </Box>
+  );
+};
+
+export default ProviderDocsSidebar;

--- a/frontend/src/pages/ModuleDetailPage.tsx
+++ b/frontend/src/pages/ModuleDetailPage.tsx
@@ -1,8 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import ReactMarkdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
-import rehypeSanitize from 'rehype-sanitize';
+import MarkdownRenderer from '../components/MarkdownRenderer';
 import {
   Container,
   Typography,
@@ -481,47 +479,7 @@ const ModuleDetailPage: React.FC = () => {
                 README
               </Typography>
               <Divider sx={{ mb: 2 }} />
-              <Box
-                sx={(theme) => ({
-                  '& h1': { fontSize: '2rem', fontWeight: 600, mt: 2, mb: 1 },
-                  '& h2': { fontSize: '1.5rem', fontWeight: 600, mt: 2, mb: 1 },
-                  '& h3': { fontSize: '1.25rem', fontWeight: 600, mt: 2, mb: 1 },
-                  '& p': { mb: 2 },
-                  '& code': {
-                    backgroundColor: theme.palette.mode === 'dark' ? '#2d2d2d' : '#f5f5f5',
-                    color: theme.palette.mode === 'dark' ? '#e6e6e6' : '#1e1e1e',
-                    padding: '2px 6px',
-                    borderRadius: '4px',
-                    fontFamily: 'monospace',
-                    fontSize: '0.875rem',
-                  },
-                  '& pre': {
-                    backgroundColor: theme.palette.mode === 'dark' ? '#2d2d2d' : '#f5f5f5',
-                    color: theme.palette.mode === 'dark' ? '#e6e6e6' : '#1e1e1e',
-                    padding: 2,
-                    borderRadius: 1,
-                    overflow: 'auto',
-                  },
-                  '& pre code': {
-                    backgroundColor: 'transparent',
-                    padding: 0,
-                  },
-                  '& ul, & ol': { pl: 3, mb: 2 },
-                  '& li': { mb: 1 },
-                  '& table': { borderCollapse: 'collapse', width: '100%', mb: 2 },
-                  '& th, & td': {
-                    border: theme.palette.mode === 'dark' ? '1px solid #444' : '1px solid #ddd',
-                    padding: '8px 12px',
-                    textAlign: 'left',
-                  },
-                  '& th': {
-                    backgroundColor: theme.palette.mode === 'dark' ? '#2d2d2d' : '#f5f5f5',
-                    fontWeight: 600
-                  },
-                })}
-              >
-                <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeSanitize]}>{selectedVersion.readme}</ReactMarkdown>
-              </Box>
+              <MarkdownRenderer>{selectedVersion.readme}</MarkdownRenderer>
             </Paper>
           )}
         </Box>

--- a/frontend/src/pages/ProviderDetailPage.tsx
+++ b/frontend/src/pages/ProviderDetailPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
 import {
   Container,
   Typography,
@@ -30,6 +30,8 @@ import {
   DialogContentText,
   DialogActions,
   TextField,
+  Tabs,
+  Tab,
 } from '@mui/material';
 import ArrowBack from '@mui/icons-material/ArrowBack';
 import ContentCopy from '@mui/icons-material/ContentCopy';
@@ -37,10 +39,13 @@ import Delete from '@mui/icons-material/Delete';
 import Warning from '@mui/icons-material/Warning';
 import Restore from '@mui/icons-material/Restore';
 import Add from '@mui/icons-material/Add';
+import GitHub from '@mui/icons-material/GitHub';
 import api from '../services/api';
-import { Provider, ProviderVersion } from '../types';
+import { Provider, ProviderVersion, ProviderDocEntry } from '../types';
 import { useAuth } from '../contexts/AuthContext';
 import { REGISTRY_HOST } from '../config';
+import ProviderDocsSidebar from '../components/ProviderDocsSidebar';
+import ProviderDocContent from '../components/ProviderDocContent';
 
 const ProviderDetailPage: React.FC = () => {
   const { namespace, type } = useParams<{
@@ -48,8 +53,15 @@ const ProviderDetailPage: React.FC = () => {
     type: string;
   }>();
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
   const { isAuthenticated, allowedScopes } = useAuth();
   const canManage = isAuthenticated && (allowedScopes.includes('admin') || allowedScopes.includes('providers:write'));
+
+  const activeTab = searchParams.get('tab') === 'docs' ? 1 : 0;
+  const docParam = searchParams.get('doc');
+  const docParts = docParam ? docParam.split('/') : [];
+  const selectedDocCategory = docParts[0] ?? null;
+  const selectedDocSlug = docParts[1] ?? null;
 
   // Use 'type' as the name for display
   const name = type;
@@ -69,9 +81,38 @@ const ProviderDetailPage: React.FC = () => {
   const [deprecationMessage, setDeprecationMessage] = useState('');
   const [deprecating, setDeprecating] = useState(false);
 
+  const [docs, setDocs] = useState<ProviderDocEntry[]>([]);
+  const [docsLoading, setDocsLoading] = useState(false);
+
   useEffect(() => {
     loadProviderDetails();
   }, [namespace, type]);
+
+  // Fetch doc index for mirrored providers when version is selected
+  useEffect(() => {
+    if (!provider?.source || !selectedVersion || !namespace || !type) return;
+    setDocsLoading(true);
+    api
+      .getProviderDocs(namespace, type, selectedVersion.version, undefined, 'hcl')
+      .then((data) => setDocs(data.docs))
+      .catch(() => { /* non-fatal */ })
+      .finally(() => setDocsLoading(false));
+  }, [provider?.source, selectedVersion?.version, namespace, type]);
+
+  // Auto-select first doc when Documentation tab is opened with no selection
+  useEffect(() => {
+    if (activeTab !== 1 || docParam || docs.length === 0) return;
+    const overview = docs.find((d) => d.category === 'overview');
+    const first = overview ?? docs[0];
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        next.set('doc', `${first.category}/${first.slug}`);
+        return next;
+      },
+      { replace: true }
+    );
+  }, [activeTab, docParam, docs]);
 
   const loadProviderDetails = async () => {
     if (!namespace || !type) return;
@@ -214,6 +255,34 @@ const ProviderDetailPage: React.FC = () => {
     }
   };
 
+  const handleTabChange = (_: React.SyntheticEvent, newValue: number) => {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        if (newValue === 1) {
+          next.set('tab', 'docs');
+        } else {
+          next.delete('tab');
+          next.delete('doc');
+        }
+        return next;
+      },
+      { replace: true }
+    );
+  };
+
+  const handleDocSelect = (category: string, slug: string) => {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        next.set('tab', 'docs');
+        next.set('doc', `${category}/${slug}`);
+        return next;
+      },
+      { replace: true }
+    );
+  };
+
   const getTerraformExample = () => {
     if (!provider || !selectedVersion) return '';
 
@@ -259,7 +328,7 @@ provider "${name}" {
 
   if (error || !provider) {
     return (
-      <Container maxWidth="lg" sx={{ py: 4 }}>
+      <Container maxWidth="xl" sx={{ py: 4 }}>
         <Alert severity="error">{error || 'Provider not found'}</Alert>
         <Button
           startIcon={<ArrowBack />}
@@ -272,8 +341,18 @@ provider "${name}" {
     );
   }
 
+  const hasDocs = provider.source && selectedVersion;
+
+  // Derive GitHub repo URL from namespace/type convention for mirrored providers
+  const githubUrl = provider.source
+    ? `https://github.com/${namespace}/terraform-provider-${type}`
+    : null;
+  const changelogUrl = githubUrl && selectedVersion
+    ? `${githubUrl}/releases/tag/v${selectedVersion.version}`
+    : null;
+
   return (
-    <Container maxWidth="lg" sx={{ py: 4 }}>
+    <Container maxWidth="xl" sx={{ py: 4 }}>
       {/* Breadcrumbs */}
       <Breadcrumbs sx={{ mb: 3 }}>
         <Link
@@ -292,7 +371,7 @@ provider "${name}" {
       </Breadcrumbs>
 
       {/* Header */}
-      <Box sx={{ mb: 4 }}>
+      <Box sx={{ mb: 3 }}>
         <Stack direction="row" alignItems="center" justifyContent="space-between" spacing={2} sx={{ mb: 2 }}>
           <Stack direction="row" alignItems="center" spacing={2}>
             <IconButton onClick={() => navigate('/providers')}>
@@ -370,200 +449,358 @@ provider "${name}" {
         </Stack>
       </Box>
 
-      <Box sx={{ display: 'flex', gap: 3, flexDirection: { xs: 'column', md: 'row' } }}>
-        {/* Main Content */}
-        <Box sx={{ flex: 1 }}>
-          {/* Usage Example */}
-          <Paper sx={{ p: 3, mb: 3 }}>
-            <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 2 }}>
-              <Typography variant="h6">Usage Example</Typography>
-              <Tooltip title={copiedSource ? 'Copied!' : 'Copy source'}>
-                <IconButton onClick={handleCopySource} size="small">
-                  <ContentCopy />
-                </IconButton>
-              </Tooltip>
-            </Stack>
+      {/* Tabs */}
+      {hasDocs && (
+        <Box sx={{ borderBottom: 1, borderColor: 'divider', mb: 3 }}>
+          <Tabs value={activeTab} onChange={handleTabChange}>
+            <Tab label="Overview" />
+            <Tab label="Documentation" />
+          </Tabs>
+        </Box>
+      )}
+
+      {/* Overview Tab */}
+      {activeTab === 0 && (
+        <Box sx={{ display: 'flex', gap: 3, flexDirection: { xs: 'column', md: 'row' } }}>
+          {/* Main Content */}
+          <Box sx={{ flex: 1 }}>
+            {/* Usage Example */}
+            <Paper sx={{ p: 3, mb: 3 }}>
+              <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 2 }}>
+                <Typography variant="h6">Usage Example</Typography>
+                <Tooltip title={copiedSource ? 'Copied!' : 'Copy source'}>
+                  <IconButton onClick={handleCopySource} size="small">
+                    <ContentCopy />
+                  </IconButton>
+                </Tooltip>
+              </Stack>
+              <Box
+                component="pre"
+                sx={{
+                  p: 2,
+                  backgroundColor: (theme) => theme.palette.mode === 'dark' ? '#2d2d2d' : '#f5f5f5',
+                  color: (theme) => theme.palette.mode === 'dark' ? '#e6e6e6' : '#1e1e1e',
+                  borderRadius: 1,
+                  overflow: 'auto',
+                  fontSize: '0.875rem',
+                }}
+              >
+                <code>{getTerraformExample()}</code>
+              </Box>
+            </Paper>
+
+            {/* Platforms Table */}
+            {selectedVersion && selectedVersion.platforms && selectedVersion.platforms.length > 0 && (
+              <Paper sx={{ p: 3 }}>
+                <Typography variant="h6" gutterBottom>
+                  Available Platforms
+                </Typography>
+                <Divider sx={{ mb: 2 }} />
+                <TableContainer>
+                  <Table size="small">
+                    <TableHead>
+                      <TableRow>
+                        <TableCell>OS</TableCell>
+                        <TableCell>Architecture</TableCell>
+                        <TableCell>SHA256 Sum</TableCell>
+                        <TableCell width="50px"></TableCell>
+                      </TableRow>
+                    </TableHead>
+                    <TableBody>
+                      {selectedVersion.platforms.map((platform) => (
+                        <TableRow key={platform.id}>
+                          <TableCell>{platform.os}</TableCell>
+                          <TableCell>{platform.arch}</TableCell>
+                          <TableCell sx={{ fontFamily: 'monospace', fontSize: '0.75rem', wordBreak: 'break-all' }}>
+                            {platform.shasum || 'N/A'}
+                          </TableCell>
+                          <TableCell>
+                            {platform.shasum && (
+                              <Tooltip title={copiedChecksum === platform.shasum ? "Copied!" : "Copy checksum"}>
+                                <IconButton
+                                  size="small"
+                                  onClick={() => handleCopyChecksum(platform.shasum)}
+                                >
+                                  <ContentCopy fontSize="small" />
+                                </IconButton>
+                              </Tooltip>
+                            )}
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </TableContainer>
+              </Paper>
+            )}
+          </Box>
+
+          {/* Sidebar - Provider Information and Version Details */}
+          <Box sx={{ width: { xs: '100%', md: 320 }, flexShrink: 0 }}>
+            {/* Provider Information */}
+            <Paper sx={{ p: 3, mb: 3 }}>
+              <Typography variant="h6" gutterBottom>
+                Provider Information
+              </Typography>
+              <Divider sx={{ mb: 2 }} />
+              <Box sx={{ '& > *': { mb: 1 } }}>
+                <Typography variant="body2">
+                  <strong>Namespace:</strong> {namespace}
+                </Typography>
+                <Typography variant="body2">
+                  <strong>Name:</strong> {name}
+                </Typography>
+                <Typography variant="body2">
+                  <strong>Latest Version:</strong> {versions.length > 0 ? (versions.find(v => !v.deprecated) ?? versions[0]).version : 'N/A'}
+                </Typography>
+                <Typography variant="body2">
+                  <strong>Total Downloads:</strong> {provider.download_count ?? 0}
+                </Typography>
+                {githubUrl && (
+                  <Box sx={{ mt: 1 }}>
+                    <Button
+                      variant="outlined"
+                      size="small"
+                      startIcon={<GitHub fontSize="small" />}
+                      href={githubUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      fullWidth
+                    >
+                      GitHub Repository
+                    </Button>
+                  </Box>
+                )}
+                {changelogUrl && (
+                  <Box sx={{ mt: 1 }}>
+                    <Button
+                      variant="outlined"
+                      size="small"
+                      href={changelogUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      fullWidth
+                    >
+                      Changelog v{selectedVersion?.version}
+                    </Button>
+                  </Box>
+                )}
+                {provider.created_by_name && (
+                  <Typography variant="body2" sx={{ mt: 1 }}>
+                    <strong>Created By:</strong> {provider.created_by_name}
+                  </Typography>
+                )}
+              </Box>
+            </Paper>
+
+            {/* Selected Version Details */}
+            {selectedVersion && (
+              <Paper sx={{ p: 3 }}>
+                <Typography variant="h6" gutterBottom>
+                  Version {selectedVersion.version} Details
+                </Typography>
+                <Divider sx={{ mb: 2 }} />
+                <Typography variant="body2" sx={{ mb: 2 }}>
+                  <strong>Published:</strong>{' '}
+                  {new Date(selectedVersion.published_at).toISOString().split('T')[0]}
+                </Typography>
+                <Typography variant="body2" sx={{ mb: 2 }}>
+                  <strong>Downloads:</strong> {selectedVersion.download_count ?? 0}
+                </Typography>
+                {selectedVersion.published_by_name && (
+                  <Typography variant="body2" sx={{ mb: 2 }}>
+                    <strong>Published By:</strong> {selectedVersion.published_by_name}
+                  </Typography>
+                )}
+
+                {/* Deprecation Status */}
+                {selectedVersion.deprecated && (
+                  <Alert severity="warning" sx={{ mb: 2 }}>
+                    <Typography variant="body2">
+                      <strong>Deprecated</strong>
+                      {selectedVersion.deprecated_at && (
+                        <> on {new Date(selectedVersion.deprecated_at).toISOString().split('T')[0]}</>
+                      )}
+                    </Typography>
+                    {selectedVersion.deprecation_message && (
+                      <Typography variant="body2" sx={{ mt: 1 }}>
+                        {selectedVersion.deprecation_message}
+                      </Typography>
+                    )}
+                  </Alert>
+                )}
+
+                {canManage && (
+                  <Stack spacing={1}>
+                    {selectedVersion.deprecated ? (
+                      <Button
+                        variant="outlined"
+                        color="success"
+                        size="small"
+                        startIcon={<Restore />}
+                        onClick={handleUndeprecateVersion}
+                        disabled={deprecating}
+                        fullWidth
+                      >
+                        {deprecating ? 'Removing Deprecation...' : 'Remove Deprecation'}
+                      </Button>
+                    ) : (
+                      <Button
+                        variant="outlined"
+                        color="warning"
+                        size="small"
+                        startIcon={<Warning />}
+                        onClick={() => setDeprecateDialogOpen(true)}
+                        fullWidth
+                      >
+                        Deprecate Version
+                      </Button>
+                    )}
+                    <Button
+                      variant="outlined"
+                      color="error"
+                      size="small"
+                      startIcon={<Delete />}
+                      onClick={() => openDeleteVersionDialog(selectedVersion.version)}
+                      fullWidth
+                    >
+                      Delete This Version
+                    </Button>
+                  </Stack>
+                )}
+              </Paper>
+            )}
+          </Box>
+        </Box>
+      )}
+
+      {/* Documentation Tab */}
+      {activeTab === 1 && hasDocs && (
+        <Box sx={{ display: 'flex', gap: 3, alignItems: 'flex-start' }}>
+          {/* Doc panel */}
+          <Paper sx={{ display: 'flex', flex: 1, height: '75vh', overflow: 'hidden', minWidth: 0 }}>
             <Box
-              component="pre"
               sx={{
-                p: 2,
-                backgroundColor: (theme) => theme.palette.mode === 'dark' ? '#2d2d2d' : '#f5f5f5',
-                color: (theme) => theme.palette.mode === 'dark' ? '#e6e6e6' : '#1e1e1e',
-                borderRadius: 1,
-                overflow: 'auto',
-                fontSize: '0.875rem',
+                width: 300,
+                flexShrink: 0,
+                borderRight: 1,
+                borderColor: 'divider',
+                display: 'flex',
+                flexDirection: 'column',
               }}
             >
-              <code>{getTerraformExample()}</code>
+              <ProviderDocsSidebar
+                providerName={name ?? ''}
+                docs={docs}
+                selectedCategory={selectedDocCategory ?? undefined}
+                selectedSlug={selectedDocSlug ?? undefined}
+                onSelect={handleDocSelect}
+                loading={docsLoading}
+              />
+            </Box>
+            <Box sx={{ flex: 1, overflowY: 'auto' }}>
+              {selectedDocCategory && selectedDocSlug && selectedVersion ? (
+                <ProviderDocContent
+                  namespace={namespace!}
+                  type={type!}
+                  version={selectedVersion.version}
+                  category={selectedDocCategory}
+                  slug={selectedDocSlug}
+                />
+              ) : (
+                <Box sx={{ p: 4, textAlign: 'center' }}>
+                  <Typography color="text.secondary">Select a document from the sidebar.</Typography>
+                </Box>
+              )}
             </Box>
           </Paper>
 
-          {/* Platforms Table */}
-          {selectedVersion && selectedVersion.platforms && selectedVersion.platforms.length > 0 && (
-            <Paper sx={{ p: 3 }}>
-              <Typography variant="h6" gutterBottom>
-                Available Platforms
-              </Typography>
+          {/* Info cards — same as overview tab */}
+          <Box sx={{ width: 320, flexShrink: 0 }}>
+            <Paper sx={{ p: 3, mb: 3 }}>
+              <Typography variant="h6" gutterBottom>Provider Information</Typography>
               <Divider sx={{ mb: 2 }} />
-              <TableContainer>
-                <Table size="small">
-                  <TableHead>
-                    <TableRow>
-                      <TableCell>OS</TableCell>
-                      <TableCell>Architecture</TableCell>
-                      <TableCell>SHA256 Sum</TableCell>
-                      <TableCell width="50px"></TableCell>
-                    </TableRow>
-                  </TableHead>
-                  <TableBody>
-                    {selectedVersion.platforms.map((platform) => (
-                      <TableRow key={platform.id}>
-                        <TableCell>{platform.os}</TableCell>
-                        <TableCell>{platform.arch}</TableCell>
-                        <TableCell sx={{ fontFamily: 'monospace', fontSize: '0.75rem', wordBreak: 'break-all' }}>
-                          {platform.shasum || 'N/A'}
-                        </TableCell>
-                        <TableCell>
-                          {platform.shasum && (
-                            <Tooltip title={copiedChecksum === platform.shasum ? "Copied!" : "Copy checksum"}>
-                              <IconButton
-                                size="small"
-                                onClick={() => handleCopyChecksum(platform.shasum)}
-                              >
-                                <ContentCopy fontSize="small" />
-                              </IconButton>
-                            </Tooltip>
-                          )}
-                        </TableCell>
-                      </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
-              </TableContainer>
+              <Box sx={{ '& > *': { mb: 1 } }}>
+                <Typography variant="body2"><strong>Namespace:</strong> {namespace}</Typography>
+                <Typography variant="body2"><strong>Name:</strong> {name}</Typography>
+                <Typography variant="body2">
+                  <strong>Latest Version:</strong> {versions.length > 0 ? (versions.find(v => !v.deprecated) ?? versions[0]).version : 'N/A'}
+                </Typography>
+                <Typography variant="body2"><strong>Total Downloads:</strong> {provider.download_count ?? 0}</Typography>
+                {githubUrl && (
+                  <Box sx={{ mt: 1 }}>
+                    <Button variant="outlined" size="small" startIcon={<GitHub fontSize="small" />}
+                      href={githubUrl} target="_blank" rel="noopener noreferrer" fullWidth>
+                      GitHub Repository
+                    </Button>
+                  </Box>
+                )}
+                {changelogUrl && (
+                  <Box sx={{ mt: 1 }}>
+                    <Button variant="outlined" size="small"
+                      href={changelogUrl} target="_blank" rel="noopener noreferrer" fullWidth>
+                      Changelog v{selectedVersion?.version}
+                    </Button>
+                  </Box>
+                )}
+                {provider.created_by_name && (
+                  <Typography variant="body2" sx={{ mt: 1 }}><strong>Created By:</strong> {provider.created_by_name}</Typography>
+                )}
+              </Box>
             </Paper>
-          )}
-        </Box>
 
-        {/* Sidebar - Provider Information and Version Details */}
-        <Box sx={{ width: { xs: '100%', md: 350 } }}>
-          {/* Provider Information */}
-          <Paper sx={{ p: 3, mb: 3 }}>
-            <Typography variant="h6" gutterBottom>
-              Provider Information
-            </Typography>
-            <Divider sx={{ mb: 2 }} />
-            <Box sx={{ '& > *': { mb: 1 } }}>
-              <Typography variant="body2">
-                <strong>Namespace:</strong> {namespace}
-              </Typography>
-              <Typography variant="body2">
-                <strong>Name:</strong> {name}
-              </Typography>
-              <Typography variant="body2">
-                <strong>Latest Version:</strong> {versions.length > 0 ? (versions.find(v => !v.deprecated) ?? versions[0]).version : 'N/A'}
-              </Typography>
-              <Typography variant="body2">
-                <strong>Total Downloads:</strong> {provider.download_count ?? 0}
-              </Typography>
-              {provider.source && selectedVersion && (
-                <Typography variant="body2">
-                  <strong>Documentation:</strong>{' '}
-                  <Link
-                    href={`https://registry.terraform.io/providers/${namespace}/${type}/${selectedVersion.version}/docs`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    registry.terraform.io ↗
-                  </Link>
+            {selectedVersion && (
+              <Paper sx={{ p: 3 }}>
+                <Typography variant="h6" gutterBottom>Version {selectedVersion.version} Details</Typography>
+                <Divider sx={{ mb: 2 }} />
+                <Typography variant="body2" sx={{ mb: 1 }}>
+                  <strong>Published:</strong> {new Date(selectedVersion.published_at).toISOString().split('T')[0]}
                 </Typography>
-              )}
-              {provider.created_by_name && (
-                <Typography variant="body2">
-                  <strong>Created By:</strong> {provider.created_by_name}
+                <Typography variant="body2" sx={{ mb: 1 }}>
+                  <strong>Downloads:</strong> {selectedVersion.download_count ?? 0}
                 </Typography>
-              )}
-            </Box>
-          </Paper>
-
-          {/* Selected Version Details */}
-          {selectedVersion && (
-            <Paper sx={{ p: 3 }}>
-              <Typography variant="h6" gutterBottom>
-                Version {selectedVersion.version} Details
-              </Typography>
-              <Divider sx={{ mb: 2 }} />
-              <Typography variant="body2" sx={{ mb: 2 }}>
-                <strong>Published:</strong>{' '}
-                {new Date(selectedVersion.published_at).toISOString().split('T')[0]}
-              </Typography>
-              <Typography variant="body2" sx={{ mb: 2 }}>
-                <strong>Downloads:</strong> {selectedVersion.download_count ?? 0}
-              </Typography>
-              {selectedVersion.published_by_name && (
-                <Typography variant="body2" sx={{ mb: 2 }}>
-                  <strong>Published By:</strong> {selectedVersion.published_by_name}
-                </Typography>
-              )}
-
-              {/* Deprecation Status */}
-              {selectedVersion.deprecated && (
-                <Alert severity="warning" sx={{ mb: 2 }}>
-                  <Typography variant="body2">
-                    <strong>Deprecated</strong>
-                    {selectedVersion.deprecated_at && (
-                      <> on {new Date(selectedVersion.deprecated_at).toISOString().split('T')[0]}</>
-                    )}
+                {selectedVersion.published_by_name && (
+                  <Typography variant="body2" sx={{ mb: 2 }}>
+                    <strong>Published By:</strong> {selectedVersion.published_by_name}
                   </Typography>
-                  {selectedVersion.deprecation_message && (
-                    <Typography variant="body2" sx={{ mt: 1 }}>
-                      {selectedVersion.deprecation_message}
+                )}
+                {selectedVersion.deprecated && (
+                  <Alert severity="warning" sx={{ mb: 2 }}>
+                    <Typography variant="body2">
+                      <strong>Deprecated</strong>
+                      {selectedVersion.deprecated_at && (
+                        <> on {new Date(selectedVersion.deprecated_at).toISOString().split('T')[0]}</>
+                      )}
                     </Typography>
-                  )}
-                </Alert>
-              )}
-
-              {canManage && (
-                <Stack spacing={1}>
-                  {selectedVersion.deprecated ? (
-                    <Button
-                      variant="outlined"
-                      color="success"
-                      size="small"
-                      startIcon={<Restore />}
-                      onClick={handleUndeprecateVersion}
-                      disabled={deprecating}
-                      fullWidth
-                    >
-                      {deprecating ? 'Removing Deprecation...' : 'Remove Deprecation'}
+                    {selectedVersion.deprecation_message && (
+                      <Typography variant="body2" sx={{ mt: 1 }}>{selectedVersion.deprecation_message}</Typography>
+                    )}
+                  </Alert>
+                )}
+                {canManage && (
+                  <Stack spacing={1}>
+                    {selectedVersion.deprecated ? (
+                      <Button variant="outlined" color="success" size="small" startIcon={<Restore />}
+                        onClick={handleUndeprecateVersion} disabled={deprecating} fullWidth>
+                        {deprecating ? 'Removing...' : 'Remove Deprecation'}
+                      </Button>
+                    ) : (
+                      <Button variant="outlined" color="warning" size="small" startIcon={<Warning />}
+                        onClick={() => setDeprecateDialogOpen(true)} fullWidth>
+                        Deprecate Version
+                      </Button>
+                    )}
+                    <Button variant="outlined" color="error" size="small" startIcon={<Delete />}
+                      onClick={() => openDeleteVersionDialog(selectedVersion.version)} fullWidth>
+                      Delete This Version
                     </Button>
-                  ) : (
-                    <Button
-                      variant="outlined"
-                      color="warning"
-                      size="small"
-                      startIcon={<Warning />}
-                      onClick={() => setDeprecateDialogOpen(true)}
-                      fullWidth
-                    >
-                      Deprecate Version
-                    </Button>
-                  )}
-                  <Button
-                    variant="outlined"
-                    color="error"
-                    size="small"
-                    startIcon={<Delete />}
-                    onClick={() => openDeleteVersionDialog(selectedVersion.version)}
-                    fullWidth
-                  >
-                    Delete This Version
-                  </Button>
-                </Stack>
-              )}
-            </Paper>
-          )}
+                  </Stack>
+                )}
+              </Paper>
+            )}
+          </Box>
         </Box>
-      </Box>
+      )}
 
       {/* Delete Provider Confirmation Dialog */}
       <Dialog

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -258,6 +258,24 @@ class ApiClient {
     return response.data;
   }
 
+  async getProviderDocs(namespace: string, type: string, version: string, category?: string, language?: string) {
+    const params: Record<string, string> = {};
+    if (category) params.category = category;
+    if (language) params.language = language;
+    const response = await this.client.get(
+      `/api/v1/providers/${namespace}/${type}/versions/${version}/docs`,
+      { params }
+    );
+    return response.data;
+  }
+
+  async getProviderDocContent(namespace: string, type: string, version: string, category: string, slug: string) {
+    const response = await this.client.get(
+      `/api/v1/providers/${namespace}/${type}/versions/${version}/docs/${category}/${slug}`
+    );
+    return response.data;
+  }
+
   // Helper to transform user from API format to frontend format
   private transformUser(user: any) {
     return {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -189,6 +189,27 @@ export interface ProviderPlatform {
   download_count: number;
 }
 
+export interface ProviderDocEntry {
+  id: string;
+  title: string;
+  slug: string;
+  category: string;
+  subcategory?: string;
+  language: string;
+}
+
+export interface ProviderDocsResponse {
+  docs: ProviderDocEntry[];
+  categories: string[];
+}
+
+export interface ProviderDocContent {
+  content: string;
+  title: string;
+  category: string;
+  slug: string;
+}
+
 export interface PaginationMeta {
   page: number;
   per_page: number;


### PR DESCRIPTION
## Summary

- feat: provider documentation tab — ProviderDetailPage gains a Documentation tab with a collapsible sidebar grouped by subcategory → resource type and inline markdown rendering
- feat: shared MarkdownRenderer component — extracted from ModuleDetailPage for reuse
- feat: Overview tab — GitHub Repository and Changelog buttons replace the external documentation link; info cards sidebar carried through to the Documentation tab

## Changelog

- feat: provider documentation tab with categorised sidebar, inline markdown rendering, and shared MarkdownRenderer component
- feat: Overview tab GitHub Repository and Changelog buttons; info cards sidebar on Documentation tab