### PR TITLE
fix: enforce package.json version sync with release tag and bump to v0.3.5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,21 @@ jobs:
         with:
           fetch-depth: 0 # need full history to walk ancestry
 
+      - name: Verify package.json version matches release tag
+        working-directory: frontend
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            TAG="${{ github.event.inputs.tag }}"
+          else
+            TAG="${{ github.ref_name }}"
+          fi
+          PKG_VERSION="v$(node -p "require('./package.json').version")"
+          if [ "${PKG_VERSION}" != "${TAG}" ]; then
+            echo "::error::package.json version (${PKG_VERSION}) does not match release tag (${TAG}). Bump frontend/package.json 'version' before pushing the tag."
+            exit 1
+          fi
+          echo "Version check passed: ${TAG}"
+
       - name: Check tagged commit is reachable from main
         run: |
           git fetch origin main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.3.5] - 2026-03-25
+
+### Fixed
+- fix: bump `package.json` version to `0.3.5` so `__APP_VERSION__` bakes the correct version string into the Vite bundle at build time — prior releases emitted the wrong version in the About modal because `package.json` was not bumped before tagging
+- fix: enforce `package.json` version sync in release workflow — `release.yml` guard job now fails fast if `frontend/package.json` `"version"` does not match the pushed tag, preventing future mismatches at release time
+
+### Maintenance
+- chore: document `package.json` version-sync requirement in `CLAUDE.md` — new CRITICAL step 2 in the Releasing section calls out the mandatory bump before committing the release
+
+---
+
 ## [0.3.4] - 2026-03-24
 
 ### Maintenance

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,14 +73,21 @@ When a release is called for:
    ## [X.Y.Z] - YYYY-MM-DD
    ```
 
-2. Commit directly on `development` and push (**no tag yet**):
+2. **CRITICAL — version sync:** Update `frontend/package.json` `"version"` to match the
+   release version (e.g., `"0.3.5"` for release `v0.3.5`). This value is baked into the
+   Vite bundle as `__APP_VERSION__` at build time and is what the About modal displays as
+   the frontend version chip. **The release workflow fails if `package.json` does not
+   match the tag** — but catching it only at tag-push time means the fix must go into
+   another PR. Bump it now, in the same commit as the CHANGELOG promotion.
+
+3. Commit directly on `development` and push (**no tag yet**):
 
    ```bash
    git commit -m "chore: release vX.Y.Z"
    git push origin development
    ```
 
-3. **UAT — local build validation** before merging to `main`:
+4. **UAT — local build validation** before merging to `main`:
 
    ```bash
    cd deployments
@@ -93,9 +100,9 @@ When a release is called for:
    mirrored provider and a module to confirm downloads work end-to-end. **Do not merge to
    `main` until the local build passes.**
 
-4. Merge `development` → `main` via PR (step 7 above).
+5. Merge `development` → `main` via PR (step 7 above).
 
-5. **After the PR is merged**, tag the commit that landed on `main` and push the tag:
+6. **After the PR is merged**, tag the commit that landed on `main` and push the tag:
 
    ```bash
    git fetch origin

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terraform-registry-frontend",
-  "version": "0.3.3",
+  "version": "0.3.5",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- Bumps `frontend/package.json` `"version"` to `0.3.5` so `__APP_VERSION__` bakes the correct version into the Vite bundle; the About modal now shows `Frontend v0.3.5`
- Adds a guard step to `release.yml` that fails the pipeline if `package.json` version does not match the pushed tag — prevents future version drift at release time
- Documents the mandatory `package.json` version bump as CRITICAL step 2 in the Releasing section of `CLAUDE.md`

## Changelog

- fix: bump `package.json` version to `0.3.5` so `__APP_VERSION__` bakes the correct version string into the Vite bundle at build time — prior releases emitted the wrong version in the About modal because `package.json` was not bumped before tagging
- fix: enforce `package.json` version sync in release workflow — `release.yml` guard job now fails fast if `frontend/package.json` `"version"` does not match the pushed tag, preventing future mismatches at release time
- chore: document `package.json` version-sync requirement in `CLAUDE.md` — new CRITICAL step 2 in the Releasing section calls out the mandatory bump before committing the release