### PR TITLE
fix: exchange HttpOnly cookie for JWT on SSO callback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,22 @@ When a release is called for:
    > Tagging on `development` before the merge leaves the tag pointing at the wrong commit —
    > it will never appear in `main`'s history as a tagged release.
 
+7. **Update deployment configs in the backend repo** to reference the new frontend version.
+   The backend repository (`terraform-registry-backend`) hosts all Kubernetes, Helm, and
+   cloud deployment configs that include frontend image tags. After a frontend release,
+   update these files in the backend repo:
+
+   **Helm chart** (in `deployments/helm/`):
+   - `values.yaml` — update `frontend.image.tag`
+   - `values-aks.yaml`, `values-eks.yaml`, `values-gke.yaml` — update `frontend.image.tag`
+
+   **Kustomize overlays** (in `deployments/kubernetes/overlays/`):
+   - `eks/kustomization.yaml` — update frontend `newTag`
+   - `gke/kustomization.yaml` — update frontend `newTag`
+
+   > The frontend repo's own `deployments/` directory uses Docker Compose with
+   > `${REGISTRY_TAG:-latest}` — no hardcoded tags to update here.
+
 ---
 
 ## Project Overview

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "terraform-registry-frontend",
-  "version": "0.3.8",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "terraform-registry-frontend",
-      "version": "0.3.8",
+      "version": "0.4.2",
       "dependencies": {
         "@emotion/react": "^11.11.3",
         "@emotion/styled": "^11.11.0",

--- a/frontend/src/pages/CallbackPage.tsx
+++ b/frontend/src/pages/CallbackPage.tsx
@@ -9,6 +9,8 @@ import {
 } from '@mui/material';
 import { useAuth } from '../contexts/AuthContext';
 
+const API_BASE_URL = import.meta.env.DEV ? '' : (import.meta.env.VITE_API_URL || '');
+
 const CallbackPage: React.FC = () => {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
@@ -16,8 +18,7 @@ const CallbackPage: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    const handleCallback = () => {
-      const token = searchParams.get('token');
+    const handleCallback = async () => {
       const errorParam = searchParams.get('error');
       const errorDescription = searchParams.get('error_description');
 
@@ -25,6 +26,27 @@ const CallbackPage: React.FC = () => {
         setError(errorDescription || errorParam);
         setTimeout(() => navigate('/login'), 3000);
         return;
+      }
+
+      // Check URL param first (backward compat / dev mode)
+      let token = searchParams.get('token');
+
+      // If no URL param, exchange the HttpOnly cookie for a token.
+      // The backend sets a tfr_auth_token cookie during the OIDC callback redirect;
+      // this endpoint reads it, validates the JWT, returns it in the response body,
+      // and clears the cookie.
+      if (!token) {
+        try {
+          const response = await fetch(`${API_BASE_URL}/api/v1/auth/exchange-token`, {
+            credentials: 'include',
+          });
+          if (response.ok) {
+            const data = await response.json();
+            token = data.token;
+          }
+        } catch {
+          // fall through to error below
+        }
       }
 
       if (!token) {


### PR DESCRIPTION
## Summary
- Update `CallbackPage.tsx` to call `GET /api/v1/auth/exchange-token` with `credentials: 'include'` when no `?token=` query param is present (the SSO flow)
- Retains backward compatibility: `?token=` param still works for dev mode
- Sync `package-lock.json` version to match `package.json` (0.4.2)
- Document in CLAUDE.md that frontend releases require updating backend deployment configs

## Changelog
- fix: exchange HttpOnly cookie for JWT on SSO callback page instead of expecting token in URL
- chore: sync package-lock.json version and document release steps

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run build` — compiles clean
- [ ] Deploy to AKS (after backend), test SSO login end-to-end
- [ ] Verify token is not visible in URL bar after SSO login
- [ ] Verify localStorage contains `auth_token` after successful login