### PR TITLE
fix: remove continue-on-error from E2E job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,11 +128,6 @@ jobs:
     name: E2E (gated/manual)
     runs-on: ubuntu-latest
     needs: [lint, typecheck, unit-test, build]
-    # E2E is best-effort: failures are reported but do not block the calling
-    # workflow (release.yml).  The compose stack may fail to start when the
-    # required backend image is unavailable or when Docker resources are
-    # constrained on the runner.
-    continue-on-error: true
     if: >-
       github.event_name == 'workflow_dispatch' ||
       github.event_name == 'workflow_call' ||


### PR DESCRIPTION
Closes #136

## Summary
- Remove `continue-on-error: true` from the e2e-gated job in CI
- The underlying backend bug (missing SystemSettings columns causing 500 on `/api/v1/setup/status`) is fixed in sethbacon/terraform-registry-backend#187

## Changelog
- fix: remove continue-on-error from E2E job so test failures block the pipeline