### PR TITLE
chore: enable @typescript-eslint/no-unused-vars ESLint rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - refactor: normalize all API imports to use default `api` import instead of mixed `api`/`apiClient` named exports
 - refactor: extract shared `formatDate`, `getScopeInfo`, and `getScopeColor` utilities to `utils/` directory, removing duplicate definitions from 4 admin pages
 - refactor: consolidate local `ApprovalRequest` and `MirrorPolicy` type definitions into shared `types/rbac.ts`
+- chore: enable `@typescript-eslint/no-unused-vars` ESLint rule and fix all violations
 
 ### Fixed
 

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -28,7 +28,7 @@ export default [
     rules: {
       // TypeScript rules — disabled for pre-existing codebase (address in follow-up)
       '@typescript-eslint/no-explicit-any': 'off',
-      '@typescript-eslint/no-unused-vars': 'off',
+      '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
       // React hooks — enforce both rules to prevent stale closures and rule violations
       'react-hooks/rules-of-hooks': 'error',
       'react-hooks/exhaustive-deps': 'error',


### PR DESCRIPTION
## Summary
- Enable `@typescript-eslint/no-unused-vars` as `'error'` with `argsIgnorePattern: '^_'` and `varsIgnorePattern: '^_'`
- Zero existing violations found — prior refactoring had already cleaned up all unused imports/variables

## Changelog
- chore: enable `@typescript-eslint/no-unused-vars` ESLint rule (zero violations — prior refactoring was already clean)

## Test plan
- [ ] `npm run lint` passes with zero warnings
- [ ] `npm run build` succeeds
- [ ] `npm test` passes

Closes #81