### PR TITLE
release: v0.3.3

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -106,4 +106,12 @@ server {
     location /ready {
         proxy_pass http://backend:8080/ready;
     }
+
+    location /version {
+        proxy_pass http://backend:8080/version;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terraform-registry-frontend",
-  "version": "0.3.0",
+  "version": "0.3.3",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
- `fix: bump package.json version to 0.3.3` — `__APP_VERSION__` was stuck at 0.3.0 across all releases; About modal now shows the correct frontend version