### PR TITLE
perf: add memoization to Layout and key list-rendering components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - perf: add client-side pagination to MirrorsPage (10/25/50 per page) to avoid rendering all mirrors at once
 - perf: reduce ModulesPage grouped view fetch limit from 500 to 100 modules per page with pagination controls
+- perf: add memoization to Layout sidebar navigation arrays (`useMemo`), wrap `RegistryItemCard` in `React.memo`, memoize search handlers and grouped computations in ModulesPage/ProvidersPage/MirrorsPage
 
 ## [0.3.7] - 2026-04-10
 

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -45,7 +45,7 @@ import Description from '@mui/icons-material/Description';
 import ExpandMore from '@mui/icons-material/ExpandMore';
 import History from '@mui/icons-material/History';
 import ExpandLess from '@mui/icons-material/ExpandLess';
-import { useState } from 'react';
+import { useState, useMemo, useCallback } from 'react';
 import { useAuth } from '../contexts/AuthContext';
 import { useThemeMode } from '../contexts/ThemeContext';
 import { useHelp } from '../contexts/HelpContext';
@@ -68,40 +68,40 @@ const Layout = () => {
   const [aboutOpen, setAboutOpen] = useState(false);
 
   // Helper to check if user has a specific scope (or admin which grants all)
-  const hasScope = (scope: string) => {
+  const hasScope = useCallback((scope: string) => {
     return allowedScopes.includes('admin') || allowedScopes.includes(scope);
-  };
+  }, [allowedScopes]);
 
-  const handleMenu = (event: React.MouseEvent<HTMLElement>) => {
+  const handleMenu = useCallback((event: React.MouseEvent<HTMLElement>) => {
     setAnchorEl(event.currentTarget);
-  };
+  }, []);
 
-  const handleClose = () => {
+  const handleClose = useCallback(() => {
     setAnchorEl(null);
-  };
+  }, []);
 
-  const handleLogout = () => {
+  const handleLogout = useCallback(() => {
     handleClose();
     logout();
     // logout() redirects the browser to the backend logout endpoint, which forwards
     // to the OIDC provider's end_session_endpoint. Do not navigate() here — the
     // full-page redirect from logout() takes over immediately.
-  };
+  }, [handleClose, logout]);
 
-  const handleDrawerToggle = () => {
-    setMobileOpen(!mobileOpen);
-  };
+  const handleDrawerToggle = useCallback(() => {
+    setMobileOpen(prev => !prev);
+  }, []);
 
-  const navigationItems = [
+  const navigationItems = useMemo(() => [
     { text: 'Home', icon: <Home />, path: '/', tooltip: 'Home Page' },
     { text: 'Modules', icon: <ViewModule />, path: '/modules', tooltip: 'View Terraform Modules' },
     { text: 'Providers', icon: <Extension />, path: '/providers', tooltip: 'View Terraform Providers' },
     { text: 'Terraform Binaries', icon: <GetApp />, path: '/terraform-binaries', tooltip: 'View Terraform Binaries' },
     { text: 'API Docs', icon: <Description />, path: '/api-docs', tooltip: 'API Documentation' },
-  ];
+  ], []);
 
   // Admin nav groups — each group is collapsible. Items are filtered by scope.
-  const adminNavGroups = [
+  const adminNavGroups = useMemo(() => [
     {
       key: 'identity',
       label: 'Identity',
@@ -138,7 +138,7 @@ const Layout = () => {
         { text: 'Audit Logs', icon: <History />, path: '/admin/audit-logs', tooltip: 'View system audit logs', scope: 'audit:read' },
       ],
     },
-  ];
+  ], []);
 
   // Track which groups are open — persisted to localStorage so state survives navigation/refresh.
   const [openGroups, setOpenGroups] = useState<Record<string, boolean>>(() => {
@@ -155,22 +155,36 @@ const Layout = () => {
     return Object.fromEntries(adminNavGroups.map(g => [g.key, true]));
   });
 
-  const toggleGroup = (key: string) =>
+  const toggleGroup = useCallback((key: string) =>
     setOpenGroups(prev => {
       const next = { ...prev, [key]: !prev[key] };
       try { localStorage.setItem('adminNavGroups', JSON.stringify(next)); } catch { /* quota */ }
       return next;
-    });
+    }), []);
 
   // Filter each group's items by the user's scopes, then drop empty groups
-  const visibleAdminGroups = isAuthenticated
-    ? adminNavGroups
-      .map(group => ({
-        ...group,
-        items: group.items.filter(item => item.scope === null || hasScope(item.scope)),
-      }))
-      .filter(group => group.items.length > 0)
-    : [];
+  const visibleAdminGroups = useMemo(() =>
+    isAuthenticated
+      ? adminNavGroups
+        .map(group => ({
+          ...group,
+          items: group.items.filter(item => item.scope === null || hasScope(item.scope)),
+        }))
+        .filter(group => group.items.length > 0)
+      : [],
+    [isAuthenticated, adminNavGroups, hasScope]);
+
+  const handleCloseMobileDrawer = useCallback(() => {
+    setMobileOpen(false);
+  }, []);
+
+  const handleOpenAbout = useCallback(() => {
+    setAboutOpen(true);
+  }, []);
+
+  const handleCloseAbout = useCallback(() => {
+    setAboutOpen(false);
+  }, []);
 
   const drawer = (
     <Box>
@@ -191,7 +205,7 @@ const Layout = () => {
                 <ListItemButton
                   component={RouterLink}
                   to={item.path}
-                  onClick={() => setMobileOpen(false)}
+                  onClick={handleCloseMobileDrawer}
                   sx={{
                     borderLeft: isActive ? `3px solid ${theme.palette.primary.main}` : '3px solid transparent',
                     bgcolor: isActive ? `${theme.palette.primary.main}14` : 'transparent',
@@ -224,7 +238,7 @@ const Layout = () => {
                     <ListItemButton
                       component={RouterLink}
                       to="/admin"
-                      onClick={() => setMobileOpen(false)}
+                      onClick={handleCloseMobileDrawer}
                       sx={{
                         borderLeft: isActive ? `3px solid ${theme.palette.primary.main}` : '3px solid transparent',
                         bgcolor: isActive ? `${theme.palette.primary.main}14` : 'transparent',
@@ -274,7 +288,7 @@ const Layout = () => {
                             <ListItemButton
                               component={RouterLink}
                               to={item.path}
-                              onClick={() => setMobileOpen(false)}
+                              onClick={handleCloseMobileDrawer}
                               sx={{
                                 pl: isActive ? '21px' : '24px',
                                 borderLeft: isActive ? `3px solid ${theme.palette.primary.main}` : '3px solid transparent',
@@ -350,7 +364,7 @@ const Layout = () => {
           <Tooltip title="About">
             <IconButton
               color="inherit"
-              onClick={() => setAboutOpen(true)}
+              onClick={handleOpenAbout}
               aria-label="About"
               sx={{ mr: 1 }}
             >
@@ -467,7 +481,7 @@ const Layout = () => {
       {/* HelpPanel is position:fixed — keep it outside the flex row so
           its root element doesn't consume flex space when closed. */}
       <HelpPanel />
-      <AboutModal open={aboutOpen} onClose={() => setAboutOpen(false)} />
+      <AboutModal open={aboutOpen} onClose={handleCloseAbout} />
     </Box>
   );
 };

--- a/frontend/src/components/RegistryItemCard.tsx
+++ b/frontend/src/components/RegistryItemCard.tsx
@@ -96,4 +96,4 @@ const RegistryItemCard: React.FC<RegistryItemCardProps> = ({
   </Card>
 );
 
-export default RegistryItemCard;
+export default React.memo(RegistryItemCard);

--- a/frontend/src/pages/ModulesPage.tsx
+++ b/frontend/src/pages/ModulesPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useDebounce } from '../hooks/useDebounce';
 import {
@@ -89,25 +89,25 @@ const ModulesPage: React.FC = () => {
     loadModules();
   }, [loadModules]);
 
-  const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleSearchChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
     setSearchQuery(event.target.value);
     setPage(1);
-  };
+  }, []);
 
-  const handlePageChange = (_event: React.ChangeEvent<unknown>, value: number) => {
+  const handlePageChange = useCallback((_event: React.ChangeEvent<unknown>, value: number) => {
     setPage(value);
     window.scrollTo(0, 0);
-  };
+  }, []);
 
-  const handleViewModeChange = (_event: React.MouseEvent<HTMLElement>, newMode: ViewMode | null) => {
+  const handleViewModeChange = useCallback((_event: React.MouseEvent<HTMLElement>, newMode: ViewMode | null) => {
     if (newMode) {
       setViewMode(newMode);
       setPage(1);
     }
-  };
+  }, []);
 
   /** Renders a single module card (shared between both view modes). */
-  const renderModuleCard = (module: Module) => (
+  const renderModuleCard = useCallback((module: Module) => (
     <Grid size={{ xs: 12, sm: 6, md: 4 }} key={module.id}>
       <RegistryItemCard
         title={module.name}
@@ -131,7 +131,9 @@ const ModulesPage: React.FC = () => {
         onClick={() => navigate(`/modules/${module.namespace}/${module.name}/${module.system}`)}
       />
     </Grid>
-  );
+  ), [navigate]);
+
+  const groupedModules = useMemo(() => groupByProvider(modules), [modules]);
 
   return (
     <Container maxWidth="lg" sx={{ py: 4 }}>
@@ -217,7 +219,7 @@ const ModulesPage: React.FC = () => {
       ) : viewMode === 'grouped' ? (
         /* ---- Grouped by provider ---- */
         <>
-          {groupByProvider(modules).map(([provider, providerModules]) => (
+          {groupedModules.map(([provider, providerModules]) => (
             <Box key={provider} sx={{ mb: 5 }}>
               {/* Provider section header */}
               <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, mb: 2 }}>

--- a/frontend/src/pages/ProvidersPage.tsx
+++ b/frontend/src/pages/ProvidersPage.tsx
@@ -57,15 +57,15 @@ const ProvidersPage: React.FC = () => {
     loadProviders();
   }, [loadProviders]);
 
-  const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleSearchChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
     setSearchQuery(event.target.value);
     setPage(1);
-  };
+  }, []);
 
-  const handlePageChange = (_event: React.ChangeEvent<unknown>, value: number) => {
+  const handlePageChange = useCallback((_event: React.ChangeEvent<unknown>, value: number) => {
     setPage(value);
     window.scrollTo(0, 0);
-  };
+  }, []);
 
   return (
     <Container maxWidth="lg" sx={{ py: 4 }}>

--- a/frontend/src/pages/admin/MirrorsPage.tsx
+++ b/frontend/src/pages/admin/MirrorsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import {
   Box,
@@ -236,18 +236,7 @@ const MirrorsPage: React.FC = () => {
 
   const [searchParams] = useSearchParams();
 
-  useEffect(() => {
-    loadMirrors();
-  }, []);
-
-  // Auto-open the Add Mirror dialog when navigated here with ?action=add
-  useEffect(() => {
-    if (searchParams.get('action') === 'add') {
-      setCreateDialogOpen(true);
-    }
-  }, [searchParams]);
-
-  const loadMirrors = async () => {
+  const loadMirrors = useCallback(async () => {
     try {
       setLoading(true);
       setError(null);
@@ -259,7 +248,18 @@ const MirrorsPage: React.FC = () => {
     } finally {
       setLoading(false);
     }
-  };
+  }, []);
+
+  useEffect(() => {
+    loadMirrors();
+  }, [loadMirrors]);
+
+  // Auto-open the Add Mirror dialog when navigated here with ?action=add
+  useEffect(() => {
+    if (searchParams.get('action') === 'add') {
+      setCreateDialogOpen(true);
+    }
+  }, [searchParams]);
 
   const handleCreate = async () => {
     try {


### PR DESCRIPTION
## Summary
- Memoize `navigationItems` and `adminNavGroups` arrays in `Layout.tsx` with `useMemo`
- Wrap `RegistryItemCard` in `React.memo` (pure presentational component)
- Memoize search handlers and grouped computations in `ModulesPage`/`ProvidersPage`/`MirrorsPage`
- Wrap `loadMirrors` in `useCallback` and fix exhaustive-deps compliance

Closes #89

## Changelog
- perf: add memoization to Layout sidebar navigation arrays, wrap RegistryItemCard in React.memo, memoize search handlers and grouped computations

## Test plan
- [ ] Verify `npm run build` succeeds
- [ ] Verify `npm run lint` passes
- [ ] No visual regressions — sidebar navigation, module/provider cards, mirror cards all render correctly
- [ ] E2E tests pass