### PR TITLE
fix: remove tautological E2E assertions and strengthen weak checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - perf: reduce ModulesPage grouped view fetch limit from 500 to 100 modules per page with pagination controls
 - perf: add memoization to Layout sidebar navigation arrays (`useMemo`), wrap `RegistryItemCard` in `React.memo`, memoize search handlers and grouped computations in ModulesPage/ProvidersPage/MirrorsPage
 
+### Fixed
+
+- fix: remove `|| true` tautology from E2E admin test and strengthen weak assertions across 9 test files with descriptive comments and more specific checks
+
 ## [0.3.7] - 2026-04-10
 
 ### Added

--- a/e2e/tests/admin.spec.ts
+++ b/e2e/tests/admin.spec.ts
@@ -28,6 +28,7 @@ test.describe('Admin: Users', () => {
     const hasTable = await page.locator('table, [class*="MuiTable"]').count() > 0;
     const hasEmptyState = await page.getByText(/no users/i).isVisible().catch(() => false);
 
+    // Page should show either a users table or a "no users" empty state
     expect(hasTable || hasEmptyState).toBe(true);
   });
 
@@ -64,6 +65,7 @@ test.describe('Admin: Organizations', () => {
       .isVisible()
       .catch(() => false);
 
+    // Page should show either an organizations table or a "no organizations" empty state
     expect(hasTable || hasEmptyState).toBe(true);
   });
 });
@@ -83,6 +85,7 @@ test.describe('Admin: API Keys', () => {
     const hasTable = await table.count() > 0;
     const hasEmptyState = await emptyState.isVisible().catch(() => false);
 
+    // Page should show either an API keys table or a "No API keys found" empty state
     expect(hasTable || hasEmptyState).toBe(true);
   });
 
@@ -125,8 +128,8 @@ test.describe('Admin: Provider Mirrors', () => {
       .getByText(/no mirror|no configuration|add.*mirror/i)
       .isVisible()
       .catch(() => false);
-    // At minimum the heading is visible — content check passed above
-    expect(hasCards || hasEmptyText || true).toBe(true);
+    // Page may show mirror config cards or an empty-state message depending on test data
+    expect(hasCards || hasEmptyText).toBe(true);
   });
 
   test('page has labelled Refresh and Add Mirror buttons', async ({ loggedInPage: page }) => {
@@ -209,7 +212,7 @@ test.describe('Admin: Dashboard', () => {
 
     // Stat cards or content should be present
     const content = await page.locator('main, [class*="MuiContainer"]').first().textContent();
-    expect(content).toBeTruthy();
+    expect(content).not.toBeNull();
     expect(content!.length).toBeGreaterThan(5);
   });
 
@@ -260,7 +263,7 @@ test.describe('Admin: Roles', () => {
     }
 
     const content = await page.locator('main, [class*="MuiContainer"]').first().textContent();
-    expect(content).toBeTruthy();
+    expect(content).not.toBeNull();
     expect(content!.length).toBeGreaterThan(5);
   });
 
@@ -281,6 +284,7 @@ test.describe('Admin: Roles', () => {
     const hasTable = (await page.locator('table').count()) > 0;
     const hasEmptyState = await page.getByText(/no roles/i).isVisible().catch(() => false);
 
+    // Page should show role items (accordion or table) or a "no roles" empty state
     expect(hasAccordion || hasTable || hasEmptyState).toBe(true);
   });
 });
@@ -300,7 +304,7 @@ test.describe('Admin: SCM Providers', () => {
     }
 
     const content = await page.locator('main, [class*="MuiContainer"]').first().textContent();
-    expect(content).toBeTruthy();
+    expect(content).not.toBeNull();
     expect(content!.length).toBeGreaterThan(5);
   });
 
@@ -339,7 +343,7 @@ test.describe('Admin: SCM Providers', () => {
       .isVisible()
       .catch(() => false);
 
-    // Either cards exist or the empty state is shown
+    // Page should show SCM provider cards or an empty-state message
     expect(hasCards || hasEmptyState).toBe(true);
   });
 });
@@ -407,7 +411,7 @@ test.describe('Admin: Storage', () => {
     await expect(stepper.or(card).or(alert).first()).toBeVisible({ timeout: 15_000 });
 
     const content = await page.locator('main, [class*="MuiContainer"]').first().textContent();
-    expect(content).toBeTruthy();
+    expect(content).not.toBeNull();
     expect(content!.length).toBeGreaterThan(5);
   });
 
@@ -427,6 +431,7 @@ test.describe('Admin: Storage', () => {
     const hasCards = (await cards.count()) > 0;
     const hasAlert = (await alert.count()) > 0;
 
+    // Page should show setup wizard (stepper), config cards, or a configured alert
     expect(hasStepper || hasCards || hasAlert).toBe(true);
   });
 });

--- a/e2e/tests/approvals.spec.ts
+++ b/e2e/tests/approvals.spec.ts
@@ -45,6 +45,7 @@ test.describe('Admin: Approval Requests', () => {
       .isVisible()
       .catch(() => false);
 
+    // Page should show approval request cards or a "no approval requests" empty state
     expect(hasCards || hasEmptyText).toBe(true);
   });
 

--- a/e2e/tests/home.spec.ts
+++ b/e2e/tests/home.spec.ts
@@ -128,7 +128,7 @@ test.describe('API Documentation page', () => {
 
     // Page should render some meaningful content
     const pageContent = await page.locator('body').textContent();
-    expect(pageContent).toBeTruthy();
+    expect(pageContent).not.toBeNull();
     expect(pageContent!.length).toBeGreaterThan(50);
   });
 

--- a/e2e/tests/modules.spec.ts
+++ b/e2e/tests/modules.spec.ts
@@ -50,6 +50,7 @@ test.describe('Modules list', () => {
     const hasCards = await page.locator('[class*="MuiCard"]').count() > 0;
     const hasEmptyState = await page.getByText('No modules found').isVisible().catch(() => false);
 
+    // Page should show module cards or a "No modules found" empty state
     expect(hasCards || hasEmptyState).toBe(true);
   });
 
@@ -110,7 +111,7 @@ test.describe('Module detail page', () => {
       .filter({ hasText: /.+/ })
       .first()
       .textContent();
-    expect(pageContent).toBeTruthy();
+    expect(pageContent).not.toBeNull();
     expect(pageContent!.trim().length).toBeGreaterThan(10);
   });
 
@@ -183,6 +184,7 @@ test.describe('Module detail page', () => {
       .isVisible()
       .catch(() => false);
 
+    // Panel should show webhook event items or a "no webhook events" empty state
     expect(hasEvents || hasEmptyState).toBe(true);
   });
 });

--- a/e2e/tests/policies.spec.ts
+++ b/e2e/tests/policies.spec.ts
@@ -46,6 +46,7 @@ test.describe('Admin: Mirror Policies', () => {
       .isVisible()
       .catch(() => false);
 
+    // Page should show policy cards or a "no mirror policies" empty state
     expect(hasCards || hasEmptyText).toBe(true);
   });
 

--- a/e2e/tests/providers.spec.ts
+++ b/e2e/tests/providers.spec.ts
@@ -48,6 +48,7 @@ test.describe('Providers list', () => {
     const hasCards = (await page.locator('[class*="MuiCard"]').count()) > 0;
     const hasEmptyState = await page.getByText('No providers found').isVisible().catch(() => false);
 
+    // Page should show provider cards or a "No providers found" empty state
     expect(hasCards || hasEmptyState).toBe(true);
   });
 
@@ -123,7 +124,7 @@ test.describe('Provider detail page', () => {
       .filter({ hasText: /.+/ })
       .first()
       .textContent();
-    expect(pageContent).toBeTruthy();
+    expect(pageContent).not.toBeNull();
     expect(pageContent!.trim().length).toBeGreaterThan(10);
   });
 });

--- a/e2e/tests/terraform-binaries.spec.ts
+++ b/e2e/tests/terraform-binaries.spec.ts
@@ -39,6 +39,7 @@ test.describe('Terraform Binaries list', () => {
       .isVisible()
       .catch(() => false);
 
+    // Page should show binary mirror cards or a "no binary mirrors configured" empty state
     expect(hasCards || hasEmptyState).toBe(true);
   });
 
@@ -114,7 +115,7 @@ test.describe('Terraform Binary detail page', () => {
       .locator('[class*="MuiContainer"]')
       .first()
       .textContent();
-    expect(content).toBeTruthy();
+    expect(content).not.toBeNull();
     expect(content!.trim().length).toBeGreaterThan(5);
   });
 });

--- a/e2e/tests/terraform-mirror-admin.spec.ts
+++ b/e2e/tests/terraform-mirror-admin.spec.ts
@@ -39,6 +39,7 @@ test.describe('Admin: Terraform Binary Mirrors', () => {
       .isVisible()
       .catch(() => false);
 
+    // Page should show mirror config cards or an empty-state message
     expect(hasCards || hasEmptyState).toBe(true);
   });
 

--- a/e2e/tests/upload.spec.ts
+++ b/e2e/tests/upload.spec.ts
@@ -21,7 +21,7 @@ test.describe('Module Upload page', () => {
 
     // Should have some content — heading or method cards
     const content = await page.locator('main, [class*="MuiContainer"]').first().textContent();
-    expect(content).toBeTruthy();
+    expect(content).not.toBeNull();
     expect(content!.length).toBeGreaterThan(5);
   });
 
@@ -109,7 +109,7 @@ test.describe('Provider Upload page', () => {
     });
 
     const content = await page.locator('main, [class*="MuiContainer"]').first().textContent();
-    expect(content).toBeTruthy();
+    expect(content).not.toBeNull();
     expect(content!.length).toBeGreaterThan(5);
   });
 


### PR DESCRIPTION
## Summary
- Remove `|| true` tautology from `admin.spec.ts` that made assertion always pass
- Add descriptive comments to 13 weak `boolA || boolB` patterns explaining valid states
- Replace 10 generic `.toBeTruthy()` assertions with more specific checks where possible

Closes #87

## Changelog
- fix: remove `|| true` tautology from E2E admin test and strengthen weak assertions across 9 test files

## Test plan
- [ ] E2E suite still passes against the test stack
- [ ] `admin.spec.ts` line ~129 now actually tests card/empty state presence