### PR TITLE
perf: add pagination to MirrorsPage and limit ModulesPage grouped view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat: add Playwright E2E tests for SetupWizardPage — covers redirect-when-complete, page structure with stepper, token validation, OIDC step progression, storage backend chips, and public accessibility; uses route mocking for incomplete setup simulation
 - feat: add Firefox to E2E cross-browser testing — conditionally included in CI only to keep local test runs fast
 
+### Changed
+
+- perf: add client-side pagination to MirrorsPage (10/25/50 per page) to avoid rendering all mirrors at once
+- perf: reduce ModulesPage grouped view fetch limit from 500 to 100 modules per page with pagination controls
+
 ## [0.3.7] - 2026-04-10
 
 ### Added

--- a/frontend/src/pages/ModulesPage.tsx
+++ b/frontend/src/pages/ModulesPage.tsx
@@ -60,14 +60,14 @@ const ModulesPage: React.FC = () => {
       setLoading(true);
       setError(null);
       if (viewMode === 'grouped') {
-        // Fetch a large batch so all providers are visible without pagination splitting groups.
+        // Fetch enough to populate grouped sections without excessive payload.
         const response = await api.searchModules({
           query: debouncedSearch || undefined,
-          limit: 500,
-          offset: 0,
+          limit: 100,
+          offset: (page - 1) * 100,
         });
         setModules(response.modules);
-        setTotalPages(1);
+        setTotalPages(Math.ceil(response.meta.total / 100));
       } else {
         const response = await api.searchModules({
           query: debouncedSearch || undefined,
@@ -233,6 +233,18 @@ const ModulesPage: React.FC = () => {
               </Grid>
             </Box>
           ))}
+
+          {totalPages > 1 && (
+            <Box sx={{ display: 'flex', justifyContent: 'center', mt: 4 }}>
+              <Pagination
+                count={totalPages}
+                page={page}
+                onChange={handlePageChange}
+                color="primary"
+                size="large"
+              />
+            </Box>
+          )}
         </>
       ) : (
         /* ---- Flat paginated grid ---- */

--- a/frontend/src/pages/admin/MirrorsPage.tsx
+++ b/frontend/src/pages/admin/MirrorsPage.tsx
@@ -22,6 +22,7 @@ import {
   TableContainer,
   TableHead,
   TableRow,
+  TablePagination,
   TextField,
   Switch,
   FormControlLabel,
@@ -211,6 +212,10 @@ const MirrorsPage: React.FC = () => {
   const [mirrorHistory, setMirrorHistory] = useState<MirrorSyncHistory[]>([]);
   const [historyLoading, setHistoryLoading] = useState(false);
   const [historyMirrorName, setHistoryMirrorName] = useState('');
+
+  // Client-side pagination
+  const [mirrorsPage, setMirrorsPage] = useState(0);
+  const [mirrorsRowsPerPage, setMirrorsRowsPerPage] = useState(10);
 
   const [formData, setFormData] = useState<Partial<CreateMirrorConfigRequest>>({
     name: '',
@@ -454,7 +459,9 @@ const MirrorsPage: React.FC = () => {
       )}
 
       <Grid container spacing={3}>
-        {mirrors.map((mirror) => {
+        {mirrors
+          .slice(mirrorsPage * mirrorsRowsPerPage, mirrorsPage * mirrorsRowsPerPage + mirrorsRowsPerPage)
+          .map((mirror) => {
           const parsed = parseMirrorConfig(mirror);
           return (
             <Grid size={{ xs: 12, md: 6 }} key={mirror.id}>
@@ -602,6 +609,22 @@ const MirrorsPage: React.FC = () => {
           </Grid>
         )}
       </Grid>
+
+      {mirrors.length > mirrorsRowsPerPage && (
+        <TablePagination
+          component="div"
+          count={mirrors.length}
+          page={mirrorsPage}
+          onPageChange={(_e, newPage) => setMirrorsPage(newPage)}
+          rowsPerPage={mirrorsRowsPerPage}
+          onRowsPerPageChange={(e) => {
+            setMirrorsRowsPerPage(parseInt(e.target.value, 10));
+            setMirrorsPage(0);
+          }}
+          rowsPerPageOptions={[10, 25, 50]}
+          sx={{ mt: 2 }}
+        />
+      )}
 
       {/* Create/Edit Dialog */}
       <Dialog


### PR DESCRIPTION
## Summary
- Add client-side `TablePagination` to `MirrorsPage` (10/25/50 per page) — no longer renders all mirror cards at once
- Reduce `ModulesPage` grouped view fetch from 500 to 100 modules per page with `Pagination` controls
- Both changes improve initial render performance for registries with many entries

Closes #90

## Changelog
- perf: add client-side pagination to MirrorsPage (10/25/50 per page) to avoid rendering all mirrors at once
- perf: reduce ModulesPage grouped view fetch limit from 500 to 100 modules per page with pagination controls

## Test plan
- [ ] Verify MirrorsPage shows pagination controls when >10 mirrors exist
- [ ] Verify ModulesPage grouped view paginates correctly with >100 modules
- [ ] Verify `npm run build` succeeds
- [ ] E2E tests `modules.spec.ts` and `admin.spec.ts` still pass