### PR TITLE
feat: add Firefox to E2E cross-browser testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
         working-directory: e2e
         run: |
           npm ci
-          npx playwright install chromium
+          npx playwright install chromium firefox
 
       - name: Run Playwright tests
         working-directory: e2e

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- feat: add Firefox to E2E cross-browser testing — conditionally included in CI only to keep local test runs fast
+
 ## [0.3.7] - 2026-04-10
 
 ### Added

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -55,5 +55,14 @@ export default defineConfig({
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
     },
+    // Firefox is included only in CI to keep local test runs fast.
+    ...(process.env.CI
+      ? [
+          {
+            name: 'firefox',
+            use: { ...devices['Desktop Firefox'] },
+          },
+        ]
+      : []),
   ],
 });


### PR DESCRIPTION
## Summary
- Add Firefox project to Playwright config, conditionally included in CI only (`process.env.CI`)
- Update `.github/workflows/ci.yml` to install both Chromium and Firefox
- Local test runs remain Chromium-only for speed

Closes #86

## Changelog
- feat: add Firefox to E2E cross-browser testing — conditionally included in CI only to keep local test runs fast

## Test plan
- [ ] Verify `npx playwright test --project=firefox` runs locally
- [ ] Confirm CI installs and runs both Chromium and Firefox browsers
- [ ] Verify local `npx playwright test` still only uses Chromium