### PR TITLE
feat: add PR template, changelog CI check, and changelog collection script

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+Closes #<!-- issue number -->
+
+## Summary
+<!-- What does this change and why? -->
+
+## Changelog
+<!-- Required: one entry that will be collected into CHANGELOG.md at release time.
+     Use the appropriate type: feat | fix | chore | docs | perf | refactor -->
+- fix:
+
+## Checklist
+- [ ] `npm run lint` passes
+- [ ] `npm run build` succeeds
+- [ ] PR targets `development` (for feature/fix) or `main` (release only)
+- [ ] Remote branch will be deleted after merge

--- a/.github/scripts/collect-changelog.sh
+++ b/.github/scripts/collect-changelog.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# .github/scripts/collect-changelog.sh
+#
+# Collects ## Changelog entries from PR bodies merged to development since
+# the last release tag and prints a formatted CHANGELOG.md block.
+#
+# Usage:
+#   .github/scripts/collect-changelog.sh [previous-tag]
+#   .github/scripts/collect-changelog.sh v0.2.25
+#
+# If previous-tag is omitted the most recent git tag is used automatically.
+# Requires: gh CLI, jq
+
+set -euo pipefail
+
+PREVIOUS_TAG="${1:-$(git describe --tags --abbrev=0 2>/dev/null || echo "")}"
+
+if [ -z "$PREVIOUS_TAG" ]; then
+  echo "No previous tag found — collecting all merged PRs." >&2
+  SINCE_FILTER=""
+else
+  SINCE_DATE=$(git log -1 --format=%cI "$PREVIOUS_TAG" 2>/dev/null || echo "")
+  echo "Collecting entries merged after $PREVIOUS_TAG ($SINCE_DATE)" >&2
+  SINCE_FILTER="merged:>${SINCE_DATE}"
+fi
+
+# Fetch merged PRs to development
+PRS=$(gh pr list \
+  --base development \
+  --state merged \
+  --search "$SINCE_FILTER" \
+  --json number,title,body,mergedAt \
+  --limit 100)
+
+PR_COUNT=$(echo "$PRS" | jq 'length')
+echo "Found $PR_COUNT merged PRs to development since $PREVIOUS_TAG" >&2
+echo "" >&2
+
+TODAY=$(date -u +%Y-%m-%d)
+NEW_VERSION="${2:-UNRELEASED}"
+
+echo "## [$NEW_VERSION] - $TODAY"
+echo ""
+
+declare -A SECTIONS
+SECTIONS[feat]=""
+SECTIONS[fix]=""
+SECTIONS[chore]=""
+SECTIONS[docs]=""
+SECTIONS[perf]=""
+SECTIONS[refactor]=""
+
+MISSING=()
+
+while IFS= read -r pr; do
+  NUMBER=$(echo "$pr" | jq -r '.number')
+  TITLE=$(echo "$pr" | jq -r '.title')
+  BODY=$(echo "$pr" | jq -r '.body // ""')
+
+  # Extract bullet lines under ## Changelog until next ## header
+  ENTRIES=$(printf '%s' "$BODY" | awk '/^## Changelog/{found=1;next} found && /^##/{exit} found && /^- /{print}')
+
+  if [ -z "$ENTRIES" ]; then
+    MISSING+=("#$NUMBER: $TITLE")
+    continue
+  fi
+
+  while IFS= read -r entry; do
+    TYPE=$(echo "$entry" | sed 's/^- \([a-z]*\):.*/\1/')
+    if [[ -v SECTIONS[$TYPE] ]]; then
+      SECTIONS[$TYPE]+="$entry"$'\n'
+    else
+      SECTIONS[chore]+="$entry"$'\n'
+    fi
+  done <<< "$ENTRIES"
+done < <(echo "$PRS" | jq -c '.[]')
+
+# Print sections in order
+for section_key in feat fix perf refactor docs chore; do
+  content="${SECTIONS[$section_key]}"
+  if [ -n "$content" ]; then
+    case $section_key in
+      feat)     echo "### Added" ;;
+      fix)      echo "### Fixed" ;;
+      perf)     echo "### Performance" ;;
+      refactor) echo "### Changed" ;;
+      docs)     echo "### Documentation" ;;
+      chore)    echo "### Maintenance" ;;
+    esac
+    echo "$content"
+  fi
+done
+
+# Warn about PRs with no changelog entry
+if [ ${#MISSING[@]} -gt 0 ]; then
+  echo "" >&2
+  echo "⚠️  These PRs had no ## Changelog entry:" >&2
+  for m in "${MISSING[@]}"; do
+    echo "   $m" >&2
+  done
+fi

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,44 @@
+name: PR Checks
+
+# Validates PR hygiene on feature/fix branches.
+# Runs only on PRs targeting development — release PRs (development → main) are exempt.
+on:
+  pull_request:
+    branches:
+      - development
+
+jobs:
+  changelog-entry:
+    name: Changelog entry present
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for ## Changelog section with an entry
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          # Must have a ## Changelog section
+          if ! printf '%s' "$PR_BODY" | grep -q '^## Changelog'; then
+            echo "::error::PR body is missing a '## Changelog' section."
+            echo "Add a '## Changelog' section with one entry (see CLAUDE.md step 8)."
+            echo "Example:"
+            echo "  ## Changelog"
+            echo "  - fix: short description of what was fixed"
+            exit 1
+          fi
+
+          # Must have at least one bullet entry under ## Changelog
+          ENTRY=$(printf '%s' "$PR_BODY" | awk '/^## Changelog/{found=1;next} found && /^##/{exit} found && /^- /{print;exit}')
+          if [ -z "$ENTRY" ]; then
+            echo "::error::## Changelog section has no bullet entry."
+            echo "Add at least one line like: - fix: short description"
+            exit 1
+          fi
+
+          # Must not be the unedited placeholder
+          if echo "$ENTRY" | grep -qE '^\- (fix|feat|chore):$'; then
+            echo "::error::## Changelog entry looks like an unedited placeholder: $ENTRY"
+            echo "Replace it with an actual description."
+            exit 1
+          fi
+
+          echo "✅ Changelog entry found: $ENTRY"


### PR DESCRIPTION
## Summary

Adds workflow automation to ensure changelog entries are never forgotten:

1. **PR template** — every new PR pre-fills a `## Changelog` section so authors always see the prompt
2. **CI validation** (`pr-checks.yml`) — fails the PR if the `## Changelog` section is missing, empty, or still has the unedited placeholder text
3. **Collection script** (`collect-changelog.sh`) — at release time, run `.github/scripts/collect-changelog.sh [previous-tag] [new-version]` to automatically gather all `## Changelog` bullets from merged PRs and format them into a `CHANGELOG.md` block

## Changelog
- feat: add PR template and CI changelog enforcement workflow