### PR TITLE
refactor: normalize API import style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat: add foundational unit tests for useDebounce, ProtectedRoute, AuthContext, and api service (18 tests across 4 files)
 - feat: add React error boundaries wrapping all routes — prevents white screen crashes by showing a user-friendly fallback UI with reload options
 
+### Changed
+
+- refactor: normalize all API imports to use default `api` import instead of mixed `api`/`apiClient` named exports
+
 ### Fixed
 
 - fix: remove duplicate `ProviderPlatform` interface — keep complete 10-field definition, delete narrower duplicate that was missing `storage_path` and `storage_backend`

--- a/frontend/src/components/PublishFromSCMWizard.tsx
+++ b/frontend/src/components/PublishFromSCMWizard.tsx
@@ -22,7 +22,7 @@ import {
   RadioGroup,
   FormLabel,
 } from '@mui/material';
-import { apiClient } from '../services/api';
+import api from '../services/api';
 import RepositoryBrowser from './RepositoryBrowser';
 import type { SCMProvider, SCMRepository, SCMTag } from '../types/scm';
 
@@ -66,7 +66,7 @@ const PublishFromSCMWizard: React.FC<PublishFromSCMWizardProps> = ({
   const loadProviders = async () => {
     try {
       setLoading(true);
-      const data = await apiClient.listSCMProviders();
+      const data = await api.listSCMProviders();
       setProviders(Array.isArray(data) ? data.filter((p: SCMProvider) => p.is_active) : []);
     } catch (err: any) {
       setError('Failed to load SCM providers');
@@ -106,7 +106,7 @@ const PublishFromSCMWizard: React.FC<PublishFromSCMWizardProps> = ({
         }
         // Link with the exact tag as the pattern and auto-publish disabled.
         // Then trigger an immediate sync so that single version is imported.
-        await apiClient.linkModuleToSCM(moduleId, {
+        await api.linkModuleToSCM(moduleId, {
           provider_id: selectedProvider.id,
           repository_owner: selectedRepository.owner,
           repository_name: selectedRepository.name,
@@ -116,12 +116,12 @@ const PublishFromSCMWizard: React.FC<PublishFromSCMWizardProps> = ({
           tag_pattern: selectedTag.tag_name,
         });
         try {
-          await apiClient.triggerManualSync(moduleId);
+          await api.triggerManualSync(moduleId);
         } catch {
           // non-fatal — user can trigger sync manually from the module page
         }
       } else {
-        await apiClient.linkModuleToSCM(moduleId, {
+        await api.linkModuleToSCM(moduleId, {
           provider_id: selectedProvider.id,
           repository_owner: selectedRepository.owner,
           repository_name: selectedRepository.name,

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
 import { User, AuthContextType, RoleTemplateInfo } from '../types';
-import { apiClient } from '../services/api';
+import api from '../services/api';
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
@@ -60,7 +60,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
   const fetchCurrentUser = async () => {
     try {
-      const response = await apiClient.getCurrentUserWithRole();
+      const response = await api.getCurrentUserWithRole();
       setUser(response.user);
       setRoleTemplate(response.role_template || null);
       setAllowedScopes(response.allowed_scopes || []);
@@ -76,7 +76,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   const login = async (userOrProvider: User | 'oidc' | 'azuread'): Promise<void> => {
     if (typeof userOrProvider === 'string') {
       // OAuth login - redirects to OAuth provider
-      apiClient.login(userOrProvider);
+      api.login(userOrProvider);
     } else {
       // Direct user object (dev mode) - SECURITY: Always fetch actual user data from API
       // Never trust client-provided user data for authorization decisions
@@ -105,12 +105,12 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     // Redirect to the backend logout endpoint, which terminates the OIDC SSO session
     // at the identity provider level. Without this, the IdP session remains active and
     // clicking "Login with OIDC" again would silently re-authenticate the user.
-    apiClient.logout();
+    api.logout();
   };
 
   const refreshToken = async () => {
     try {
-      const response = await apiClient.refreshToken();
+      const response = await api.refreshToken();
       localStorage.setItem('auth_token', response.token);
     } catch (error) {
       console.error('Failed to refresh token:', error);

--- a/frontend/src/contexts/__tests__/AuthContext.test.tsx
+++ b/frontend/src/contexts/__tests__/AuthContext.test.tsx
@@ -4,7 +4,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 // Mock the api module
 vi.mock('../../services/api', () => ({
-  apiClient: {
+  default: {
     getCurrentUserWithRole: vi.fn(),
     login: vi.fn(),
     logout: vi.fn(),

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -12,7 +12,7 @@ import {
 import LoginIcon from '@mui/icons-material/Login';
 import { useAuth } from '../contexts/AuthContext';
 import { useNavigate } from 'react-router-dom';
-import { apiClient } from '../services/api';
+import api from '../services/api';
 
 const LoginPage: React.FC = () => {
   const { login } = useAuth();
@@ -37,7 +37,7 @@ const LoginPage: React.FC = () => {
   const handleDevLogin = async () => {
     // Call the dev login endpoint to get a JWT (no hardcoded keys)
     // This endpoint is gated by DevModeMiddleware and returns 403 in production
-    const response = await apiClient.devLogin();
+    const response = await api.devLogin();
     localStorage.setItem('auth_token', response.token);
 
     // Clear any cached user data to force fresh fetch from API
@@ -66,7 +66,7 @@ const LoginPage: React.FC = () => {
       // returned an error (e.g. 400 provider not configured).
       if (res.type === 'opaqueredirect' || res.status === 0) {
         // Normal redirect — let the browser follow it
-        apiClient.login(provider);
+        api.login(provider);
         return;
       }
       // The backend returned a non-redirect response — extract the error message
@@ -80,7 +80,7 @@ const LoginPage: React.FC = () => {
       setLoginError(message);
     } catch {
       // Network error or CORS issue — fall back to direct redirect
-      apiClient.login(provider);
+      api.login(provider);
     }
   };
 

--- a/frontend/src/pages/ModuleDetailPage.tsx
+++ b/frontend/src/pages/ModuleDetailPage.tsx
@@ -49,7 +49,7 @@ import WebhookIcon from '@mui/icons-material/Webhook';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import SecurityIcon from '@mui/icons-material/Security';
-import api, { apiClient } from '../services/api';
+import api from '../services/api';
 import { Module, ModuleVersion, ModuleScan, ModuleDoc } from '../types';
 import type { ModuleSCMLink, SCMWebhookEvent } from '../types/scm';
 import { useAuth } from '../contexts/AuthContext';
@@ -182,7 +182,7 @@ const ModuleDetailPage: React.FC = () => {
 
   const loadSCMLink = async (moduleId: string) => {
     try {
-      const link = await apiClient.getModuleSCMInfo(moduleId);
+      const link = await api.getModuleSCMInfo(moduleId);
       setScmLink(link);
     } catch {
       setScmLink(null); // 404 = not linked, which is fine
@@ -194,7 +194,7 @@ const ModuleDetailPage: React.FC = () => {
   const loadWebhookEvents = async (moduleId: string) => {
     try {
       setWebhookEventsLoading(true);
-      const events = await apiClient.getWebhookEvents(moduleId);
+      const events = await api.getWebhookEvents(moduleId);
       setWebhookEvents(Array.isArray(events) ? events : []);
     } catch {
       setWebhookEvents([]);
@@ -210,7 +210,7 @@ const ModuleDetailPage: React.FC = () => {
     setScanNotFound(false);
     setModuleScan(null);
     try {
-      const scan = await apiClient.getModuleScan(namespace, name, system, version);
+      const scan = await api.getModuleScan(namespace, name, system, version);
       setModuleScan(scan);
     } catch (err: any) {
       if (err?.response?.status === 404) {
@@ -226,7 +226,7 @@ const ModuleDetailPage: React.FC = () => {
     setDocsLoading(true);
     setModuleDocs(null);
     try {
-      const docs = await apiClient.getModuleDocs(namespace, name, system, version);
+      const docs = await api.getModuleDocs(namespace, name, system, version);
       setModuleDocs(docs);
     } catch {
       setModuleDocs(null);
@@ -239,7 +239,7 @@ const ModuleDetailPage: React.FC = () => {
     if (!module?.id) return;
     try {
       setScmUnlinking(true);
-      await apiClient.unlinkModuleFromSCM(module.id);
+      await api.unlinkModuleFromSCM(module.id);
       setScmLink(null);
     } catch (err: any) {
       setError(err?.response?.data?.error || 'Failed to unlink repository');
@@ -264,7 +264,7 @@ const ModuleDetailPage: React.FC = () => {
     console.log('Triggering manual sync for module:', module.id);
     try {
       setScmSyncing(true);
-      await apiClient.triggerManualSync(module.id);
+      await api.triggerManualSync(module.id);
       setError(null);
       // Start polling so newly imported versions appear without manual refresh.
       pollForVersions();

--- a/frontend/src/pages/SetupWizardPage.tsx
+++ b/frontend/src/pages/SetupWizardPage.tsx
@@ -34,7 +34,7 @@ import ErrorIcon from '@mui/icons-material/Error';
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
 import { useNavigate } from 'react-router-dom';
-import { apiClient } from '../services/api';
+import api from '../services/api';
 import type {
   SetupStatus,
   OIDCConfigInput,
@@ -97,7 +97,7 @@ const SetupWizardPage: React.FC = () => {
   const checkSetupStatus = useCallback(async () => {
     try {
       setLoading(true);
-      const status = await apiClient.getSetupStatus();
+      const status = await api.getSetupStatus();
       setSetupStatus(status);
 
       if (status.setup_completed) {
@@ -129,7 +129,7 @@ const SetupWizardPage: React.FC = () => {
     try {
       setTokenValidating(true);
       setError(null);
-      const result = await apiClient.validateSetupToken(setupToken.trim());
+      const result = await api.validateSetupToken(setupToken.trim());
       if (result.valid) {
         setTokenValid(true);
         setSuccess('Setup token verified successfully');
@@ -150,7 +150,7 @@ const SetupWizardPage: React.FC = () => {
       setOidcTesting(true);
       setError(null);
       setOidcTestResult(null);
-      const result = await apiClient.testOIDCConfig(setupToken, oidcForm);
+      const result = await api.testOIDCConfig(setupToken, oidcForm);
       setOidcTestResult(result);
       if (!result.success) {
         setError(result.message);
@@ -167,7 +167,7 @@ const SetupWizardPage: React.FC = () => {
     try {
       setOidcSaving(true);
       setError(null);
-      await apiClient.saveOIDCConfig(setupToken, oidcForm);
+      await api.saveOIDCConfig(setupToken, oidcForm);
       setOidcSaved(true);
       setSuccess('OIDC provider configured successfully');
     } catch (err: any) {
@@ -183,7 +183,7 @@ const SetupWizardPage: React.FC = () => {
       setStorageTesting(true);
       setError(null);
       setStorageTestResult(null);
-      const result = await apiClient.testSetupStorageConfig(setupToken, storageForm);
+      const result = await api.testSetupStorageConfig(setupToken, storageForm);
       setStorageTestResult(result);
       if (!result.success) {
         setError(result.message);
@@ -202,7 +202,7 @@ const SetupWizardPage: React.FC = () => {
     try {
       setStorageSaving(true);
       setError(null);
-      await apiClient.saveSetupStorageConfig(setupToken, storageForm);
+      await api.saveSetupStorageConfig(setupToken, storageForm);
       setStorageSaved(true);
       setSuccess('Storage backend configured successfully');
     } catch (err: any) {
@@ -217,7 +217,7 @@ const SetupWizardPage: React.FC = () => {
     try {
       setAdminSaving(true);
       setError(null);
-      await apiClient.configureAdmin(setupToken, { email: adminEmail.trim().toLowerCase() });
+      await api.configureAdmin(setupToken, { email: adminEmail.trim().toLowerCase() });
       setAdminSaved(true);
       setSuccess('Admin user configured successfully');
     } catch (err: any) {
@@ -232,7 +232,7 @@ const SetupWizardPage: React.FC = () => {
     try {
       setCompleting(true);
       setError(null);
-      const result = await apiClient.completeSetup(setupToken);
+      const result = await api.completeSetup(setupToken);
       setSuccess(result.message);
       // Redirect to login after 3 seconds
       setTimeout(() => navigate('/login', { replace: true }), 3000);

--- a/frontend/src/pages/admin/ApprovalsPage.tsx
+++ b/frontend/src/pages/admin/ApprovalsPage.tsx
@@ -26,7 +26,7 @@ import RefreshIcon from '@mui/icons-material/Refresh';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import CancelIcon from '@mui/icons-material/Cancel';
 import HourglassEmptyIcon from '@mui/icons-material/HourglassEmpty';
-import { apiClient } from '../../services/api';
+import api from '../../services/api';
 
 interface ApprovalRequest {
   id: string;
@@ -78,7 +78,7 @@ const ApprovalsPage: React.FC = () => {
     try {
       setLoading(true);
       setError(null);
-      const data = await apiClient.listApprovalRequests(
+      const data = await api.listApprovalRequests(
         statusFilter ? { status: statusFilter } : undefined
       );
       setApprovals(Array.isArray(data) ? data : []);
@@ -93,7 +93,7 @@ const ApprovalsPage: React.FC = () => {
   const handleCreate = async () => {
     try {
       setError(null);
-      await apiClient.createApprovalRequest({
+      await api.createApprovalRequest({
         mirror_config_id: createForm.mirror_config_id,
         provider_namespace: createForm.provider_namespace,
         provider_name: createForm.provider_name || undefined,
@@ -113,7 +113,7 @@ const ApprovalsPage: React.FC = () => {
     try {
       setReviewing(true);
       setError(null);
-      await apiClient.reviewApproval(reviewingApproval.id, {
+      await api.reviewApproval(reviewingApproval.id, {
         status: reviewForm.status,
         notes: reviewForm.notes || undefined,
       });

--- a/frontend/src/pages/admin/MirrorPoliciesPage.tsx
+++ b/frontend/src/pages/admin/MirrorPoliciesPage.tsx
@@ -32,7 +32,7 @@ import RefreshIcon from '@mui/icons-material/Refresh';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import BlockIcon from '@mui/icons-material/Block';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
-import { apiClient } from '../../services/api';
+import api from '../../services/api';
 
 interface MirrorPolicy {
   id: string;
@@ -104,7 +104,7 @@ const MirrorPoliciesPage: React.FC = () => {
     try {
       setLoading(true);
       setError(null);
-      const data = await apiClient.listMirrorPolicies();
+      const data = await api.listMirrorPolicies();
       setPolicies(Array.isArray(data) ? data : []);
     } catch (err: any) {
       setError(err.response?.data?.error || 'Failed to load mirror policies');
@@ -131,10 +131,10 @@ const MirrorPoliciesPage: React.FC = () => {
       };
 
       if (editingPolicy) {
-        await apiClient.updateMirrorPolicy(editingPolicy.id, payload);
+        await api.updateMirrorPolicy(editingPolicy.id, payload);
         setSuccess('Policy updated successfully');
       } else {
-        await apiClient.createMirrorPolicy(payload);
+        await api.createMirrorPolicy(payload);
         setSuccess('Policy created successfully');
       }
 
@@ -153,7 +153,7 @@ const MirrorPoliciesPage: React.FC = () => {
     if (!policyToDelete) return;
     try {
       setError(null);
-      await apiClient.deleteMirrorPolicy(policyToDelete.id);
+      await api.deleteMirrorPolicy(policyToDelete.id);
       setDeleteDialogOpen(false);
       setPolicyToDelete(null);
       setSuccess('Policy deleted successfully');
@@ -167,7 +167,7 @@ const MirrorPoliciesPage: React.FC = () => {
     try {
       setEvaluating(true);
       setEvaluateResult(null);
-      const result = await apiClient.evaluateMirrorPolicy({
+      const result = await api.evaluateMirrorPolicy({
         registry: evaluateForm.registry,
         namespace: evaluateForm.namespace,
         provider: evaluateForm.provider,

--- a/frontend/src/pages/admin/MirrorsPage.tsx
+++ b/frontend/src/pages/admin/MirrorsPage.tsx
@@ -42,7 +42,7 @@ import ErrorIcon from '@mui/icons-material/Error';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ScheduleIcon from '@mui/icons-material/Schedule';
-import { apiClient } from '../../services/api';
+import api from '../../services/api';
 import {
   type MirrorConfiguration,
   type MirrorSyncHistory,
@@ -244,7 +244,7 @@ const MirrorsPage: React.FC = () => {
     try {
       setLoading(true);
       setError(null);
-      const data = await apiClient.listMirrors();
+      const data = await api.listMirrors();
       setMirrors(Array.isArray(data) ? data : []);
     } catch (err: any) {
       setError(err.response?.data?.error || 'Failed to load mirrors');
@@ -264,7 +264,7 @@ const MirrorsPage: React.FC = () => {
         version_filter: versionFilterInput.trim() || undefined,
         platform_filter: platformFilterInput.split(',').map(s => s.trim()).filter(Boolean),
       };
-      await apiClient.createMirror(data as CreateMirrorConfigRequest);
+      await api.createMirror(data as CreateMirrorConfigRequest);
       setCreateDialogOpen(false);
       resetForm();
       setSuccess('Mirror configuration created successfully');
@@ -289,7 +289,7 @@ const MirrorsPage: React.FC = () => {
         enabled: formData.enabled,
         sync_interval_hours: formData.sync_interval_hours,
       };
-      await apiClient.updateMirror(editingMirror.id, data);
+      await api.updateMirror(editingMirror.id, data);
       setEditingMirror(null);
       resetForm();
       setSuccess('Mirror configuration updated successfully');
@@ -303,7 +303,7 @@ const MirrorsPage: React.FC = () => {
     if (!mirrorToDelete) return;
     try {
       setError(null);
-      await apiClient.deleteMirror(mirrorToDelete.id);
+      await api.deleteMirror(mirrorToDelete.id);
       setDeleteConfirmOpen(false);
       setMirrorToDelete(null);
       setSuccess('Mirror configuration deleted successfully');
@@ -316,7 +316,7 @@ const MirrorsPage: React.FC = () => {
   const handleTriggerSync = async (mirror: MirrorConfiguration) => {
     try {
       setError(null);
-      await apiClient.triggerMirrorSync(mirror.id);
+      await api.triggerMirrorSync(mirror.id);
       setSuccess(`Sync triggered for "${mirror.name}"`);
       await loadMirrors();
     } catch (err: any) {
@@ -329,7 +329,7 @@ const MirrorsPage: React.FC = () => {
     setProvidersDialogOpen(true);
     setProvidersLoading(true);
     try {
-      const providers = await apiClient.getMirrorProviders(mirror.id);
+      const providers = await api.getMirrorProviders(mirror.id);
       setMirrorProviders(Array.isArray(providers) ? providers : []);
     } catch {
       setMirrorProviders([]);
@@ -343,7 +343,7 @@ const MirrorsPage: React.FC = () => {
     setHistoryDialogOpen(true);
     setHistoryLoading(true);
     try {
-      const status = await apiClient.getMirrorStatus(mirror.id);
+      const status = await api.getMirrorStatus(mirror.id);
       setMirrorHistory(status.recent_syncs ?? []);
     } catch {
       setMirrorHistory([]);

--- a/frontend/src/pages/admin/OIDCSettingsPage.tsx
+++ b/frontend/src/pages/admin/OIDCSettingsPage.tsx
@@ -34,7 +34,7 @@ import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
 import ManageAccountsIcon from '@mui/icons-material/ManageAccounts';
 import SaveIcon from '@mui/icons-material/Save';
-import { apiClient } from '../../services/api';
+import api from '../../services/api';
 import type { OIDCConfigResponse, OIDCGroupMapping, OIDCGroupMappingInput, Organization } from '../../types';
 
 // Available roles that can be assigned to mapped groups — must match system role template names
@@ -77,7 +77,7 @@ const OIDCSettingsPage: React.FC = () => {
     setLoading(true);
     setError(null);
     try {
-      const data = await apiClient.getAdminOIDCConfig();
+      const data = await api.getAdminOIDCConfig();
       setConfig(data);
       setGroupClaimName(data.group_claim_name ?? '');
       setDefaultRole(data.default_role ?? '');
@@ -100,7 +100,7 @@ const OIDCSettingsPage: React.FC = () => {
         group_mappings: mappings,
         default_role: defaultRole,
       };
-      const updated = await apiClient.updateOIDCGroupMapping(input);
+      const updated = await api.updateOIDCGroupMapping(input);
       setConfig(updated);
       setGroupClaimName(updated.group_claim_name ?? '');
       setDefaultRole(updated.default_role ?? '');
@@ -118,7 +118,7 @@ const OIDCSettingsPage: React.FC = () => {
   const loadOrgs = async () => {
     setOrgLoading(true);
     try {
-      const orgs: Organization[] = await apiClient.listOrganizations(1, 200);
+      const orgs: Organization[] = await api.listOrganizations(1, 200);
       setOrgOptions(orgs.map(o => o.name));
     } catch {
       setOrgOptions([]);

--- a/frontend/src/pages/admin/SCMProvidersPage.tsx
+++ b/frontend/src/pages/admin/SCMProvidersPage.tsx
@@ -34,7 +34,7 @@ import CloudIcon from '@mui/icons-material/Cloud';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import LinkOffIcon from '@mui/icons-material/LinkOff';
-import { apiClient } from '../../services/api';
+import api from '../../services/api';
 import { useAuth } from '../../contexts/AuthContext';
 import type { SCMProvider, SCMProviderType, CreateSCMProviderRequest } from '../../types/scm';
 import type { UserMembership } from '../../types';
@@ -80,7 +80,7 @@ const SCMProvidersPage: React.FC = () => {
   const loadMemberships = async () => {
     try {
       if (user?.id) {
-        const data = await apiClient.getCurrentUserMemberships();
+        const data = await api.getCurrentUserMemberships();
         setMemberships(data || []);
         // Set first organization as default if available
         if (data && data.length > 0 && !formData.organization_id) {
@@ -99,13 +99,13 @@ const SCMProvidersPage: React.FC = () => {
     try {
       setLoading(true);
       setError(null);
-      const data = await apiClient.listSCMProviders();
+      const data = await api.listSCMProviders();
       const providerList = Array.isArray(data) ? data : [];
       setProviders(providerList);
 
       // Fetch token status for each provider in parallel
       const statusEntries = await Promise.allSettled(
-        providerList.map((p) => apiClient.getSCMTokenStatus(p.id).then((s) => [p.id, s] as const))
+        providerList.map((p) => api.getSCMTokenStatus(p.id).then((s) => [p.id, s] as const))
       );
       const statuses: Record<string, TokenStatus> = {};
       statusEntries.forEach((result) => {
@@ -126,7 +126,7 @@ const SCMProvidersPage: React.FC = () => {
   const handleCreate = async () => {
     try {
       setError(null);
-      await apiClient.createSCMProvider(formData as CreateSCMProviderRequest);
+      await api.createSCMProvider(formData as CreateSCMProviderRequest);
       setCreateDialogOpen(false);
       resetForm();
       await loadProviders();
@@ -139,7 +139,7 @@ const SCMProvidersPage: React.FC = () => {
     if (!editingProvider) return;
     try {
       setError(null);
-      await apiClient.updateSCMProvider(editingProvider.id, {
+      await api.updateSCMProvider(editingProvider.id, {
         name: formData.name,
         base_url: formData.base_url,
         tenant_id: formData.tenant_id,
@@ -159,7 +159,7 @@ const SCMProvidersPage: React.FC = () => {
     if (!providerToDelete) return;
     try {
       setError(null);
-      await apiClient.deleteSCMProvider(providerToDelete.id);
+      await api.deleteSCMProvider(providerToDelete.id);
       setDeleteConfirmOpen(false);
       setProviderToDelete(null);
       await loadProviders();
@@ -175,7 +175,7 @@ const SCMProvidersPage: React.FC = () => {
       setPatDialogOpen(true);
     } else {
       try {
-        const response = await apiClient.initiateSCMOAuth(provider.id);
+        const response = await api.initiateSCMOAuth(provider.id);
         window.location.href = response.authorization_url;
       } catch (err: any) {
         setError(err.response?.data?.error || 'Failed to initiate OAuth');
@@ -187,7 +187,7 @@ const SCMProvidersPage: React.FC = () => {
     if (!patProvider || !patValue) return;
     try {
       setError(null);
-      await apiClient.saveSCMToken(patProvider.id, patValue);
+      await api.saveSCMToken(patProvider.id, patValue);
       setPatDialogOpen(false);
       setPatValue('');
       setPatProvider(null);
@@ -491,7 +491,7 @@ const SCMProvidersPage: React.FC = () => {
                       color="warning"
                       onClick={async () => {
                         try {
-                          await apiClient.revokeSCMToken(provider.id);
+                          await api.revokeSCMToken(provider.id);
                           await loadProviders();
                         } catch (err: any) {
                           setError(err.response?.data?.error || 'Failed to disconnect');

--- a/frontend/src/pages/admin/StoragePage.tsx
+++ b/frontend/src/pages/admin/StoragePage.tsx
@@ -30,7 +30,7 @@ import FolderIcon from '@mui/icons-material/Folder';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import InfoIcon from '@mui/icons-material/Info';
-import { apiClient } from '../../services/api';
+import api from '../../services/api';
 import type { StorageConfigResponse, StorageConfigInput, StorageBackendType, SetupStatus } from '../../types';
 
 const StoragePage: React.FC = () => {
@@ -61,11 +61,11 @@ const StoragePage: React.FC = () => {
       setLoading(true);
       setError(null);
 
-      const status = await apiClient.getSetupStatus();
+      const status = await api.getSetupStatus();
       setSetupStatus(status);
 
       if (!status.setup_required) {
-        const configList = await apiClient.listStorageConfigs();
+        const configList = await api.listStorageConfigs();
         setConfigs(Array.isArray(configList) ? configList : []);
       }
     } catch (err: any) {
@@ -106,7 +106,7 @@ const StoragePage: React.FC = () => {
     try {
       setTesting(true);
       setError(null);
-      const result = await apiClient.testStorageConfig(formData);
+      const result = await api.testStorageConfig(formData);
       if (result.success) {
         setSuccess('Storage configuration is valid!');
       }
@@ -121,7 +121,7 @@ const StoragePage: React.FC = () => {
     try {
       setSaving(true);
       setError(null);
-      await apiClient.createStorageConfig(formData);
+      await api.createStorageConfig(formData);
       setSuccess('Storage configuration saved successfully!');
       await loadData();
       setActiveStep(0);

--- a/frontend/src/services/__tests__/api.test.ts
+++ b/frontend/src/services/__tests__/api.test.ts
@@ -1,14 +1,14 @@
 import { describe, it, expect } from 'vitest'
 
 describe('api service', () => {
-  it('exports both default and named apiClient pointing to same instance', async () => {
+  it('exports a default api client instance', async () => {
     const mod = await import('../api')
-    expect(mod.default).toBe(mod.apiClient)
+    expect(mod.default).toBeDefined()
   })
 
-  it('apiClient is an object with expected public methods', async () => {
+  it('api client is an object with expected public methods', async () => {
     const mod = await import('../api')
-    const client = mod.apiClient
+    const client = mod.default
 
     expect(client).toBeDefined()
     expect(typeof client.validateSetupToken).toBe('function')
@@ -19,7 +19,7 @@ describe('api service', () => {
 
   it('exposes setup-related methods that use SetupToken header', async () => {
     const mod = await import('../api')
-    const client = mod.apiClient
+    const client = mod.default
 
     expect(typeof client.validateSetupToken).toBe('function')
     expect(typeof client.testOIDCConfig).toBe('function')

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1285,6 +1285,6 @@ class ApiClient {
   }
 }
 
-export const apiClient = new ApiClient();
+const apiClient = new ApiClient();
 export default apiClient;
 


### PR DESCRIPTION
## Summary
- Normalize all API imports to use default `api` import instead of mixed `api`/`apiClient` named exports
- Remove named `apiClient` export from `services/api.ts`
- Update 11 source files and 2 test files

## Test plan
- [ ] Zero `{ apiClient }` imports in the codebase
- [ ] `npm run build` succeeds
- [ ] `npm run lint` passes
- [ ] `npm test` passes

Closes #72