### PR TITLE
docs: update CHANGELOG.md with v0.3.1, v0.3.2, v0.3.3 entries and Unreleased section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Maintenance
+- chore: add PR template, CI changelog enforcement, and collection script — `.github/PULL_REQUEST_TEMPLATE.md` pre-fills the changelog section; `pr-checks.yml` fails PRs without a valid entry; `collect-changelog.sh` automates release-time changelog collection
+
+---
+
+## [0.3.3] - 2026-03-24
+
+### Fixed
+- fix: bump `package.json` version to `0.3.3` so `__APP_VERSION__` bakes correctly at Vite build time — prior builds always emitted `v0.3.0` because `package.json` was never updated after the initial version
+- fix: proxy `/version` endpoint through nginx to the backend so the About modal can fetch the live backend version in production deployments
+
+---
+
+## [0.3.2] - 2026-03-24
+
+### Added
+- feat: About modal with frontend and backend version info — accessible from the toolbar via an info icon; displays frontend version (baked at Vite build time from `package.json`) and backend version (fetched live from `GET /version`)
+
+---
+
+## [0.3.1] - 2026-03-24
+
+### Maintenance
+- fix: upgrade GitHub Actions to Node 24 compatible versions (checkout@v4, setup-node@v4, actions/cache@v4)
+- fix: upgrade Playwright to 1.58.2 for Node.js 24 runtime compatibility
+- chore: opt GitHub Actions runners into Node.js 24 runtime; suppress deprecation warnings
+
 ---
 
 ## [0.3.0] - 2026-03-22


### PR DESCRIPTION
## Summary

Backfills CHANGELOG.md entries for v0.3.1, v0.3.2, and v0.3.3 (which shipped without changelog entries since the PR template didn't exist yet) and pre-fills the [Unreleased] section with changes currently on development.

**v0.3.1** entries (Node 24 CI upgrades): PRs #38, #40
**v0.3.2** entries (About modal): PR #42
**v0.3.3** entries (package.json version + nginx /version proxy): PR #44

**Unreleased**: PR template + changelog enforcement (#46)

## Changelog
- docs: backfill v0.3.1–v0.3.3 CHANGELOG entries and add Unreleased section