### PR TITLE
refactor: consolidate local type definitions into shared types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix: remove duplicate `ProviderPlatform` interface — keep complete 10-field definition, delete narrower duplicate that was missing `storage_path` and `storage_backend`
 - fix: consolidate duplicate `RoleTemplate` interface — canonical definition in `types/rbac.ts`, re-exported from `types/index.ts`
 
+### Changed
+
+- refactor: consolidate local `ApprovalRequest` and `MirrorPolicy` type definitions into shared `types/rbac.ts`
+
 ---
 
 ## [0.3.6] - 2026-04-10

--- a/frontend/src/pages/admin/ApprovalsPage.tsx
+++ b/frontend/src/pages/admin/ApprovalsPage.tsx
@@ -27,24 +27,10 @@ import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import CancelIcon from '@mui/icons-material/Cancel';
 import HourglassEmptyIcon from '@mui/icons-material/HourglassEmpty';
 import { apiClient } from '../../services/api';
-
-interface ApprovalRequest {
-  id: string;
-  mirror_config_id: string;
-  organization_id?: string;
-  provider_namespace: string;
-  provider_name?: string;
-  reason?: string;
-  status: 'pending' | 'approved' | 'rejected';
-  reviewer_notes?: string;
-  reviewed_by?: string;
-  reviewed_at?: string;
-  created_at: string;
-  updated_at: string;
-}
+import { MirrorApprovalRequest } from '../../types/rbac';
 
 const ApprovalsPage: React.FC = () => {
-  const [approvals, setApprovals] = useState<ApprovalRequest[]>([]);
+  const [approvals, setApprovals] = useState<MirrorApprovalRequest[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
@@ -60,7 +46,7 @@ const ApprovalsPage: React.FC = () => {
 
   // Review dialog state
   const [reviewDialogOpen, setReviewDialogOpen] = useState(false);
-  const [reviewingApproval, setReviewingApproval] = useState<ApprovalRequest | null>(null);
+  const [reviewingApproval, setReviewingApproval] = useState<MirrorApprovalRequest | null>(null);
   const [reviewForm, setReviewForm] = useState<{
     status: 'approved' | 'rejected';
     notes: string;
@@ -129,7 +115,7 @@ const ApprovalsPage: React.FC = () => {
     }
   };
 
-  const openReviewDialog = (approval: ApprovalRequest, defaultStatus: 'approved' | 'rejected') => {
+  const openReviewDialog = (approval: MirrorApprovalRequest, defaultStatus: 'approved' | 'rejected') => {
     setReviewingApproval(approval);
     setReviewForm({ status: defaultStatus, notes: '' });
     setReviewDialogOpen(true);
@@ -243,9 +229,9 @@ const ApprovalsPage: React.FC = () => {
                     <Typography variant="caption" color="textSecondary" display="block">
                       <strong>Reviewed:</strong> {formatDate(approval.reviewed_at)}
                     </Typography>
-                    {approval.reviewer_notes && (
+                    {approval.review_notes && (
                       <Typography variant="caption" color="textSecondary" display="block">
-                        <strong>Notes:</strong> {approval.reviewer_notes}
+                        <strong>Notes:</strong> {approval.review_notes}
                       </Typography>
                     )}
                   </>

--- a/frontend/src/pages/admin/MirrorPoliciesPage.tsx
+++ b/frontend/src/pages/admin/MirrorPoliciesPage.tsx
@@ -33,22 +33,7 @@ import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import BlockIcon from '@mui/icons-material/Block';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import { apiClient } from '../../services/api';
-
-interface MirrorPolicy {
-  id: string;
-  organization_id?: string;
-  name: string;
-  description?: string;
-  policy_type: 'allow' | 'deny';
-  upstream_registry?: string;
-  namespace_pattern?: string;
-  provider_pattern?: string;
-  priority?: number;
-  is_active: boolean;
-  requires_approval: boolean;
-  created_at: string;
-  updated_at: string;
-}
+import { MirrorPolicy } from '../../types/rbac';
 
 interface PolicyFormData {
   name: string;


### PR DESCRIPTION
## Summary
- Remove local `ApprovalRequest` interface from ApprovalsPage, use `MirrorApprovalRequest` from `types/rbac.ts`
- Remove local `MirrorPolicy` interface from MirrorPoliciesPage, use shared type from `types/rbac.ts`
- Fix field name mismatch: `reviewer_notes` → `review_notes` to match canonical type

## Test plan
- [ ] `npm run build` succeeds
- [ ] `npm run lint` passes
- [ ] Zero local interface definitions in ApprovalsPage or MirrorPoliciesPage (except PolicyFormData)

Closes #73