### PR TITLE
docs: promote unreleased items to v0.3.4 in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+---
+
+## [0.3.4] - 2026-03-24
+
 ### Maintenance
 - chore: add PR template, CI changelog enforcement, and collection script — `.github/PULL_REQUEST_TEMPLATE.md` pre-fills the changelog section; `pr-checks.yml` fails PRs without a valid entry; `collect-changelog.sh` automates release-time changelog collection
 


### PR DESCRIPTION
## Summary

Moves the [Unreleased] items into the [0.3.4] section now that v0.3.4 has been tagged and released. Leaves [Unreleased] empty for future changes.

## Changelog
- docs: promote unreleased CHANGELOG items to v0.3.4