### PR TITLE
release: v0.3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ on:
 permissions:
   packages: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   frontend-lint-build:
     name: Frontend Lint & Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,6 @@ on:
 permissions:
   packages: read
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
   frontend-lint-build:
     name: Frontend Lint & Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "npm"
@@ -39,7 +39,7 @@ jobs:
         run: npm run build
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: frontend-dist
           path: frontend/dist
@@ -52,7 +52,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
@@ -62,7 +62,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
 
@@ -93,7 +93,7 @@ jobs:
         run: npx playwright test --workers=1 --max-failures=1 --retries=1 --reporter=list
 
       - name: Upload Playwright artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report
           path: e2e/playwright-report

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,6 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository_owner }}/terraform-registry-frontend
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   # ── Branch guard — releases must originate from main ─────────────────────

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,11 +5,11 @@ name: Release
 on:
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+*'
+      - "v[0-9]+.[0-9]+.[0-9]+*"
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Tag name to release (e.g., v1.2.3)'
+        description: "Tag name to release (e.g., v1.2.3)"
         required: true
         type: string
 
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0   # need full history to walk ancestry
+          fetch-depth: 0 # need full history to walk ancestry
 
       - name: Check tagged commit is reachable from main
         run: |
@@ -53,7 +53,7 @@ jobs:
     needs: ci
     permissions:
       contents: read
-      packages: write   # required to push to ghcr.io
+      packages: write # required to push to ghcr.io
 
     steps:
       - uses: actions/checkout@v4
@@ -96,7 +96,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: docker
     permissions:
-      contents: write   # required to create releases
+      contents: write # required to create releases
 
     steps:
       - name: Extract version from tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository_owner }}/terraform-registry-frontend
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   # ── Branch guard — releases must originate from main ─────────────────────

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
     name: Verify tag is on main
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # need full history to walk ancestry
 
@@ -56,7 +56,7 @@ jobs:
       packages: write # required to push to ghcr.io
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.github/workflows/scheduled-build.yml
+++ b/.github/workflows/scheduled-build.yml
@@ -11,6 +11,9 @@ on:
     - cron: "0 8 * * 1" # Every Monday 08:00 UTC
   workflow_dispatch: {} # Allow manual triggering from the Actions UI
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   full-build:
     name: Full Build & Audit

--- a/.github/workflows/scheduled-build.yml
+++ b/.github/workflows/scheduled-build.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "npm"
@@ -65,7 +65,7 @@ jobs:
     if: failure() && github.event_name == 'schedule'
     steps:
       - name: Create failure issue
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const title = `Scheduled build failed — ${new Date().toISOString().slice(0,10)}`;

--- a/.github/workflows/scheduled-build.yml
+++ b/.github/workflows/scheduled-build.yml
@@ -11,9 +11,6 @@ on:
     - cron: "0 8 * * 1" # Every Monday 08:00 UTC
   workflow_dispatch: {} # Allow manual triggering from the Actions UI
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
   full-build:
     name: Full Build & Audit

--- a/e2e/tests/admin.spec.ts
+++ b/e2e/tests/admin.spec.ts
@@ -401,15 +401,10 @@ test.describe('Admin: Storage', () => {
   test('storage page loads', async ({ loggedInPage: page }) => {
     await page.goto('/admin/storage');
 
-    await page.waitForSelector(
-      '[class*="MuiCard"], [class*="MuiCircularProgress"], [class*="MuiStepper"]',
-      { timeout: 10_000 }
-    );
-
-    const loadingSpinner = page.locator('[class*="MuiCircularProgress"]').first();
-    if (await loadingSpinner.isVisible()) {
-      await expect(loadingSpinner).toBeHidden({ timeout: 15_000 });
-    }
+    const stepper = page.locator('[class*="MuiStepper"]');
+    const card = page.locator('[class*="MuiCard"]');
+    const alert = page.locator('[class*="MuiAlert"]');
+    await expect(stepper.or(card).or(alert).first()).toBeVisible({ timeout: 15_000 });
 
     const content = await page.locator('main, [class*="MuiContainer"]').first().textContent();
     expect(content).toBeTruthy();
@@ -419,23 +414,18 @@ test.describe('Admin: Storage', () => {
   test('storage page shows setup wizard, configuration, or configured alert', async ({ loggedInPage: page }) => {
     await page.goto('/admin/storage');
 
-    const loadingSpinner = page.locator('[class*="MuiCircularProgress"]').first();
-    if (await loadingSpinner.isVisible()) {
-      await expect(loadingSpinner).toBeHidden({ timeout: 15_000 });
-    }
-
-    await page.waitForSelector(
-      '[class*="MuiStepper"], [class*="MuiCard"], [class*="MuiSelect"], [class*="MuiAlert"]',
-      { timeout: 10_000 }
-    );
-
-    // Three possible states:
+    // Three possible settled states:
     // 1. First-time setup wizard (MuiStepper)
     // 2. Storage configured and showing config cards (MuiCard)
     // 3. Storage already configured — shows warning alert only (MuiAlert, no Card/Stepper)
-    const hasStepper = (await page.locator('[class*="MuiStepper"]').count()) > 0;
-    const hasCards = (await page.locator('[class*="MuiCard"]').count()) > 0;
-    const hasAlert = (await page.locator('[class*="MuiAlert"]').count()) > 0;
+    const stepper = page.locator('[class*="MuiStepper"]');
+    const cards = page.locator('[class*="MuiCard"]');
+    const alert = page.locator('[class*="MuiAlert"]');
+    await expect(stepper.or(cards).or(alert).first()).toBeVisible({ timeout: 15_000 });
+
+    const hasStepper = (await stepper.count()) > 0;
+    const hasCards = (await cards.count()) > 0;
+    const hasAlert = (await alert.count()) > 0;
 
     expect(hasStepper || hasCards || hasAlert).toBe(true);
   });


### PR DESCRIPTION
## Summary

- Upgrades all GitHub Actions to Node 24 compatible versions (`checkout@v6`, `setup-node@v5`, `upload-artifact@v7`, `github-script@v8`) across `ci.yml`, `release.yml`, and `scheduled-build.yml`
- Required ahead of GitHub forcing Node.js 24 as the default runner on June 2, 2026

## Test plan

- [x] CI passed on PR #38