### PR TITLE
fix: E2E test failures — seed data, rate limit config, and selector ambiguity

### DIFF
--- a/deployments/create-dev-admin-user.sql
+++ b/deployments/create-dev-admin-user.sql
@@ -28,6 +28,15 @@ BEGIN
     VALUES (v_org_id, v_user_id, v_admin_role_template_id)
     ON CONFLICT (organization_id, user_id) DO UPDATE SET role_template_id = EXCLUDED.role_template_id;
 
+    -- Mark setup as completed so the frontend does not show the Setup Wizard
+    -- and the E2E test for setup-redirect-when-complete passes.
+    UPDATE system_settings
+       SET setup_completed = true,
+           oidc_configured = true,
+           storage_configured = true,
+           updated_at = NOW()
+     WHERE id = 1;
+
     -- Dev login now uses JWT via POST /api/v1/dev/login (no hardcoded API key needed)
-    RAISE NOTICE 'Dev admin user and org membership with admin role assigned.';
+    RAISE NOTICE 'Dev admin user and org membership with admin role assigned (setup marked completed).';
 END $$;

--- a/deployments/docker-compose.test.yml
+++ b/deployments/docker-compose.test.yml
@@ -37,6 +37,9 @@ services:
       - TFR_JWT_SECRET=test-jwt-secret-for-e2e-only-not-for-production
       # ENCRYPTION_KEY required for SCM integration — fixed 32-byte value for test only
       - ENCRYPTION_KEY=00000000000000000000000000000000
+      # Disable rate limiting so the E2E suite (40+ tests each making API calls) does not
+      # trigger 429 responses mid-run.
+      - TFR_SECURITY_RATE_LIMITING_ENABLED=false
       # PUBLIC_URL tells the backend the browser-facing address for OAuth callbacks and
       # post-logout redirects.  Without this, deriveFrontendURL falls back to the internal
       # base_url (http://localhost:8080) so logout would redirect to the raw backend instead

--- a/e2e/tests/setup-wizard.spec.ts
+++ b/e2e/tests/setup-wizard.spec.ts
@@ -213,10 +213,10 @@ test.describe('Setup Wizard — OIDC & Storage steps (mocked API)', () => {
     ).toBeVisible({ timeout: 10_000 });
 
     // Backend type chips should be present
-    await expect(page.getByText('Local')).toBeVisible();
-    await expect(page.getByText('Azure Blob')).toBeVisible();
-    await expect(page.getByText('AWS S3')).toBeVisible();
-    await expect(page.getByText('Google Cloud')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Local' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Azure Blob' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'AWS S3' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Google Cloud' })).toBeVisible();
   });
 });
 


### PR DESCRIPTION
Closes #105

Fixes three E2E test failures that surfaced in the v0.4.1 release gated check:

1. **setup-wizard redirect test** (`setup-wizard.spec.ts:18`): The seed SQL now marks `system_settings.setup_completed = true` so the frontend redirects away from `/setup` as expected.

2. **auth logout test** (`auth.spec.ts:67`): The docker-compose env var was corrected from `TFR_SERVER_RATE_LIMITING_ENABLED` to `TFR_SECURITY_RATE_LIMITING_ENABLED` (matching the backend's Viper key path `security.rate_limiting.enabled`). This requires sethbacon/terraform-registry-backend#151 which makes the backend actually respect this config flag.

3. **setup-wizard storage chips test** (`setup-wizard.spec.ts:177`): Changed `getByText('Local')` to `getByRole('button', { name: 'Local' })` since MUI Chips render as buttons — the old selector matched both the chip and a description containing "local".

## Changelog
- fix: seed `system_settings.setup_completed = true` in E2E test stack so setup-redirect test passes
- fix: use correct env var `TFR_SECURITY_RATE_LIMITING_ENABLED` to disable rate limiting in test stack
- fix: use `getByRole('button')` for MUI Chip selectors in setup-wizard E2E spec