### PR TITLE
fix: remove duplicate ProviderPlatform and RoleTemplate interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- fix: remove duplicate `ProviderPlatform` interface — keep complete 10-field definition, delete narrower duplicate that was missing `storage_path` and `storage_backend`
+- fix: consolidate duplicate `RoleTemplate` interface — canonical definition in `types/rbac.ts`, re-exported from `types/index.ts`
+
 ---
 
 ## [0.3.6] - 2026-04-10

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -10,14 +10,7 @@ export interface User {
   updated_at: string;
 }
 
-export interface RoleTemplate {
-  id: string;
-  name: string;
-  display_name: string;
-  description?: string;
-  scopes: string[];
-  is_system?: boolean;
-}
+export type { RoleTemplate } from './rbac';
 
 export interface RoleTemplateInfo {
   id?: string;
@@ -176,17 +169,6 @@ export interface ProviderVersion {
   deprecated_at?: string;
   deprecation_message?: string;
   created_at: string;
-}
-
-export interface ProviderPlatform {
-  id: string;
-  provider_version_id: string;
-  os: string;
-  arch: string;
-  filename: string;
-  size_bytes: number;
-  shasum: string;
-  download_count: number;
 }
 
 export interface ProviderDocEntry {


### PR DESCRIPTION
## Summary
- Remove duplicate `ProviderPlatform` interface (keep complete 10-field definition, delete narrower duplicate missing `storage_path` and `storage_backend`)
- Consolidate duplicate `RoleTemplate` interface — canonical definition in `types/rbac.ts`, re-exported from `types/index.ts`

## Test plan
- [ ] `npm run build` succeeds
- [ ] `npm run lint` passes
- [ ] Single `ProviderPlatform` interface with all 10 fields
- [ ] Single `RoleTemplate` definition in `types/rbac.ts` with re-export from `types/index.ts`

Closes #65
Closes #66