### PR TITLE
feat: Phase 5 — UX & accessibility improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- feat: add skip-to-content keyboard navigation link for accessibility
+- feat: add `aria-label` to all 45 icon-only buttons across 14 files for screen reader accessibility
+- feat: add `aria-busy` and `aria-live` attributes to all page-level loading containers (23 files) for screen reader state announcements
+- feat: add TanStack Query data-fetching abstraction with proof-of-concept migration of ModulesPage, ProvidersPage, and DashboardPage — replaces manual `useState`/`useEffect`/`try-catch` boilerplate with `useQuery`, adds request caching and deduplication
+- feat: add error reporting service placeholder (`services/errorReporting.ts`) with Sentry-compatible `init`/`captureError`/`setUser` interface — hooks into ErrorBoundary and global `unhandledrejection` handler, gated behind `VITE_ERROR_REPORTING_DSN` env var
+- docs: document tag protection rule command in CLAUDE.md
+
 ### Fixed
 
 - fix: update module scan API path from `/admin/modules/` to `/modules/` to match backend route fix (sethbacon/terraform-registry-backend#147)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -308,7 +308,21 @@ docker compose -f docker-compose.test.yml up -d --build
 
 `terraform`, `terraform-registry`, `react`, `typescript`, `material-ui`, `vite`, `private-registry`
 
+### Tag Protection Rule (documented 2026-04-13)
+
+To protect release tags (`v*.*.*`) from deletion, apply a repository ruleset via the GitHub CLI or UI:
+
+```bash
+gh api repos/{owner}/{repo}/rulesets --method POST \
+  --field name="Protect release tags" \
+  --field target=tag \
+  --field enforcement=active \
+  --field 'conditions[ref_name][include][]=refs/tags/v*.*.*' \
+  --field 'rules[][type]=deletion'
+```
+
+Alternatively, in the GitHub UI: **Settings > Rules > Rulesets > New ruleset** targeting tags matching `v*.*.*` with a "Restrict deletions" rule.
+
 ### Remaining Recommendations (not yet applied)
 
 - **Enable secret scanning non-provider patterns and validity checks** for broader secret detection
-- **Add a tag protection rule** to prevent deletion of release tags (`v*.*.*`)

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -20,3 +20,8 @@
 # Controls whether the Dev Login button is available in the UI.
 # Values: development | production
 # VITE_MODE=development
+
+# Error reporting DSN endpoint.
+# Accepts a Sentry DSN or any URL that accepts POST requests with error payloads.
+# When not set, errors are logged to the browser console only.
+# VITE_ERROR_REPORTING_DSN=https://your-sentry-dsn-or-endpoint

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "terraform-registry-frontend",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "terraform-registry-frontend",
-      "version": "0.3.7",
+      "version": "0.3.8",
       "dependencies": {
         "@emotion/react": "^11.11.3",
         "@emotion/styled": "^11.11.0",
@@ -15,6 +15,8 @@
         "@fortawesome/react-fontawesome": "^3.2.0",
         "@mui/icons-material": "^7.0.0",
         "@mui/material": "^7.0.0",
+        "@tanstack/react-query": "^5.99.0",
+        "@tanstack/react-query-devtools": "^5.99.0",
         "axios": "^1.15.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -2810,6 +2812,59 @@
       },
       "engines": {
         "node": ">=12.20.0"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.99.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.99.0.tgz",
+      "integrity": "sha512-3Jv3WQG0BCcH7G+7lf/bP8QyBfJOXeY+T08Rin3GZ1bshvwlbPt7NrDHMEzGdKIOmOzvIQmxjk28YEQX60k7pQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.99.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.99.0.tgz",
+      "integrity": "sha512-m4ufXaJ8FjWXw7xDtyzE/6fkZAyQFg9WrbMrUpt8ZecRJx58jiFOZ2lxZMphZdIpAnIeto/S8stbwLKLusyckQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.99.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.99.0.tgz",
+      "integrity": "sha512-OY2bCqPemT1LlqJ8Y2CUau4KELnIhhG9Ol3ZndPbdnB095pRbPo1cHuXTndg8iIwtoHTgwZjyaDnQ0xD0mYwAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.99.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.99.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.99.0.tgz",
+      "integrity": "sha512-CqqX7LCU9yOfCY/vBURSx2YSD83ryfX+QkfkaKionTfg1s2Hdm572Ro99gW3QPoJjzvsj1HM4pnN4nbDy3MXKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.99.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.99.0",
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,8 @@
     "@fortawesome/react-fontawesome": "^3.2.0",
     "@mui/icons-material": "^7.0.0",
     "@mui/material": "^7.0.0",
+    "@tanstack/react-query": "^5.99.0",
+    "@tanstack/react-query-devtools": "^5.99.0",
     "axios": "^1.15.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,7 @@
 import { Suspense, lazy } from 'react';
 import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { CssBaseline } from '@mui/material';
 import { ThemeProvider } from './contexts/ThemeContext';
 import { AuthProvider } from './contexts/AuthContext';
@@ -36,6 +38,16 @@ const MirrorPoliciesPage = lazy(() => import('./pages/admin/MirrorPoliciesPage')
 const OIDCSettingsPage = lazy(() => import('./pages/admin/OIDCSettingsPage'));
 const AuditLogPage = lazy(() => import('./pages/admin/AuditLogPage'));
 
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 30_000,
+      retry: 1,
+      refetchOnWindowFocus: false,
+    },
+  },
+});
+
 const loader = <div>Loading...</div>;
 
 function App() {
@@ -44,6 +56,7 @@ function App() {
       <CssBaseline />
       <AuthProvider>
         <HelpProvider>
+          <QueryClientProvider client={queryClient}>
           <Router>
             <ErrorBoundary>
               <Routes>
@@ -95,6 +108,8 @@ function App() {
               </Routes>
             </ErrorBoundary>
           </Router>
+          <ReactQueryDevtools initialIsOpen={false} />
+          </QueryClientProvider>
         </HelpProvider>
       </AuthProvider>
     </ThemeProvider>

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,6 +1,7 @@
 import { Component } from 'react';
 import type { ErrorInfo, ReactNode } from 'react';
 import { Alert, AlertTitle, Box, Button, Container, Stack, Typography } from '@mui/material';
+import { captureError } from '../services/errorReporting';
 
 interface ErrorBoundaryProps {
   children: ReactNode;
@@ -23,7 +24,7 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
   }
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
-    console.error('ErrorBoundary caught an error:', error, errorInfo);
+    captureError(error, { componentStack: errorInfo?.componentStack ?? undefined });
   }
 
   handleReset = (): void => {

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -319,6 +319,7 @@ const Layout = () => {
 
   return (
     <Box sx={{ display: 'flex' }}>
+      <a href="#main-content" className="skip-link">Skip to main content</a>
       <AppBar
         position="fixed"
         sx={{
@@ -450,6 +451,8 @@ const Layout = () => {
 
       <Box
         component="main"
+        id="main-content"
+        tabIndex={-1}
         sx={{
           flexGrow: 1,
           // minWidth:0 lets the flex child shrink correctly on narrow viewports.

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -17,7 +17,7 @@ const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children, requiredScope
 
   if (isLoading) {
     return (
-      <Box display="flex" justifyContent="center" alignItems="center" minHeight="100vh">
+      <Box display="flex" justifyContent="center" alignItems="center" minHeight="100vh" aria-busy="true">
         <CircularProgress />
       </Box>
     );

--- a/frontend/src/components/ProviderDocContent.tsx
+++ b/frontend/src/components/ProviderDocContent.tsx
@@ -55,25 +55,21 @@ const ProviderDocContent: React.FC<ProviderDocContentProps> = ({
     };
   }, [namespace, type, version, category, slug]);
 
-  if (loading) {
-    return (
-      <Box sx={{ display: 'flex', justifyContent: 'center', pt: 4 }}>
-        <CircularProgress />
-      </Box>
-    );
-  }
-
-  if (error) {
-    return (
-      <Box sx={{ pt: 2, pb: 4, pl: 2, pr: 5 }}>
-        <Alert severity="error">{error}</Alert>
-      </Box>
-    );
-  }
-
   return (
-    <Box sx={{ p: 2 }}>
-      <MarkdownRenderer>{content ?? ''}</MarkdownRenderer>
+    <Box aria-busy={loading} aria-live="polite">
+      {loading ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', pt: 4 }}>
+          <CircularProgress />
+        </Box>
+      ) : error ? (
+        <Box sx={{ pt: 2, pb: 4, pl: 2, pr: 5 }}>
+          <Alert severity="error">{error}</Alert>
+        </Box>
+      ) : (
+        <Box sx={{ p: 2 }}>
+          <MarkdownRenderer>{content ?? ''}</MarkdownRenderer>
+        </Box>
+      )}
     </Box>
   );
 };

--- a/frontend/src/components/PublishFromSCMWizard.tsx
+++ b/frontend/src/components/PublishFromSCMWizard.tsx
@@ -428,7 +428,7 @@ const PublishFromSCMWizard: React.FC<PublishFromSCMWizardProps> = ({
   };
 
   return (
-    <Box>
+    <Box aria-busy={loading} aria-live="polite">
       <Stepper activeStep={activeStep} sx={{ mb: 4 }}>
         {steps.map((label) => (
           <Step key={label}>

--- a/frontend/src/components/RepositoryBrowser.tsx
+++ b/frontend/src/components/RepositoryBrowser.tsx
@@ -145,16 +145,14 @@ const RepositoryBrowser: React.FC<RepositoryBrowserProps> = ({
       repo.description?.toLowerCase().includes(searchQuery.toLowerCase())
   );
 
-  if (loading) {
-    return (
-      <Box display="flex" justifyContent="center" alignItems="center" minHeight="200px">
-        <CircularProgress />
-      </Box>
-    );
-  }
-
   return (
-    <Box>
+    <Box aria-busy={loading} aria-live="polite">
+      {loading ? (
+        <Box display="flex" justifyContent="center" alignItems="center" minHeight="200px">
+          <CircularProgress />
+        </Box>
+      ) : (
+        <Box>
       <Box mb={2} display="flex" gap={1}>
         <TextField
           fullWidth
@@ -171,7 +169,7 @@ const RepositoryBrowser: React.FC<RepositoryBrowserProps> = ({
           }}
         />
         <Tooltip title="Refresh">
-          <IconButton onClick={loadRepositories} size="small">
+          <IconButton onClick={loadRepositories} size="small" aria-label="Refresh repositories">
             <RefreshIcon />
           </IconButton>
         </Tooltip>
@@ -317,6 +315,8 @@ const RepositoryBrowser: React.FC<RepositoryBrowserProps> = ({
             </Accordion>
           ))}
         </Box>
+      )}
+    </Box>
       )}
     </Box>
   );

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -20,3 +20,20 @@ code {
 #root {
   min-height: 100vh;
 }
+
+.skip-link {
+  position: absolute;
+  top: -100%;
+  left: 16px;
+  z-index: 10000;
+  padding: 8px 16px;
+  background-color: #1976d2;
+  color: #fff;
+  text-decoration: none;
+  font-weight: 600;
+  border-radius: 0 0 4px 4px;
+  transition: top 0.2s ease;
+}
+.skip-link:focus {
+  top: 0;
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,6 +2,14 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'
 import './index.css'
+import { init as initErrorReporting, captureError } from './services/errorReporting'
+
+initErrorReporting()
+
+window.addEventListener('unhandledrejection', (event) => {
+  const error = event.reason instanceof Error ? event.reason : new Error(String(event.reason))
+  captureError(error, { type: 'unhandledrejection' })
+})
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/frontend/src/pages/CallbackPage.tsx
+++ b/frontend/src/pages/CallbackPage.tsx
@@ -46,7 +46,7 @@ const CallbackPage: React.FC = () => {
   }, [searchParams, setToken, navigate]);
 
   return (
-    <Container maxWidth="sm" sx={{ mx: 'auto' }}>
+    <Container maxWidth="sm" sx={{ mx: 'auto' }} aria-busy={!error} aria-live="polite">
       <Box
         sx={{
           minHeight: '100vh',

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -428,6 +428,7 @@ const HomePage: React.FC = () => {
                     <Tooltip title={copied ? 'Copied!' : 'Copy to clipboard'} placement="top">
                       <IconButton
                         size="small"
+                        aria-label="Copy usage example"
                         onClick={handleCopyCredentials}
                         sx={{ position: 'absolute', top: 4, right: 4, opacity: 0.6, '&:hover': { opacity: 1 } }}
                       >

--- a/frontend/src/pages/ModuleDetailPage.tsx
+++ b/frontend/src/pages/ModuleDetailPage.tsx
@@ -389,31 +389,25 @@ const ModuleDetailPage: React.FC = () => {
 }`;
   };
 
-  if (loading) {
-    return (
-      <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
-        <CircularProgress />
-      </Box>
-    );
-  }
-
-  if (error || !module) {
-    return (
-      <Container maxWidth="lg" sx={{ py: 4 }}>
-        <Alert severity="error">{error || 'Module not found'}</Alert>
-        <Button
-          startIcon={<ArrowBack />}
-          onClick={() => navigate('/modules')}
-          sx={{ mt: 2 }}
-        >
-          Back to Modules
-        </Button>
-      </Container>
-    );
-  }
-
   return (
-    <Container maxWidth="lg" sx={{ py: 4 }}>
+    <Box aria-busy={loading} aria-live="polite">
+      {loading ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+          <CircularProgress />
+        </Box>
+      ) : error || !module ? (
+        <Container maxWidth="lg" sx={{ py: 4 }}>
+          <Alert severity="error">{error || 'Module not found'}</Alert>
+          <Button
+            startIcon={<ArrowBack />}
+            onClick={() => navigate('/modules')}
+            sx={{ mt: 2 }}
+          >
+            Back to Modules
+          </Button>
+        </Container>
+      ) : (
+        <Container maxWidth="lg" sx={{ py: 4 }}>
       {/* Breadcrumbs */}
       <Breadcrumbs sx={{ mb: 3 }}>
         <Link
@@ -436,7 +430,7 @@ const ModuleDetailPage: React.FC = () => {
       <Box sx={{ mb: 4 }}>
         <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 2 }}>
           <Stack direction="row" alignItems="center" spacing={2}>
-            <IconButton onClick={() => navigate('/modules')}>
+            <IconButton aria-label="Back to modules" onClick={() => navigate('/modules')}>
               <ArrowBack />
             </IconButton>
             <Typography variant="h4" component="h1">
@@ -511,7 +505,7 @@ const ModuleDetailPage: React.FC = () => {
             <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 2 }}>
               <Typography variant="h6">Usage Example</Typography>
               <Tooltip title={copiedSource ? 'Copied!' : 'Copy source'}>
-                <IconButton onClick={handleCopySource} size="small">
+                <IconButton aria-label="Copy source URL" onClick={handleCopySource} size="small">
                   <ContentCopy />
                 </IconButton>
               </Tooltip>
@@ -786,7 +780,7 @@ const ModuleDetailPage: React.FC = () => {
                   <WebhookIcon fontSize="small" color="action" />
                   <Typography variant="h6">Webhook Events</Typography>
                 </Box>
-                <IconButton size="small">
+                <IconButton size="small" aria-label="Toggle webhook events">
                   {webhookEventsExpanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
                 </IconButton>
               </Box>
@@ -1131,6 +1125,8 @@ const ModuleDetailPage: React.FC = () => {
         </DialogActions>
       </Dialog>
     </Container>
+      )}
+    </Box>
   );
 };
 

--- a/frontend/src/pages/ModulesPage.tsx
+++ b/frontend/src/pages/ModulesPage.tsx
@@ -1,5 +1,6 @@
-import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import React, { useState, useCallback, useMemo } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
 import { useDebounce } from '../hooks/useDebounce';
 import {
   Container,
@@ -22,6 +23,7 @@ import CloudUpload from '@mui/icons-material/CloudUpload';
 import ViewModuleIcon from '@mui/icons-material/ViewModule';
 import CategoryIcon from '@mui/icons-material/Category';
 import api from '../services/api';
+import { queryKeys } from '../services/queryKeys';
 import { Module } from '../types';
 import { useAuth } from '../contexts/AuthContext';
 import { ProviderIcon, providerDisplayName } from '../components/ProviderIcon';
@@ -45,49 +47,29 @@ const ModulesPage: React.FC = () => {
   const navigate = useNavigate();
   const { isAuthenticated } = useAuth();
   const [searchParams] = useSearchParams();
-  const [modules, setModules] = useState<Module[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState(searchParams.get('q') ?? '');
   const debouncedSearch = useDebounce(searchQuery, 300);
   const [page, setPage] = useState(1);
-  const [totalPages, setTotalPages] = useState(1);
   const [viewMode, setViewMode] = useState<ViewMode>('grid');
-  const limit = 12;
+  const limit = viewMode === 'grouped' ? 100 : 12;
 
-  const loadModules = useCallback(async () => {
-    try {
-      setLoading(true);
-      setError(null);
-      if (viewMode === 'grouped') {
-        // Fetch enough to populate grouped sections without excessive payload.
-        const response = await api.searchModules({
-          query: debouncedSearch || undefined,
-          limit: 100,
-          offset: (page - 1) * 100,
-        });
-        setModules(response.modules);
-        setTotalPages(Math.ceil(response.meta.total / 100));
-      } else {
-        const response = await api.searchModules({
-          query: debouncedSearch || undefined,
-          limit,
-          offset: (page - 1) * limit,
-        });
-        setModules(response.modules);
-        setTotalPages(Math.ceil(response.meta.total / limit));
-      }
-    } catch (err) {
-      console.error('Failed to load modules:', err);
-      setError('Failed to load modules. Please try again.');
-    } finally {
-      setLoading(false);
-    }
-  }, [page, debouncedSearch, viewMode]);
+  const { data: queryData, isLoading: loading, error: queryError } = useQuery({
+    queryKey: queryKeys.modules.search({
+      query: debouncedSearch || undefined,
+      limit,
+      offset: (page - 1) * limit,
+      viewMode,
+    }),
+    queryFn: () => api.searchModules({
+      query: debouncedSearch || undefined,
+      limit,
+      offset: (page - 1) * limit,
+    }),
+  });
 
-  useEffect(() => {
-    loadModules();
-  }, [loadModules]);
+  const modules = useMemo(() => queryData?.modules ?? [], [queryData]);
+  const totalPages = queryData ? Math.ceil(queryData.meta.total / limit) : 1;
+  const error = queryError ? 'Failed to load modules. Please try again.' : null;
 
   const handleSearchChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
     setSearchQuery(event.target.value);
@@ -136,7 +118,7 @@ const ModulesPage: React.FC = () => {
   const groupedModules = useMemo(() => groupByProvider(modules), [modules]);
 
   return (
-    <Container maxWidth="lg" sx={{ py: 4 }}>
+    <Container maxWidth="lg" sx={{ py: 4 }} aria-busy={loading} aria-live="polite">
       {/* Header */}
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
         <Box>

--- a/frontend/src/pages/ProviderDetailPage.tsx
+++ b/frontend/src/pages/ProviderDetailPage.tsx
@@ -315,33 +315,10 @@ provider "${name}" {
 }`;
   };
 
-  if (loading) {
-    return (
-      <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
-        <CircularProgress />
-      </Box>
-    );
-  }
-
-  if (error || !provider) {
-    return (
-      <Container maxWidth="xl" sx={{ py: 4 }}>
-        <Alert severity="error">{error || 'Provider not found'}</Alert>
-        <Button
-          startIcon={<ArrowBack />}
-          onClick={() => navigate('/providers')}
-          sx={{ mt: 2 }}
-        >
-          Back to Providers
-        </Button>
-      </Container>
-    );
-  }
-
-  const hasDocs = provider.source && selectedVersion;
+  const hasDocs = provider?.source && selectedVersion;
 
   // Derive GitHub repo URL from namespace/type convention for mirrored providers
-  const githubUrl = provider.source
+  const githubUrl = provider?.source
     ? `https://github.com/${namespace}/terraform-provider-${type}`
     : null;
   const changelogUrl = githubUrl && selectedVersion
@@ -349,7 +326,24 @@ provider "${name}" {
     : null;
 
   return (
-    <Container maxWidth="xl" sx={{ py: 4 }}>
+    <Box aria-busy={loading} aria-live="polite">
+      {loading ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+          <CircularProgress />
+        </Box>
+      ) : error || !provider ? (
+        <Container maxWidth="xl" sx={{ py: 4 }}>
+          <Alert severity="error">{error || 'Provider not found'}</Alert>
+          <Button
+            startIcon={<ArrowBack />}
+            onClick={() => navigate('/providers')}
+            sx={{ mt: 2 }}
+          >
+            Back to Providers
+          </Button>
+        </Container>
+      ) : (
+        <Container maxWidth="xl" sx={{ py: 4 }}>
       {/* Breadcrumbs */}
       <Breadcrumbs sx={{ mb: 3 }}>
         <Link
@@ -371,7 +365,7 @@ provider "${name}" {
       <Box sx={{ mb: 3 }}>
         <Stack direction="row" alignItems="center" justifyContent="space-between" spacing={2} sx={{ mb: 2 }}>
           <Stack direction="row" alignItems="center" spacing={2}>
-            <IconButton onClick={() => navigate('/providers')}>
+            <IconButton aria-label="Back to providers" onClick={() => navigate('/providers')}>
               <ArrowBack />
             </IconButton>
             <Typography variant="h4" component="h1">
@@ -466,7 +460,7 @@ provider "${name}" {
               <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 2 }}>
                 <Typography variant="h6">Usage Example</Typography>
                 <Tooltip title={copiedSource ? 'Copied!' : 'Copy source'}>
-                  <IconButton onClick={handleCopySource} size="small">
+                  <IconButton aria-label="Copy source URL" onClick={handleCopySource} size="small">
                     <ContentCopy />
                   </IconButton>
                 </Tooltip>
@@ -516,6 +510,7 @@ provider "${name}" {
                               <Tooltip title={copiedChecksum === platform.shasum ? "Copied!" : "Copy checksum"}>
                                 <IconButton
                                   size="small"
+                                  aria-label="Copy checksum"
                                   onClick={() => handleCopyChecksum(platform.shasum)}
                                 >
                                   <ContentCopy fontSize="small" />
@@ -885,6 +880,8 @@ provider "${name}" {
         </DialogActions>
       </Dialog>
     </Container>
+      )}
+    </Box>
   );
 };
 

--- a/frontend/src/pages/ProvidersPage.tsx
+++ b/frontend/src/pages/ProvidersPage.tsx
@@ -1,5 +1,6 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useCallback } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
 import { useDebounce } from '../hooks/useDebounce';
 import {
   Container,
@@ -17,6 +18,7 @@ import {
 import SearchIcon from '@mui/icons-material/Search';
 import CloudUpload from '@mui/icons-material/CloudUpload';
 import api from '../services/api';
+import { queryKeys } from '../services/queryKeys';
 import { Provider } from '../types';
 import { useAuth } from '../contexts/AuthContext';
 import RegistryItemCard from '../components/RegistryItemCard';
@@ -25,37 +27,27 @@ const ProvidersPage: React.FC = () => {
   const navigate = useNavigate();
   const { isAuthenticated } = useAuth();
   const [searchParams] = useSearchParams();
-  const [providers, setProviders] = useState<Provider[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState(searchParams.get('q') ?? '');
   const debouncedSearch = useDebounce(searchQuery, 300);
   const [page, setPage] = useState(1);
-  const [totalPages, setTotalPages] = useState(1);
   const limit = 12;
 
-  const loadProviders = useCallback(async () => {
-    try {
-      setLoading(true);
-      setError(null);
-      const response = await api.searchProviders({
-        query: debouncedSearch || undefined,
-        limit,
-        offset: (page - 1) * limit,
-      });
-      setProviders(response.providers);
-      setTotalPages(Math.ceil(response.meta.total / limit));
-    } catch (err) {
-      console.error('Failed to load providers:', err);
-      setError('Failed to load providers. Please try again.');
-    } finally {
-      setLoading(false);
-    }
-  }, [page, debouncedSearch]);
+  const { data: queryData, isLoading: loading, error: queryError } = useQuery({
+    queryKey: queryKeys.providers.search({
+      query: debouncedSearch || undefined,
+      limit,
+      offset: (page - 1) * limit,
+    }),
+    queryFn: () => api.searchProviders({
+      query: debouncedSearch || undefined,
+      limit,
+      offset: (page - 1) * limit,
+    }),
+  });
 
-  useEffect(() => {
-    loadProviders();
-  }, [loadProviders]);
+  const providers: Provider[] = queryData?.providers ?? [];
+  const totalPages = queryData ? Math.ceil(queryData.meta.total / limit) : 1;
+  const error = queryError ? 'Failed to load providers. Please try again.' : null;
 
   const handleSearchChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
     setSearchQuery(event.target.value);
@@ -68,7 +60,7 @@ const ProvidersPage: React.FC = () => {
   }, []);
 
   return (
-    <Container maxWidth="lg" sx={{ py: 4 }}>
+    <Container maxWidth="lg" sx={{ py: 4 }} aria-busy={loading} aria-live="polite">
       {/* Header */}
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
         <Box>

--- a/frontend/src/pages/SetupWizardPage.tsx
+++ b/frontend/src/pages/SetupWizardPage.tsx
@@ -274,20 +274,18 @@ const SetupWizardPage: React.FC = () => {
     setStorageSaved(false);
   };
 
-  if (loading) {
-    return (
-      <Container maxWidth="md" sx={{ display: 'flex', justifyContent: 'center', mt: 8 }}>
-        <CircularProgress />
-      </Container>
-    );
-  }
-
-  if (setupStatus?.setup_completed) {
+  if (!loading && setupStatus?.setup_completed) {
     return null; // Will redirect
   }
 
   return (
-    <Container maxWidth="md" sx={{ py: 4 }}>
+    <Box aria-busy={loading} aria-live="polite">
+      {loading ? (
+        <Container maxWidth="md" sx={{ display: 'flex', justifyContent: 'center', mt: 8 }}>
+          <CircularProgress />
+        </Container>
+      ) : (
+        <Container maxWidth="md" sx={{ py: 4 }}>
       <Paper elevation={3} sx={{ p: 4 }}>
         {/* Header */}
         <Box sx={{ textAlign: 'center', mb: 4 }}>
@@ -425,7 +423,7 @@ const SetupWizardPage: React.FC = () => {
                 InputProps={{
                   endAdornment: (
                     <InputAdornment position="end">
-                      <IconButton onClick={() => setShowClientSecret(!showClientSecret)} edge="end">
+                      <IconButton onClick={() => setShowClientSecret(!showClientSecret)} edge="end" aria-label="Toggle password visibility">
                         {showClientSecret ? <VisibilityOffIcon /> : <VisibilityIcon />}
                       </IconButton>
                     </InputAdornment>
@@ -909,6 +907,8 @@ const SetupWizardPage: React.FC = () => {
         </Typography>
       </Paper>
     </Container>
+      )}
+    </Box>
   );
 };
 

--- a/frontend/src/pages/TerraformBinariesPage.tsx
+++ b/frontend/src/pages/TerraformBinariesPage.tsx
@@ -76,7 +76,7 @@ const TerraformBinariesPage: React.FC = () => {
   }, []);
 
   return (
-    <Container maxWidth="lg" sx={{ py: 4 }}>
+    <Container maxWidth="lg" sx={{ py: 4 }} aria-busy={loading} aria-live="polite">
       <Box sx={{ mb: 2 }}>
         <Typography variant="h4" gutterBottom>
           Terraform Binary Mirrors

--- a/frontend/src/pages/TerraformBinaryDetailPage.tsx
+++ b/frontend/src/pages/TerraformBinaryDetailPage.tsx
@@ -174,7 +174,7 @@ const VersionRow: React.FC<VersionRowProps> = ({
         }}
       >
         <TableCell width={48}>
-          <IconButton size="small" onClick={() => setOpen((p) => !p)}>
+          <IconButton size="small" aria-label="Toggle version details" onClick={() => setOpen((p) => !p)}>
             {open ? <ExpandLessIcon /> : <ExpandMoreIcon />}
           </IconButton>
         </TableCell>
@@ -204,7 +204,7 @@ const VersionRow: React.FC<VersionRowProps> = ({
             <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 0.5 }}>
               {version.is_deprecated ? (
                 <Tooltip title="Remove deprecation (re-enable syncing)">
-                  <IconButton size="small" onClick={() => onUndeprecate(version)}>
+                  <IconButton size="small" aria-label="Undeprecate version" onClick={() => onUndeprecate(version)}>
                     <RestoreIcon fontSize="small" />
                   </IconButton>
                 </Tooltip>
@@ -212,6 +212,7 @@ const VersionRow: React.FC<VersionRowProps> = ({
                 <Tooltip title="Mark as deprecated (prevents re-sync)">
                   <IconButton
                     size="small"
+                    aria-label="Deprecate version"
                     color="warning"
                     onClick={() => onDeprecate(version)}
                     disabled={version.sync_status === 'syncing'}
@@ -224,6 +225,7 @@ const VersionRow: React.FC<VersionRowProps> = ({
                 <span>
                   <IconButton
                     size="small"
+                    aria-label="Delete version"
                     color="error"
                     onClick={() => onDelete(version)}
                     disabled={version.sync_status === 'syncing'}
@@ -401,27 +403,6 @@ const TerraformBinaryDetailPage: React.FC = () => {
   // Render
   // ---------------------------------------------------------------------------
 
-  if (loading) {
-    return (
-      <Container>
-        <Box sx={{ display: 'flex', justifyContent: 'center', mt: 8 }}>
-          <CircularProgress />
-        </Box>
-      </Container>
-    );
-  }
-
-  if (error) {
-    return (
-      <Container sx={{ py: 4 }}>
-        <Alert severity="error">{error}</Alert>
-        <Button sx={{ mt: 2 }} startIcon={<ArrowBack />} onClick={() => navigate('/terraform-binaries')}>
-          Back to Mirrors
-        </Button>
-      </Container>
-    );
-  }
-
   const toolLabel =
     config?.tool === 'terraform'
       ? 'Terraform (HashiCorp)'
@@ -433,7 +414,22 @@ const TerraformBinaryDetailPage: React.FC = () => {
     config?.tool === 'terraform' ? 'primary' : config?.tool === 'opentofu' ? 'secondary' : 'default';
 
   return (
-    <Container maxWidth="lg" sx={{ py: 4 }}>
+    <Box aria-busy={loading} aria-live="polite">
+      {loading ? (
+        <Container>
+          <Box sx={{ display: 'flex', justifyContent: 'center', mt: 8 }}>
+            <CircularProgress />
+          </Box>
+        </Container>
+      ) : error ? (
+        <Container sx={{ py: 4 }}>
+          <Alert severity="error">{error}</Alert>
+          <Button sx={{ mt: 2 }} startIcon={<ArrowBack />} onClick={() => navigate('/terraform-binaries')}>
+            Back to Mirrors
+          </Button>
+        </Container>
+      ) : (
+        <Container maxWidth="lg" sx={{ py: 4 }}>
       {/* Breadcrumbs */}
       <Breadcrumbs sx={{ mb: 2 }}>
         <Link component={RouterLink} to="/terraform-binaries" underline="hover" color="inherit">
@@ -447,7 +443,7 @@ const TerraformBinaryDetailPage: React.FC = () => {
       {/* Back button + title */}
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
         <Tooltip title="Back to mirrors">
-          <IconButton size="small" onClick={() => navigate('/terraform-binaries')}>
+          <IconButton size="small" aria-label="Back to binaries" onClick={() => navigate('/terraform-binaries')}>
             <ArrowBack />
           </IconButton>
         </Tooltip>
@@ -581,6 +577,8 @@ const TerraformBinaryDetailPage: React.FC = () => {
         </DialogActions>
       </Dialog>
     </Container>
+      )}
+    </Box>
   );
 };
 

--- a/frontend/src/pages/admin/APIKeysPage.tsx
+++ b/frontend/src/pages/admin/APIKeysPage.tsx
@@ -445,7 +445,7 @@ const APIKeysPage: React.FC = () => {
   );
 
   return (
-    <Container maxWidth="lg" sx={{ py: 4 }}>
+    <Container maxWidth="lg" sx={{ py: 4 }} aria-busy={loading} aria-live="polite">
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
         <Box>
           <Typography variant="h4" gutterBottom>
@@ -549,6 +549,7 @@ const APIKeysPage: React.FC = () => {
                           <Tooltip title="Edit">
                             <IconButton
                               size="small"
+                              aria-label="Edit API key"
                               onClick={() => handleEditClick(apiKey)}
                             >
                               <EditIcon fontSize="small" />
@@ -557,6 +558,7 @@ const APIKeysPage: React.FC = () => {
                           <Tooltip title="Rotate">
                             <IconButton
                               size="small"
+                              aria-label="Rotate API key"
                               onClick={() => handleRotateClick(apiKey)}
                             >
                               <AutorenewIcon fontSize="small" />
@@ -565,6 +567,7 @@ const APIKeysPage: React.FC = () => {
                           <Tooltip title="Delete">
                             <IconButton
                               size="small"
+                              aria-label="Delete API key"
                               onClick={() => handleDeleteClick(apiKey)}
                               color="error"
                             >
@@ -606,7 +609,7 @@ const APIKeysPage: React.FC = () => {
                   readOnly: true,
                   endAdornment: (
                     <InputAdornment position="end">
-                      <IconButton onClick={() => handleCopyKey(newKeyValue)}>
+                      <IconButton aria-label="Copy API key" onClick={() => handleCopyKey(newKeyValue)}>
                         <CopyIcon />
                       </IconButton>
                     </InputAdornment>
@@ -773,7 +776,7 @@ const APIKeysPage: React.FC = () => {
                   readOnly: true,
                   endAdornment: (
                     <InputAdornment position="end">
-                      <IconButton onClick={() => handleCopyKey(rotatedKeyValue)}>
+                      <IconButton aria-label="Copy rotated key" onClick={() => handleCopyKey(rotatedKeyValue)}>
                         <CopyIcon />
                       </IconButton>
                     </InputAdornment>

--- a/frontend/src/pages/admin/ApprovalsPage.tsx
+++ b/frontend/src/pages/admin/ApprovalsPage.tsx
@@ -135,16 +135,14 @@ const ApprovalsPage: React.FC = () => {
     }
   };
 
-  if (loading) {
-    return (
-      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '400px' }}>
-        <CircularProgress />
-      </Box>
-    );
-  }
-
   return (
-    <Container maxWidth="lg" sx={{ py: 4 }}>
+    <Container maxWidth="lg" sx={{ py: 4 }} aria-busy={loading} aria-live="polite">
+      {loading ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '400px' }}>
+          <CircularProgress />
+        </Box>
+      ) : (
+        <>
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
         <Box>
           <Typography variant="h4">Approval Requests</Typography>
@@ -390,6 +388,8 @@ const ApprovalsPage: React.FC = () => {
           </Button>
         </DialogActions>
       </Dialog>
+        </>
+      )}
     </Container>
   );
 };

--- a/frontend/src/pages/admin/AuditLogPage.tsx
+++ b/frontend/src/pages/admin/AuditLogPage.tsx
@@ -192,7 +192,7 @@ const AuditLogPage: React.FC = () => {
   };
 
   return (
-    <Container maxWidth="lg" sx={{ py: 4 }}>
+    <Container maxWidth="lg" sx={{ py: 4 }} aria-busy={loading} aria-live="polite">
       {/* Header */}
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', mb: 3 }}>
         <Box>

--- a/frontend/src/pages/admin/DashboardPage.tsx
+++ b/frontend/src/pages/admin/DashboardPage.tsx
@@ -1,5 +1,7 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { queryKeys } from '../../services/queryKeys';
 import {
   Container,
   Typography,
@@ -368,64 +370,38 @@ const QuickLink: React.FC<QuickLinkProps> = ({ label, icon, route, color }) => {
 
 const DashboardPage: React.FC = () => {
   const { allowedScopes } = useAuth();
-  const [data, setData] = useState<DashboardData | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [refreshing, setRefreshing] = useState(false);
+  const queryClient = useQueryClient();
+
+  const { data: raw, isLoading: loading, isFetching: refreshing, error: queryError } = useQuery({
+    queryKey: queryKeys.dashboard.stats(),
+    queryFn: () => api.getDashboardStats(),
+  });
+
+  const error = queryError ? 'Failed to load dashboard statistics.' : null;
+
+  // Normalise: backend may not yet have mirror fields on older builds.
+  const data: DashboardData | null = raw ? {
+    modules: raw.modules ?? { total: 0, versions: 0, downloads: 0, by_system: [] },
+    providers: raw.providers ?? { total: 0, manual: 0, mirrored: 0, total_versions: 0, manual_versions: 0, mirrored_versions: 0, downloads: 0 },
+    users: raw.users ?? 0,
+    organizations: raw.organizations ?? 0,
+    downloads: raw.downloads ?? 0,
+    scm_providers: raw.scm_providers ?? 0,
+    binary_mirrors: raw.binary_mirrors ?? { total: 0, healthy: 0, failed: 0, syncing: 0, platforms: 0, downloads: 0, by_tool: [] },
+    provider_mirrors: raw.provider_mirrors ?? { total: 0, healthy: 0, failed: 0 },
+    recent_syncs: raw.recent_syncs ?? [],
+  } : null;
 
   const hasScope = (scope: string) =>
     allowedScopes.includes('admin') || allowedScopes.includes(scope);
 
-  const load = async (silent = false) => {
-    if (!silent) setLoading(true);
-    else setRefreshing(true);
-    setError(null);
-    try {
-      const raw = await api.getDashboardStats();
-      // Normalise: backend may not yet have mirror fields on older builds.
-      setData({
-        modules: raw.modules ?? { total: 0, versions: 0, downloads: 0, by_system: [] },
-        providers: raw.providers ?? { total: 0, manual: 0, mirrored: 0, total_versions: 0, manual_versions: 0, mirrored_versions: 0, downloads: 0 },
-        users: raw.users ?? 0,
-        organizations: raw.organizations ?? 0,
-        downloads: raw.downloads ?? 0,
-        scm_providers: raw.scm_providers ?? 0,
-        binary_mirrors: raw.binary_mirrors ?? { total: 0, healthy: 0, failed: 0, syncing: 0, platforms: 0, downloads: 0, by_tool: [] },
-        provider_mirrors: raw.provider_mirrors ?? { total: 0, healthy: 0, failed: 0 },
-        recent_syncs: raw.recent_syncs ?? [],
-      });
-    } catch {
-      setError('Failed to load dashboard statistics.');
-    } finally {
-      setLoading(false);
-      setRefreshing(false);
-    }
-  };
-
-  useEffect(() => { load(); }, []);
-
-  if (loading) {
-    return (
-      <Box sx={{ display: 'flex', justifyContent: 'center', py: 10 }}>
-        <CircularProgress />
-      </Box>
-    );
-  }
-
-  if (error || !data) {
-    return (
-      <Container maxWidth="lg" sx={{ py: 4 }}>
-        <Alert severity="error">{error ?? 'Failed to load dashboard'}</Alert>
-      </Container>
-    );
-  }
-
   // ---- Zone 1: health pills ------------------------------------------------
-  const anyMirrorIssue =
-    data.binary_mirrors.failed > 0 || data.provider_mirrors.failed > 0;
+  const anyMirrorIssue = data
+    ? data.binary_mirrors.failed > 0 || data.provider_mirrors.failed > 0
+    : false;
 
   // ---- Zone 2: stat cards --------------------------------------------------
-  const statCards: (StatCardProps & { scope: string | null; gridMd: number })[] = [
+  const statCards: (StatCardProps & { scope: string | null; gridMd: number })[] = !data ? [] : [
     // Row 1 — content cards (each md=6)
     {
       title: 'Modules', value: data.modules.total,
@@ -470,7 +446,7 @@ const DashboardPage: React.FC = () => {
   ].filter(c => c.scope === null || hasScope(c.scope));
 
   // ---- Zone 3 left: recent syncs -------------------------------------------
-  const recentSyncs = data.recent_syncs.slice(0, 8);
+  const recentSyncs = data ? data.recent_syncs.slice(0, 8) : [];
 
   // ---- Zone 3 right: quick links -------------------------------------------
   const quickLinks: (QuickLinkProps & { scope: string | null })[] = [
@@ -485,8 +461,15 @@ const DashboardPage: React.FC = () => {
   ].filter(l => l.scope === null || hasScope(l.scope));
 
   return (
-    <Container maxWidth="lg" sx={{ py: 4 }}>
-
+    <Container maxWidth="lg" sx={{ py: 4 }} aria-busy={loading} aria-live="polite">
+      {loading ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 10 }}>
+          <CircularProgress />
+        </Box>
+      ) : (error || !data) ? (
+        <Alert severity="error">{error ?? 'Failed to load dashboard'}</Alert>
+      ) : (
+      <>
       {/* Header */}
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
         <Box>
@@ -498,7 +481,7 @@ const DashboardPage: React.FC = () => {
         <Button
           variant="outlined"
           startIcon={<Refresh />}
-          onClick={() => load(true)}
+          onClick={() => queryClient.invalidateQueries({ queryKey: queryKeys.dashboard.stats() })}
           disabled={refreshing}
         >
           Refresh
@@ -634,6 +617,8 @@ const DashboardPage: React.FC = () => {
         </Grid>
 
       </Grid>
+      </>
+      )}
     </Container>
   );
 };

--- a/frontend/src/pages/admin/MirrorPoliciesPage.tsx
+++ b/frontend/src/pages/admin/MirrorPoliciesPage.tsx
@@ -195,16 +195,14 @@ const MirrorPoliciesPage: React.FC = () => {
     return <Chip label="Deny" size="small" color="error" icon={<BlockIcon />} />;
   };
 
-  if (loading) {
-    return (
-      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '400px' }}>
-        <CircularProgress />
-      </Box>
-    );
-  }
-
   return (
-    <Container maxWidth="lg" sx={{ py: 4 }}>
+    <Container maxWidth="lg" sx={{ py: 4 }} aria-busy={loading} aria-live="polite">
+      {loading ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '400px' }}>
+          <CircularProgress />
+        </Box>
+      ) : (
+        <>
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
         <Box>
           <Typography variant="h4">Mirror Policies</Typography>
@@ -321,13 +319,14 @@ const MirrorPoliciesPage: React.FC = () => {
 
               <CardActions>
                 <Tooltip title="Edit">
-                  <IconButton size="small" onClick={() => openEditDialog(policy)}>
+                  <IconButton size="small" aria-label="Edit policy" onClick={() => openEditDialog(policy)}>
                     <EditIcon />
                   </IconButton>
                 </Tooltip>
                 <Tooltip title="Delete">
                   <IconButton
                     size="small"
+                    aria-label="Delete policy"
                     color="error"
                     onClick={() => {
                       setPolicyToDelete(policy);
@@ -566,6 +565,8 @@ const MirrorPoliciesPage: React.FC = () => {
           </Button>
         </DialogActions>
       </Dialog>
+        </>
+      )}
     </Container>
   );
 };

--- a/frontend/src/pages/admin/MirrorsPage.tsx
+++ b/frontend/src/pages/admin/MirrorsPage.tsx
@@ -67,7 +67,7 @@ const VersionPlatformRow: React.FC<{ version: MirroredProviderVersion }> = ({ ve
     <>
       <TableRow sx={{ '& > *': { borderBottom: 'unset' } }}>
         <TableCell sx={{ pl: 1 }}>
-          <IconButton size="small" onClick={() => setOpen((p) => !p)} disabled={platforms.length === 0}>
+          <IconButton size="small" aria-label="Toggle platforms" onClick={() => setOpen((p) => !p)} disabled={platforms.length === 0}>
             {open ? <ExpandLessIcon fontSize="inherit" /> : <ExpandMoreIcon fontSize="inherit" />}
           </IconButton>
         </TableCell>
@@ -139,7 +139,7 @@ const ProviderRow: React.FC<{ provider: MirroredProvider }> = ({ provider }) => 
     <>
       <TableRow hover sx={{ '& > *': { borderBottom: 'unset' } }}>
         <TableCell>
-          <IconButton size="small" onClick={() => setOpen((p) => !p)} disabled={versions.length === 0}>
+          <IconButton size="small" aria-label="Toggle versions" onClick={() => setOpen((p) => !p)} disabled={versions.length === 0}>
             {open ? <ExpandLessIcon /> : <ExpandMoreIcon />}
           </IconButton>
         </TableCell>
@@ -408,16 +408,14 @@ const MirrorsPage: React.FC = () => {
     }
   };
 
-  if (loading) {
-    return (
-      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '400px' }}>
-        <CircularProgress />
-      </Box>
-    );
-  }
-
   return (
-    <Container maxWidth="lg" sx={{ py: 4 }}>
+    <Container maxWidth="lg" sx={{ py: 4 }} aria-busy={loading} aria-live="polite">
+      {loading ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '400px' }}>
+          <CircularProgress />
+        </Box>
+      ) : (
+        <>
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
         <Box>
           <Typography variant="h4">Mirroring — Provider Config</Typography>
@@ -555,7 +553,7 @@ const MirrorsPage: React.FC = () => {
                       </Button>
                     </Tooltip>
                     <Tooltip title="View sync history">
-                      <IconButton size="small" onClick={() => handleViewHistory(mirror)}>
+                      <IconButton size="small" aria-label="View sync history" onClick={() => handleViewHistory(mirror)}>
                         <HistoryIcon fontSize="small" />
                       </IconButton>
                     </Tooltip>
@@ -565,6 +563,7 @@ const MirrorsPage: React.FC = () => {
                       <span>
                         <IconButton
                           size="small"
+                          aria-label="Sync mirror"
                           color="primary"
                           onClick={() => handleTriggerSync(mirror)}
                           disabled={mirror.last_sync_status === 'in_progress'}
@@ -574,13 +573,14 @@ const MirrorsPage: React.FC = () => {
                       </span>
                     </Tooltip>
                     <Tooltip title="Edit">
-                      <IconButton size="small" onClick={() => openEditDialog(mirror)}>
+                      <IconButton size="small" aria-label="Edit mirror" onClick={() => openEditDialog(mirror)}>
                         <EditIcon fontSize="small" />
                       </IconButton>
                     </Tooltip>
                     <Tooltip title="Delete">
                       <IconButton
                         size="small"
+                        aria-label="Delete mirror"
                         color="error"
                         onClick={() => {
                           setMirrorToDelete(mirror);
@@ -878,6 +878,8 @@ const MirrorsPage: React.FC = () => {
           </Button>
         </DialogActions>
       </Dialog>
+        </>
+      )}
     </Container>
   );
 };

--- a/frontend/src/pages/admin/OIDCSettingsPage.tsx
+++ b/frontend/src/pages/admin/OIDCSettingsPage.tsx
@@ -160,18 +160,14 @@ const OIDCSettingsPage: React.FC = () => {
     setDeleteIndex(null);
   };
 
-  if (loading) {
-    return (
-      <Container maxWidth="lg">
+  return (
+    <Container maxWidth="lg" aria-busy={loading} aria-live="polite">
+      {loading ? (
         <Box sx={{ display: 'flex', justifyContent: 'center', mt: 8 }}>
           <CircularProgress />
         </Box>
-      </Container>
-    );
-  }
-
-  return (
-    <Container maxWidth="lg">
+      ) : (
+        <>
       {/* Header */}
       <Box sx={{ mb: 4 }}>
         <Stack direction="row" alignItems="center" spacing={2} sx={{ mb: 1 }}>
@@ -295,10 +291,10 @@ const OIDCSettingsPage: React.FC = () => {
                           <Chip label={m.role} size="small" color="primary" variant="outlined" />
                         </TableCell>
                         <TableCell align="right">
-                          <IconButton size="small" onClick={() => openEditDialog(i)}>
+                          <IconButton size="small" aria-label="Edit claim mapping" onClick={() => openEditDialog(i)}>
                             <EditIcon fontSize="small" />
                           </IconButton>
-                          <IconButton size="small" color="error" onClick={() => setDeleteIndex(i)}>
+                          <IconButton size="small" aria-label="Delete claim mapping" color="error" onClick={() => setDeleteIndex(i)}>
                             <DeleteIcon fontSize="small" />
                           </IconButton>
                         </TableCell>
@@ -418,6 +414,8 @@ const OIDCSettingsPage: React.FC = () => {
           </Button>
         </DialogActions>
       </Dialog>
+        </>
+      )}
     </Container>
   );
 };

--- a/frontend/src/pages/admin/OrganizationsPage.tsx
+++ b/frontend/src/pages/admin/OrganizationsPage.tsx
@@ -321,6 +321,7 @@ const OrganizationsPage: React.FC = () => {
                     <TableCell align="right">
                       <IconButton
                         size="small"
+                        aria-label="Edit organization"
                         onClick={() => handleOpenDialog(org)}
                         color="primary"
                       >
@@ -328,6 +329,7 @@ const OrganizationsPage: React.FC = () => {
                       </IconButton>
                       <IconButton
                         size="small"
+                        aria-label="Delete organization"
                         onClick={() => handleDeleteClick(org)}
                         color="error"
                       >
@@ -488,6 +490,7 @@ const OrganizationsPage: React.FC = () => {
                         <TableCell align="right">
                           <IconButton
                             size="small"
+                            aria-label="Remove member"
                             onClick={() => handleRemoveMember(member.user_id)}
                             color="error"
                             title="Remove member"

--- a/frontend/src/pages/admin/RolesPage.tsx
+++ b/frontend/src/pages/admin/RolesPage.tsx
@@ -73,18 +73,14 @@ const RolesPage: React.FC = () => {
     setExpandedRole(isExpanded ? roleId : false);
   };
 
-  if (loading) {
-    return (
-      <Container maxWidth="lg">
+  return (
+    <Container maxWidth="lg" aria-busy={loading} aria-live="polite">
+      {loading ? (
         <Box display="flex" justifyContent="center" alignItems="center" minHeight="400px">
           <CircularProgress />
         </Box>
-      </Container>
-    );
-  }
-
-  return (
-    <Container maxWidth="lg">
+      ) : (
+        <>
       <Box sx={{ mb: 4 }}>
         <Stack direction="row" alignItems="center" spacing={2} sx={{ mb: 2 }}>
           <ShieldIcon sx={{ fontSize: 32, color: 'primary.main' }} />
@@ -292,6 +288,8 @@ const RolesPage: React.FC = () => {
           </Box>
         )}
       </Paper>
+        </>
+      )}
     </Container>
   );
 };

--- a/frontend/src/pages/admin/SCMProvidersPage.tsx
+++ b/frontend/src/pages/admin/SCMProvidersPage.tsx
@@ -308,16 +308,14 @@ const SCMProvidersPage: React.FC = () => {
     }
   };
 
-  if (loading) {
-    return (
-      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '400px' }}>
-        <CircularProgress />
-      </Box>
-    );
-  }
-
   return (
-    <Container maxWidth="lg" sx={{ py: 4 }}>
+    <Container maxWidth="lg" sx={{ py: 4 }} aria-busy={loading} aria-live="polite">
+      {loading ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '400px' }}>
+          <CircularProgress />
+        </Box>
+      ) : (
+        <>
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
         <Box>
           <Typography variant="h4">SCM Providers</Typography>
@@ -419,6 +417,7 @@ const SCMProvidersPage: React.FC = () => {
                       <Tooltip title="Copy to clipboard">
                         <IconButton
                           size="small"
+                          aria-label="Copy callback URL"
                           onClick={() => copyToClipboard(getCallbackUrl(provider.id))}
                           sx={{ flexShrink: 0 }}
                         >
@@ -482,6 +481,7 @@ const SCMProvidersPage: React.FC = () => {
                 }>
                   <IconButton
                     size="small"
+                    aria-label="Connect SCM provider"
                     color="primary"
                     onClick={() => handleConnect(provider)}
                   >
@@ -492,6 +492,7 @@ const SCMProvidersPage: React.FC = () => {
                   <Tooltip title="Disconnect">
                     <IconButton
                       size="small"
+                      aria-label="Disconnect SCM provider"
                       color="warning"
                       onClick={async () => {
                         try {
@@ -509,6 +510,7 @@ const SCMProvidersPage: React.FC = () => {
                 <Tooltip title="Edit">
                   <IconButton
                     size="small"
+                    aria-label="Edit SCM provider"
                     onClick={() => openEditDialog(provider)}
                   >
                     <EditIcon />
@@ -517,6 +519,7 @@ const SCMProvidersPage: React.FC = () => {
                 <Tooltip title="Delete">
                   <IconButton
                     size="small"
+                    aria-label="Delete SCM provider"
                     color="error"
                     onClick={() => {
                       setProviderToDelete(provider);
@@ -745,6 +748,8 @@ const SCMProvidersPage: React.FC = () => {
           </Button>
         </DialogActions>
       </Dialog>
+        </>
+      )}
     </Container>
   );
 };

--- a/frontend/src/pages/admin/StoragePage.tsx
+++ b/frontend/src/pages/admin/StoragePage.tsx
@@ -710,18 +710,16 @@ const StoragePage: React.FC = () => {
     </Container>
   );
 
-  if (loading) {
-    return (
-      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '400px' }}>
-        <CircularProgress />
-      </Box>
-    );
-  }
-
   return (
-    <>
-      {setupStatus?.setup_required ? renderSetupWizard() : renderExistingConfigs()}
-    </>
+    <Box aria-busy={loading} aria-live="polite">
+      {loading ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '400px' }}>
+          <CircularProgress />
+        </Box>
+      ) : (
+        setupStatus?.setup_required ? renderSetupWizard() : renderExistingConfigs()
+      )}
+    </Box>
   );
 };
 

--- a/frontend/src/pages/admin/TerraformMirrorPage.tsx
+++ b/frontend/src/pages/admin/TerraformMirrorPage.tsx
@@ -114,7 +114,7 @@ const VersionRow: React.FC<{
     <>
       <TableRow hover sx={{ '& > *': { borderBottom: 'unset' } }}>
         <TableCell>
-          <IconButton size="small" onClick={handleExpand}>
+          <IconButton size="small" aria-label="Toggle version details" onClick={handleExpand}>
             {open ? <ExpandLessIcon /> : <ExpandMoreIcon />}
           </IconButton>
         </TableCell>
@@ -138,6 +138,7 @@ const VersionRow: React.FC<{
             <span>
               <IconButton
                 size="small"
+                aria-label="Delete version"
                 color="error"
                 onClick={() => onDelete(version)}
                 disabled={version.sync_status === 'syncing'}
@@ -287,7 +288,7 @@ const ConfigCard: React.FC<{
           </Button>
         </Tooltip>
         <Tooltip title="View sync history">
-          <IconButton size="small" onClick={() => onViewHistory(config)}>
+          <IconButton size="small" aria-label="View sync history" onClick={() => onViewHistory(config)}>
             <HistoryIcon fontSize="small" />
           </IconButton>
         </Tooltip>
@@ -295,18 +296,18 @@ const ConfigCard: React.FC<{
       <Box>
         <Tooltip title="Trigger sync">
           <span>
-            <IconButton size="small" onClick={() => onSync(config)} disabled={syncing || !config.enabled}>
+            <IconButton size="small" aria-label="Sync mirror" onClick={() => onSync(config)} disabled={syncing || !config.enabled}>
               <SyncIcon fontSize="small" />
             </IconButton>
           </span>
         </Tooltip>
         <Tooltip title="Edit configuration">
-          <IconButton size="small" onClick={() => onEdit(config)}>
+          <IconButton size="small" aria-label="Edit mirror" onClick={() => onEdit(config)}>
             <EditIcon fontSize="small" />
           </IconButton>
         </Tooltip>
         <Tooltip title="Delete mirror">
-          <IconButton size="small" color="error" onClick={() => onDelete(config)}>
+          <IconButton size="small" aria-label="Delete mirror" color="error" onClick={() => onDelete(config)}>
             <DeleteIcon fontSize="small" />
           </IconButton>
         </Tooltip>
@@ -590,16 +591,14 @@ const TerraformMirrorPage: React.FC = () => {
   // ---------------------------------------------------------------------------
   // Render
   // ---------------------------------------------------------------------------
-  if (loading) {
-    return (
-      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '400px' }}>
-        <CircularProgress />
-      </Box>
-    );
-  }
-
   return (
-    <Container maxWidth="lg" sx={{ py: 4 }}>
+    <Box aria-busy={loading} aria-live="polite">
+      {loading ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '400px' }}>
+          <CircularProgress />
+        </Box>
+      ) : (
+        <Container maxWidth="lg" sx={{ py: 4 }}>
       {/* Header */}
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
         <Box>
@@ -1089,6 +1088,8 @@ const TerraformMirrorPage: React.FC = () => {
         </DialogActions>
       </Dialog>
     </Container>
+      )}
+    </Box>
   );
 };
 

--- a/frontend/src/pages/admin/UsersPage.tsx
+++ b/frontend/src/pages/admin/UsersPage.tsx
@@ -440,6 +440,7 @@ const UsersPage: React.FC = () => {
                     <TableCell align="right">
                       <IconButton
                         size="small"
+                        aria-label="Edit user"
                         onClick={() => handleOpenDialog(user)}
                         color="primary"
                       >
@@ -447,6 +448,7 @@ const UsersPage: React.FC = () => {
                       </IconButton>
                       <IconButton
                         size="small"
+                        aria-label="Delete user"
                         onClick={() => handleDeleteClick(user)}
                         color="error"
                       >
@@ -543,6 +545,7 @@ const UsersPage: React.FC = () => {
                       </FormControl>
                       <IconButton
                         size="small"
+                        aria-label="Remove from organization"
                         onClick={() => handleRemoveMembership(m.organization_id)}
                         color="error"
                       >

--- a/frontend/src/services/errorReporting.ts
+++ b/frontend/src/services/errorReporting.ts
@@ -1,0 +1,37 @@
+let dsn: string | null = null;
+let currentUser: string | null = null;
+
+export function init(): void {
+  const configuredDsn = import.meta.env.VITE_ERROR_REPORTING_DSN;
+  if (configuredDsn) {
+    dsn = configuredDsn;
+    console.log('[ErrorReporting] Initialized with DSN endpoint');
+  } else {
+    console.log('[ErrorReporting] No DSN configured — errors will be logged to console only');
+  }
+}
+
+export function captureError(error: Error, context?: Record<string, unknown>): void {
+  console.error('[ErrorReporting]', error.message, context);
+
+  if (dsn) {
+    fetch(dsn, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        message: error.message,
+        stack: error.stack,
+        context,
+        timestamp: new Date().toISOString(),
+        url: window.location.href,
+        userAgent: navigator.userAgent,
+        ...(currentUser ? { userId: currentUser } : {}),
+      }),
+    }).catch(() => {});
+  }
+}
+
+export function setUser(userId: string): void {
+  currentUser = userId;
+  console.log(`[ErrorReporting] User context set: ${userId}`);
+}

--- a/frontend/src/services/queryKeys.ts
+++ b/frontend/src/services/queryKeys.ts
@@ -1,0 +1,16 @@
+export const queryKeys = {
+  modules: {
+    _def: ['modules'] as const,
+    search: (params: { query?: string; limit: number; offset: number; viewMode: string }) =>
+      [...queryKeys.modules._def, 'search', params] as const,
+  },
+  providers: {
+    _def: ['providers'] as const,
+    search: (params: { query?: string; limit: number; offset: number }) =>
+      [...queryKeys.providers._def, 'search', params] as const,
+  },
+  dashboard: {
+    _def: ['dashboard'] as const,
+    stats: () => [...queryKeys.dashboard._def, 'stats'] as const,
+  },
+} as const;

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -8,6 +8,7 @@ interface ImportMetaEnv {
   readonly MODE: string;
   readonly VITE_API_URL?: string;
   readonly VITE_USE_MOCK_DATA?: string;
+  readonly VITE_ERROR_REPORTING_DSN?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary
- Add skip-to-content keyboard navigation link for accessibility
- Add `aria-label` to all 45 icon-only buttons across 14 files for screen reader accessibility
- Add `aria-busy`/`aria-live` attributes to all page-level loading containers (23 files)
- Add TanStack Query data-fetching abstraction with proof-of-concept migration of ModulesPage, ProvidersPage, and DashboardPage
- Add error reporting service placeholder with Sentry-compatible interface, gated behind `VITE_ERROR_REPORTING_DSN`
- Document tag protection rule command in CLAUDE.md

Closes #99

## Test plan
- [x] `npm run lint` passes (zero warnings)
- [x] `npm run build` succeeds
- [x] `npm test` — all 18 unit tests pass
- [ ] Tab on page load reveals "Skip to main content" link
- [ ] Verify icon buttons announced correctly by screen reader
- [ ] TanStack Query devtools visible in dev mode
- [ ] ModulesPage, ProvidersPage, DashboardPage load data correctly with caching