### PR TITLE
fix: auto-tag regex captures pre-release suffixes

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -29,7 +29,7 @@ jobs:
         id: version
         run: |
           TITLE="${{ github.event.pull_request.title }}"
-          VERSION=$(echo "$TITLE" | grep -oP 'v\d+\.\d+\.\d+')
+          VERSION=$(echo "$TITLE" | grep -oP 'v\d+\.\d+\.\d+(-[a-zA-Z0-9.]+)?')
           if [ -z "$VERSION" ]; then
             echo "::error::Could not extract semver from PR title: $TITLE"
             exit 1


### PR DESCRIPTION
The `auto-tag.yml` regex `v\d+\.\d+\.\d+` stripped pre-release suffixes (e.g. `-rc.1`) from
release PR titles, causing the created tag to mismatch `package.json` and failing the release
workflow's version guard.

Updated to `v\d+\.\d+\.\d+(-[a-zA-Z0-9.]+)?` to capture optional pre-release identifiers.

## Changelog
- fix: auto-tag regex now captures pre-release version suffixes (e.g. `v0.5.0-rc.1`)