### PR TITLE
perf: run E2E suite with 4 workers, amortise login to once per worker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
 
       - name: Run Playwright tests
         working-directory: e2e
-        run: npx playwright test --workers=1 --max-failures=1 --retries=1 --reporter=list
+        run: npx playwright test --max-failures=1 --retries=1 --reporter=list
 
       - name: Upload Playwright artifacts
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ frontend/.env.local
 e2e/node_modules/
 e2e/playwright-report/
 e2e/test-results/
+e2e/.auth/

--- a/e2e/fixtures/auth.ts
+++ b/e2e/fixtures/auth.ts
@@ -1,10 +1,12 @@
 import { test as base, expect, type Page } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+
+const AUTH_DIR = path.join(__dirname, '../.auth');
 
 /**
  * Logs in via the "Dev Login (Admin)" button on the login page.
  * This requires the backend to be running with DEV_MODE=true.
- *
- * Returns the authenticated Page object for use in tests.
  */
 async function devLogin(page: Page): Promise<void> {
   await page.goto('/login');
@@ -24,12 +26,60 @@ async function devLogin(page: Page): Promise<void> {
   });
 }
 
+type WorkerFixtures = {
+  workerStorageState: string;
+};
+
 /**
- * Custom fixture that provides a page already authenticated as admin.
+ * Custom test with two auth-related fixtures:
+ *
+ * workerStorageState (worker-scoped):
+ *   Runs once per Playwright worker. Launches a temporary browser context,
+ *   performs the dev-login round-trip, and saves the resulting cookies /
+ *   localStorage to a per-worker JSON file in e2e/.auth/.  This means login
+ *   happens at most `workers` times per run, not once per test.
+ *
+ * storageState (built-in override):
+ *   Feeds the saved auth file into Playwright's built-in context factory so
+ *   every `page` fixture created by this extended `test` object already carries
+ *   the authenticated session. trace / video / screenshot continue to work
+ *   because the standard `page` fixture is still used.
+ *
+ * loggedInPage:
+ *   A transparent alias for `page`. Tests that previously called devLogin() on
+ *   every case now get a pre-authenticated page for free.
+ *
+ * Tests that intentionally use an unauthenticated context (e.g. auth.spec.ts)
+ * import from '@playwright/test' directly, bypassing this fixture entirely.
  */
-export const test = base.extend<{ loggedInPage: Page }>({
+export const test = base.extend<{ loggedInPage: Page }, WorkerFixtures>({
+  workerStorageState: [
+    async ({ browser }, use) => {
+      fs.mkdirSync(AUTH_DIR, { recursive: true });
+      const storageFile = path.join(
+        AUTH_DIR,
+        `worker-${test.info().parallelIndex}.json`,
+      );
+
+      const context = await browser.newContext({
+        baseURL: process.env.BASE_URL ?? 'https://localhost:3000',
+        ignoreHTTPSErrors: true,
+      });
+      const page = await context.newPage();
+      await devLogin(page);
+      await context.storageState({ path: storageFile });
+      await context.close();
+
+      await use(storageFile);
+    },
+    { scope: 'worker' },
+  ],
+
+  // Override the built-in storageState fixture so Playwright's context factory
+  // initialises every page with the worker's authenticated session.
+  storageState: ({ workerStorageState }, use) => use(workerStorageState),
+
   loggedInPage: async ({ page }, use) => {
-    await devLogin(page);
     await use(page);
   },
 });

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -32,8 +32,7 @@ export default defineConfig({
   /* Stop after the first failure so CI feedback is fast */
   maxFailures: 1,
 
-  /* One worker on CI to avoid port conflicts */
-  workers: process.env.CI ? 1 : undefined,
+  workers: process.env.CI ? 4 : undefined,
 
   reporter: [['html'], ['list']],
 


### PR DESCRIPTION
Commits the e2e parallelism changes that were authored during the v0.5.2 release session but were never pushed to a branch before the release workflow ran.

## Changelog
- perf: run Playwright E2E suite with 4 parallel workers on CI (up from 1) — GH runners handle I/O-bound Playwright workers well within the 2-vCPU budget
- perf: amortise dev-login cost to once per worker via worker-scoped `storageState` override — reduces ~75 serial login round-trips to at most 4 per run