### PR TITLE
fix: increase logout waitForURL timeout and add E2E retries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
 
       - name: Run Playwright tests
         working-directory: e2e
-        run: npx playwright test --workers=1 --max-failures=1 --reporter=list
+        run: npx playwright test --workers=1 --max-failures=1 --retries=1 --reporter=list
 
       - name: Upload Playwright artifacts
         uses: actions/upload-artifact@v4

--- a/e2e/tests/auth.spec.ts
+++ b/e2e/tests/auth.spec.ts
@@ -90,7 +90,8 @@ test.describe('Logout', () => {
     // Logout redirects to the backend /auth/logout endpoint which terminates any
     // OIDC SSO session and then redirects back to the frontend home page ('/').
     // In dev mode (no OIDC) the backend falls back directly to the home page.
-    await page.waitForURL((url) => url.pathname === '/', { timeout: 10_000 });
+    // 30 s — covers the backend redirect latency + full SPA page load on slow CI runners.
+    await page.waitForURL((url) => url.pathname === '/', { timeout: 30_000 });
     expect(page.url()).not.toContain('/login');
 
     // Security check: swagger-ui-react persists Authorize dialog entries under


### PR DESCRIPTION
## Summary

- The E2E logout test consistently fails on slow GitHub-hosted runners because `waitForURL` has a 10 s timeout that covers both the backend redirect round-trip and the full SPA page load — this is too tight
- Same failure occurred in v0.2.8; the v0.2.9 fix (adding `TFR_SERVER_PUBLIC_URL`) was correct but 10 s is still too short on loaded runners
- Increase the specific `waitForURL` timeout from 10 s to 30 s (matches the `loggedInPage` fixture precedent noted in the Playwright config)
- Add `--retries=1` to the CI Playwright command as a second layer of resilience against transient failures

## Changelog

- fix: increase logout E2E `waitForURL` timeout to 30 s and add `--retries=1` to CI Playwright command