### PR TITLE
fix: add scanning:read to scope display mapping

### DIFF
--- a/frontend/src/pages/admin/RolesPage.tsx
+++ b/frontend/src/pages/admin/RolesPage.tsx
@@ -32,7 +32,7 @@ const SCOPE_CATEGORIES: Record<string, string[]> = {
   'Registry Access': ['modules:read', 'modules:write', 'providers:read', 'providers:write'],
   'DevOps': ['mirrors:read', 'mirrors:manage', 'scm:read', 'scm:manage'],
   'User & Organization': ['users:read', 'users:write', 'organizations:read', 'organizations:write'],
-  'System': ['api_keys:manage', 'audit:read', 'admin'],
+  'System': ['api_keys:manage', 'audit:read', 'scanning:read', 'admin'],
 };
 
 const RolesPage: React.FC = () => {

--- a/frontend/src/types/rbac.ts
+++ b/frontend/src/types/rbac.ts
@@ -80,6 +80,7 @@ export const AVAILABLE_SCOPES = [
   { value: 'scm:manage', label: 'SCM Manage', description: 'Create and manage SCM provider integrations' },
   { value: 'api_keys:manage', label: 'API Keys Manage', description: 'Create and manage API keys' },
   { value: 'audit:read', label: 'Audit Read', description: 'View audit logs' },
+  { value: 'scanning:read', label: 'Scanning Read', description: 'View scan results and statistics' },
   { value: 'admin', label: 'Administrator', description: 'Full access to all features' },
 ] as const;
 


### PR DESCRIPTION
Adds the `scanning:read` scope to the frontend display mappings so it renders
as "Scanning Read" with description "View scan results and statistics" instead
of the raw scope string.

**Changes:**
- `rbac.ts`: Add `scanning:read` entry to `AVAILABLE_SCOPES`
- `RolesPage.tsx`: Add `scanning:read` to `SCOPE_CATEGORIES.System`

Closes #130

## Changelog
- fix: add scanning:read to scope display mapping (Closes #130)