### PR TITLE
fix: upgrade Playwright to 1.58.2 for Node.js 24 runtime

### DIFF
--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "terraform-registry-e2e",
       "devDependencies": {
-        "@playwright/test": "^1.41.0",
+        "@playwright/test": "1.58.2",
         "@types/node": "^25.2.3"
       }
     },

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -8,7 +8,7 @@
     "report": "playwright show-report"
   },
   "devDependencies": {
-    "@playwright/test": "^1.41.0",
+    "@playwright/test": "1.58.2",
     "@types/node": "^25.2.3"
   }
 }


### PR DESCRIPTION
## Summary

- Bumps `@playwright/test` from `^1.41.0` to `1.58.2` (pinned exact)
- Playwright 1.50+ ships a bundled Node.js 22 runtime, resolving the Node.js 20 deprecation annotation on GitHub Actions runners ahead of the June 2026 default change
- No test behaviour changes — browser API surface is stable across this range

## Test plan

- [ ] E2E job passes on this PR
- [ ] No Node.js 20 deprecation warnings in CI output