### PR TITLE
fix: update module scan API path to match backend route fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- fix: update module scan API path from `/admin/modules/` to `/modules/` to match backend route fix (sethbacon/terraform-registry-backend#147)
+
 ## [0.3.8] - 2026-04-10
 
 ### Added

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -645,7 +645,7 @@ class ApiClient {
 
   async getModuleScan(namespace: string, name: string, system: string, version: string): Promise<import('../types').ModuleScan> {
     const response = await this.client.get(
-      `/api/v1/admin/modules/${namespace}/${name}/${system}/versions/${version}/scan`
+      `/api/v1/modules/${namespace}/${name}/${system}/versions/${version}/scan`
     );
     return response.data;
   }


### PR DESCRIPTION
Closes #97

The backend moved the module scan endpoint from `/api/v1/admin/modules/:namespace/...` to `/api/v1/modules/:namespace/...` to resolve a gin wildcard panic (sethbacon/terraform-registry-backend#148). This updates the frontend API call to match.