### PR TITLE
release: v0.3.1

### DIFF
--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "terraform-registry-e2e",
       "devDependencies": {
-        "@playwright/test": "^1.41.0",
+        "@playwright/test": "1.58.2",
         "@types/node": "^25.2.3"
       }
     },

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -8,7 +8,7 @@
     "report": "playwright show-report"
   },
   "devDependencies": {
-    "@playwright/test": "^1.41.0",
+    "@playwright/test": "1.58.2",
     "@types/node": "^25.2.3"
   }
 }


### PR DESCRIPTION
## Summary

- Upgrades GitHub Actions to Node 24 compatible versions (`checkout@v6`, `setup-node@v5`, `upload-artifact@v7`, `github-script@v8`)
- Upgrades Playwright from `^1.41.0` to `1.58.2` — ships bundled Node.js 22 runtime, resolving Node.js 20 deprecation warnings on GitHub Actions runners

## Test plan

- [x] CI passed on PR #38 (action upgrades)
- [x] CI passed on PR #40 (Playwright upgrade)