### PR TITLE
feat: module detail UX improvements, security scanning page, and API docs sorting

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -37,6 +37,7 @@ const ApprovalsPage = lazy(() => import('./pages/admin/ApprovalsPage'));
 const MirrorPoliciesPage = lazy(() => import('./pages/admin/MirrorPoliciesPage'));
 const OIDCSettingsPage = lazy(() => import('./pages/admin/OIDCSettingsPage'));
 const AuditLogPage = lazy(() => import('./pages/admin/AuditLogPage'));
+const SecurityScanningPage = lazy(() => import('./pages/admin/SecurityScanningPage'));
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -101,6 +102,7 @@ function App() {
                   <Route path="/admin/policies" element={<ProtectedRoute requiredScope="admin"><ErrorBoundary><Suspense fallback={loader}><MirrorPoliciesPage /></Suspense></ErrorBoundary></ProtectedRoute>} />
                   <Route path="/admin/oidc" element={<ProtectedRoute requiredScope="admin"><ErrorBoundary><Suspense fallback={loader}><OIDCSettingsPage /></Suspense></ErrorBoundary></ProtectedRoute>} />
                   <Route path="/admin/audit-logs" element={<ProtectedRoute requiredScope="audit:read"><ErrorBoundary><Suspense fallback={loader}><AuditLogPage /></Suspense></ErrorBoundary></ProtectedRoute>} />
+                  <Route path="/admin/security-scanning" element={<ProtectedRoute requiredScope="admin"><ErrorBoundary><Suspense fallback={loader}><SecurityScanningPage /></Suspense></ErrorBoundary></ProtectedRoute>} />
 
                   {/* Catch all */}
                   <Route path="*" element={<Navigate to="/" replace />} />

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -37,6 +37,7 @@ import Brightness7 from '@mui/icons-material/Brightness7';
 import HelpOutline from '@mui/icons-material/HelpOutline';
 import InfoOutlined from '@mui/icons-material/InfoOutlined';
 import Shield from '@mui/icons-material/Shield';
+import Security from '@mui/icons-material/Security';
 import Storage from '@mui/icons-material/Storage';
 import HourglassEmpty from '@mui/icons-material/HourglassEmpty';
 import Policy from '@mui/icons-material/Policy';
@@ -135,6 +136,7 @@ const Layout = () => {
       label: 'System',
       items: [
         { text: 'Storage', icon: <Storage />, path: '/admin/storage', tooltip: 'Configure backend storage for binaries and providers', scope: 'admin' },
+        { text: 'Security Scanning', icon: <Security />, path: '/admin/security-scanning', tooltip: 'View security scanning configuration and status', scope: 'admin' },
         { text: 'Audit Logs', icon: <History />, path: '/admin/audit-logs', tooltip: 'View system audit logs', scope: 'audit:read' },
       ],
     },

--- a/frontend/src/components/ModuleDocumentation.tsx
+++ b/frontend/src/components/ModuleDocumentation.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import {
   Box,
-  Paper,
   Typography,
-  Divider,
   Chip,
   Table,
   TableHead,
@@ -20,7 +18,15 @@ interface ModuleDocumentationProps {
 }
 
 const ModuleDocumentation: React.FC<ModuleDocumentationProps> = ({ moduleDocs, docsLoading }) => {
-  if (docsLoading || !moduleDocs) return null;
+  if (docsLoading) return null;
+
+  if (!moduleDocs) {
+    return (
+      <Typography variant="body2" color="text.secondary">
+        No inputs, outputs, or provider requirements detected for this module version.
+      </Typography>
+    );
+  }
 
   const inputs = moduleDocs.inputs ?? [];
   const outputs = moduleDocs.outputs ?? [];
@@ -32,13 +38,15 @@ const ModuleDocumentation: React.FC<ModuleDocumentationProps> = ({ moduleDocs, d
     providers.length === 0 &&
     !moduleDocs.requirements?.required_version
   ) {
-    return null;
+    return (
+      <Typography variant="body2" color="text.secondary">
+        No inputs, outputs, or provider requirements detected for this module version.
+      </Typography>
+    );
   }
 
   return (
-    <Paper sx={{ p: 3, mt: 3 }}>
-      <Typography variant="h6" gutterBottom>Module Documentation</Typography>
-      <Divider sx={{ mb: 2 }} />
+    <Box>
 
       {moduleDocs.requirements?.required_version && (
         <Box mb={2}>
@@ -144,7 +152,7 @@ const ModuleDocumentation: React.FC<ModuleDocumentationProps> = ({ moduleDocs, d
           </TableContainer>
         </Box>
       )}
-    </Paper>
+    </Box>
   );
 };
 

--- a/frontend/src/hooks/useModuleDetail.ts
+++ b/frontend/src/hooks/useModuleDetail.ts
@@ -327,6 +327,16 @@ export function useModuleDetail() {
     }
   };
 
+  const handleUpdateDescription = async (newDescription: string) => {
+    if (!module?.id) return;
+    try {
+      await api.updateModule(module.id, { description: newDescription });
+      setModule(prev => prev ? { ...prev, description: newDescription } : prev);
+    } catch (err: unknown) {
+      setError(getErrorMessage(err, 'Failed to update description'));
+    }
+  };
+
   const getTerraformExample = () => {
     if (!module || !selectedVersion) return '';
 
@@ -402,6 +412,7 @@ export function useModuleDetail() {
     openDeleteVersionDialog,
     handleDeprecateVersion,
     handleUndeprecateVersion,
+    handleUpdateDescription,
     getTerraformExample,
   };
 }

--- a/frontend/src/pages/ApiDocumentation.tsx
+++ b/frontend/src/pages/ApiDocumentation.tsx
@@ -432,10 +432,10 @@ const ApiDocumentation: React.FC = () => {
             docExpansion="list"
             deepLinking
             tryItOutEnabled
-            tagsSorter="alpha"
             requestInterceptor={requestInterceptor}
             persistAuthorization
             onComplete={onComplete}
+            {...{ tagsSorter: 'alpha' } as Record<string, unknown>}
           />
         </Box>
       </Box>

--- a/frontend/src/pages/ApiDocumentation.tsx
+++ b/frontend/src/pages/ApiDocumentation.tsx
@@ -247,6 +247,7 @@ function buildNavTags(spec: OpenAPISpec): NavTag[] {
       }
     }
   }
+  tags.sort((a, b) => a.label.localeCompare(b.label));
   return tags;
 }
 
@@ -431,6 +432,7 @@ const ApiDocumentation: React.FC = () => {
             docExpansion="list"
             deepLinking
             tryItOutEnabled
+            tagsSorter="alpha"
             requestInterceptor={requestInterceptor}
             persistAuthorization
             onComplete={onComplete}

--- a/frontend/src/pages/ModuleDetailPage.tsx
+++ b/frontend/src/pages/ModuleDetailPage.tsx
@@ -25,12 +25,17 @@ import {
   DialogContentText,
   DialogActions,
   TextField,
+  Tabs,
+  Tab,
 } from '@mui/material';
 import ArrowBack from '@mui/icons-material/ArrowBack';
 import ContentCopy from '@mui/icons-material/ContentCopy';
 import Add from '@mui/icons-material/Add';
 import Delete from '@mui/icons-material/Delete';
 import Warning from '@mui/icons-material/Warning';
+import EditIcon from '@mui/icons-material/Edit';
+import Check from '@mui/icons-material/Check';
+import Close from '@mui/icons-material/Close';
 import PublishFromSCMWizard from '../components/PublishFromSCMWizard';
 import ModuleDocumentation from '../components/ModuleDocumentation';
 import SecurityScanPanel from '../components/SecurityScanPanel';
@@ -41,6 +46,9 @@ import { useModuleDetail } from '../hooks/useModuleDetail';
 
 const ModuleDetailPage: React.FC = () => {
   const navigate = useNavigate();
+  const [editingDescription, setEditingDescription] = React.useState(false);
+  const [editDescription, setEditDescription] = React.useState('');
+  const [docTab, setDocTab] = React.useState(0);
   const {
     namespace,
     name,
@@ -93,6 +101,7 @@ const ModuleDetailPage: React.FC = () => {
     openDeleteVersionDialog,
     handleDeprecateVersion,
     handleUndeprecateVersion,
+    handleUpdateDescription,
     getTerraformExample,
   } = useModuleDetail();
 
@@ -115,327 +124,395 @@ const ModuleDetailPage: React.FC = () => {
         </Container>
       ) : (
         <Container maxWidth="lg" sx={{ py: 4 }}>
-      {/* Breadcrumbs */}
-      <Breadcrumbs sx={{ mb: 3 }}>
-        <Link
-          component="button"
-          variant="body1"
-          onClick={() => navigate('/modules')}
-          sx={{ cursor: 'pointer' }}
-        >
-          Modules
-        </Link>
-        <Typography color="text.primary">{namespace}</Typography>
-        <Typography color="text.primary">{name}</Typography>
-        <Typography color="text.primary">{system}</Typography>
-        {selectedVersion && (
-          <Typography color="text.primary">v{selectedVersion.version}</Typography>
-        )}
-      </Breadcrumbs>
+          {/* Breadcrumbs */}
+          <Breadcrumbs sx={{ mb: 3 }}>
+            <Link
+              component="button"
+              variant="body1"
+              onClick={() => navigate('/modules')}
+              sx={{ cursor: 'pointer' }}
+            >
+              Modules
+            </Link>
+            <Typography color="text.primary">{namespace}</Typography>
+            <Typography color="text.primary">{name}</Typography>
+            <Typography color="text.primary">{system}</Typography>
+            {selectedVersion && (
+              <Typography color="text.primary">v{selectedVersion.version}</Typography>
+            )}
+          </Breadcrumbs>
 
-      {/* Header */}
-      <Box sx={{ mb: 4 }}>
-        <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 2 }}>
-          <Stack direction="row" alignItems="center" spacing={2}>
-            <IconButton aria-label="Back to modules" onClick={() => navigate('/modules')}>
-              <ArrowBack />
-            </IconButton>
-            <Typography variant="h4" component="h1">
-              {name}
-            </Typography>
-          </Stack>
-          {canManage && (
-            <Button
-              variant="contained"
-              startIcon={<Add />}
-              onClick={handlePublishNewVersion}
-            >
-              Publish New Version
-            </Button>
-          )}
-        </Stack>
-        <Typography variant="body1" color="text.secondary" gutterBottom>
-          {module.description || 'No description available'}
-        </Typography>
-        <Stack direction="row" spacing={1} alignItems="center" sx={{ mt: 2 }} flexWrap="wrap">
-          <Chip label={`${namespace}/${system}`} />
-          <FormControl size="small" sx={{ minWidth: 220 }}>
-            <Select
-              value={selectedVersion?.version || ''}
-              onChange={(e) => {
-                const version = versions.find(v => v.version === e.target.value);
-                if (version) setSelectedVersion(version);
-              }}
-              displayEmpty
-            >
-              {versions.map((v) => (
-                <MenuItem
-                  key={v.id}
-                  value={v.version}
-                  sx={{ color: v.deprecated ? 'text.disabled' : 'inherit' }}
-                >
-                  v{v.version}
-                  {versions.find(ver => !ver.deprecated)?.id === v.id ? ' (latest)' : ''}
-                  {v.deprecated ? ' [DEPRECATED]' : ''}
-                </MenuItem>
-              ))}
-            </Select>
-          </FormControl>
-          {selectedVersion?.deprecated && (
-            <Chip
-              label="Deprecated"
-              color="warning"
-              size="small"
-              icon={<Warning />}
-            />
-          )}
-          <Chip label={`${module.download_count ?? 0} downloads`} />
-          {canManage && (
-            <Button
-              variant="outlined"
-              color="error"
-              size="small"
-              startIcon={<Delete />}
-              onClick={() => setDeleteModuleDialogOpen(true)}
-            >
-              Delete Module
-            </Button>
-          )}
-        </Stack>
-      </Box>
-
-      <Box sx={{ display: 'flex', gap: 3, flexDirection: { xs: 'column', md: 'row' } }}>
-        {/* Main Content */}
-        <Box sx={{ flex: 1 }}>
-          {/* Usage Example */}
-          <Paper sx={{ p: 3, mb: 3 }}>
-            <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 2 }}>
-              <Typography variant="h6">Usage Example</Typography>
-              <Tooltip title={copiedSource ? 'Copied!' : 'Copy source'}>
-                <IconButton aria-label="Copy source URL" onClick={handleCopySource} size="small">
-                  <ContentCopy />
+          {/* Header */}
+          <Box sx={{ mb: 4 }}>
+            <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 2 }}>
+              <Stack direction="row" alignItems="center" spacing={2}>
+                <IconButton aria-label="Back to modules" onClick={() => navigate('/modules')}>
+                  <ArrowBack />
                 </IconButton>
-              </Tooltip>
-            </Stack>
-            <Box
-              component="pre"
-              sx={{
-                p: 2,
-                backgroundColor: (theme) => theme.palette.mode === 'dark' ? '#2d2d2d' : '#f5f5f5',
-                color: (theme) => theme.palette.mode === 'dark' ? '#e6e6e6' : '#1e1e1e',
-                borderRadius: 1,
-                overflow: 'auto',
-                fontSize: '0.875rem',
-              }}
-            >
-              <code>{getTerraformExample()}</code>
-            </Box>
-          </Paper>
-
-          {/* README */}
-          {selectedVersion && selectedVersion.readme && (
-            <Paper sx={{ p: 3 }}>
-              <Typography variant="h6" gutterBottom>
-                README
-              </Typography>
-              <Divider sx={{ mb: 2 }} />
-              <MarkdownRenderer>{selectedVersion.readme}</MarkdownRenderer>
-            </Paper>
-          )}
-
-          {/* Module Documentation */}
-          <ModuleDocumentation moduleDocs={moduleDocs} docsLoading={docsLoading} />
-        </Box>
-
-        {/* Sidebar - Module Information and Version Details */}
-        <Box sx={{ width: { xs: '100%', md: 350 } }}>
-          {/* Module Information */}
-          <Paper sx={{ p: 3, mb: 3 }}>
-            <Typography variant="h6" gutterBottom>
-              Module Information
-            </Typography>
-            <Divider sx={{ mb: 2 }} />
-            <Box sx={{ '& > *': { mb: 1 } }}>
-              <Typography variant="body2">
-                <strong>Namespace:</strong> {namespace}
-              </Typography>
-              <Typography variant="body2">
-                <strong>Name:</strong> {name}
-              </Typography>
-              <Typography variant="body2">
-                <strong>Provider:</strong> {system}
-              </Typography>
-              <Typography variant="body2">
-                <strong>Latest Version:</strong> {versions.length > 0 ? (versions.find(v => !v.deprecated) ?? versions[0]).version : 'N/A'}
-              </Typography>
-              <Typography variant="body2">
-                <strong>Total Downloads:</strong> {module.download_count ?? 0}
-              </Typography>
-              <Typography variant="body2">
-                <strong>Organization:</strong> {module.organization_name || namespace}
-              </Typography>
-              {module.created_by_name && (
-                <Typography variant="body2">
-                  <strong>Created By:</strong> {module.created_by_name}
+                <Typography variant="h4" component="h1">
+                  {name}
                 </Typography>
+              </Stack>
+              {canManage && (
+                <Button
+                  variant="contained"
+                  startIcon={<Add />}
+                  onClick={handlePublishNewVersion}
+                >
+                  Publish New Version
+                </Button>
               )}
+            </Stack>
+            <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 0 }}>
+              {editingDescription ? (
+                <>
+                  <TextField
+                    size="small"
+                    fullWidth
+                    value={editDescription}
+                    onChange={(e) => setEditDescription(e.target.value)}
+                    placeholder="Module description"
+                    autoFocus
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') {
+                        handleUpdateDescription(editDescription);
+                        setEditingDescription(false);
+                      } else if (e.key === 'Escape') {
+                        setEditingDescription(false);
+                      }
+                    }}
+                  />
+                  <IconButton
+                    size="small"
+                    color="primary"
+                    onClick={() => {
+                      handleUpdateDescription(editDescription);
+                      setEditingDescription(false);
+                    }}
+                    aria-label="Save description"
+                  >
+                    <Check fontSize="small" />
+                  </IconButton>
+                  <IconButton
+                    size="small"
+                    onClick={() => setEditingDescription(false)}
+                    aria-label="Cancel editing"
+                  >
+                    <Close fontSize="small" />
+                  </IconButton>
+                </>
+              ) : (
+                <>
+                  <Typography variant="body1" color="text.secondary">
+                    {module.description || 'No description available'}
+                  </Typography>
+                  {canManage && (
+                    <Tooltip title="Edit description">
+                      <IconButton
+                        size="small"
+                        onClick={() => {
+                          setEditDescription(module.description || '');
+                          setEditingDescription(true);
+                        }}
+                        aria-label="Edit description"
+                      >
+                        <EditIcon fontSize="small" />
+                      </IconButton>
+                    </Tooltip>
+                  )}
+                </>
+              )}
+            </Stack>
+            <Stack direction="row" spacing={1} alignItems="center" sx={{ mt: 2 }} flexWrap="wrap">
+              <Chip label={`${namespace}/${system}`} />
+              <FormControl size="small" sx={{ minWidth: 220 }}>
+                <Select
+                  value={selectedVersion?.version || ''}
+                  onChange={(e) => {
+                    const version = versions.find(v => v.version === e.target.value);
+                    if (version) setSelectedVersion(version);
+                  }}
+                  displayEmpty
+                >
+                  {versions.map((v) => (
+                    <MenuItem
+                      key={v.id}
+                      value={v.version}
+                      sx={{ color: v.deprecated ? 'text.disabled' : 'inherit' }}
+                    >
+                      v{v.version}
+                      {versions.find(ver => !ver.deprecated)?.id === v.id ? ' (latest)' : ''}
+                      {v.deprecated ? ' [DEPRECATED]' : ''}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+              {selectedVersion?.deprecated && (
+                <Chip
+                  label="Deprecated"
+                  color="warning"
+                  size="small"
+                  icon={<Warning />}
+                />
+              )}
+              <Chip label={`${module.download_count ?? 0} downloads`} />
+              {canManage && (
+                <Button
+                  variant="outlined"
+                  color="error"
+                  size="small"
+                  startIcon={<Delete />}
+                  onClick={() => setDeleteModuleDialogOpen(true)}
+                >
+                  Delete Module
+                </Button>
+              )}
+            </Stack>
+          </Box>
+
+          <Box sx={{ display: 'flex', gap: 3, flexDirection: { xs: 'column', md: 'row' } }}>
+            {/* Main Content */}
+            <Box sx={{ flex: 1 }}>
+              {/* Usage Example */}
+              <Paper sx={{ p: 3, mb: 3 }}>
+                <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 2 }}>
+                  <Typography variant="h6">Usage Example</Typography>
+                  <Tooltip title={copiedSource ? 'Copied!' : 'Copy source'}>
+                    <IconButton aria-label="Copy source URL" onClick={handleCopySource} size="small">
+                      <ContentCopy />
+                    </IconButton>
+                  </Tooltip>
+                </Stack>
+                <Box
+                  component="pre"
+                  sx={{
+                    p: 2,
+                    backgroundColor: (theme) => theme.palette.mode === 'dark' ? '#2d2d2d' : '#f5f5f5',
+                    color: (theme) => theme.palette.mode === 'dark' ? '#e6e6e6' : '#1e1e1e',
+                    borderRadius: 1,
+                    overflow: 'auto',
+                    fontSize: '0.875rem',
+                  }}
+                >
+                  <code>{getTerraformExample()}</code>
+                </Box>
+              </Paper>
+
+              {/* Documentation Tabs */}
+              <Paper sx={{ p: 3 }}>
+                <Tabs
+                  value={docTab}
+                  onChange={(_, newValue) => setDocTab(newValue)}
+                  sx={{ mb: 2 }}
+                >
+                  <Tab label="README" />
+                  <Tab label="Inputs / Outputs" />
+                </Tabs>
+                <Divider sx={{ mb: 2 }} />
+                {docTab === 0 && (
+                  selectedVersion && selectedVersion.readme ? (
+                    <MarkdownRenderer>{selectedVersion.readme}</MarkdownRenderer>
+                  ) : (
+                    <Typography variant="body2" color="text.secondary">
+                      No README provided for this module version.
+                    </Typography>
+                  )
+                )}
+                {docTab === 1 && (
+                  <ModuleDocumentation moduleDocs={moduleDocs} docsLoading={docsLoading} />
+                )}
+              </Paper>
             </Box>
-          </Paper>
 
-          <SCMRepositoryPanel
-            isAuthenticated={isAuthenticated}
-            scmLinkLoaded={scmLinkLoaded}
-            scmLink={scmLink}
-            scmSyncing={scmSyncing}
-            scmUnlinking={scmUnlinking}
-            onSync={handleSCMSync}
-            onUnlink={handleSCMUnlink}
-            onOpenWizard={() => setScmWizardOpen(true)}
-          />
+            {/* Sidebar - Module Information and Version Details */}
+            <Box sx={{ width: { xs: '100%', md: 350 } }}>
+              {/* Module Information */}
+              <Paper sx={{ p: 3, mb: 3 }}>
+                <Typography variant="h6" gutterBottom>
+                  Module Information
+                </Typography>
+                <Divider sx={{ mb: 2 }} />
+                <Box sx={{ '& > *': { mb: 1 } }}>
+                  <Typography variant="body2">
+                    <strong>Namespace:</strong> {namespace}
+                  </Typography>
+                  <Typography variant="body2">
+                    <strong>Name:</strong> {name}
+                  </Typography>
+                  <Typography variant="body2">
+                    <strong>Provider:</strong> {system}
+                  </Typography>
+                  <Typography variant="body2">
+                    <strong>Latest Version:</strong> {versions.length > 0 ? (versions.find(v => !v.deprecated) ?? versions[0]).version : 'N/A'}
+                  </Typography>
+                  <Typography variant="body2">
+                    <strong>Total Downloads:</strong> {module.download_count ?? 0}
+                  </Typography>
+                  <Typography variant="body2">
+                    <strong>Organization:</strong> {module.organization_name || namespace}
+                  </Typography>
+                  {module.created_by_name && (
+                    <Typography variant="body2">
+                      <strong>Created By:</strong> {module.created_by_name}
+                    </Typography>
+                  )}
+                </Box>
+              </Paper>
 
-          <WebhookEventsPanel
-            isAuthenticated={isAuthenticated}
-            scmLink={scmLink}
-            moduleId={module?.id}
-            webhookEvents={webhookEvents}
-            webhookEventsLoaded={webhookEventsLoaded}
-            webhookEventsLoading={webhookEventsLoading}
-            webhookEventsExpanded={webhookEventsExpanded}
-            onToggleExpanded={() => setWebhookEventsExpanded(!webhookEventsExpanded)}
-            onLoadEvents={loadWebhookEvents}
-          />
+              <SCMRepositoryPanel
+                isAuthenticated={isAuthenticated}
+                scmLinkLoaded={scmLinkLoaded}
+                scmLink={scmLink}
+                scmSyncing={scmSyncing}
+                scmUnlinking={scmUnlinking}
+                onSync={handleSCMSync}
+                onUnlink={handleSCMUnlink}
+                onOpenWizard={() => setScmWizardOpen(true)}
+              />
 
-          <VersionDetailsPanel
-            selectedVersion={selectedVersion}
-            canManage={canManage}
-            deprecating={deprecating}
-            onUndeprecate={handleUndeprecateVersion}
-            onOpenDeprecateDialog={() => setDeprecateDialogOpen(true)}
-            onOpenDeleteVersionDialog={openDeleteVersionDialog}
-          />
+              <WebhookEventsPanel
+                isAuthenticated={isAuthenticated}
+                scmLink={scmLink}
+                moduleId={module?.id}
+                webhookEvents={webhookEvents}
+                webhookEventsLoaded={webhookEventsLoaded}
+                webhookEventsLoading={webhookEventsLoading}
+                webhookEventsExpanded={webhookEventsExpanded}
+                onToggleExpanded={() => setWebhookEventsExpanded(!webhookEventsExpanded)}
+                onLoadEvents={loadWebhookEvents}
+              />
 
-          <SecurityScanPanel
-            canManage={canManage}
-            selectedVersion={selectedVersion}
-            moduleScan={moduleScan}
-            scanLoading={scanLoading}
-            scanNotFound={scanNotFound}
-          />
-        </Box>
-      </Box>
+              <VersionDetailsPanel
+                selectedVersion={selectedVersion}
+                canManage={canManage}
+                deprecating={deprecating}
+                onUndeprecate={handleUndeprecateVersion}
+                onOpenDeprecateDialog={() => setDeprecateDialogOpen(true)}
+                onOpenDeleteVersionDialog={openDeleteVersionDialog}
+              />
 
-      {/* Delete Module Confirmation Dialog */}
-      <Dialog
-        open={deleteModuleDialogOpen}
-        onClose={() => setDeleteModuleDialogOpen(false)}
-      >
-        <DialogTitle>Delete Module</DialogTitle>
-        <DialogContent>
-          <DialogContentText>
-            Are you sure you want to delete the module <strong>{namespace}/{name}/{system}</strong>?
-            This will permanently delete all versions and associated files.
-            This action cannot be undone.
-          </DialogContentText>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setDeleteModuleDialogOpen(false)} disabled={deleting}>
-            Cancel
-          </Button>
-          <Button onClick={handleDeleteModule} color="error" disabled={deleting}>
-            {deleting ? 'Deleting...' : 'Delete Module'}
-          </Button>
-        </DialogActions>
-      </Dialog>
+              <SecurityScanPanel
+                canManage={canManage}
+                selectedVersion={selectedVersion}
+                moduleScan={moduleScan}
+                scanLoading={scanLoading}
+                scanNotFound={scanNotFound}
+              />
+            </Box>
+          </Box>
 
-      {/* Delete Version Confirmation Dialog */}
-      <Dialog
-        open={deleteVersionDialogOpen}
-        onClose={() => setDeleteVersionDialogOpen(false)}
-      >
-        <DialogTitle>Delete Version</DialogTitle>
-        <DialogContent>
-          <DialogContentText>
-            Are you sure you want to delete version <strong>{versionToDelete}</strong> of{' '}
-            <strong>{namespace}/{name}/{system}</strong>?
-            This will permanently delete the version and its associated files.
-            This action cannot be undone.
-          </DialogContentText>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setDeleteVersionDialogOpen(false)} disabled={deleting}>
-            Cancel
-          </Button>
-          <Button onClick={handleDeleteVersion} color="error" disabled={deleting}>
-            {deleting ? 'Deleting...' : 'Delete Version'}
-          </Button>
-        </DialogActions>
-      </Dialog>
-
-      {/* SCM Link Wizard Dialog */}
-      <Dialog
-        open={scmWizardOpen}
-        onClose={() => setScmWizardOpen(false)}
-        maxWidth="md"
-        fullWidth
-      >
-        <DialogTitle>Link Repository</DialogTitle>
-        <DialogContent>
-          {module?.id && (
-            <PublishFromSCMWizard
-              moduleId={module.id}
-              moduleSystem={system}
-              onComplete={() => {
-                setScmWizardOpen(false);
-                // Reload SCM link immediately, then poll for versions the
-                // background sync will create over the next several seconds.
-                if (module?.id) loadSCMLink(module.id);
-                pollForVersions();
-              }}
-              onCancel={() => setScmWizardOpen(false)}
-            />
-          )}
-        </DialogContent>
-      </Dialog>
-
-      {/* Deprecate Version Dialog */}
-      <Dialog
-        open={deprecateDialogOpen}
-        onClose={() => setDeprecateDialogOpen(false)}
-      >
-        <DialogTitle>Deprecate Version</DialogTitle>
-        <DialogContent>
-          <DialogContentText sx={{ mb: 2 }}>
-            Are you sure you want to deprecate version <strong>{selectedVersion?.version}</strong> of{' '}
-            <strong>{namespace}/{name}/{system}</strong>?
-            This will mark the version as deprecated, warning users not to use it.
-          </DialogContentText>
-          <TextField
-            autoFocus
-            label="Deprecation Message (optional)"
-            placeholder="e.g., Use version 2.0.0 instead - this version has a critical bug"
-            fullWidth
-            multiline
-            rows={3}
-            value={deprecationMessage}
-            onChange={(e) => setDeprecationMessage(e.target.value)}
-          />
-        </DialogContent>
-        <DialogActions>
-          <Button
-            onClick={() => {
-              setDeprecateDialogOpen(false);
-              setDeprecationMessage('');
-            }}
-            disabled={deprecating}
+          {/* Delete Module Confirmation Dialog */}
+          <Dialog
+            open={deleteModuleDialogOpen}
+            onClose={() => setDeleteModuleDialogOpen(false)}
           >
-            Cancel
-          </Button>
-          <Button onClick={handleDeprecateVersion} color="warning" disabled={deprecating}>
-            {deprecating ? 'Deprecating...' : 'Deprecate Version'}
-          </Button>
-        </DialogActions>
-      </Dialog>
-    </Container>
+            <DialogTitle>Delete Module</DialogTitle>
+            <DialogContent>
+              <DialogContentText>
+                Are you sure you want to delete the module <strong>{namespace}/{name}/{system}</strong>?
+                This will permanently delete all versions and associated files.
+                This action cannot be undone.
+              </DialogContentText>
+            </DialogContent>
+            <DialogActions>
+              <Button onClick={() => setDeleteModuleDialogOpen(false)} disabled={deleting}>
+                Cancel
+              </Button>
+              <Button onClick={handleDeleteModule} color="error" disabled={deleting}>
+                {deleting ? 'Deleting...' : 'Delete Module'}
+              </Button>
+            </DialogActions>
+          </Dialog>
+
+          {/* Delete Version Confirmation Dialog */}
+          <Dialog
+            open={deleteVersionDialogOpen}
+            onClose={() => setDeleteVersionDialogOpen(false)}
+          >
+            <DialogTitle>Delete Version</DialogTitle>
+            <DialogContent>
+              <DialogContentText>
+                Are you sure you want to delete version <strong>{versionToDelete}</strong> of{' '}
+                <strong>{namespace}/{name}/{system}</strong>?
+                This will permanently delete the version and its associated files.
+                This action cannot be undone.
+              </DialogContentText>
+            </DialogContent>
+            <DialogActions>
+              <Button onClick={() => setDeleteVersionDialogOpen(false)} disabled={deleting}>
+                Cancel
+              </Button>
+              <Button onClick={handleDeleteVersion} color="error" disabled={deleting}>
+                {deleting ? 'Deleting...' : 'Delete Version'}
+              </Button>
+            </DialogActions>
+          </Dialog>
+
+          {/* SCM Link Wizard Dialog */}
+          <Dialog
+            open={scmWizardOpen}
+            onClose={() => setScmWizardOpen(false)}
+            maxWidth="md"
+            fullWidth
+          >
+            <DialogTitle>Link Repository</DialogTitle>
+            <DialogContent>
+              {module?.id && (
+                <PublishFromSCMWizard
+                  moduleId={module.id}
+                  moduleSystem={system}
+                  onComplete={() => {
+                    setScmWizardOpen(false);
+                    // Reload SCM link immediately, then poll for versions the
+                    // background sync will create over the next several seconds.
+                    if (module?.id) loadSCMLink(module.id);
+                    pollForVersions();
+                  }}
+                  onCancel={() => setScmWizardOpen(false)}
+                />
+              )}
+            </DialogContent>
+          </Dialog>
+
+          {/* Deprecate Version Dialog */}
+          <Dialog
+            open={deprecateDialogOpen}
+            onClose={() => setDeprecateDialogOpen(false)}
+          >
+            <DialogTitle>Deprecate Version</DialogTitle>
+            <DialogContent>
+              <DialogContentText sx={{ mb: 2 }}>
+                Are you sure you want to deprecate version <strong>{selectedVersion?.version}</strong> of{' '}
+                <strong>{namespace}/{name}/{system}</strong>?
+                This will mark the version as deprecated, warning users not to use it.
+              </DialogContentText>
+              <TextField
+                autoFocus
+                label="Deprecation Message (optional)"
+                placeholder="e.g., Use version 2.0.0 instead - this version has a critical bug"
+                fullWidth
+                multiline
+                rows={3}
+                value={deprecationMessage}
+                onChange={(e) => setDeprecationMessage(e.target.value)}
+              />
+            </DialogContent>
+            <DialogActions>
+              <Button
+                onClick={() => {
+                  setDeprecateDialogOpen(false);
+                  setDeprecationMessage('');
+                }}
+                disabled={deprecating}
+              >
+                Cancel
+              </Button>
+              <Button onClick={handleDeprecateVersion} color="warning" disabled={deprecating}>
+                {deprecating ? 'Deprecating...' : 'Deprecate Version'}
+              </Button>
+            </DialogActions>
+          </Dialog>
+        </Container>
       )}
     </Box>
   );

--- a/frontend/src/pages/admin/DashboardPage.tsx
+++ b/frontend/src/pages/admin/DashboardPage.tsx
@@ -36,6 +36,7 @@ import Error from '@mui/icons-material/Error';
 import Sync from '@mui/icons-material/Sync';
 import Refresh from '@mui/icons-material/Refresh';
 import ArrowForward from '@mui/icons-material/ArrowForward';
+import Security from '@mui/icons-material/Security';
 import api from '../../services/api';
 import { useAuth } from '../../contexts/AuthContext';
 
@@ -92,6 +93,14 @@ interface DashboardData {
     total: number;
     healthy: number;
     failed: number;
+  };
+  scanning: {
+    enabled: boolean;
+    total: number;
+    pending: number;
+    clean: number;
+    findings: number;
+    error: number;
   };
   recent_syncs: RecentSyncEntry[];
 }
@@ -389,6 +398,7 @@ const DashboardPage: React.FC = () => {
     scm_providers: raw.scm_providers ?? 0,
     binary_mirrors: raw.binary_mirrors ?? { total: 0, healthy: 0, failed: 0, syncing: 0, platforms: 0, downloads: 0, by_tool: [] },
     provider_mirrors: raw.provider_mirrors ?? { total: 0, healthy: 0, failed: 0 },
+    scanning: raw.scanning ?? { enabled: false, total: 0, pending: 0, clean: 0, findings: 0, error: 0 },
     recent_syncs: raw.recent_syncs ?? [],
   } : null;
 
@@ -522,6 +532,16 @@ const DashboardPage: React.FC = () => {
             failed={0}
             icon={<Storage fontSize="small" />}
             route="/admin/storage"
+          />
+        )}
+        {hasScope('admin') && data.scanning.enabled && (
+          <HealthPill
+            label="Security Scanning"
+            total={data.scanning.total}
+            failed={data.scanning.error}
+            syncing={data.scanning.pending}
+            icon={<Security fontSize="small" />}
+            route="/admin/security-scanning"
           />
         )}
       </Box>

--- a/frontend/src/pages/admin/SecurityScanningPage.tsx
+++ b/frontend/src/pages/admin/SecurityScanningPage.tsx
@@ -1,0 +1,198 @@
+import React from 'react';
+import { useQuery } from '@tanstack/react-query';
+import {
+  Container,
+  Typography,
+  Box,
+  Paper,
+  CircularProgress,
+  Alert,
+  Chip,
+  Divider,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Tooltip,
+  Grid,
+} from '@mui/material';
+import CheckCircle from '@mui/icons-material/CheckCircle';
+import Error from '@mui/icons-material/Error';
+import HourglassEmpty from '@mui/icons-material/HourglassEmpty';
+import api from '../../services/api';
+
+function statusChip(status: string) {
+  switch (status) {
+    case 'clean': return <Chip label="Clean" size="small" color="success" variant="outlined" />;
+    case 'findings': return <Chip label="Findings" size="small" color="warning" variant="outlined" />;
+    case 'error': return <Chip label="Error" size="small" color="error" variant="outlined" />;
+    case 'pending': return <Chip label="Pending" size="small" variant="outlined" />;
+    case 'scanning': return <Chip label="Scanning" size="small" color="info" variant="outlined" />;
+    default: return <Chip label={status} size="small" variant="outlined" />;
+  }
+}
+
+function timeAgo(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(diff / 60_000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return `${Math.floor(hrs / 24)}d ago`;
+}
+
+const SecurityScanningPage: React.FC = () => {
+  const { data: config, isLoading: configLoading, error: configError } = useQuery({
+    queryKey: ['scanning', 'config'],
+    queryFn: () => api.getScanningConfig(),
+  });
+
+  const { data: stats, isLoading: statsLoading, error: statsError } = useQuery({
+    queryKey: ['scanning', 'stats'],
+    queryFn: () => api.getScanningStats(),
+  });
+
+  const loading = configLoading || statsLoading;
+  const error = configError || statsError;
+
+  return (
+    <Container maxWidth="lg" sx={{ py: 4 }}>
+      <Typography variant="h4" fontWeight={700} gutterBottom>
+        Security Scanning
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+        Module security scanning configuration and status
+      </Typography>
+
+      {loading ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+          <CircularProgress />
+        </Box>
+      ) : error ? (
+        <Alert severity="error">Failed to load scanning data.</Alert>
+      ) : (
+        <>
+          {/* Configuration */}
+          <Paper sx={{ p: 3, mb: 3 }}>
+            <Typography variant="h6" gutterBottom>Configuration</Typography>
+            <Divider sx={{ mb: 2 }} />
+            <Grid container spacing={2}>
+              <Grid size={{ xs: 12, sm: 6, md: 4 }}>
+                <Typography variant="caption" color="text.secondary">Status</Typography>
+                <Box sx={{ mt: 0.5 }}>
+                  <Chip
+                    icon={config?.enabled ? <CheckCircle /> : <Error />}
+                    label={config?.enabled ? 'Enabled' : 'Disabled'}
+                    color={config?.enabled ? 'success' : 'default'}
+                    variant="outlined"
+                  />
+                </Box>
+              </Grid>
+              <Grid size={{ xs: 12, sm: 6, md: 4 }}>
+                <Typography variant="caption" color="text.secondary">Scanner Tool</Typography>
+                <Typography variant="body1" fontFamily="monospace">{config?.tool || '—'}</Typography>
+              </Grid>
+              <Grid size={{ xs: 12, sm: 6, md: 4 }}>
+                <Typography variant="caption" color="text.secondary">Expected Version</Typography>
+                <Typography variant="body1" fontFamily="monospace">{config?.expected_version || 'Not pinned'}</Typography>
+              </Grid>
+              <Grid size={{ xs: 12, sm: 6, md: 4 }}>
+                <Typography variant="caption" color="text.secondary">Severity Threshold</Typography>
+                <Typography variant="body1" fontFamily="monospace">{config?.severity_threshold || '—'}</Typography>
+              </Grid>
+              <Grid size={{ xs: 12, sm: 6, md: 4 }}>
+                <Typography variant="caption" color="text.secondary">Timeout</Typography>
+                <Typography variant="body1" fontFamily="monospace">{config?.timeout || '—'}</Typography>
+              </Grid>
+              <Grid size={{ xs: 12, sm: 6, md: 4 }}>
+                <Typography variant="caption" color="text.secondary">Workers / Interval</Typography>
+                <Typography variant="body1" fontFamily="monospace">
+                  {config?.worker_count ?? '—'} workers, every {config?.scan_interval_mins ?? '—'}m
+                </Typography>
+              </Grid>
+            </Grid>
+          </Paper>
+
+          {/* Summary Stats */}
+          {stats && (
+            <Box sx={{ display: 'flex', gap: 1.5, flexWrap: 'wrap', mb: 3 }}>
+              {[
+                { label: 'Total Scans', value: stats.total, icon: <CheckCircle fontSize="small" /> },
+                { label: 'Pending', value: stats.pending, icon: <HourglassEmpty fontSize="small" /> },
+                { label: 'Clean', value: stats.clean, color: 'success.main' },
+                { label: 'Findings', value: stats.findings, color: 'warning.main' },
+                { label: 'Errors', value: stats.error, color: 'error.main' },
+              ].map((item) => (
+                <Paper key={item.label} sx={{ px: 2, py: 1.5, flex: 1, minWidth: 120 }}>
+                  <Typography variant="caption" color="text.secondary">{item.label}</Typography>
+                  <Typography variant="h5" fontWeight={700} sx={{ color: item.color }}>
+                    {item.value}
+                  </Typography>
+                </Paper>
+              ))}
+            </Box>
+          )}
+
+          {/* Recent Scans */}
+          <Paper sx={{ p: 3 }}>
+            <Typography variant="h6" gutterBottom>Recent Scans</Typography>
+            <Divider sx={{ mb: 2 }} />
+            {!stats?.recent_scans?.length ? (
+              <Typography variant="body2" color="text.secondary">
+                No scans recorded yet.
+              </Typography>
+            ) : (
+              <TableContainer>
+                <Table size="small">
+                  <TableHead>
+                    <TableRow>
+                      <TableCell>Module</TableCell>
+                      <TableCell>Version</TableCell>
+                      <TableCell>Scanner</TableCell>
+                      <TableCell>Status</TableCell>
+                      <TableCell align="right">Critical</TableCell>
+                      <TableCell align="right">High</TableCell>
+                      <TableCell align="right">Medium</TableCell>
+                      <TableCell align="right">Low</TableCell>
+                      <TableCell align="right">When</TableCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {stats.recent_scans.map((scan) => (
+                      <TableRow key={scan.id} hover>
+                        <TableCell>
+                          <Typography variant="body2" fontFamily="monospace" noWrap>
+                            {scan.namespace}/{scan.module_name}/{scan.system}
+                          </Typography>
+                        </TableCell>
+                        <TableCell>{scan.module_version}</TableCell>
+                        <TableCell>{scan.scanner}</TableCell>
+                        <TableCell>{statusChip(scan.status)}</TableCell>
+                        <TableCell align="right">{scan.critical_count}</TableCell>
+                        <TableCell align="right">{scan.high_count}</TableCell>
+                        <TableCell align="right">{scan.medium_count}</TableCell>
+                        <TableCell align="right">{scan.low_count}</TableCell>
+                        <TableCell align="right">
+                          <Tooltip title={scan.scanned_at ? new Date(scan.scanned_at).toLocaleString() : 'Not scanned yet'}>
+                            <Typography variant="caption" color="text.secondary">
+                              {scan.scanned_at ? timeAgo(scan.scanned_at) : '—'}
+                            </Typography>
+                          </Tooltip>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </TableContainer>
+            )}
+          </Paper>
+        </>
+      )}
+    </Container>
+  );
+};
+
+export default SecurityScanningPage;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -645,10 +645,25 @@ class ApiClient {
     return response.data;
   }
 
+  async updateModule(id: string, data: { description?: string; source?: string }) {
+    const response = await this.client.put(`/api/v1/admin/modules/${id}`, data);
+    return response.data;
+  }
+
   async getModuleScan(namespace: string, name: string, system: string, version: string): Promise<import('../types').ModuleScan> {
     const response = await this.client.get(
       `/api/v1/modules/${namespace}/${name}/${system}/versions/${version}/scan`
     );
+    return response.data;
+  }
+
+  async getScanningConfig(): Promise<import('../types').ScanningConfig> {
+    const response = await this.client.get('/api/v1/admin/scanning/config');
+    return response.data;
+  }
+
+  async getScanningStats(): Promise<import('../types').ScanningStats> {
+    const response = await this.client.get('/api/v1/admin/scanning/stats');
     return response.data;
   }
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -422,6 +422,46 @@ export interface ModuleScan {
 
 // ---- Module terraform-docs ----
 
+// ---- Security Scanning Admin ----
+
+export interface ScanningConfig {
+  enabled: boolean;
+  tool: string;
+  expected_version?: string;
+  severity_threshold: string;
+  timeout: string;
+  worker_count: number;
+  scan_interval_mins: number;
+}
+
+export interface RecentScanEntry {
+  id: string;
+  module_version: string;
+  module_name: string;
+  namespace: string;
+  system: string;
+  scanner: string;
+  status: ModuleScanStatus;
+  critical_count: number;
+  high_count: number;
+  medium_count: number;
+  low_count: number;
+  scanned_at: string | null;
+  created_at: string;
+}
+
+export interface ScanningStats {
+  total: number;
+  pending: number;
+  scanning: number;
+  clean: number;
+  findings: number;
+  error: number;
+  recent_scans: RecentScanEntry[];
+}
+
+// ---- Module terraform-docs ----
+
 export interface ModuleInputVar {
   name: string;
   type: string;


### PR DESCRIPTION
## Summary
- Add tabbed documentation view (README / Inputs-Outputs) on module detail page for consistent display regardless of README presence
- Add inline description editing on module detail page (uses existing PUT /admin/modules/:id API)
- Add SecurityScanningPage admin page showing scanning config, stats, and recent scans table
- Add scanning status HealthPill to admin dashboard (Zone 1)
- Sort API documentation sections alphabetically in both sidebar and Swagger UI

## Changelog
- feat: add tabbed README / Inputs-Outputs documentation view on module detail page
- feat: add inline module description editing on module detail page
- feat: add Security Scanning admin page with configuration and recent scans
- feat: add scanning health status HealthPill to admin dashboard
- feat: sort API documentation sections alphabetically

## Test plan
- [ ] Verify module detail page shows both README and Inputs/Outputs tabs
- [ ] Verify module detail page shows empty states when README or docs are missing
- [ ] Verify inline description editing works for users with manage permissions
- [ ] Verify Security Scanning admin page loads config and stats
- [ ] Verify Dashboard shows scanning HealthPill when scanning is enabled
- [ ] Verify API docs page sections are sorted alphabetically