### PR TITLE
release: v0.3.2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,8 @@ git remote prune origin                          # prune stale remote-tracking r
    Closes #<issue-number>"
    ```
 
+   Do not add `Co-Authored-By:` trailers or `🤖 Generated with [Claude Code]` footers to commit messages or PR bodies.
+
 5. **Push to origin**:
 
    ```bash

--- a/frontend/src/components/AboutModal.tsx
+++ b/frontend/src/components/AboutModal.tsx
@@ -1,0 +1,143 @@
+import { useEffect, useState } from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Typography,
+  Box,
+  Chip,
+  Divider,
+  Link,
+  CircularProgress,
+} from '@mui/material';
+import { VersionInfo } from '../types';
+import apiClient from '../services/api';
+
+interface AboutModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const AboutModal = ({ open, onClose }: AboutModalProps) => {
+  const [backendVersion, setBackendVersion] = useState<VersionInfo | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    setLoading(true);
+    apiClient.getVersionInfo()
+      .then(setBackendVersion)
+      .catch(() => setBackendVersion(null))
+      .finally(() => setLoading(false));
+  }, [open]);
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>About Terraform Registry</DialogTitle>
+      <DialogContent dividers>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          A self-hosted Terraform module and provider registry with support for SCM
+          integration, provider mirroring, Terraform binary distribution, and
+          multi-tenancy.
+        </Typography>
+
+        <Divider sx={{ my: 2 }} />
+
+        <Typography variant="subtitle2" gutterBottom>
+          Versions
+        </Typography>
+        <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', mb: 2 }}>
+          <Chip
+            label={`Frontend v${__APP_VERSION__}`}
+            size="small"
+            color="primary"
+            variant="outlined"
+          />
+          {loading ? (
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+              <CircularProgress size={14} />
+              <Typography variant="caption" color="text.secondary">
+                Loading backend version…
+              </Typography>
+            </Box>
+          ) : backendVersion ? (
+            <Chip
+              label={`Backend v${backendVersion.version}`}
+              size="small"
+              color="secondary"
+              variant="outlined"
+            />
+          ) : (
+            <Chip
+              label="Backend unavailable"
+              size="small"
+              variant="outlined"
+              color="default"
+            />
+          )}
+        </Box>
+
+        {backendVersion && (
+          <Box sx={{ mb: 2 }}>
+            <Typography variant="body2" color="text.secondary">
+              API version: {backendVersion.api_version}
+            </Typography>
+            {backendVersion.build_date && backendVersion.build_date !== 'unknown' && (
+              <Typography variant="body2" color="text.secondary">
+                Built: {new Date(backendVersion.build_date).toLocaleString()}
+              </Typography>
+            )}
+          </Box>
+        )}
+
+        <Divider sx={{ my: 2 }} />
+
+        <Typography variant="subtitle2" gutterBottom>
+          License
+        </Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          Released under the{' '}
+          <Link
+            href="https://www.apache.org/licenses/LICENSE-2.0"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Apache License 2.0
+          </Link>
+          .
+        </Typography>
+
+        <Divider sx={{ my: 2 }} />
+
+        <Typography variant="subtitle2" gutterBottom>
+          Source
+        </Typography>
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+          <Link
+            href="https://github.com/sethbacon/terraform-registry-backend"
+            target="_blank"
+            rel="noopener noreferrer"
+            variant="body2"
+          >
+            GitHub — Backend
+          </Link>
+          <Link
+            href="https://github.com/sethbacon/terraform-registry-frontend"
+            target="_blank"
+            rel="noopener noreferrer"
+            variant="body2"
+          >
+            GitHub — Frontend
+          </Link>
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Close</Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default AboutModal;

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -35,6 +35,7 @@ import GetApp from '@mui/icons-material/GetApp';
 import Brightness4 from '@mui/icons-material/Brightness4';
 import Brightness7 from '@mui/icons-material/Brightness7';
 import HelpOutline from '@mui/icons-material/HelpOutline';
+import InfoOutlined from '@mui/icons-material/InfoOutlined';
 import Shield from '@mui/icons-material/Shield';
 import Storage from '@mui/icons-material/Storage';
 import HourglassEmpty from '@mui/icons-material/HourglassEmpty';
@@ -50,6 +51,7 @@ import { useThemeMode } from '../contexts/ThemeContext';
 import { useHelp } from '../contexts/HelpContext';
 import DevUserSwitcher from './DevUserSwitcher';
 import HelpPanel, { HELP_PANEL_WIDTH } from './HelpPanel';
+import AboutModal from './AboutModal';
 
 const drawerWidth = 240;
 
@@ -63,6 +65,7 @@ const Layout = () => {
 
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const [mobileOpen, setMobileOpen] = useState(false);
+  const [aboutOpen, setAboutOpen] = useState(false);
 
   // Helper to check if user has a specific scope (or admin which grants all)
   const hasScope = (scope: string) => {
@@ -344,6 +347,16 @@ const Layout = () => {
               <HelpOutline />
             </IconButton>
           </Tooltip>
+          <Tooltip title="About">
+            <IconButton
+              color="inherit"
+              onClick={() => setAboutOpen(true)}
+              aria-label="About"
+              sx={{ mr: 1 }}
+            >
+              <InfoOutlined />
+            </IconButton>
+          </Tooltip>
           {isAuthenticated ? (
             <div>
               <IconButton
@@ -454,6 +467,7 @@ const Layout = () => {
       {/* HelpPanel is position:fixed — keep it outside the flex row so
           its root element doesn't consume flex space when closed. */}
       <HelpPanel />
+      <AboutModal open={aboutOpen} onClose={() => setAboutOpen(false)} />
     </Box>
   );
 };

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1260,6 +1260,15 @@ class ApiClient {
     a.click();
     URL.revokeObjectURL(url);
   }
+
+  // ============================================================================
+  // Version
+  // ============================================================================
+
+  async getVersionInfo(): Promise<import('../types').VersionInfo> {
+    const response = await this.client.get('/version');
+    return response.data;
+  }
 }
 
 export const apiClient = new ApiClient();

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -401,3 +401,14 @@ export interface AuditLogListResponse {
   logs: AuditLog[];
   pagination: PaginationMeta;
 }
+
+export interface VersionInfo {
+  version: string;
+  build_date: string;
+  api_version: string;
+  protocols: {
+    modules: string;
+    providers: string;
+    mirror: string;
+  };
+}

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,5 +1,7 @@
 /// <reference types="vite/client" />
 
+declare const __APP_VERSION__: string;
+
 interface ImportMetaEnv {
   readonly DEV: boolean;
   readonly PROD: boolean;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import path from 'path'
 import fs from 'fs'
+import pkg from './package.json'
 
 // Only read certs when they exist (skipped during Docker build)
 const certPath = path.resolve(__dirname, '../backend/certs/server.crt')
@@ -14,6 +15,9 @@ const proxyTarget = process.env.VITE_PROXY_TARGET ?? 'http://localhost:8080'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  define: {
+    __APP_VERSION__: JSON.stringify(pkg.version),
+  },
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),


### PR DESCRIPTION
## Summary

- `feat: add About modal with frontend and backend version info` — InfoOutlined icon in AppBar opens a dialog showing frontend version (from package.json at build time), backend version/build date/API version (live from GET /version), license and GitHub links
- `fix: proxy /version through nginx` — nginx was missing a location block for `/version`, causing the SPA fallback to serve index.html; axios received HTML and `backendVersion.version` was `undefined`

## Test plan

- [ ] CI passes on this PR
- [ ] After merge, tag `v0.3.2` on main to trigger release workflow
- [ ] About modal shows correct frontend and backend versions