### PR TITLE
docs: add SECURITY.md and .env.example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 frontend/node_modules/
 frontend/dist/
+frontend/.env
+frontend/.env.local
 e2e/node_modules/
 e2e/playwright-report/
 e2e/test-results/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,20 +14,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat: configure Vitest testing framework with happy-dom, @testing-library/react, and @testing-library/jest-dom
 - feat: add foundational unit tests for useDebounce, ProtectedRoute, AuthContext, and api service (18 tests across 4 files)
 - feat: add React error boundaries wrapping all routes — prevents white screen crashes by showing a user-friendly fallback UI with reload options
+- docs: add `SECURITY.md` with vulnerability reporting instructions, supported versions, and disclosure policy
+- docs: add `frontend/.env.example` documenting all four `VITE_*` environment variables
+- docs: add `.env` and `.env.local` to `.gitignore`
 
 ### Changed
 
 - refactor: normalize all API imports to use default `api` import instead of mixed `api`/`apiClient` named exports
+- refactor: extract shared `formatDate`, `getScopeInfo`, and `getScopeColor` utilities to `utils/` directory, removing duplicate definitions from 4 admin pages
+- refactor: consolidate local `ApprovalRequest` and `MirrorPolicy` type definitions into shared `types/rbac.ts`
 
 ### Fixed
 
 - fix: remove duplicate `ProviderPlatform` interface — keep complete 10-field definition, delete narrower duplicate that was missing `storage_path` and `storage_backend`
 - fix: consolidate duplicate `RoleTemplate` interface — canonical definition in `types/rbac.ts`, re-exported from `types/index.ts`
-
-### Changed
-
-- refactor: extract shared `formatDate`, `getScopeInfo`, and `getScopeColor` utilities to `utils/` directory, removing duplicate definitions from 4 admin pages
-- refactor: consolidate local `ApprovalRequest` and `MirrorPolicy` type definitions into shared `types/rbac.ts`
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -310,7 +310,6 @@ docker compose -f docker-compose.test.yml up -d --build
 
 ### Remaining Recommendations (not yet applied)
 
-- **Add SECURITY.md** for private vulnerability reporting
 - **Tighten ESLint rules** — `@typescript-eslint/no-explicit-any`, `@typescript-eslint/no-unused-vars`, and `react-hooks/exhaustive-deps` are currently disabled; re-enabling would improve code quality
 - **Enable secret scanning non-provider patterns and validity checks** for broader secret detection
 - **Add a tag protection rule** to prevent deletion of release tags (`v*.*.*`)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,51 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 0.3.x   | :white_check_mark: |
+| < 0.3   | :x:                |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this project, please report it responsibly.
+
+**Do NOT open a public GitHub issue for security vulnerabilities.**
+
+Instead, please use one of the following channels:
+
+1. **GitHub Security Advisories** (preferred): Use the [Report a Vulnerability](https://github.com/sethbacon/terraform-registry-frontend/security/advisories/new) feature on this repository.
+2. **Email**: Contact the maintainer directly at the email address listed on their GitHub profile.
+
+### What to include
+
+- A description of the vulnerability
+- Steps to reproduce the issue
+- The potential impact
+- Any suggested fixes (optional)
+
+### What to expect
+
+- **Acknowledgment**: Within 48 hours of your report.
+- **Status update**: Within 7 days with an assessment and remediation timeline.
+- **Resolution**: Security patches are prioritized and typically released within 30 days of confirmation.
+
+### Scope
+
+The following are considered in-scope:
+
+- Cross-site scripting (XSS) in the frontend
+- Authentication or authorization bypasses
+- Sensitive data exposure (tokens, credentials)
+- Dependency vulnerabilities with a known exploit path
+
+The following are out of scope:
+
+- The backend API (see [terraform-registry-backend](https://github.com/sethbacon/terraform-registry-backend) for its security policy)
+- Vulnerabilities that require physical access to the server
+- Social engineering attacks
+
+## License
+
+This project is licensed under the [Apache License 2.0](LICENSE).

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,22 @@
+# Frontend Environment Variables
+#
+# Copy this file to .env and uncomment the variables you want to override.
+# All values shown are the defaults used when the variable is not set.
+
+# Base URL for API requests.
+# In dev mode (npm run dev), this is empty — requests go through the Vite proxy.
+# In production (Docker/nginx), the nginx config proxies /api/* to the backend.
+# VITE_API_URL=/api/v1
+
+# Enable mock API responses for offline/disconnected development.
+# When true, the API client returns static mock data instead of calling the backend.
+# VITE_USE_MOCK_DATA=false
+
+# Backend target for the Vite dev server proxy.
+# Override this if your backend runs on a different host/port or uses TLS.
+# VITE_PROXY_TARGET=http://localhost:8080
+
+# Build mode passed as a Docker build arg (not a runtime env var).
+# Controls whether the Dev Login button is available in the UI.
+# Values: development | production
+# VITE_MODE=development


### PR DESCRIPTION
## Summary
- Add `SECURITY.md` with vulnerability reporting instructions, supported versions, and disclosure policy
- Add `frontend/.env.example` documenting all four `VITE_*` environment variables
- Add `.env` and `.env.local` to `.gitignore`
- Update `CLAUDE.md` remaining recommendations to remove SECURITY.md item
- Consolidate duplicate `### Changed` sections in CHANGELOG

## Changelog
- docs: add `SECURITY.md` with vulnerability reporting instructions and disclosure policy
- docs: add `frontend/.env.example` documenting all `VITE_*` environment variables

## Test plan
- [ ] `SECURITY.md` exists at project root with reporting instructions
- [ ] `frontend/.env.example` documents all 4 environment variables
- [ ] `.gitignore` includes `.env` patterns

Closes #77
Closes #78