### PR TITLE
feat: add React error boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- feat: add React error boundaries wrapping all routes — prevents white screen crashes by showing a user-friendly fallback UI with reload options
+
 ---
 
 ## [0.3.6] - 2026-04-10

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import { ThemeProvider } from './contexts/ThemeContext';
 import { AuthProvider } from './contexts/AuthContext';
 import { HelpProvider } from './contexts/HelpContext';
 import Layout from './components/Layout';
+import ErrorBoundary from './components/ErrorBoundary';
 import ProtectedRoute from './components/ProtectedRoute';
 // Critical-path pages loaded eagerly (small, always needed on first visit)
 import HomePage from './pages/HomePage';
@@ -44,53 +45,55 @@ function App() {
       <AuthProvider>
         <HelpProvider>
           <Router>
-            <Routes>
-              {/* Public routes */}
-              <Route path="/login" element={<LoginPage />} />
-              <Route path="/auth/callback" element={<CallbackPage />} />
-              <Route path="/setup" element={<SetupWizardPage />} />
+            <ErrorBoundary>
+              <Routes>
+                {/* Public routes */}
+                <Route path="/login" element={<LoginPage />} />
+                <Route path="/auth/callback" element={<CallbackPage />} />
+                <Route path="/setup" element={<SetupWizardPage />} />
 
-              {/* Layout routes */}
-              <Route element={<Layout />}>
-                <Route path="/" element={<HomePage />} />
+                {/* Layout routes */}
+                <Route element={<Layout />}>
+                  <Route path="/" element={<HomePage />} />
 
-                {/* Modules */}
-                <Route path="/modules" element={<ModulesPage />} />
-                <Route path="/modules/:namespace/:name/:system" element={<Suspense fallback={loader}><ModuleDetailPage /></Suspense>} />
+                  {/* Modules */}
+                  <Route path="/modules" element={<ModulesPage />} />
+                  <Route path="/modules/:namespace/:name/:system" element={<ErrorBoundary><Suspense fallback={loader}><ModuleDetailPage /></Suspense></ErrorBoundary>} />
 
-                {/* Providers */}
-                <Route path="/providers" element={<ProvidersPage />} />
-                <Route path="/providers/:namespace/:type" element={<Suspense fallback={loader}><ProviderDetailPage /></Suspense>} />
+                  {/* Providers */}
+                  <Route path="/providers" element={<ProvidersPage />} />
+                  <Route path="/providers/:namespace/:type" element={<ErrorBoundary><Suspense fallback={loader}><ProviderDetailPage /></Suspense></ErrorBoundary>} />
 
-                {/* Terraform Binaries */}
-                <Route path="/terraform-binaries" element={<TerraformBinariesPage />} />
-                <Route path="/terraform-binaries/:name" element={<Suspense fallback={loader}><TerraformBinaryDetailPage /></Suspense>} />
+                  {/* Terraform Binaries */}
+                  <Route path="/terraform-binaries" element={<TerraformBinariesPage />} />
+                  <Route path="/terraform-binaries/:name" element={<ErrorBoundary><Suspense fallback={loader}><TerraformBinaryDetailPage /></Suspense></ErrorBoundary>} />
 
-                {/* API Documentation */}
-                <Route path="/api-docs" element={<Suspense fallback={loader}><ApiDocumentation /></Suspense>} />
+                  {/* API Documentation */}
+                  <Route path="/api-docs" element={<ErrorBoundary><Suspense fallback={loader}><ApiDocumentation /></Suspense></ErrorBoundary>} />
 
-                {/* Admin routes (protected with scope requirements) */}
-                <Route path="/admin" element={<ProtectedRoute><Suspense fallback={loader}><DashboardPage /></Suspense></ProtectedRoute>} />
-                <Route path="/admin/users" element={<ProtectedRoute requiredScope="users:read"><Suspense fallback={loader}><UsersPage /></Suspense></ProtectedRoute>} />
-                <Route path="/admin/organizations" element={<ProtectedRoute requiredScope="organizations:read"><Suspense fallback={loader}><OrganizationsPage /></Suspense></ProtectedRoute>} />
-                <Route path="/admin/roles" element={<ProtectedRoute requiredScope="users:read"><Suspense fallback={loader}><RolesPage /></Suspense></ProtectedRoute>} />
-                <Route path="/admin/apikeys" element={<ProtectedRoute><Suspense fallback={loader}><APIKeysPage /></Suspense></ProtectedRoute>} />
-                <Route path="/admin/upload" element={<Navigate to="/admin/upload/module" replace />} />
-                <Route path="/admin/upload/module" element={<ProtectedRoute requiredScope="modules:write"><Suspense fallback={loader}><ModuleUploadPage /></Suspense></ProtectedRoute>} />
-                <Route path="/admin/upload/provider" element={<ProtectedRoute requiredScope="providers:write"><Suspense fallback={loader}><ProviderUploadPage /></Suspense></ProtectedRoute>} />
-                <Route path="/admin/scm-providers" element={<ProtectedRoute requiredScope="scm:read"><Suspense fallback={loader}><SCMProvidersPage /></Suspense></ProtectedRoute>} />
-                <Route path="/admin/mirrors" element={<ProtectedRoute requiredScope="mirrors:read"><Suspense fallback={loader}><MirrorsPage /></Suspense></ProtectedRoute>} />
-                <Route path="/admin/terraform-mirror" element={<ProtectedRoute requiredScope="mirrors:read"><Suspense fallback={loader}><TerraformMirrorPage /></Suspense></ProtectedRoute>} />
-                <Route path="/admin/storage" element={<ProtectedRoute requiredScope="admin"><Suspense fallback={loader}><StoragePage /></Suspense></ProtectedRoute>} />
-                <Route path="/admin/approvals" element={<ProtectedRoute requiredScope="mirrors:read"><Suspense fallback={loader}><ApprovalsPage /></Suspense></ProtectedRoute>} />
-                <Route path="/admin/policies" element={<ProtectedRoute requiredScope="admin"><Suspense fallback={loader}><MirrorPoliciesPage /></Suspense></ProtectedRoute>} />
-                <Route path="/admin/oidc" element={<ProtectedRoute requiredScope="admin"><Suspense fallback={loader}><OIDCSettingsPage /></Suspense></ProtectedRoute>} />
-                <Route path="/admin/audit-logs" element={<ProtectedRoute requiredScope="audit:read"><Suspense fallback={loader}><AuditLogPage /></Suspense></ProtectedRoute>} />
+                  {/* Admin routes (protected with scope requirements) */}
+                  <Route path="/admin" element={<ProtectedRoute><ErrorBoundary><Suspense fallback={loader}><DashboardPage /></Suspense></ErrorBoundary></ProtectedRoute>} />
+                  <Route path="/admin/users" element={<ProtectedRoute requiredScope="users:read"><ErrorBoundary><Suspense fallback={loader}><UsersPage /></Suspense></ErrorBoundary></ProtectedRoute>} />
+                  <Route path="/admin/organizations" element={<ProtectedRoute requiredScope="organizations:read"><ErrorBoundary><Suspense fallback={loader}><OrganizationsPage /></Suspense></ErrorBoundary></ProtectedRoute>} />
+                  <Route path="/admin/roles" element={<ProtectedRoute requiredScope="users:read"><ErrorBoundary><Suspense fallback={loader}><RolesPage /></Suspense></ErrorBoundary></ProtectedRoute>} />
+                  <Route path="/admin/apikeys" element={<ProtectedRoute><ErrorBoundary><Suspense fallback={loader}><APIKeysPage /></Suspense></ErrorBoundary></ProtectedRoute>} />
+                  <Route path="/admin/upload" element={<Navigate to="/admin/upload/module" replace />} />
+                  <Route path="/admin/upload/module" element={<ProtectedRoute requiredScope="modules:write"><ErrorBoundary><Suspense fallback={loader}><ModuleUploadPage /></Suspense></ErrorBoundary></ProtectedRoute>} />
+                  <Route path="/admin/upload/provider" element={<ProtectedRoute requiredScope="providers:write"><ErrorBoundary><Suspense fallback={loader}><ProviderUploadPage /></Suspense></ErrorBoundary></ProtectedRoute>} />
+                  <Route path="/admin/scm-providers" element={<ProtectedRoute requiredScope="scm:read"><ErrorBoundary><Suspense fallback={loader}><SCMProvidersPage /></Suspense></ErrorBoundary></ProtectedRoute>} />
+                  <Route path="/admin/mirrors" element={<ProtectedRoute requiredScope="mirrors:read"><ErrorBoundary><Suspense fallback={loader}><MirrorsPage /></Suspense></ErrorBoundary></ProtectedRoute>} />
+                  <Route path="/admin/terraform-mirror" element={<ProtectedRoute requiredScope="mirrors:read"><ErrorBoundary><Suspense fallback={loader}><TerraformMirrorPage /></Suspense></ErrorBoundary></ProtectedRoute>} />
+                  <Route path="/admin/storage" element={<ProtectedRoute requiredScope="admin"><ErrorBoundary><Suspense fallback={loader}><StoragePage /></Suspense></ErrorBoundary></ProtectedRoute>} />
+                  <Route path="/admin/approvals" element={<ProtectedRoute requiredScope="mirrors:read"><ErrorBoundary><Suspense fallback={loader}><ApprovalsPage /></Suspense></ErrorBoundary></ProtectedRoute>} />
+                  <Route path="/admin/policies" element={<ProtectedRoute requiredScope="admin"><ErrorBoundary><Suspense fallback={loader}><MirrorPoliciesPage /></Suspense></ErrorBoundary></ProtectedRoute>} />
+                  <Route path="/admin/oidc" element={<ProtectedRoute requiredScope="admin"><ErrorBoundary><Suspense fallback={loader}><OIDCSettingsPage /></Suspense></ErrorBoundary></ProtectedRoute>} />
+                  <Route path="/admin/audit-logs" element={<ProtectedRoute requiredScope="audit:read"><ErrorBoundary><Suspense fallback={loader}><AuditLogPage /></Suspense></ErrorBoundary></ProtectedRoute>} />
 
-                {/* Catch all */}
-                <Route path="*" element={<Navigate to="/" replace />} />
-              </Route>
-            </Routes>
+                  {/* Catch all */}
+                  <Route path="*" element={<Navigate to="/" replace />} />
+                </Route>
+              </Routes>
+            </ErrorBoundary>
           </Router>
         </HelpProvider>
       </AuthProvider>

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,0 +1,83 @@
+import { Component } from 'react';
+import type { ErrorInfo, ReactNode } from 'react';
+import { Alert, AlertTitle, Box, Button, Container, Stack, Typography } from '@mui/material';
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  fallback?: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+}
+
+class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    console.error('ErrorBoundary caught an error:', error, errorInfo);
+  }
+
+  handleReset = (): void => {
+    this.setState({ hasError: false, error: null });
+  };
+
+  handleReload = (): void => {
+    window.location.reload();
+  };
+
+  render(): ReactNode {
+    if (this.state.hasError) {
+      if (this.props.fallback) {
+        return this.props.fallback;
+      }
+
+      return (
+        <Container maxWidth="sm" sx={{ py: 8 }}>
+          <Alert severity="error">
+            <AlertTitle>Something went wrong</AlertTitle>
+            <Typography variant="body2" sx={{ mb: 2 }}>
+              An unexpected error occurred. You can try again or reload the page.
+            </Typography>
+            {this.state.error && (
+              <Box
+                component="pre"
+                sx={{
+                  fontSize: '0.75rem',
+                  whiteSpace: 'pre-wrap',
+                  wordBreak: 'break-word',
+                  bgcolor: 'action.hover',
+                  p: 1,
+                  borderRadius: 1,
+                  mb: 2,
+                }}
+              >
+                {this.state.error.message}
+              </Box>
+            )}
+            <Stack direction="row" spacing={1}>
+              <Button size="small" variant="outlined" onClick={this.handleReset}>
+                Try Again
+              </Button>
+              <Button size="small" variant="contained" onClick={this.handleReload}>
+                Reload Page
+              </Button>
+            </Stack>
+          </Alert>
+        </Container>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;


### PR DESCRIPTION
## Summary
- Add `ErrorBoundary` class component with user-friendly fallback UI (MUI Alert + Reload/Try Again buttons)
- Wrap top-level `<Routes>` and each lazy-loaded `<Suspense>` route individually so one page crash doesn't take down the whole app

## Test plan
- [ ] `npm run build` succeeds
- [ ] `npm run lint` passes
- [ ] Manually throwing an error in a component renders the fallback UI instead of a white screen
- [ ] Other routes remain navigable after one route errors

Closes #64