### PR TITLE
fix: correct cosign-installer commit SHA in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,7 +127,7 @@ jobs:
           push-to-registry: true
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@3454372be428fad9c35427ed1bb7bafb18260451 # v3.8.2
+        uses: sigstore/cosign-installer@3454372f43399081ed03b604cb2d021dabca52bb # v3.8.2
 
       - name: Sign image with cosign (keyless)
         run: cosign sign --yes "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}"


### PR DESCRIPTION
The pinned SHA `3454372be428fad9c35427ed1bb7bafb18260451` for `sigstore/cosign-installer@v3.8.2`
was a typo — the correct commit is `3454372f43399081ed03b604cb2d021dabca52bb`. This caused the
Docker job in `release.yml` to fail at "Set up job" with "unable to find version".

## Changelog
- fix: correct cosign-installer commit SHA in release workflow