### PR TITLE
feat: add unit tests raising line coverage from 15% to 51%

### DIFF
--- a/frontend/src/components/__tests__/AboutModal.test.tsx
+++ b/frontend/src/components/__tests__/AboutModal.test.tsx
@@ -1,0 +1,117 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const getVersionInfoMock = vi.fn()
+vi.mock('../../services/api', () => ({
+  default: {
+    getVersionInfo: (...args: unknown[]) => getVersionInfoMock(...args),
+  },
+}))
+
+import AboutModal from '../AboutModal'
+
+describe('AboutModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('does not fetch version info when closed', () => {
+    render(<AboutModal open={false} onClose={vi.fn()} />)
+    expect(getVersionInfoMock).not.toHaveBeenCalled()
+  })
+
+  it('fetches version info when opened', async () => {
+    getVersionInfoMock.mockResolvedValue({
+      version: '1.2.3',
+      api_version: 'v1',
+      build_date: '2025-06-01T00:00:00Z',
+    })
+    render(<AboutModal open={true} onClose={vi.fn()} />)
+    await waitFor(() => {
+      expect(getVersionInfoMock).toHaveBeenCalled()
+    })
+  })
+
+  it('renders the dialog title', () => {
+    getVersionInfoMock.mockReturnValue(new Promise(() => {}))
+    render(<AboutModal open={true} onClose={vi.fn()} />)
+    expect(screen.getByText('About Terraform Registry')).toBeInTheDocument()
+  })
+
+  it('shows loading state while fetching backend version', () => {
+    getVersionInfoMock.mockReturnValue(new Promise(() => {}))
+    render(<AboutModal open={true} onClose={vi.fn()} />)
+    expect(screen.getByText('Loading backend version…')).toBeInTheDocument()
+  })
+
+  it('shows backend version after load', async () => {
+    getVersionInfoMock.mockResolvedValue({
+      version: '1.2.3',
+      api_version: 'v1',
+      build_date: '2025-06-01T00:00:00Z',
+    })
+    render(<AboutModal open={true} onClose={vi.fn()} />)
+    await waitFor(() => {
+      expect(screen.getByText('Backend v1.2.3')).toBeInTheDocument()
+    })
+    expect(screen.getByText('API version: v1')).toBeInTheDocument()
+  })
+
+  it('shows "Backend unavailable" when API fails', async () => {
+    getVersionInfoMock.mockRejectedValue(new Error('Network error'))
+    render(<AboutModal open={true} onClose={vi.fn()} />)
+    await waitFor(() => {
+      expect(screen.getByText('Backend unavailable')).toBeInTheDocument()
+    })
+  })
+
+  it('calls onClose when Close button is clicked', async () => {
+    const onClose = vi.fn()
+    getVersionInfoMock.mockResolvedValue({ version: '1.0.0', api_version: 'v1' })
+    const user = userEvent.setup()
+    render(<AboutModal open={true} onClose={onClose} />)
+    await user.click(screen.getByText('Close'))
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('shows license section', () => {
+    getVersionInfoMock.mockReturnValue(new Promise(() => {}))
+    render(<AboutModal open={true} onClose={vi.fn()} />)
+    expect(screen.getByText('License')).toBeInTheDocument()
+    expect(screen.getByText('Apache License 2.0')).toBeInTheDocument()
+  })
+
+  it('shows source links', () => {
+    getVersionInfoMock.mockReturnValue(new Promise(() => {}))
+    render(<AboutModal open={true} onClose={vi.fn()} />)
+    expect(screen.getByText('Source')).toBeInTheDocument()
+    expect(screen.getByText('GitHub — Backend')).toBeInTheDocument()
+    expect(screen.getByText('GitHub — Frontend')).toBeInTheDocument()
+  })
+
+  it('shows build date when available', async () => {
+    getVersionInfoMock.mockResolvedValue({
+      version: '1.0.0',
+      api_version: 'v1',
+      build_date: '2025-06-01T00:00:00Z',
+    })
+    render(<AboutModal open={true} onClose={vi.fn()} />)
+    await waitFor(() => {
+      expect(screen.getByText(/Built:/)).toBeInTheDocument()
+    })
+  })
+
+  it('does not show build date when unknown', async () => {
+    getVersionInfoMock.mockResolvedValue({
+      version: '1.0.0',
+      api_version: 'v1',
+      build_date: 'unknown',
+    })
+    render(<AboutModal open={true} onClose={vi.fn()} />)
+    await waitFor(() => {
+      expect(screen.getByText('Backend v1.0.0')).toBeInTheDocument()
+    })
+    expect(screen.queryByText(/Built:/)).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/__tests__/HelpPanel.test.tsx
+++ b/frontend/src/components/__tests__/HelpPanel.test.tsx
@@ -1,0 +1,179 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect, vi } from 'vitest'
+
+// Mock the HelpContext
+const mockCloseHelp = vi.fn()
+vi.mock('../../contexts/HelpContext', () => ({
+  useHelp: () => ({
+    helpOpen: true,
+    closeHelp: mockCloseHelp,
+  }),
+}))
+
+// Import after mock
+import HelpPanel, { HELP_PANEL_WIDTH } from '../HelpPanel'
+
+function renderAtPath(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <HelpPanel />
+    </MemoryRouter>
+  )
+}
+
+describe('HELP_PANEL_WIDTH', () => {
+  it('is 320', () => {
+    expect(HELP_PANEL_WIDTH).toBe(320)
+  })
+})
+
+describe('HelpPanel', () => {
+  it('renders home help for /', () => {
+    renderAtPath('/')
+    expect(screen.getByText('Home')).toBeInTheDocument()
+    expect(screen.getByText(/home page provides a quick-start overview/)).toBeInTheDocument()
+  })
+
+  it('renders modules help for /modules', () => {
+    renderAtPath('/modules')
+    expect(screen.getByText('Modules')).toBeInTheDocument()
+    expect(screen.getByText(/Lists all Terraform modules/)).toBeInTheDocument()
+  })
+
+  it('renders module detail help for parameterized module routes', () => {
+    renderAtPath('/modules/hashicorp/consul/aws')
+    expect(screen.getByText('Module Detail')).toBeInTheDocument()
+  })
+
+  it('renders providers help for /providers', () => {
+    renderAtPath('/providers')
+    expect(screen.getByText('Providers')).toBeInTheDocument()
+  })
+
+  it('renders provider detail help for parameterized provider routes', () => {
+    renderAtPath('/providers/hashicorp/aws')
+    expect(screen.getByText('Provider Detail')).toBeInTheDocument()
+  })
+
+  it('renders terraform binaries help', () => {
+    renderAtPath('/terraform-binaries')
+    expect(screen.getByText('Terraform Binary Mirrors')).toBeInTheDocument()
+  })
+
+  it('renders terraform binary detail help for parameterized route', () => {
+    renderAtPath('/terraform-binaries/terraform')
+    expect(screen.getByText('Binary Mirror Detail')).toBeInTheDocument()
+  })
+
+  it('renders API docs help', () => {
+    renderAtPath('/api-docs')
+    expect(screen.getByText('API Reference')).toBeInTheDocument()
+  })
+
+  it('renders dashboard help for /admin', () => {
+    renderAtPath('/admin')
+    expect(screen.getByText('Dashboard')).toBeInTheDocument()
+  })
+
+  it('renders users help', () => {
+    renderAtPath('/admin/users')
+    expect(screen.getByText('Users')).toBeInTheDocument()
+  })
+
+  it('renders organizations help', () => {
+    renderAtPath('/admin/organizations')
+    expect(screen.getByText('Organizations')).toBeInTheDocument()
+  })
+
+  it('renders roles help', () => {
+    renderAtPath('/admin/roles')
+    expect(screen.getByText('Roles & Permissions')).toBeInTheDocument()
+  })
+
+  it('renders OIDC help', () => {
+    renderAtPath('/admin/oidc')
+    expect(screen.getByText('OIDC Groups')).toBeInTheDocument()
+  })
+
+  it('renders API keys help', () => {
+    renderAtPath('/admin/apikeys')
+    expect(screen.getByText('API Keys')).toBeInTheDocument()
+  })
+
+  it('renders upload help', () => {
+    renderAtPath('/admin/upload')
+    expect(screen.getByText('Upload')).toBeInTheDocument()
+  })
+
+  it('renders SCM providers help', () => {
+    renderAtPath('/admin/scm-providers')
+    expect(screen.getByText('SCM Providers')).toBeInTheDocument()
+  })
+
+  it('renders mirrors help', () => {
+    renderAtPath('/admin/mirrors')
+    expect(screen.getByText('Provider Mirrors')).toBeInTheDocument()
+  })
+
+  it('renders storage help', () => {
+    renderAtPath('/admin/storage')
+    expect(screen.getByText('Storage')).toBeInTheDocument()
+  })
+
+  it('renders audit logs help', () => {
+    renderAtPath('/admin/audit-logs')
+    expect(screen.getByText('Audit Logs')).toBeInTheDocument()
+  })
+
+  it('renders terraform mirror help', () => {
+    renderAtPath('/admin/terraform-mirror')
+    expect(screen.getByText('Terraform Binary Mirror')).toBeInTheDocument()
+  })
+
+  it('renders approvals help', () => {
+    renderAtPath('/admin/approvals')
+    expect(screen.getByText('Approval Requests')).toBeInTheDocument()
+  })
+
+  it('renders mirror policies help', () => {
+    renderAtPath('/admin/policies')
+    expect(screen.getByText('Mirror Policies')).toBeInTheDocument()
+  })
+
+  it('renders default help for unknown paths', () => {
+    renderAtPath('/some/unknown/path')
+    expect(screen.getByText('Help')).toBeInTheDocument()
+    expect(screen.getByText(/Navigate to a page/)).toBeInTheDocument()
+  })
+
+  it('shows action headings', () => {
+    renderAtPath('/modules')
+    expect(screen.getByText('Search')).toBeInTheDocument()
+    expect(screen.getByText('View Module')).toBeInTheDocument()
+    expect(screen.getByText('Upload a Module')).toBeInTheDocument()
+  })
+
+  it('shows close button', () => {
+    renderAtPath('/')
+    expect(screen.getByLabelText('Close help panel')).toBeInTheDocument()
+  })
+
+  it('calls closeHelp when close button is clicked', async () => {
+    const user = userEvent.setup()
+    renderAtPath('/')
+    await user.click(screen.getByLabelText('Close help panel'))
+    expect(mockCloseHelp).toHaveBeenCalled()
+  })
+
+  it('shows API Docs footer link', () => {
+    renderAtPath('/')
+    expect(screen.getByText('API Docs')).toBeInTheDocument()
+  })
+
+  it('shows "What you can do" section', () => {
+    renderAtPath('/')
+    expect(screen.getByText('What you can do')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/__tests__/Layout.test.tsx
+++ b/frontend/src/components/__tests__/Layout.test.tsx
@@ -1,0 +1,338 @@
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+
+const mockLogout = vi.fn()
+const mockUseAuth = vi.fn()
+vi.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => mockUseAuth(),
+}))
+
+const mockToggleTheme = vi.fn()
+const mockUseThemeMode = vi.fn()
+vi.mock('../../contexts/ThemeContext', () => ({
+  useThemeMode: () => mockUseThemeMode(),
+}))
+
+const mockOpenHelp = vi.fn()
+const mockUseHelp = vi.fn()
+vi.mock('../../contexts/HelpContext', () => ({
+  useHelp: () => mockUseHelp(),
+}))
+
+vi.mock('../DevUserSwitcher', () => ({
+  default: () => <div data-testid="dev-user-switcher" />,
+}))
+
+vi.mock('../HelpPanel', () => ({
+  default: () => <div data-testid="help-panel" />,
+  HELP_PANEL_WIDTH: 320,
+}))
+
+vi.mock('../AboutModal', () => ({
+  default: ({ open, onClose }: { open: boolean; onClose: () => void }) =>
+    open ? <div data-testid="about-modal"><button onClick={onClose}>Close</button></div> : null,
+}))
+
+import Layout from '../Layout'
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function setAuth(overrides: Partial<ReturnType<typeof mockUseAuth>> = {}) {
+  mockUseAuth.mockReturnValue({
+    user: null,
+    isAuthenticated: false,
+    logout: mockLogout,
+    allowedScopes: [],
+    ...overrides,
+  })
+}
+
+function renderLayout(route = '/') {
+  return render(
+    <MemoryRouter initialEntries={[route]}>
+      <Layout />
+    </MemoryRouter>,
+  )
+}
+
+// ── Setup ──────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  localStorage.clear()
+  mockUseThemeMode.mockReturnValue({ mode: 'light', toggleTheme: mockToggleTheme })
+  mockUseHelp.mockReturnValue({ helpOpen: false, openHelp: mockOpenHelp, closeHelp: vi.fn() })
+  setAuth()
+})
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('Layout', () => {
+  // 1. Basic rendering
+  it('renders the app bar title and navigation items', () => {
+    renderLayout()
+
+    // App bar contains the title
+    expect(screen.getAllByText('Terraform Registry').length).toBeGreaterThanOrEqual(1)
+
+    // All public nav items are present
+    expect(screen.getByText('Home')).toBeInTheDocument()
+    expect(screen.getByText('Modules')).toBeInTheDocument()
+    expect(screen.getByText('Providers')).toBeInTheDocument()
+    expect(screen.getByText('Terraform Binaries')).toBeInTheDocument()
+    expect(screen.getByText('API Docs')).toBeInTheDocument()
+  })
+
+  // 2. Unauthenticated state
+  it('shows Login button when not authenticated', () => {
+    renderLayout()
+
+    expect(screen.getByRole('link', { name: 'Login' })).toBeInTheDocument()
+    expect(screen.queryByLabelText('account of current user')).not.toBeInTheDocument()
+  })
+
+  // 3. Authenticated state — user menu
+  it('shows account icon and user email in menu when authenticated', async () => {
+    const user = userEvent.setup()
+    setAuth({
+      isAuthenticated: true,
+      user: { email: 'alice@example.com', id: '1', name: 'Alice', username: 'alice' },
+    })
+    renderLayout()
+
+    // Login button should not be present
+    expect(screen.queryByRole('link', { name: 'Login' })).not.toBeInTheDocument()
+
+    // Click account icon to open menu
+    const accountBtn = screen.getByLabelText('account of current user')
+    await user.click(accountBtn)
+
+    expect(screen.getByText('alice@example.com')).toBeInTheDocument()
+    expect(screen.getByText('Logout')).toBeInTheDocument()
+  })
+
+  // 4. Logout
+  it('calls logout when Logout menu item is clicked', async () => {
+    const user = userEvent.setup()
+    setAuth({
+      isAuthenticated: true,
+      user: { email: 'bob@test.com', id: '2', name: 'Bob', username: 'bob' },
+    })
+    renderLayout()
+
+    await user.click(screen.getByLabelText('account of current user'))
+    await user.click(screen.getByText('Logout'))
+
+    expect(mockLogout).toHaveBeenCalledOnce()
+  })
+
+  // 5. Admin nav hidden when unauthenticated
+  it('does not show admin navigation when unauthenticated', () => {
+    renderLayout()
+
+    expect(screen.queryByText('Dashboard')).not.toBeInTheDocument()
+    expect(screen.queryByText('Users')).not.toBeInTheDocument()
+    expect(screen.queryByText('Organizations')).not.toBeInTheDocument()
+  })
+
+  // 6. Admin nav visible for admin scope
+  it('shows all admin navigation groups for admin scope', () => {
+    setAuth({ isAuthenticated: true, allowedScopes: ['admin'] })
+    renderLayout()
+
+    // Dashboard link
+    expect(screen.getByText('Dashboard')).toBeInTheDocument()
+
+    // Identity group
+    expect(screen.getByText('Identity')).toBeInTheDocument()
+    expect(screen.getByText('Organizations')).toBeInTheDocument()
+    expect(screen.getByText('Roles')).toBeInTheDocument()
+    expect(screen.getByText('Users')).toBeInTheDocument()
+    expect(screen.getByText('OIDC Groups')).toBeInTheDocument()
+    expect(screen.getByText('API Keys')).toBeInTheDocument()
+
+    // Source Control group — label and item share the same text
+    expect(screen.getAllByText('Source Control').length).toBe(2)
+
+    // Mirroring group
+    expect(screen.getByText('Mirroring')).toBeInTheDocument()
+    expect(screen.getByText('Provider Config')).toBeInTheDocument()
+    expect(screen.getByText('Approvals')).toBeInTheDocument()
+    expect(screen.getByText('Mirror Policies')).toBeInTheDocument()
+
+    // System group
+    expect(screen.getByText('System')).toBeInTheDocument()
+    expect(screen.getByText('Storage')).toBeInTheDocument()
+    expect(screen.getByText('Security Scanning')).toBeInTheDocument()
+    expect(screen.getByText('Audit Logs')).toBeInTheDocument()
+  })
+
+  // 7. Scoped admin nav — limited scopes only see allowed items
+  it('filters admin nav items based on user scopes', () => {
+    setAuth({
+      isAuthenticated: true,
+      allowedScopes: ['mirrors:read'],
+    })
+    renderLayout()
+
+    // Should see API Keys (scope: null — always visible) and mirroring items
+    expect(screen.getByText('API Keys')).toBeInTheDocument()
+    expect(screen.getByText('Provider Config')).toBeInTheDocument()
+    expect(screen.getByText('Approvals')).toBeInTheDocument()
+    expect(screen.getByText('Binaries Config')).toBeInTheDocument()
+
+    // Should NOT see admin-only items
+    expect(screen.queryByText('OIDC Groups')).not.toBeInTheDocument()
+    expect(screen.queryByText('Storage')).not.toBeInTheDocument()
+    expect(screen.queryByText('Security Scanning')).not.toBeInTheDocument()
+    expect(screen.queryByText('Mirror Policies')).not.toBeInTheDocument()
+
+    // Should NOT see items requiring other scopes
+    expect(screen.queryByText('Organizations')).not.toBeInTheDocument()
+    expect(screen.queryByText('Audit Logs')).not.toBeInTheDocument()
+  })
+
+  // 8. Collapsible admin groups
+  it('collapses and expands admin nav groups on click', async () => {
+    const user = userEvent.setup()
+    setAuth({ isAuthenticated: true, allowedScopes: ['admin'] })
+    renderLayout()
+
+    // Identity group items are visible by default (open)
+    expect(screen.getByText('Users')).toBeInTheDocument()
+
+    // Click the Identity group header to collapse it
+    await user.click(screen.getByText('Identity'))
+
+    // Items should be hidden after collapse animation (unmountOnExit)
+    // Wait for the Collapse transition to complete
+    await vi.waitFor(() => {
+      expect(screen.queryByText('Users')).not.toBeInTheDocument()
+    })
+
+    // Click again to re-expand
+    await user.click(screen.getByText('Identity'))
+    await vi.waitFor(() => {
+      expect(screen.getByText('Users')).toBeInTheDocument()
+    })
+  })
+
+  // 9. Theme toggle
+  it('calls toggleTheme when theme button is clicked', async () => {
+    const user = userEvent.setup()
+    renderLayout()
+
+    await user.click(screen.getByLabelText('toggle dark mode'))
+    expect(mockToggleTheme).toHaveBeenCalledOnce()
+  })
+
+  // 10. Help button
+  it('calls openHelp when help button is clicked', async () => {
+    const user = userEvent.setup()
+    renderLayout()
+
+    await user.click(screen.getByLabelText('Context help'))
+    expect(mockOpenHelp).toHaveBeenCalledOnce()
+  })
+
+  // 11. About modal
+  it('opens About modal when About button is clicked', async () => {
+    const user = userEvent.setup()
+    renderLayout()
+
+    expect(screen.queryByTestId('about-modal')).not.toBeInTheDocument()
+
+    await user.click(screen.getByLabelText('About'))
+    expect(screen.getByTestId('about-modal')).toBeInTheDocument()
+  })
+
+  // 12. Active nav item — home route
+  it('highlights the active navigation item based on route', () => {
+    setAuth({ isAuthenticated: true, allowedScopes: ['admin'] })
+    renderLayout('/modules')
+
+    // The Modules nav item should have the active border styling
+    // We verify by checking the link is rendered and has the correct href
+    const modulesLink = screen.getByText('Modules').closest('a')
+    expect(modulesLink).toHaveAttribute('href', '/modules')
+  })
+
+  // 13. DevUserSwitcher shown when authenticated
+  it('renders DevUserSwitcher when authenticated', () => {
+    setAuth({ isAuthenticated: true })
+    renderLayout()
+
+    expect(screen.getByTestId('dev-user-switcher')).toBeInTheDocument()
+  })
+
+  // 14. DevUserSwitcher hidden when not authenticated
+  it('does not render DevUserSwitcher when not authenticated', () => {
+    renderLayout()
+
+    expect(screen.queryByTestId('dev-user-switcher')).not.toBeInTheDocument()
+  })
+
+  // 15. Skip-to-content link
+  it('renders a skip-to-content link for accessibility', () => {
+    renderLayout()
+
+    const skipLink = screen.getByText('Skip to main content')
+    expect(skipLink).toBeInTheDocument()
+    expect(skipLink.getAttribute('href')).toBe('#main-content')
+  })
+
+  // 16. Close About modal
+  it('closes About modal when close callback fires', async () => {
+    const user = userEvent.setup()
+    renderLayout()
+
+    await user.click(screen.getByLabelText('About'))
+    expect(screen.getByTestId('about-modal')).toBeInTheDocument()
+
+    await user.click(within(screen.getByTestId('about-modal')).getByText('Close'))
+    expect(screen.queryByTestId('about-modal')).not.toBeInTheDocument()
+  })
+
+  // 17. Closing user menu without logging out
+  it('closes user menu when clicking away (handleClose)', async () => {
+    const user = userEvent.setup()
+    setAuth({
+      isAuthenticated: true,
+      user: { email: 'carol@test.com', id: '3', name: 'Carol', username: 'carol' },
+    })
+    renderLayout()
+
+    // Open the menu
+    await user.click(screen.getByLabelText('account of current user'))
+    expect(screen.getByRole('presentation')).toBeInTheDocument()
+
+    // Press Escape to close the menu — MUI backdrop/presentation should disappear
+    await user.keyboard('{Escape}')
+    await vi.waitFor(() => {
+      expect(screen.queryByRole('presentation')).not.toBeInTheDocument()
+    })
+
+    // logout should NOT have been called
+    expect(mockLogout).not.toHaveBeenCalled()
+  })
+
+  // 18. localStorage persistence of admin nav group state
+  it('persists collapsed admin group state to localStorage', async () => {
+    const user = userEvent.setup()
+    setAuth({ isAuthenticated: true, allowedScopes: ['admin'] })
+    renderLayout()
+
+    // Collapse the Identity group
+    await user.click(screen.getByText('Identity'))
+
+    // Check that localStorage was updated
+    const stored = localStorage.getItem('adminNavGroups')
+    expect(stored).toBeTruthy()
+    const parsed = JSON.parse(stored!)
+    expect(parsed.identity).toBe(false)
+  })
+})

--- a/frontend/src/components/__tests__/ModuleDocumentation.test.tsx
+++ b/frontend/src/components/__tests__/ModuleDocumentation.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import ModuleDocumentation from '../ModuleDocumentation'
+import type { ModuleDoc } from '../../types'
+
+describe('ModuleDocumentation', () => {
+  it('returns null when loading', () => {
+    const { container } = render(
+      <ModuleDocumentation moduleDocs={null} docsLoading={true} />
+    )
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('shows empty message when moduleDocs is null', () => {
+    render(<ModuleDocumentation moduleDocs={null} docsLoading={false} />)
+    expect(screen.getByText(/No inputs, outputs, or provider requirements/)).toBeInTheDocument()
+  })
+
+  it('shows empty message when all sections are empty', () => {
+    const emptyDocs: ModuleDoc = {
+      inputs: [],
+      outputs: [],
+      providers: [],
+      requirements: null,
+    }
+    render(<ModuleDocumentation moduleDocs={emptyDocs} docsLoading={false} />)
+    expect(screen.getByText(/No inputs, outputs, or provider requirements/)).toBeInTheDocument()
+  })
+
+  it('renders inputs table', () => {
+    const docs: ModuleDoc = {
+      inputs: [
+        { name: 'vpc_id', type: 'string', description: 'VPC ID', required: true, default: undefined },
+        { name: 'region', type: 'string', description: 'AWS region', required: false, default: 'us-east-1' },
+      ],
+      outputs: [],
+      providers: [],
+      requirements: null,
+    }
+    render(<ModuleDocumentation moduleDocs={docs} docsLoading={false} />)
+    expect(screen.getByText('Inputs')).toBeInTheDocument()
+    expect(screen.getByText('vpc_id')).toBeInTheDocument()
+    expect(screen.getByText('region')).toBeInTheDocument()
+    expect(screen.getByText('Yes')).toBeInTheDocument()
+    expect(screen.getByText('No')).toBeInTheDocument()
+  })
+
+  it('renders outputs table', () => {
+    const docs: ModuleDoc = {
+      inputs: [],
+      outputs: [
+        { name: 'subnet_ids', description: 'List of subnet IDs', sensitive: false },
+        { name: 'db_password', description: 'Database password', sensitive: true },
+      ],
+      providers: [],
+      requirements: null,
+    }
+    render(<ModuleDocumentation moduleDocs={docs} docsLoading={false} />)
+    expect(screen.getByText('Outputs')).toBeInTheDocument()
+    expect(screen.getByText('subnet_ids')).toBeInTheDocument()
+    expect(screen.getByText('db_password')).toBeInTheDocument()
+    // "Sensitive" appears in both table header and chip
+    expect(screen.getAllByText('Sensitive').length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('renders provider requirements table', () => {
+    const docs: ModuleDoc = {
+      inputs: [],
+      outputs: [],
+      providers: [
+        { name: 'aws', source: 'hashicorp/aws', version_constraints: '>= 5.0' },
+      ],
+      requirements: null,
+    }
+    render(<ModuleDocumentation moduleDocs={docs} docsLoading={false} />)
+    expect(screen.getByText('Provider Requirements')).toBeInTheDocument()
+    expect(screen.getByText('hashicorp/aws')).toBeInTheDocument()
+    expect(screen.getByText('>= 5.0')).toBeInTheDocument()
+  })
+
+  it('renders terraform version requirement', () => {
+    const docs: ModuleDoc = {
+      inputs: [{ name: 'x', type: 'string', description: 'test', required: true, default: undefined }],
+      outputs: [],
+      providers: [],
+      requirements: { required_version: '>= 1.5.0' },
+    }
+    render(<ModuleDocumentation moduleDocs={docs} docsLoading={false} />)
+    expect(screen.getByText('Terraform Version Requirement')).toBeInTheDocument()
+    expect(screen.getByText('>= 1.5.0')).toBeInTheDocument()
+  })
+
+  it('renders all sections together', () => {
+    const docs: ModuleDoc = {
+      inputs: [{ name: 'name', type: 'string', description: 'Name', required: true, default: undefined }],
+      outputs: [{ name: 'id', description: 'Resource ID', sensitive: false }],
+      providers: [{ name: 'aws', source: 'hashicorp/aws', version_constraints: '~> 5.0' }],
+      requirements: { required_version: '>= 1.5.0' },
+    }
+    render(<ModuleDocumentation moduleDocs={docs} docsLoading={false} />)
+    expect(screen.getByText('Inputs')).toBeInTheDocument()
+    expect(screen.getByText('Outputs')).toBeInTheDocument()
+    expect(screen.getByText('Provider Requirements')).toBeInTheDocument()
+    expect(screen.getByText('Terraform Version Requirement')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/__tests__/ProviderDocContent.test.tsx
+++ b/frontend/src/components/__tests__/ProviderDocContent.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const getProviderDocContentMock = vi.fn()
+vi.mock('../../services/api', () => ({
+  default: {
+    getProviderDocContent: (...args: unknown[]) => getProviderDocContentMock(...args),
+  },
+}))
+
+vi.mock('../MarkdownRenderer', () => ({
+  default: ({ children }: { children: string }) => <div data-testid="markdown">{children}</div>,
+}))
+
+import ProviderDocContent from '../ProviderDocContent'
+
+describe('ProviderDocContent', () => {
+  const defaultProps = {
+    namespace: 'hashicorp',
+    type: 'aws',
+    version: '5.0.0',
+    category: 'resources',
+    slug: 'aws_instance',
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows loading spinner initially', () => {
+    getProviderDocContentMock.mockReturnValue(new Promise(() => {}))
+    render(<ProviderDocContent {...defaultProps} />)
+    expect(screen.getByRole('progressbar')).toBeInTheDocument()
+  })
+
+  it('renders content after load', async () => {
+    getProviderDocContentMock.mockResolvedValue({
+      content: '# AWS Instance\n\nManages an EC2 instance.',
+    })
+    render(<ProviderDocContent {...defaultProps} />)
+    await waitFor(() => {
+      expect(screen.getByTestId('markdown')).toHaveTextContent('# AWS Instance')
+    })
+  })
+
+  it('strips frontmatter from content', async () => {
+    getProviderDocContentMock.mockResolvedValue({
+      content: '---\ntitle: AWS Instance\n---\n# AWS Instance\n\nBody content.',
+    })
+    render(<ProviderDocContent {...defaultProps} />)
+    await waitFor(() => {
+      const md = screen.getByTestId('markdown')
+      expect(md.textContent).not.toContain('title: AWS Instance')
+      expect(md.textContent).toContain('# AWS Instance')
+    })
+  })
+
+  it('shows error on API failure', async () => {
+    getProviderDocContentMock.mockRejectedValue(new Error('Not found'))
+    render(<ProviderDocContent {...defaultProps} />)
+    await waitFor(() => {
+      expect(screen.getByText('Failed to load documentation.')).toBeInTheDocument()
+    })
+  })
+
+  it('handles content without frontmatter', async () => {
+    getProviderDocContentMock.mockResolvedValue({
+      content: 'Plain markdown content.',
+    })
+    render(<ProviderDocContent {...defaultProps} />)
+    await waitFor(() => {
+      expect(screen.getByTestId('markdown')).toHaveTextContent('Plain markdown content.')
+    })
+  })
+})

--- a/frontend/src/components/__tests__/ProviderIcon.test.tsx
+++ b/frontend/src/components/__tests__/ProviderIcon.test.tsx
@@ -1,0 +1,110 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { ProviderIcon, providerDisplayName } from '../ProviderIcon'
+
+describe('providerDisplayName', () => {
+  it('returns display name for known providers', () => {
+    expect(providerDisplayName('aws')).toBe('AWS')
+    expect(providerDisplayName('azurerm')).toBe('Azure')
+    expect(providerDisplayName('google')).toBe('Google')
+    expect(providerDisplayName('hashicorp')).toBe('HashiCorp')
+    expect(providerDisplayName('vmware')).toBe('VMware')
+    expect(providerDisplayName('oci')).toBe('Oracle Cloud')
+  })
+
+  it('is case-insensitive', () => {
+    expect(providerDisplayName('AWS')).toBe('AWS')
+    expect(providerDisplayName('Azurerm')).toBe('Azure')
+    expect(providerDisplayName('GOOGLE')).toBe('Google')
+  })
+
+  it('title-cases unknown providers', () => {
+    expect(providerDisplayName('custom')).toBe('Custom')
+    expect(providerDisplayName('datadog')).toBe('Datadog')
+  })
+
+  it('handles single-char names', () => {
+    expect(providerDisplayName('x')).toBe('X')
+  })
+})
+
+describe('ProviderIcon', () => {
+  it('returns null for unknown providers', () => {
+    const { container } = render(<ProviderIcon provider="unknown-provider" />)
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('renders Font Awesome icon for aws', () => {
+    render(<ProviderIcon provider="aws" />)
+    const icon = screen.getByLabelText('AWS')
+    expect(icon).toBeInTheDocument()
+  })
+
+  it('renders Font Awesome icon for azurerm', () => {
+    render(<ProviderIcon provider="azurerm" />)
+    expect(screen.getByLabelText('Azure')).toBeInTheDocument()
+  })
+
+  it('renders simple-icons SVG for hashicorp', () => {
+    render(<ProviderIcon provider="hashicorp" />)
+    const svg = screen.getByLabelText('HashiCorp')
+    expect(svg).toBeInTheDocument()
+    expect(svg.tagName.toLowerCase()).toBe('svg')
+  })
+
+  it('renders simple-icons SVG for google', () => {
+    render(<ProviderIcon provider="google" />)
+    expect(screen.getByLabelText('Google')).toBeInTheDocument()
+  })
+
+  it('renders simple-icons SVG for vsphere', () => {
+    render(<ProviderIcon provider="vsphere" />)
+    expect(screen.getByLabelText('VMware vSphere')).toBeInTheDocument()
+  })
+
+  it('renders avatar for oci', () => {
+    render(<ProviderIcon provider="oci" />)
+    const avatar = screen.getByLabelText('Oracle Cloud')
+    expect(avatar).toBeInTheDocument()
+    expect(avatar).toHaveTextContent('OCI')
+  })
+
+  it('renders avatar for oracle', () => {
+    render(<ProviderIcon provider="oracle" />)
+    const avatar = screen.getByLabelText('Oracle')
+    expect(avatar).toBeInTheDocument()
+    expect(avatar).toHaveTextContent('OC')
+  })
+
+  it('respects custom size prop', () => {
+    render(<ProviderIcon provider="aws" size={48} />)
+    const icon = screen.getByLabelText('AWS')
+    expect(icon).toBeInTheDocument()
+  })
+
+  it('is case-insensitive', () => {
+    render(<ProviderIcon provider="AWS" />)
+    expect(screen.getByLabelText('AWS')).toBeInTheDocument()
+  })
+
+  it('renders azure alias same as azurerm', () => {
+    render(<ProviderIcon provider="azure" />)
+    expect(screen.getByLabelText('Azure')).toBeInTheDocument()
+  })
+
+  it('renders microsoft provider', () => {
+    render(<ProviderIcon provider="microsoft" />)
+    expect(screen.getByLabelText('Microsoft')).toBeInTheDocument()
+  })
+
+  it('renders googlecloud with simple-icons', () => {
+    render(<ProviderIcon provider="googlecloud" />)
+    const svg = screen.getByLabelText('Google Cloud')
+    expect(svg.tagName.toLowerCase()).toBe('svg')
+  })
+
+  it('renders vcenter as VMware vCenter', () => {
+    render(<ProviderIcon provider="vcenter" />)
+    expect(screen.getByLabelText('VMware vCenter')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/__tests__/SCMRepositoryPanel.test.tsx
+++ b/frontend/src/components/__tests__/SCMRepositoryPanel.test.tsx
@@ -1,0 +1,107 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi } from 'vitest'
+import SCMRepositoryPanel from '../SCMRepositoryPanel'
+import type { ModuleSCMLink } from '../../types/scm'
+
+const defaultLink: ModuleSCMLink = {
+  id: 'link-1',
+  module_id: 'mod-1',
+  provider_id: 'scm-1',
+  repository_owner: 'myorg',
+  repository_name: 'terraform-vpc',
+  default_branch: 'main',
+  tag_pattern: 'v*',
+  auto_publish_enabled: true,
+  webhook_secret: '',
+  last_sync_at: '2025-06-01T12:00:00Z',
+  created_at: '2025-01-01T00:00:00Z',
+  updated_at: '2025-06-01T12:00:00Z',
+}
+
+const defaultProps = {
+  isAuthenticated: true,
+  scmLinkLoaded: true,
+  scmLink: defaultLink,
+  scmSyncing: false,
+  scmUnlinking: false,
+  onSync: vi.fn(),
+  onUnlink: vi.fn(),
+  onOpenWizard: vi.fn(),
+}
+
+describe('SCMRepositoryPanel', () => {
+  it('returns null when not authenticated', () => {
+    const { container } = render(
+      <SCMRepositoryPanel {...defaultProps} isAuthenticated={false} />
+    )
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('returns null when scm link not loaded', () => {
+    const { container } = render(
+      <SCMRepositoryPanel {...defaultProps} scmLinkLoaded={false} />
+    )
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('renders repository info when linked', () => {
+    render(<SCMRepositoryPanel {...defaultProps} />)
+    expect(screen.getByText('Source Repository')).toBeInTheDocument()
+    expect(screen.getByText('myorg/terraform-vpc')).toBeInTheDocument()
+    expect(screen.getByText(/Branch: main/)).toBeInTheDocument()
+    expect(screen.getByText('Auto-publish on')).toBeInTheDocument()
+  })
+
+  it('shows auto-publish off chip', () => {
+    render(
+      <SCMRepositoryPanel
+        {...defaultProps}
+        scmLink={{ ...defaultLink, auto_publish_enabled: false }}
+      />
+    )
+    expect(screen.getByText('Auto-publish off')).toBeInTheDocument()
+  })
+
+  it('shows Sync Now button', () => {
+    render(<SCMRepositoryPanel {...defaultProps} />)
+    expect(screen.getByText('Sync Now')).toBeInTheDocument()
+  })
+
+  it('shows Syncing... when syncing', () => {
+    render(<SCMRepositoryPanel {...defaultProps} scmSyncing={true} />)
+    expect(screen.getByText('Syncing...')).toBeInTheDocument()
+  })
+
+  it('shows Unlink Repository button', () => {
+    render(<SCMRepositoryPanel {...defaultProps} />)
+    expect(screen.getByText('Unlink Repository')).toBeInTheDocument()
+  })
+
+  it('shows Unlinking... when unlinking', () => {
+    render(<SCMRepositoryPanel {...defaultProps} scmUnlinking={true} />)
+    expect(screen.getByText('Unlinking...')).toBeInTheDocument()
+  })
+
+  it('calls onSync when sync button clicked', async () => {
+    const onSync = vi.fn()
+    const user = userEvent.setup()
+    render(<SCMRepositoryPanel {...defaultProps} onSync={onSync} />)
+    await user.click(screen.getByText('Sync Now'))
+    expect(onSync).toHaveBeenCalled()
+  })
+
+  it('shows Link Repository when no scmLink', () => {
+    render(<SCMRepositoryPanel {...defaultProps} scmLink={null} />)
+    expect(screen.getByText('Link Repository')).toBeInTheDocument()
+    expect(screen.getByText(/Not linked to a repository/)).toBeInTheDocument()
+  })
+
+  it('calls onOpenWizard when Link Repository is clicked', async () => {
+    const onOpenWizard = vi.fn()
+    const user = userEvent.setup()
+    render(<SCMRepositoryPanel {...defaultProps} scmLink={null} onOpenWizard={onOpenWizard} />)
+    await user.click(screen.getByText('Link Repository'))
+    expect(onOpenWizard).toHaveBeenCalled()
+  })
+})

--- a/frontend/src/components/__tests__/VersionDetailsPanel.test.tsx
+++ b/frontend/src/components/__tests__/VersionDetailsPanel.test.tsx
@@ -1,0 +1,192 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi } from 'vitest'
+import VersionDetailsPanel from '../VersionDetailsPanel'
+import type { ModuleVersion } from '../../types'
+
+function makeVersion(overrides: Partial<ModuleVersion> = {}): ModuleVersion {
+  return {
+    id: 'v-1',
+    version: '1.0.0',
+    namespace: 'hashicorp',
+    name: 'consul',
+    system: 'aws',
+    download_count: 42,
+    published_at: '2025-01-15T10:00:00Z',
+    created_at: '2025-01-15T10:00:00Z',
+    deprecated: false,
+    ...overrides,
+  } as ModuleVersion
+}
+
+describe('VersionDetailsPanel', () => {
+  const defaultProps = {
+    canManage: false,
+    deprecating: false,
+    onUndeprecate: vi.fn(),
+    onOpenDeprecateDialog: vi.fn(),
+    onOpenDeleteVersionDialog: vi.fn(),
+  }
+
+  it('returns null when selectedVersion is null', () => {
+    const { container } = render(
+      <VersionDetailsPanel {...defaultProps} selectedVersion={null} />
+    )
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('renders version number heading', () => {
+    render(
+      <VersionDetailsPanel {...defaultProps} selectedVersion={makeVersion()} />
+    )
+    expect(screen.getByText('Version 1.0.0 Details')).toBeInTheDocument()
+  })
+
+  it('renders published date', () => {
+    render(
+      <VersionDetailsPanel {...defaultProps} selectedVersion={makeVersion()} />
+    )
+    // Should contain a date string
+    expect(screen.getByText(/Published:/)).toBeInTheDocument()
+  })
+
+  it('renders download count', () => {
+    render(
+      <VersionDetailsPanel {...defaultProps} selectedVersion={makeVersion({ download_count: 100 })} />
+    )
+    expect(screen.getByText(/100/)).toBeInTheDocument()
+  })
+
+  it('renders N/A when no published date', () => {
+    render(
+      <VersionDetailsPanel
+        {...defaultProps}
+        selectedVersion={makeVersion({ published_at: undefined, created_at: undefined })}
+      />
+    )
+    expect(screen.getByText(/N\/A/)).toBeInTheDocument()
+  })
+
+  it('renders published_by_name when present', () => {
+    render(
+      <VersionDetailsPanel
+        {...defaultProps}
+        selectedVersion={makeVersion({ published_by_name: 'John Doe' })}
+      />
+    )
+    expect(screen.getByText('John Doe')).toBeInTheDocument()
+  })
+
+  it('shows deprecation alert when deprecated', () => {
+    render(
+      <VersionDetailsPanel
+        {...defaultProps}
+        selectedVersion={makeVersion({
+          deprecated: true,
+          deprecated_at: '2025-06-01T00:00:00Z',
+          deprecation_message: 'Use v2 instead',
+        })}
+      />
+    )
+    expect(screen.getByText(/Deprecated/)).toBeInTheDocument()
+    expect(screen.getByText('Use v2 instead')).toBeInTheDocument()
+  })
+
+  it('shows deprecate button when canManage and not deprecated', () => {
+    render(
+      <VersionDetailsPanel
+        {...defaultProps}
+        canManage={true}
+        selectedVersion={makeVersion()}
+      />
+    )
+    expect(screen.getByText('Deprecate Version')).toBeInTheDocument()
+  })
+
+  it('shows undeprecate button when canManage and deprecated', () => {
+    render(
+      <VersionDetailsPanel
+        {...defaultProps}
+        canManage={true}
+        selectedVersion={makeVersion({ deprecated: true })}
+      />
+    )
+    expect(screen.getByText('Remove Deprecation')).toBeInTheDocument()
+  })
+
+  it('shows "Removing Deprecation..." when deprecating in progress', () => {
+    render(
+      <VersionDetailsPanel
+        {...defaultProps}
+        canManage={true}
+        deprecating={true}
+        selectedVersion={makeVersion({ deprecated: true })}
+      />
+    )
+    expect(screen.getByText('Removing Deprecation...')).toBeInTheDocument()
+  })
+
+  it('shows delete button when canManage', () => {
+    render(
+      <VersionDetailsPanel
+        {...defaultProps}
+        canManage={true}
+        selectedVersion={makeVersion()}
+      />
+    )
+    expect(screen.getByText('Delete This Version')).toBeInTheDocument()
+  })
+
+  it('hides manage buttons when canManage is false', () => {
+    render(
+      <VersionDetailsPanel {...defaultProps} selectedVersion={makeVersion()} />
+    )
+    expect(screen.queryByText('Deprecate Version')).not.toBeInTheDocument()
+    expect(screen.queryByText('Delete This Version')).not.toBeInTheDocument()
+  })
+
+  it('calls onOpenDeprecateDialog when deprecate is clicked', async () => {
+    const onOpenDeprecateDialog = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <VersionDetailsPanel
+        {...defaultProps}
+        canManage={true}
+        onOpenDeprecateDialog={onOpenDeprecateDialog}
+        selectedVersion={makeVersion()}
+      />
+    )
+    await user.click(screen.getByText('Deprecate Version'))
+    expect(onOpenDeprecateDialog).toHaveBeenCalled()
+  })
+
+  it('calls onOpenDeleteVersionDialog with version when delete is clicked', async () => {
+    const onOpenDeleteVersionDialog = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <VersionDetailsPanel
+        {...defaultProps}
+        canManage={true}
+        onOpenDeleteVersionDialog={onOpenDeleteVersionDialog}
+        selectedVersion={makeVersion({ version: '2.0.0' })}
+      />
+    )
+    await user.click(screen.getByText('Delete This Version'))
+    expect(onOpenDeleteVersionDialog).toHaveBeenCalledWith('2.0.0')
+  })
+
+  it('calls onUndeprecate when remove deprecation is clicked', async () => {
+    const onUndeprecate = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <VersionDetailsPanel
+        {...defaultProps}
+        canManage={true}
+        onUndeprecate={onUndeprecate}
+        selectedVersion={makeVersion({ deprecated: true })}
+      />
+    )
+    await user.click(screen.getByText('Remove Deprecation'))
+    expect(onUndeprecate).toHaveBeenCalled()
+  })
+})

--- a/frontend/src/components/__tests__/WebhookEventsPanel.test.tsx
+++ b/frontend/src/components/__tests__/WebhookEventsPanel.test.tsx
@@ -1,0 +1,124 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi } from 'vitest'
+import WebhookEventsPanel from '../WebhookEventsPanel'
+import type { ModuleSCMLink, SCMWebhookEvent } from '../../types/scm'
+
+const defaultLink: ModuleSCMLink = {
+  id: 'link-1',
+  module_id: 'mod-1',
+  provider_id: 'scm-1',
+  repository_owner: 'myorg',
+  repository_name: 'terraform-vpc',
+  default_branch: 'main',
+  tag_pattern: 'v*',
+  auto_publish_enabled: true,
+  webhook_secret: '',
+  created_at: '2025-01-01T00:00:00Z',
+  updated_at: '2025-06-01T00:00:00Z',
+}
+
+const fakeEvents: SCMWebhookEvent[] = [
+  {
+    id: 'evt-1',
+    module_source_repo_id: 'link-1',
+    event_type: 'tag_push',
+    ref_name: 'v1.0.0',
+    commit_sha: 'abc123',
+    payload: {},
+    state: 'succeeded',
+    created_at: '2025-06-01T12:00:00Z',
+    updated_at: '2025-06-01T12:05:00Z',
+  },
+  {
+    id: 'evt-2',
+    module_source_repo_id: 'link-1',
+    event_type: 'tag_push',
+    ref_name: 'v1.1.0',
+    commit_sha: 'def456',
+    payload: {},
+    state: 'failed',
+    error_message: 'Archive extraction failed',
+    created_at: '2025-06-02T12:00:00Z',
+    updated_at: '2025-06-02T12:01:00Z',
+  },
+]
+
+const defaultProps = {
+  isAuthenticated: true,
+  scmLink: defaultLink,
+  moduleId: 'mod-1',
+  webhookEvents: fakeEvents,
+  webhookEventsLoaded: true,
+  webhookEventsLoading: false,
+  webhookEventsExpanded: true,
+  onToggleExpanded: vi.fn(),
+  onLoadEvents: vi.fn().mockResolvedValue(undefined),
+}
+
+describe('WebhookEventsPanel', () => {
+  it('returns null when not authenticated', () => {
+    const { container } = render(
+      <WebhookEventsPanel {...defaultProps} isAuthenticated={false} />
+    )
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('returns null when no scmLink', () => {
+    const { container } = render(
+      <WebhookEventsPanel {...defaultProps} scmLink={null} />
+    )
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('renders webhook events heading', () => {
+    render(<WebhookEventsPanel {...defaultProps} />)
+    expect(screen.getByText('Webhook Events')).toBeInTheDocument()
+  })
+
+  it('renders event list when expanded', () => {
+    render(<WebhookEventsPanel {...defaultProps} />)
+    expect(screen.getByText(/tag_push — v1.0.0/)).toBeInTheDocument()
+    expect(screen.getByText('succeeded')).toBeInTheDocument()
+    expect(screen.getByText('failed')).toBeInTheDocument()
+  })
+
+  it('shows error message for failed events', () => {
+    render(<WebhookEventsPanel {...defaultProps} />)
+    expect(screen.getByText('Archive extraction failed')).toBeInTheDocument()
+  })
+
+  it('shows empty message when no events', () => {
+    render(
+      <WebhookEventsPanel {...defaultProps} webhookEvents={[]} />
+    )
+    expect(screen.getByText('No webhook events recorded yet.')).toBeInTheDocument()
+  })
+
+  it('shows loading spinner when loading', () => {
+    render(
+      <WebhookEventsPanel {...defaultProps} webhookEventsLoading={true} webhookEvents={[]} />
+    )
+    expect(screen.getByRole('progressbar')).toBeInTheDocument()
+  })
+
+  it('shows Refresh button when loaded', () => {
+    render(<WebhookEventsPanel {...defaultProps} />)
+    expect(screen.getByText('Refresh')).toBeInTheDocument()
+  })
+
+  it('calls onToggleExpanded when header clicked', async () => {
+    const onToggleExpanded = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <WebhookEventsPanel {...defaultProps} onToggleExpanded={onToggleExpanded} />
+    )
+    await user.click(screen.getByText('Webhook Events'))
+    expect(onToggleExpanded).toHaveBeenCalled()
+  })
+
+  it('toggle button has aria label', () => {
+    render(<WebhookEventsPanel {...defaultProps} />)
+    expect(screen.getByLabelText('Toggle webhook events')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/__tests__/CallbackPage.test.tsx
+++ b/frontend/src/pages/__tests__/CallbackPage.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock the AuthContext
+const mockSetToken = vi.fn()
+vi.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => ({
+    setToken: mockSetToken,
+  }),
+}))
+
+// Must import after mock setup
+import CallbackPage from '../CallbackPage'
+
+// Mock window.location.replace
+beforeEach(() => {
+  vi.clearAllMocks()
+  Object.defineProperty(window, 'location', {
+    writable: true,
+    value: { ...window.location, replace: vi.fn() },
+  })
+})
+
+function renderWithParams(search: string) {
+  return render(
+    <MemoryRouter initialEntries={[`/auth/callback${search}`]}>
+      <CallbackPage />
+    </MemoryRouter>
+  )
+}
+
+describe('CallbackPage', () => {
+  it('shows loading spinner initially', () => {
+    renderWithParams('?token=abc123')
+    expect(screen.getByText('Completing authentication...')).toBeInTheDocument()
+  })
+
+  it('shows error when error param is present', async () => {
+    renderWithParams('?error=access_denied&error_description=User+denied+access')
+    await waitFor(() => {
+      expect(screen.getByText('Authentication Error')).toBeInTheDocument()
+      expect(screen.getByText('User denied access')).toBeInTheDocument()
+    })
+  })
+
+  it('shows fallback error message when only error param', async () => {
+    renderWithParams('?error=server_error')
+    await waitFor(() => {
+      expect(screen.getByText('server_error')).toBeInTheDocument()
+    })
+  })
+
+  it('shows error when no token is available', async () => {
+    // Mock fetch to return non-ok
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: false,
+    } as Response)
+
+    renderWithParams('')
+    await waitFor(() => {
+      expect(screen.getByText('No authentication token received.')).toBeInTheDocument()
+    })
+  })
+
+  it('calls setToken when token param is present', async () => {
+    renderWithParams('?token=jwt-token-123')
+    await waitFor(() => {
+      expect(mockSetToken).toHaveBeenCalledWith('jwt-token-123')
+    })
+  })
+
+  it('shows redirecting message on error', async () => {
+    renderWithParams('?error=invalid_request')
+    await waitFor(() => {
+      expect(screen.getByText('Redirecting to login page...')).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/pages/__tests__/HomePage.test.tsx
+++ b/frontend/src/pages/__tests__/HomePage.test.tsx
@@ -1,0 +1,146 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
+
+// ---- Mocks ----
+
+const getSetupStatusMock = vi.fn()
+const searchModulesMock = vi.fn()
+const searchProvidersMock = vi.fn()
+const listPublicTerraformMirrorConfigsMock = vi.fn()
+
+vi.mock('../../services/api', () => ({
+  default: {
+    getSetupStatus: (...args: unknown[]) => getSetupStatusMock(...args),
+    searchModules: (...args: unknown[]) => searchModulesMock(...args),
+    searchProviders: (...args: unknown[]) => searchProvidersMock(...args),
+    listPublicTerraformMirrorConfigs: (...args: unknown[]) => listPublicTerraformMirrorConfigsMock(...args),
+  },
+}))
+
+const navigateMock = vi.fn()
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return { ...actual, useNavigate: () => navigateMock }
+})
+
+import HomePage from '../HomePage'
+
+// ---- Helpers ----
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <HomePage />
+    </MemoryRouter>,
+  )
+}
+
+function mockSuccessfulLoad() {
+  getSetupStatusMock.mockResolvedValue({ setup_required: false })
+  searchModulesMock.mockResolvedValue({
+    modules: [
+      { namespace: 'hashicorp', name: 'consul', system: 'aws' },
+      { namespace: 'hashicorp', name: 'vault', system: 'aws' },
+    ],
+    meta: { total: 10 },
+  })
+  searchProvidersMock.mockResolvedValue({
+    providers: [
+      { namespace: 'hashicorp', type: 'aws' },
+    ],
+    meta: { total: 5 },
+  })
+  listPublicTerraformMirrorConfigsMock.mockResolvedValue([
+    { name: 'terraform', tool: 'terraform' },
+  ])
+}
+
+// ---- Tests ----
+
+describe('HomePage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders heading after data loads', async () => {
+    mockSuccessfulLoad()
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('Private Terraform Registry')).toBeInTheDocument()
+    })
+  })
+
+  it('shows module count and provider count after load', async () => {
+    mockSuccessfulLoad()
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText(/10 modules/)).toBeInTheDocument()
+    })
+    expect(screen.getByText(/5 providers/)).toBeInTheDocument()
+  })
+
+  it('shows the search field', async () => {
+    mockSuccessfulLoad()
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText(/Search modules/)).toBeInTheDocument()
+    })
+  })
+
+  it('shows setup required alert when setup_required is true', async () => {
+    getSetupStatusMock.mockResolvedValue({ setup_required: true })
+    searchModulesMock.mockResolvedValue({
+      modules: [],
+      meta: { total: 0 },
+    })
+    searchProvidersMock.mockResolvedValue({
+      providers: [],
+      meta: { total: 0 },
+    })
+    listPublicTerraformMirrorConfigsMock.mockResolvedValue([])
+
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('Setup Required')).toBeInTheDocument()
+    })
+    expect(screen.getByText(/This registry has not been configured yet/)).toBeInTheDocument()
+  })
+
+  it('shows CLI usage section with credentials snippet', async () => {
+    mockSuccessfulLoad()
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('Getting Started')).toBeInTheDocument()
+    })
+    expect(screen.getByText(/Get an API Key/)).toBeInTheDocument()
+    expect(screen.getByText(/token = "<your-api-key>"/)).toBeInTheDocument()
+  })
+
+  it('shows module names from search results', async () => {
+    mockSuccessfulLoad()
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('hashicorp/consul')).toBeInTheDocument()
+    })
+    expect(screen.getByText('hashicorp/vault')).toBeInTheDocument()
+  })
+
+  it('shows toggle buttons for search type', async () => {
+    mockSuccessfulLoad()
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Modules' })).toBeInTheDocument()
+    })
+    expect(screen.getByRole('button', { name: 'Providers' })).toBeInTheDocument()
+  })
+
+  it('does not show setup alert when setup_required is false', async () => {
+    mockSuccessfulLoad()
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('Private Terraform Registry')).toBeInTheDocument()
+    })
+    expect(screen.queryByText('Setup Required')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/__tests__/LoginPage.test.tsx
+++ b/frontend/src/pages/__tests__/LoginPage.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock the AuthContext
+const mockLogin = vi.fn()
+vi.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => ({
+    login: mockLogin,
+  }),
+}))
+
+// Mock the api service
+vi.mock('../../services/api', () => ({
+  default: {
+    devLogin: vi.fn().mockResolvedValue({ token: 'test-jwt' }),
+    login: vi.fn(),
+  },
+}))
+
+import LoginPage from '../LoginPage'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  // Mock fetch for AzureAD check
+  vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+    type: 'basic',
+    status: 200,
+  } as Response)
+})
+
+function renderLoginPage() {
+  return render(
+    <MemoryRouter>
+      <LoginPage />
+    </MemoryRouter>
+  )
+}
+
+describe('LoginPage', () => {
+  it('renders the login heading', () => {
+    renderLoginPage()
+    expect(screen.getByText('Terraform Registry')).toBeInTheDocument()
+  })
+
+  it('renders the sign in subtitle', () => {
+    renderLoginPage()
+    expect(screen.getByText('Sign in to continue')).toBeInTheDocument()
+  })
+
+  it('renders SSO login button', () => {
+    renderLoginPage()
+    expect(screen.getByText('Sign in with SSO')).toBeInTheDocument()
+  })
+
+  it('shows info text about SSO', () => {
+    renderLoginPage()
+    expect(screen.getByText(/single sign-on for authentication/)).toBeInTheDocument()
+  })
+
+  it('shows contact administrator message', () => {
+    renderLoginPage()
+    expect(screen.getByText(/Contact your administrator/)).toBeInTheDocument()
+  })
+
+  it('shows dev login button in development mode', () => {
+    // import.meta.env.MODE is 'test' in vitest, not 'development'
+    // So we check that the dev button is NOT shown in test mode
+    renderLoginPage()
+    // In test mode, isDev will be false
+    expect(screen.queryByText('Dev Login (Admin)')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/__tests__/ProvidersPage.test.tsx
+++ b/frontend/src/pages/__tests__/ProvidersPage.test.tsx
@@ -1,0 +1,166 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  }
+})
+
+vi.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => ({
+    isAuthenticated: false,
+    user: null,
+    roleTemplate: null,
+    allowedScopes: [],
+    isLoading: false,
+    login: vi.fn(),
+    logout: vi.fn(),
+    refreshToken: vi.fn(),
+    setToken: vi.fn(),
+  }),
+}))
+
+vi.mock('../../components/ProviderIcon', () => ({
+  ProviderIcon: ({ provider }: { provider: string }) => <span data-testid="provider-icon">{provider}</span>,
+  providerDisplayName: (slug: string) => slug.charAt(0).toUpperCase() + slug.slice(1),
+}))
+
+const searchProvidersMock = vi.fn()
+vi.mock('../../services/api', () => ({
+  default: {
+    searchProviders: (...args: unknown[]) => searchProvidersMock(...args),
+  },
+}))
+
+import ProvidersPage from '../ProvidersPage'
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  })
+}
+
+function renderPage(initialPath = '/providers') {
+  const queryClient = createQueryClient()
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[initialPath]}>
+        <Routes>
+          <Route path="/providers" element={<ProvidersPage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+const fakeProviders = [
+  {
+    id: 'p-1',
+    namespace: 'hashicorp',
+    type: 'aws',
+    description: 'AWS provider',
+    latest_version: '5.0.0',
+    download_count: 1000,
+    source: null,
+  },
+  {
+    id: 'p-2',
+    namespace: 'hashicorp',
+    type: 'azurerm',
+    description: 'Azure RM provider',
+    latest_version: '3.0.0',
+    download_count: 500,
+    source: 'registry.terraform.io',
+  },
+]
+
+describe('ProvidersPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows loading spinner while fetching', () => {
+    searchProvidersMock.mockReturnValue(new Promise(() => {}))
+    renderPage()
+    expect(screen.getByRole('progressbar')).toBeInTheDocument()
+  })
+
+  it('renders page heading', () => {
+    searchProvidersMock.mockReturnValue(new Promise(() => {}))
+    renderPage()
+    expect(screen.getByText('Terraform Providers')).toBeInTheDocument()
+    expect(screen.getByText(/Browse and discover/)).toBeInTheDocument()
+  })
+
+  it('renders provider cards after load', async () => {
+    searchProvidersMock.mockResolvedValue({
+      providers: fakeProviders,
+      meta: { total: 2 },
+    })
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('aws')).toBeInTheDocument()
+      expect(screen.getByText('azurerm')).toBeInTheDocument()
+    })
+  })
+
+  it('shows empty state when no providers found', async () => {
+    searchProvidersMock.mockResolvedValue({
+      providers: [],
+      meta: { total: 0 },
+    })
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('No providers found')).toBeInTheDocument()
+    })
+  })
+
+  it('shows error when API fails', async () => {
+    searchProvidersMock.mockRejectedValue(new Error('Network error'))
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('Failed to load providers. Please try again.')).toBeInTheDocument()
+    })
+  })
+
+  it('shows search field', () => {
+    searchProvidersMock.mockReturnValue(new Promise(() => {}))
+    renderPage()
+    expect(screen.getByPlaceholderText('Search providers...')).toBeInTheDocument()
+  })
+
+  it('shows sort dropdown', () => {
+    searchProvidersMock.mockReturnValue(new Promise(() => {}))
+    renderPage()
+    expect(screen.getByLabelText('Sort By')).toBeInTheDocument()
+  })
+
+  it('shows network mirrored chip for mirrored providers', async () => {
+    searchProvidersMock.mockResolvedValue({
+      providers: fakeProviders,
+      meta: { total: 2 },
+    })
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('Network Mirrored')).toBeInTheDocument()
+    })
+  })
+
+  it('shows download counts', async () => {
+    searchProvidersMock.mockResolvedValue({
+      providers: fakeProviders,
+      meta: { total: 2 },
+    })
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('1000 downloads')).toBeInTheDocument()
+      expect(screen.getByText('500 downloads')).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/pages/__tests__/TerraformBinariesPage.test.tsx
+++ b/frontend/src/pages/__tests__/TerraformBinariesPage.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  }
+})
+
+const listPublicTerraformMirrorConfigsMock = vi.fn()
+const listPublicTerraformVersionsMock = vi.fn()
+vi.mock('../../services/api', () => ({
+  default: {
+    listPublicTerraformMirrorConfigs: (...args: unknown[]) => listPublicTerraformMirrorConfigsMock(...args),
+    listPublicTerraformVersions: (...args: unknown[]) => listPublicTerraformVersionsMock(...args),
+  },
+}))
+
+import TerraformBinariesPage from '../TerraformBinariesPage'
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <TerraformBinariesPage />
+    </MemoryRouter>,
+  )
+}
+
+describe('TerraformBinariesPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows loading spinner initially', () => {
+    listPublicTerraformMirrorConfigsMock.mockReturnValue(new Promise(() => {}))
+    renderPage()
+    expect(screen.getByRole('progressbar')).toBeInTheDocument()
+  })
+
+  it('renders the page heading', () => {
+    listPublicTerraformMirrorConfigsMock.mockReturnValue(new Promise(() => {}))
+    renderPage()
+    expect(screen.getByText('Terraform Binary Mirrors')).toBeInTheDocument()
+  })
+
+  it('shows empty state when no configs', async () => {
+    listPublicTerraformMirrorConfigsMock.mockResolvedValue([])
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('No binary mirrors configured')).toBeInTheDocument()
+    })
+  })
+
+  it('renders mirror cards', async () => {
+    listPublicTerraformMirrorConfigsMock.mockResolvedValue([
+      { name: 'my-terraform', description: 'Official Terraform', tool: 'terraform' },
+      { name: 'my-opentofu', description: 'OpenTofu builds', tool: 'opentofu' },
+    ])
+    listPublicTerraformVersionsMock.mockResolvedValue({ versions: [] })
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('my-terraform')).toBeInTheDocument()
+      expect(screen.getByText('my-opentofu')).toBeInTheDocument()
+    })
+  })
+
+  it('shows error when API fails', async () => {
+    listPublicTerraformMirrorConfigsMock.mockRejectedValue(new Error('fail'))
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('Failed to load Terraform binary mirrors.')).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/pages/admin/__tests__/APIKeysPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/APIKeysPage.test.tsx
@@ -1,0 +1,410 @@
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+// --- Mocks (must be before component import) ---
+
+const listAPIKeysMock = vi.fn()
+const createAPIKeyMock = vi.fn()
+const updateAPIKeyMock = vi.fn()
+const deleteAPIKeyMock = vi.fn()
+const rotateAPIKeyMock = vi.fn()
+const getCurrentUserMembershipsMock = vi.fn()
+
+vi.mock('../../../services/api', () => ({
+  default: {
+    listAPIKeys: (...args: unknown[]) => listAPIKeysMock(...args),
+    createAPIKey: (...args: unknown[]) => createAPIKeyMock(...args),
+    updateAPIKey: (...args: unknown[]) => updateAPIKeyMock(...args),
+    deleteAPIKey: (...args: unknown[]) => deleteAPIKeyMock(...args),
+    rotateAPIKey: (...args: unknown[]) => rotateAPIKeyMock(...args),
+    getCurrentUserMemberships: (...args: unknown[]) => getCurrentUserMembershipsMock(...args),
+  },
+}))
+
+vi.mock('../../../contexts/AuthContext', () => ({
+  useAuth: () => ({
+    allowedScopes: ['admin'],
+    roleTemplate: { display_name: 'Administrator' },
+    user: { id: 'user-1' },
+  }),
+}))
+
+import APIKeysPage from '../APIKeysPage'
+
+// --- Helpers ---
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  })
+}
+
+function renderPage() {
+  const qc = createQueryClient()
+  return render(
+    <QueryClientProvider client={qc}>
+      <APIKeysPage />
+    </QueryClientProvider>
+  )
+}
+
+const fakeMemberships = [
+  {
+    organization_id: 'org-1',
+    organization_name: 'Acme Corp',
+    role_template_display_name: 'Admin',
+  },
+]
+
+const fakeKeys = [
+  {
+    id: 'key-1',
+    user_id: 'user-1',
+    organization_id: 'org-1',
+    name: 'CI Pipeline Key',
+    description: 'Used in GitHub Actions',
+    key_prefix: 'tfr_abc123xyz789',
+    scopes: ['modules:read', 'providers:read'],
+    expires_at: '2099-12-31T23:59:59Z',
+    last_used_at: '2026-04-10T08:00:00Z',
+    created_at: '2026-01-01T00:00:00Z',
+  },
+  {
+    id: 'key-2',
+    user_id: 'user-1',
+    organization_id: 'org-1',
+    name: 'Expired Key',
+    description: '',
+    key_prefix: 'tfr_expired0000',
+    scopes: ['modules:read'],
+    expires_at: '2020-01-01T00:00:00Z',
+    last_used_at: null,
+    created_at: '2019-06-01T00:00:00Z',
+  },
+  {
+    id: 'key-3',
+    user_id: 'user-1',
+    organization_id: 'org-1',
+    name: 'No Expiry Key',
+    description: '',
+    key_prefix: 'tfr_noexpiry000',
+    scopes: ['admin', 'modules:write', 'providers:write'],
+    expires_at: null,
+    last_used_at: null,
+    created_at: '2026-03-15T00:00:00Z',
+  },
+]
+
+describe('APIKeysPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getCurrentUserMembershipsMock.mockResolvedValue(fakeMemberships)
+  })
+
+  // 1. Loading state
+  it('shows a loading spinner while API keys are being fetched', () => {
+    listAPIKeysMock.mockReturnValue(new Promise(() => { }))
+    renderPage()
+    expect(screen.getByRole('progressbar')).toBeInTheDocument()
+  })
+
+  // 2. Heading and subheading
+  it('renders the page heading and description', async () => {
+    listAPIKeysMock.mockResolvedValue(fakeKeys)
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('API Keys')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Manage API keys for Terraform CLI authentication')).toBeInTheDocument()
+  })
+
+  // 3. Table with API keys
+  it('renders a table with API key rows after loading', async () => {
+    listAPIKeysMock.mockResolvedValue(fakeKeys)
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('CI Pipeline Key')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Expired Key')).toBeInTheDocument()
+    expect(screen.getByText('No Expiry Key')).toBeInTheDocument()
+    // Check key tail display (last 6 chars prefixed with ...)
+    expect(screen.getByText('...xyz789')).toBeInTheDocument()
+    // Verify description is shown
+    expect(screen.getByText('Used in GitHub Actions')).toBeInTheDocument()
+  })
+
+  // 4. Empty state
+  it('shows empty state message when no API keys exist', async () => {
+    listAPIKeysMock.mockResolvedValue([])
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('No API keys found')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Create First API Key')).toBeInTheDocument()
+  })
+
+  // 5. Expiration chip: expired
+  it('displays an Expired chip for keys past their expiration', async () => {
+    listAPIKeysMock.mockResolvedValue([fakeKeys[1]])
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('Expired')).toBeInTheDocument()
+    })
+  })
+
+  // 6. Expiration chip: never (key-3 has null expires_at AND null last_used_at,
+  //    so "Never" appears both for expiration column and last-used column)
+  it('displays Never for keys with no expiration date', async () => {
+    listAPIKeysMock.mockResolvedValue([fakeKeys[2]])
+    renderPage()
+    await waitFor(() => {
+      const neverElements = screen.getAllByText('Never')
+      expect(neverElements.length).toBeGreaterThanOrEqual(1)
+    })
+  })
+
+  // 7. Scope chips rendering with overflow
+  it('shows scope chips and overflow badge for keys with many scopes', async () => {
+    listAPIKeysMock.mockResolvedValue([fakeKeys[2]])
+    renderPage()
+    // key-3 has 3 scopes, max visible is 2, so should show +1
+    await waitFor(() => {
+      expect(screen.getByText('+1')).toBeInTheDocument()
+    })
+  })
+
+  // 8. Open create dialog
+  it('opens the Create API Key dialog when the button is clicked', async () => {
+    listAPIKeysMock.mockResolvedValue([])
+    const user = userEvent.setup()
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Create API Key/i })).toBeInTheDocument()
+    })
+    await user.click(screen.getByRole('button', { name: /Create API Key/i }))
+    const dialog = screen.getByRole('dialog')
+    // Dialog title
+    expect(within(dialog).getByText('Create API Key')).toBeInTheDocument()
+    // Dialog form fields present
+    expect(within(dialog).getByLabelText(/Name/)).toBeInTheDocument()
+    expect(within(dialog).getByText('Scopes')).toBeInTheDocument()
+  })
+
+  // 9. Create button disabled when form is empty
+  it('disables the Create button when no name or scopes are provided', async () => {
+    listAPIKeysMock.mockResolvedValue([])
+    const user = userEvent.setup()
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Create API Key/i })).toBeInTheDocument()
+    })
+    await user.click(screen.getByRole('button', { name: /Create API Key/i }))
+    const dialog = screen.getByRole('dialog')
+    const createBtn = within(dialog).getByRole('button', { name: 'Create' })
+    // Name is empty so Create should be disabled
+    expect(createBtn).toBeDisabled()
+  })
+
+  // 10. Successful key creation shows the new key value
+  it('shows the newly created key and copy button after successful creation', async () => {
+    listAPIKeysMock.mockResolvedValue([])
+    createAPIKeyMock.mockResolvedValue({ key: 'tfr_newsecretkey12345' })
+    const user = userEvent.setup()
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Create API Key/i })).toBeInTheDocument()
+    })
+    await user.click(screen.getByRole('button', { name: /Create API Key/i }))
+    const dialog = screen.getByRole('dialog')
+    // Fill in name
+    const nameInput = within(dialog).getByLabelText(/Name/)
+    await user.type(nameInput, 'My New Key')
+    await user.click(within(dialog).getByRole('button', { name: 'Create' }))
+    await waitFor(() => {
+      expect(screen.getByText(/API key created successfully/)).toBeInTheDocument()
+    })
+    expect(screen.getByDisplayValue('tfr_newsecretkey12345')).toBeInTheDocument()
+    // Copy button exists
+    expect(screen.getByRole('button', { name: /Copy API key/ })).toBeInTheDocument()
+  })
+
+  // 11. Copy key to clipboard - verify UI feedback after copy button click
+  it('shows Copied to clipboard feedback when copy button is clicked', async () => {
+    listAPIKeysMock.mockResolvedValue([])
+    createAPIKeyMock.mockResolvedValue({ key: 'tfr_copyme123' })
+    const user = userEvent.setup()
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Create API Key/i })).toBeInTheDocument()
+    })
+    await user.click(screen.getByRole('button', { name: /Create API Key/i }))
+    const dialog = screen.getByRole('dialog')
+    await user.type(within(dialog).getByLabelText(/Name/), 'Copy Test')
+    await user.click(within(dialog).getByRole('button', { name: 'Create' }))
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('tfr_copyme123')).toBeInTheDocument()
+    })
+    // The copy button with its aria-label should be present
+    const copyBtn = screen.getByRole('button', { name: /Copy API key/ })
+    expect(copyBtn).toBeInTheDocument()
+    await user.click(copyBtn)
+    await waitFor(() => {
+      expect(screen.getByText('Copied to clipboard!')).toBeInTheDocument()
+    })
+  })
+
+  // 12. Delete confirmation dialog
+  it('opens delete confirmation dialog and deletes the key', async () => {
+    listAPIKeysMock.mockResolvedValue([fakeKeys[0]])
+    deleteAPIKeyMock.mockResolvedValue({})
+    const user = userEvent.setup()
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('CI Pipeline Key')).toBeInTheDocument()
+    })
+    await user.click(screen.getByRole('button', { name: /Delete API key/ }))
+    expect(screen.getByText(/Are you sure you want to delete API key/)).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: 'Delete' }))
+    await waitFor(() => {
+      expect(deleteAPIKeyMock).toHaveBeenCalledWith('key-1')
+    })
+  })
+
+  // 13. Edit dialog opens with pre-filled data
+  it('opens the edit dialog with pre-filled values when Edit is clicked', async () => {
+    listAPIKeysMock.mockResolvedValue([fakeKeys[0]])
+    const user = userEvent.setup()
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('CI Pipeline Key')).toBeInTheDocument()
+    })
+    await user.click(screen.getByRole('button', { name: /Edit API key/ }))
+    const dialog = screen.getByRole('dialog')
+    expect(within(dialog).getByText('Edit API Key')).toBeInTheDocument()
+    expect(within(dialog).getByDisplayValue('CI Pipeline Key')).toBeInTheDocument()
+    // Save and Cancel buttons should be visible
+    expect(within(dialog).getByRole('button', { name: 'Save' })).toBeInTheDocument()
+    expect(within(dialog).getByRole('button', { name: 'Cancel' })).toBeInTheDocument()
+  })
+
+  // 14. Edit dialog save
+  it('calls updateAPIKey when Save is clicked in the edit dialog', async () => {
+    listAPIKeysMock.mockResolvedValue([fakeKeys[0]])
+    updateAPIKeyMock.mockResolvedValue({})
+    const user = userEvent.setup()
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('CI Pipeline Key')).toBeInTheDocument()
+    })
+    await user.click(screen.getByRole('button', { name: /Edit API key/ }))
+    const dialog = screen.getByRole('dialog')
+    const nameInput = within(dialog).getByDisplayValue('CI Pipeline Key')
+    await user.clear(nameInput)
+    await user.type(nameInput, 'Renamed Key')
+    await user.click(within(dialog).getByRole('button', { name: 'Save' }))
+    await waitFor(() => {
+      expect(updateAPIKeyMock).toHaveBeenCalledWith('key-1', expect.objectContaining({ name: 'Renamed Key' }))
+    })
+  })
+
+  // 15. Rotate dialog opens and can rotate immediately
+  it('opens the rotate dialog and performs immediate rotation', async () => {
+    listAPIKeysMock.mockResolvedValue([fakeKeys[0]])
+    rotateAPIKeyMock.mockResolvedValue({
+      new_key: { key: 'tfr_rotated999' },
+      old_key_status: 'revoked',
+    })
+    const user = userEvent.setup()
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('CI Pipeline Key')).toBeInTheDocument()
+    })
+    await user.click(screen.getByRole('button', { name: /Rotate API key/ }))
+    const dialog = screen.getByRole('dialog')
+    expect(within(dialog).getByText('Rotate API Key')).toBeInTheDocument()
+    expect(within(dialog).getByText(/Rotating key/)).toBeInTheDocument()
+    // Default is "Revoke old key immediately"
+    expect(within(dialog).getByLabelText(/Revoke old key immediately/)).toBeChecked()
+    await user.click(within(dialog).getByRole('button', { name: 'Rotate Key' }))
+    await waitFor(() => {
+      expect(rotateAPIKeyMock).toHaveBeenCalledWith('key-1', 0)
+    })
+    await waitFor(() => {
+      expect(screen.getByText(/Key rotated successfully/)).toBeInTheDocument()
+    })
+    expect(screen.getByDisplayValue('tfr_rotated999')).toBeInTheDocument()
+    // Old key revoked message
+    expect(screen.getByText(/old key has been revoked immediately/)).toBeInTheDocument()
+  })
+
+  // 16. Rotate with grace period
+  it('shows grace period slider when grace period option is selected', async () => {
+    listAPIKeysMock.mockResolvedValue([fakeKeys[0]])
+    const user = userEvent.setup()
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('CI Pipeline Key')).toBeInTheDocument()
+    })
+    await user.click(screen.getByRole('button', { name: /Rotate API key/ }))
+    const dialog = screen.getByRole('dialog')
+    await user.click(within(dialog).getByLabelText(/Keep old key valid for a grace period/))
+    expect(within(dialog).getByText(/Grace period: 24 hours/)).toBeInTheDocument()
+    expect(within(dialog).getByRole('slider')).toBeInTheDocument()
+  })
+
+  // 17. Error alert for create failure
+  // getErrorMessage returns the Error.message for plain Errors, so we assert on that
+  it('shows an error alert when API key creation fails', async () => {
+    listAPIKeysMock.mockResolvedValue([])
+    createAPIKeyMock.mockRejectedValue(new Error('Server error'))
+    const user = userEvent.setup()
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Create API Key/i })).toBeInTheDocument()
+    })
+    await user.click(screen.getByRole('button', { name: /Create API Key/i }))
+    const dialog = screen.getByRole('dialog')
+    await user.type(within(dialog).getByLabelText(/Name/), 'Fail Key')
+    await user.click(within(dialog).getByRole('button', { name: 'Create' }))
+    await waitFor(() => {
+      expect(screen.getByText('Server error')).toBeInTheDocument()
+    })
+  })
+
+  // 18. Usage instructions section
+  it('shows the usage instructions section with terraformrc example', async () => {
+    listAPIKeysMock.mockResolvedValue([])
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('Using API Keys')).toBeInTheDocument()
+    })
+    expect(screen.getByText(/To use an API key with Terraform CLI/)).toBeInTheDocument()
+    expect(screen.getByText(/\.terraformrc/)).toBeInTheDocument()
+  })
+
+  // 19. No organization membership warning
+  it('shows a warning when the user has no organization memberships', async () => {
+    getCurrentUserMembershipsMock.mockResolvedValue([])
+    listAPIKeysMock.mockResolvedValue([])
+    renderPage()
+    await waitFor(() => {
+      expect(
+        screen.getByText(/not a member of any organization/)
+      ).toBeInTheDocument()
+    })
+  })
+
+  // 20. Last used column shows Never when not used
+  it('shows Never for last used when key has not been used', async () => {
+    listAPIKeysMock.mockResolvedValue([fakeKeys[2]])
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('No Expiry Key')).toBeInTheDocument()
+    })
+    // "Never" appears both for expiration and last used; check multiple
+    const neverTexts = screen.getAllByText('Never')
+    expect(neverTexts.length).toBeGreaterThanOrEqual(2)
+  })
+})

--- a/frontend/src/pages/admin/__tests__/ApprovalsPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/ApprovalsPage.test.tsx
@@ -1,0 +1,188 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const listApprovalRequestsMock = vi.fn()
+vi.mock('../../../services/api', () => ({
+  default: {
+    listApprovalRequests: (...args: unknown[]) => listApprovalRequestsMock(...args),
+  },
+}))
+
+import ApprovalsPage from '../ApprovalsPage'
+
+function renderWithProviders(ui: React.ReactElement) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>)
+}
+
+const fakeApprovals = [
+  {
+    id: 'apr-1',
+    mirror_config_id: 'mirror-1',
+    provider_namespace: 'hashicorp',
+    provider_name: 'aws',
+    reason: 'Need aws provider for production',
+    status: 'pending' as const,
+    auto_approved: false,
+    created_at: '2025-06-01T12:00:00Z',
+    updated_at: '2025-06-01T12:00:00Z',
+  },
+  {
+    id: 'apr-2',
+    mirror_config_id: 'mirror-2',
+    provider_namespace: 'hashicorp',
+    provider_name: '',
+    status: 'approved' as const,
+    auto_approved: true,
+    reviewed_at: '2025-06-02T14:00:00Z',
+    review_notes: 'Auto-approved per policy',
+    created_at: '2025-06-02T12:00:00Z',
+    updated_at: '2025-06-02T14:00:00Z',
+  },
+  {
+    id: 'apr-3',
+    mirror_config_id: 'mirror-3',
+    provider_namespace: 'datadog',
+    provider_name: 'datadog',
+    status: 'rejected' as const,
+    auto_approved: false,
+    reviewed_at: '2025-06-03T10:00:00Z',
+    created_at: '2025-06-03T08:00:00Z',
+    updated_at: '2025-06-03T10:00:00Z',
+  },
+]
+
+describe('ApprovalsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows loading spinner while fetching', () => {
+    listApprovalRequestsMock.mockReturnValue(new Promise(() => {}))
+    renderWithProviders(<ApprovalsPage />)
+    expect(screen.getByRole('progressbar')).toBeInTheDocument()
+  })
+
+  it('renders heading and subheading after load', async () => {
+    listApprovalRequestsMock.mockResolvedValue(fakeApprovals)
+    renderWithProviders(<ApprovalsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Approval Requests')).toBeInTheDocument()
+    })
+    expect(
+      screen.getByText('Review and manage mirror provider approval requests')
+    ).toBeInTheDocument()
+  })
+
+  it('renders approval cards', async () => {
+    listApprovalRequestsMock.mockResolvedValue(fakeApprovals)
+    renderWithProviders(<ApprovalsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('hashicorp/aws')).toBeInTheDocument()
+    })
+    expect(screen.getByText('datadog/datadog')).toBeInTheDocument()
+  })
+
+  it('shows status chips for all statuses', async () => {
+    listApprovalRequestsMock.mockResolvedValue(fakeApprovals)
+    renderWithProviders(<ApprovalsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Pending')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Approved')).toBeInTheDocument()
+    expect(screen.getByText('Rejected')).toBeInTheDocument()
+  })
+
+  it('shows reason text on approval card', async () => {
+    listApprovalRequestsMock.mockResolvedValue(fakeApprovals)
+    renderWithProviders(<ApprovalsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Need aws provider for production')).toBeInTheDocument()
+    })
+  })
+
+  it('shows mirror config ID on cards', async () => {
+    listApprovalRequestsMock.mockResolvedValue(fakeApprovals)
+    renderWithProviders(<ApprovalsPage />)
+    await waitFor(() => {
+      expect(screen.getByText(/mirror-1/)).toBeInTheDocument()
+    })
+  })
+
+  it('shows review notes for reviewed approvals', async () => {
+    listApprovalRequestsMock.mockResolvedValue(fakeApprovals)
+    renderWithProviders(<ApprovalsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Auto-approved per policy')).toBeInTheDocument()
+    })
+  })
+
+  it('shows Approve and Reject buttons for pending approvals', async () => {
+    listApprovalRequestsMock.mockResolvedValue(fakeApprovals)
+    renderWithProviders(<ApprovalsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Approve')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Reject')).toBeInTheDocument()
+  })
+
+  it('shows empty message when no approvals', async () => {
+    listApprovalRequestsMock.mockResolvedValue([])
+    renderWithProviders(<ApprovalsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('No approval requests found.')).toBeInTheDocument()
+    })
+  })
+
+  it('shows Create Request and Refresh buttons', async () => {
+    listApprovalRequestsMock.mockResolvedValue([])
+    renderWithProviders(<ApprovalsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Create Request')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Refresh')).toBeInTheDocument()
+  })
+
+  it('opens create dialog on Create Request click', async () => {
+    listApprovalRequestsMock.mockResolvedValue([])
+    const user = userEvent.setup()
+    renderWithProviders(<ApprovalsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Create Request')).toBeInTheDocument()
+    })
+    await user.click(screen.getByText('Create Request'))
+    expect(screen.getByText('Create Approval Request')).toBeInTheDocument()
+    expect(screen.getByText('Submit Request')).toBeInTheDocument()
+  })
+
+  it('shows reviewed date for reviewed approvals', async () => {
+    listApprovalRequestsMock.mockResolvedValue(fakeApprovals)
+    renderWithProviders(<ApprovalsPage />)
+    await waitFor(() => {
+      expect(screen.getAllByText(/Reviewed:/).length).toBeGreaterThanOrEqual(1)
+    })
+  })
+
+  it('renders namespace-only display when provider_name empty', async () => {
+    listApprovalRequestsMock.mockResolvedValue([
+      {
+        id: 'apr-ns',
+        mirror_config_id: 'mirror-ns',
+        provider_namespace: 'customns',
+        provider_name: '',
+        status: 'pending' as const,
+        auto_approved: false,
+        created_at: '2025-06-01T00:00:00Z',
+        updated_at: '2025-06-01T00:00:00Z',
+      },
+    ])
+    renderWithProviders(<ApprovalsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('customns')).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/pages/admin/__tests__/AuditLogPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/AuditLogPage.test.tsx
@@ -1,0 +1,129 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+// ---- Mocks ----
+
+const listAuditLogsMock = vi.fn()
+vi.mock('../../../services/api', () => ({
+  default: {
+    listAuditLogs: (...args: unknown[]) => listAuditLogsMock(...args),
+    exportAuditLogsCSV: vi.fn(),
+    exportAuditLogsJSON: vi.fn(),
+  },
+}))
+
+import AuditLogPage from '../../admin/AuditLogPage'
+
+// ---- Helpers ----
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  })
+}
+
+function renderPage() {
+  const queryClient = createQueryClient()
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <AuditLogPage />
+    </QueryClientProvider>,
+  )
+}
+
+// ---- Mock data ----
+
+const fakeLogs = {
+  logs: [
+    {
+      id: 'log-1',
+      created_at: '2025-06-01T12:00:00Z',
+      action: 'POST /api/v1/modules',
+      resource_type: 'module',
+      resource_id: 'm-1',
+      user_email: 'admin@example.com',
+      user_name: 'Admin',
+      ip_address: '192.168.1.1',
+    },
+    {
+      id: 'log-2',
+      created_at: '2025-06-02T14:00:00Z',
+      action: 'DELETE /api/v1/users/u1',
+      resource_type: 'user',
+      resource_id: 'u-1',
+      user_email: 'admin@example.com',
+      ip_address: '10.0.0.1',
+    },
+  ],
+  pagination: { total: 2, page: 1, per_page: 25 },
+}
+
+// ---- Tests ----
+
+describe('AuditLogPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows loading spinner while fetching', () => {
+    listAuditLogsMock.mockReturnValue(new Promise(() => { }))
+    renderPage()
+    expect(screen.getByRole('progressbar')).toBeInTheDocument()
+  })
+
+  it('renders heading "Audit Logs"', () => {
+    listAuditLogsMock.mockReturnValue(new Promise(() => { }))
+    renderPage()
+    expect(screen.getByText('Audit Logs')).toBeInTheDocument()
+  })
+
+  it('renders table with log entries', async () => {
+    listAuditLogsMock.mockResolvedValue(fakeLogs)
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('POST /api/v1/modules')).toBeInTheDocument()
+    })
+    expect(screen.getByText('DELETE /api/v1/users/u1')).toBeInTheDocument()
+    expect(screen.getAllByText('admin@example.com').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getByText('192.168.1.1')).toBeInTheDocument()
+    expect(screen.getByText('10.0.0.1')).toBeInTheDocument()
+  })
+
+  it('shows filter controls', () => {
+    listAuditLogsMock.mockReturnValue(new Promise(() => { }))
+    renderPage()
+    expect(screen.getByLabelText('Resource Type')).toBeInTheDocument()
+    expect(screen.getByLabelText('Action')).toBeInTheDocument()
+    expect(screen.getByText('Reset')).toBeInTheDocument()
+  })
+
+  it('shows Export button', () => {
+    listAuditLogsMock.mockReturnValue(new Promise(() => { }))
+    renderPage()
+    expect(screen.getByText('Export')).toBeInTheDocument()
+  })
+
+  it('shows empty state when no logs', async () => {
+    listAuditLogsMock.mockResolvedValue({
+      logs: [],
+      pagination: { total: 0, page: 1, per_page: 25 },
+    })
+    renderPage()
+    await waitFor(() => {
+      expect(
+        screen.getByText('No audit log entries match the current filters.'),
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('shows pagination controls', async () => {
+    listAuditLogsMock.mockResolvedValue(fakeLogs)
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('POST /api/v1/modules')).toBeInTheDocument()
+    })
+    // MUI TablePagination renders "Rows per page:" text
+    expect(screen.getByText('Rows per page:')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/admin/__tests__/DashboardPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/DashboardPage.test.tsx
@@ -1,0 +1,227 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter } from 'react-router-dom'
+
+// ---- Mocks ----
+
+const getDashboardStatsMock = vi.fn()
+vi.mock('../../../services/api', () => ({
+  default: {
+    getDashboardStats: (...args: unknown[]) => getDashboardStatsMock(...args),
+  },
+}))
+
+vi.mock('../../../contexts/AuthContext', () => ({
+  useAuth: () => ({ allowedScopes: ['admin'] }),
+}))
+
+const navigateMock = vi.fn()
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom')
+  return { ...actual, useNavigate: () => navigateMock }
+})
+
+import DashboardPage from '../../admin/DashboardPage'
+
+// ---- Helpers ----
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  })
+}
+
+function renderPage() {
+  const queryClient = createQueryClient()
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <DashboardPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+// ---- Mock data ----
+
+const fakeDashboardData = {
+  modules: {
+    total: 15,
+    versions: 42,
+    downloads: 1200,
+    by_system: [
+      { system: 'aws', count: 10 },
+      { system: 'azure', count: 5 },
+    ],
+  },
+  providers: {
+    total: 8,
+    manual: 5,
+    mirrored: 3,
+    total_versions: 20,
+    manual_versions: 12,
+    mirrored_versions: 8,
+    downloads: 800,
+  },
+  users: 25,
+  organizations: 3,
+  downloads: 2500,
+  scm_providers: 2,
+  binary_mirrors: {
+    total: 2,
+    healthy: 2,
+    failed: 0,
+    syncing: 0,
+    platforms: 14,
+    downloads: 500,
+    by_tool: [
+      { tool: 'terraform', platforms: 10 },
+      { tool: 'opentofu', platforms: 4 },
+    ],
+  },
+  provider_mirrors: { total: 3, healthy: 3, failed: 0 },
+  scanning: {
+    enabled: true,
+    total: 42,
+    pending: 2,
+    clean: 38,
+    findings: 1,
+    error: 1,
+  },
+  recent_syncs: [
+    {
+      mirror_name: 'hashicorp-mirror',
+      mirror_type: 'provider',
+      status: 'success',
+      started_at: '2025-06-01T12:00:00Z',
+      versions_synced: 5,
+      platforms_synced: 0,
+      triggered_by: 'scheduler',
+    },
+    {
+      mirror_name: 'terraform-binary',
+      mirror_type: 'binary',
+      status: 'failed',
+      started_at: '2025-06-01T10:00:00Z',
+      versions_synced: 0,
+      platforms_synced: 0,
+      triggered_by: 'manual',
+    },
+  ],
+}
+
+// ---- Tests ----
+
+describe('DashboardPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows loading spinner while fetching', () => {
+    getDashboardStatsMock.mockReturnValue(new Promise(() => { }))
+    renderPage()
+    expect(screen.getByRole('progressbar')).toBeInTheDocument()
+  })
+
+  it('renders heading and subheading after load', async () => {
+    getDashboardStatsMock.mockResolvedValue(fakeDashboardData)
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('Dashboard')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Registry health at a glance')).toBeInTheDocument()
+  })
+
+  it('renders stat cards', async () => {
+    getDashboardStatsMock.mockResolvedValue(fakeDashboardData)
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getAllByText('Modules').length).toBeGreaterThanOrEqual(1)
+    })
+    expect(screen.getAllByText('Providers').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getByText('Total Downloads')).toBeInTheDocument()
+    expect(screen.getByText('Terraform Binaries')).toBeInTheDocument()
+  })
+
+  it('shows health pills', async () => {
+    getDashboardStatsMock.mockResolvedValue(fakeDashboardData)
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getAllByText('Binary Mirrors').length).toBeGreaterThanOrEqual(1)
+    })
+    expect(screen.getAllByText('Provider Mirrors').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getAllByText('Storage').length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('shows recent sync table entries', async () => {
+    getDashboardStatsMock.mockResolvedValue(fakeDashboardData)
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('hashicorp-mirror')).toBeInTheDocument()
+    })
+    expect(screen.getByText('terraform-binary')).toBeInTheDocument()
+  })
+
+  it('shows Quick Links heading and link labels', async () => {
+    getDashboardStatsMock.mockResolvedValue(fakeDashboardData)
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('Quick Links')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Upload Module')).toBeInTheDocument()
+    expect(screen.getByText('Upload Provider')).toBeInTheDocument()
+    expect(screen.getByText('Manage Users')).toBeInTheDocument()
+  })
+
+  it('shows error alert on API failure', async () => {
+    getDashboardStatsMock.mockRejectedValue(new Error('Network error'))
+    renderPage()
+    await waitFor(() => {
+      expect(
+        screen.getByText('Failed to load dashboard statistics.'),
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('shows Refresh button', async () => {
+    getDashboardStatsMock.mockResolvedValue(fakeDashboardData)
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('Refresh')).toBeInTheDocument()
+    })
+  })
+
+  it('shows empty sync message when no recent_syncs', async () => {
+    getDashboardStatsMock.mockResolvedValue({
+      ...fakeDashboardData,
+      recent_syncs: [],
+    })
+    renderPage()
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          'No sync history yet. Trigger a sync from the mirror pages.',
+        ),
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('shows mirror failure alert when failed > 0', async () => {
+    getDashboardStatsMock.mockResolvedValue({
+      ...fakeDashboardData,
+      binary_mirrors: {
+        ...fakeDashboardData.binary_mirrors,
+        failed: 1,
+      },
+    })
+    renderPage()
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          'One or more mirrors have failed their last sync. Check the mirror pages for details.',
+        ),
+      ).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/pages/admin/__tests__/MirrorPoliciesPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/MirrorPoliciesPage.test.tsx
@@ -1,0 +1,139 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter } from 'react-router-dom'
+
+const listMirrorPoliciesMock = vi.fn()
+vi.mock('../../../services/api', () => ({
+  default: {
+    listMirrorPolicies: (...args: unknown[]) => listMirrorPoliciesMock(...args),
+  },
+}))
+
+import MirrorPoliciesPage from '../MirrorPoliciesPage'
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  })
+}
+
+function renderPage() {
+  const queryClient = createQueryClient()
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <MirrorPoliciesPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+const fakePolicies = [
+  {
+    id: 'pol-1',
+    name: 'Allow HashiCorp',
+    description: 'Allow all HashiCorp providers',
+    policy_type: 'allow' as const,
+    upstream_registry: 'registry.terraform.io',
+    namespace_pattern: 'hashicorp',
+    provider_pattern: '*',
+    priority: 10,
+    is_active: true,
+    requires_approval: false,
+    created_at: '2025-06-01T00:00:00Z',
+    updated_at: '2025-06-01T00:00:00Z',
+  },
+  {
+    id: 'pol-2',
+    name: 'Deny External',
+    description: 'Block external providers',
+    policy_type: 'deny' as const,
+    upstream_registry: 'registry.terraform.io',
+    namespace_pattern: 'external-*',
+    provider_pattern: '*',
+    priority: 5,
+    is_active: false,
+    requires_approval: true,
+    created_at: '2025-06-02T00:00:00Z',
+    updated_at: '2025-06-02T00:00:00Z',
+  },
+]
+
+describe('MirrorPoliciesPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows loading spinner initially', () => {
+    listMirrorPoliciesMock.mockReturnValue(new Promise(() => { }))
+    renderPage()
+    expect(screen.getByRole('progressbar')).toBeInTheDocument()
+  })
+
+  it('renders heading and description after load', async () => {
+    listMirrorPoliciesMock.mockResolvedValue(fakePolicies)
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('Mirror Policies')).toBeInTheDocument()
+    })
+    expect(
+      screen.getByText('Define allow/deny rules for provider mirroring'),
+    ).toBeInTheDocument()
+  })
+
+  it('shows policy cards with policy data', async () => {
+    listMirrorPoliciesMock.mockResolvedValue(fakePolicies)
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('Allow HashiCorp')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Deny External')).toBeInTheDocument()
+    expect(screen.getByText('Allow all HashiCorp providers')).toBeInTheDocument()
+    expect(screen.getByText('Block external providers')).toBeInTheDocument()
+    expect(screen.getByText('Namespace: hashicorp')).toBeInTheDocument()
+    expect(screen.getByText('Namespace: external-*')).toBeInTheDocument()
+    expect(screen.getAllByText('Provider: *')).toHaveLength(2)
+    expect(screen.getByText('Priority: 10')).toBeInTheDocument()
+  })
+
+  it('shows status chips for Allow/Deny and Active/Inactive', async () => {
+    listMirrorPoliciesMock.mockResolvedValue(fakePolicies)
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('Allow')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Deny')).toBeInTheDocument()
+    expect(screen.getByText('Active')).toBeInTheDocument()
+    expect(screen.getByText('Inactive')).toBeInTheDocument()
+  })
+
+  it('shows empty state when no policies exist', async () => {
+    listMirrorPoliciesMock.mockResolvedValue([])
+    renderPage()
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          'No mirror policies found. Create one to control which providers can be mirrored.',
+        ),
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('shows Create Policy button', async () => {
+    listMirrorPoliciesMock.mockResolvedValue(fakePolicies)
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('Create Policy')).toBeInTheDocument()
+    })
+  })
+
+  it('shows error state when API fails', async () => {
+    listMirrorPoliciesMock.mockRejectedValue(new Error('Network error'))
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Network error')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/admin/__tests__/MirrorsPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/MirrorsPage.test.tsx
@@ -1,0 +1,741 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter } from 'react-router-dom'
+
+const listMirrorsMock = vi.fn()
+const createMirrorMock = vi.fn()
+const updateMirrorMock = vi.fn()
+const deleteMirrorMock = vi.fn()
+const triggerMirrorSyncMock = vi.fn()
+const getMirrorProvidersMock = vi.fn()
+const getMirrorStatusMock = vi.fn()
+
+vi.mock('../../../services/api', () => ({
+  default: {
+    listMirrors: (...args: unknown[]) => listMirrorsMock(...args),
+    createMirror: (...args: unknown[]) => createMirrorMock(...args),
+    updateMirror: (...args: unknown[]) => updateMirrorMock(...args),
+    deleteMirror: (...args: unknown[]) => deleteMirrorMock(...args),
+    triggerMirrorSync: (...args: unknown[]) => triggerMirrorSyncMock(...args),
+    getMirrorProviders: (...args: unknown[]) => getMirrorProvidersMock(...args),
+    getMirrorStatus: (...args: unknown[]) => getMirrorStatusMock(...args),
+  },
+}))
+
+import MirrorsPage from '../MirrorsPage'
+
+function renderWithProviders(
+  ui: React.ReactElement,
+  { initialEntries = ['/admin/mirrors'] }: { initialEntries?: string[] } = {},
+) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={initialEntries}>{ui}</MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+const baseMirror = {
+  id: 'mirror-1',
+  name: 'Upstream Public',
+  description: 'Main upstream mirror for hashicorp providers',
+  upstream_registry_url: 'https://registry.terraform.io',
+  namespace_filter: '["hashicorp"]',
+  provider_filter: '["aws","google"]',
+  version_filter: '>=3.0.0',
+  platform_filter: '["linux/amd64","darwin/arm64"]',
+  enabled: true,
+  sync_interval_hours: 12,
+  last_sync_at: '2025-07-01T08:00:00Z',
+  last_sync_status: 'success' as const,
+  last_sync_error: undefined,
+  created_at: '2025-06-01T00:00:00Z',
+  updated_at: '2025-07-01T08:00:00Z',
+}
+
+const failedMirror = {
+  id: 'mirror-2',
+  name: 'Datadog Mirror',
+  upstream_registry_url: 'https://registry.terraform.io',
+  enabled: false,
+  sync_interval_hours: 24,
+  last_sync_at: '2025-07-01T10:00:00Z',
+  last_sync_status: 'failed' as const,
+  last_sync_error: 'Connection timed out',
+  created_at: '2025-06-15T00:00:00Z',
+  updated_at: '2025-07-01T10:00:00Z',
+}
+
+const inProgressMirror = {
+  id: 'mirror-3',
+  name: 'Syncing Mirror',
+  upstream_registry_url: 'https://registry.terraform.io',
+  enabled: true,
+  sync_interval_hours: 6,
+  last_sync_status: 'in_progress' as const,
+  created_at: '2025-06-20T00:00:00Z',
+  updated_at: '2025-07-02T00:00:00Z',
+}
+
+const neverSyncedMirror = {
+  id: 'mirror-4',
+  name: 'New Mirror',
+  upstream_registry_url: 'https://registry.terraform.io',
+  enabled: true,
+  sync_interval_hours: 24,
+  created_at: '2025-07-02T00:00:00Z',
+  updated_at: '2025-07-02T00:00:00Z',
+}
+
+describe('MirrorsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows loading spinner while fetching', () => {
+    listMirrorsMock.mockReturnValue(new Promise(() => { }))
+    renderWithProviders(<MirrorsPage />)
+    expect(screen.getByRole('progressbar')).toBeInTheDocument()
+  })
+
+  it('renders heading and subheading after load', async () => {
+    listMirrorsMock.mockResolvedValue([])
+    renderWithProviders(<MirrorsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Mirroring — Provider Config')).toBeInTheDocument()
+    })
+    expect(
+      screen.getByText('Configure upstream registry mirroring for providers'),
+    ).toBeInTheDocument()
+  })
+
+  it('renders mirror cards with name and upstream URL', async () => {
+    listMirrorsMock.mockResolvedValue([baseMirror, failedMirror])
+    renderWithProviders(<MirrorsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Upstream Public')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Datadog Mirror')).toBeInTheDocument()
+    expect(
+      screen.getAllByText('https://registry.terraform.io').length,
+    ).toBeGreaterThanOrEqual(2)
+  })
+
+  it('shows Enabled/Disabled chips on mirror cards', async () => {
+    listMirrorsMock.mockResolvedValue([baseMirror, failedMirror])
+    renderWithProviders(<MirrorsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Enabled')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Disabled')).toBeInTheDocument()
+  })
+
+  it('shows correct status chips for sync states', async () => {
+    listMirrorsMock.mockResolvedValue([
+      baseMirror,
+      failedMirror,
+      inProgressMirror,
+      neverSyncedMirror,
+    ])
+    renderWithProviders(<MirrorsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Success')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Failed')).toBeInTheDocument()
+    expect(screen.getByText('Syncing...')).toBeInTheDocument()
+    expect(screen.getByText('Never synced')).toBeInTheDocument()
+  })
+
+  it('shows description and filter chips on mirror card', async () => {
+    listMirrorsMock.mockResolvedValue([baseMirror])
+    renderWithProviders(<MirrorsPage />)
+    await waitFor(() => {
+      expect(
+        screen.getByText('Main upstream mirror for hashicorp providers'),
+      ).toBeInTheDocument()
+    })
+    expect(screen.getByText('Namespaces: hashicorp')).toBeInTheDocument()
+    expect(screen.getByText('Providers: aws, google')).toBeInTheDocument()
+    expect(screen.getByText('Versions: >=3.0.0')).toBeInTheDocument()
+    expect(
+      screen.getByText('Platforms: linux/amd64, darwin/arm64'),
+    ).toBeInTheDocument()
+  })
+
+  it('shows sync interval and last sync date', async () => {
+    listMirrorsMock.mockResolvedValue([baseMirror])
+    renderWithProviders(<MirrorsPage />)
+    await waitFor(() => {
+      expect(screen.getByText(/Sync interval: 12 hours/)).toBeInTheDocument()
+    })
+    expect(screen.getByText(/Last sync:/)).toBeInTheDocument()
+  })
+
+  it('shows last sync error alert on failed mirror card', async () => {
+    listMirrorsMock.mockResolvedValue([failedMirror])
+    renderWithProviders(<MirrorsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Connection timed out')).toBeInTheDocument()
+    })
+  })
+
+  it('shows empty state when no mirrors exist', async () => {
+    listMirrorsMock.mockResolvedValue([])
+    renderWithProviders(<MirrorsPage />)
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          'No mirror configurations found. Add one to start mirroring providers from upstream registries.',
+        ),
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('shows Refresh and Add Mirror buttons', async () => {
+    listMirrorsMock.mockResolvedValue([])
+    renderWithProviders(<MirrorsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Refresh')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Add Mirror')).toBeInTheDocument()
+  })
+
+  it('opens create dialog when Add Mirror is clicked', async () => {
+    listMirrorsMock.mockResolvedValue([])
+    const user = userEvent.setup()
+    renderWithProviders(<MirrorsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Add Mirror')).toBeInTheDocument()
+    })
+    await user.click(screen.getByText('Add Mirror'))
+    expect(screen.getByText('Add Provider Mirror')).toBeInTheDocument()
+    expect(screen.getByLabelText('Name *')).toBeInTheDocument()
+    expect(screen.getByLabelText('Description')).toBeInTheDocument()
+    expect(screen.getByLabelText('Upstream Registry URL *')).toBeInTheDocument()
+    expect(screen.getByLabelText('Namespace Filter')).toBeInTheDocument()
+    expect(screen.getByLabelText('Provider Filter')).toBeInTheDocument()
+    expect(screen.getByLabelText('Version Filter')).toBeInTheDocument()
+    expect(screen.getByLabelText('Platform Filter')).toBeInTheDocument()
+    expect(screen.getByLabelText('Sync Interval (hours)')).toBeInTheDocument()
+    expect(screen.getByText('Create')).toBeInTheDocument()
+    expect(screen.getByText('Cancel')).toBeInTheDocument()
+  })
+
+  it('submits create form and shows success', async () => {
+    listMirrorsMock.mockResolvedValue([])
+    createMirrorMock.mockResolvedValue({ id: 'new-mirror' })
+    const user = userEvent.setup()
+    renderWithProviders(<MirrorsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Add Mirror')).toBeInTheDocument()
+    })
+    await user.click(screen.getByText('Add Mirror'))
+
+    const nameInput = screen.getByLabelText('Name *')
+    await user.clear(nameInput)
+    await user.type(nameInput, 'My New Mirror')
+
+    await user.click(screen.getByText('Create'))
+    await waitFor(() => {
+      expect(createMirrorMock).toHaveBeenCalledTimes(1)
+    })
+    const callArg = createMirrorMock.mock.calls[0][0]
+    expect(callArg.name).toBe('My New Mirror')
+    expect(callArg.upstream_registry_url).toBe('https://registry.terraform.io')
+  })
+
+  it('opens edit dialog with pre-populated form data', async () => {
+    listMirrorsMock.mockResolvedValue([baseMirror])
+    const user = userEvent.setup()
+    renderWithProviders(<MirrorsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Upstream Public')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByLabelText('Edit mirror'))
+    expect(screen.getByText('Edit Mirror')).toBeInTheDocument()
+    expect(screen.getByLabelText('Name *')).toHaveValue('Upstream Public')
+    expect(screen.getByLabelText('Upstream Registry URL *')).toHaveValue(
+      'https://registry.terraform.io',
+    )
+    expect(screen.getByLabelText('Namespace Filter')).toHaveValue('hashicorp')
+    expect(screen.getByLabelText('Provider Filter')).toHaveValue('aws, google')
+    expect(screen.getByLabelText('Version Filter')).toHaveValue('>=3.0.0')
+    expect(screen.getByLabelText('Platform Filter')).toHaveValue(
+      'linux/amd64, darwin/arm64',
+    )
+    expect(screen.getByText('Update')).toBeInTheDocument()
+  })
+
+  it('submits edit form and calls updateMirror', async () => {
+    listMirrorsMock.mockResolvedValue([baseMirror])
+    updateMirrorMock.mockResolvedValue({})
+    const user = userEvent.setup()
+    renderWithProviders(<MirrorsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Upstream Public')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByLabelText('Edit mirror'))
+    await user.click(screen.getByText('Update'))
+    await waitFor(() => {
+      expect(updateMirrorMock).toHaveBeenCalledTimes(1)
+    })
+    expect(updateMirrorMock.mock.calls[0][0]).toBe('mirror-1')
+  })
+
+  it('opens delete confirmation and deletes mirror', async () => {
+    listMirrorsMock.mockResolvedValue([baseMirror])
+    deleteMirrorMock.mockResolvedValue({})
+    const user = userEvent.setup()
+    renderWithProviders(<MirrorsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Upstream Public')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByLabelText('Delete mirror'))
+    expect(screen.getByText('Confirm Delete')).toBeInTheDocument()
+    expect(
+      screen.getByText(/Are you sure you want to delete the mirror "Upstream Public"/),
+    ).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Delete' }))
+    await waitFor(() => {
+      expect(deleteMirrorMock).toHaveBeenCalledWith('mirror-1')
+    })
+  })
+
+  it('triggers sync and shows success message', async () => {
+    listMirrorsMock.mockResolvedValue([baseMirror])
+    triggerMirrorSyncMock.mockResolvedValue({})
+    const user = userEvent.setup()
+    renderWithProviders(<MirrorsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Upstream Public')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByLabelText('Sync mirror'))
+    await waitFor(() => {
+      expect(triggerMirrorSyncMock).toHaveBeenCalledWith('mirror-1')
+    })
+    await waitFor(() => {
+      expect(
+        screen.getByText('Sync triggered for "Upstream Public"'),
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('disables sync button when sync is in progress', async () => {
+    listMirrorsMock.mockResolvedValue([inProgressMirror])
+    renderWithProviders(<MirrorsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Syncing Mirror')).toBeInTheDocument()
+    })
+    expect(screen.getByLabelText('Sync mirror')).toBeDisabled()
+  })
+
+  it('opens View Details dialog and shows providers', async () => {
+    listMirrorsMock.mockResolvedValue([baseMirror])
+    getMirrorProvidersMock.mockResolvedValue([
+      {
+        id: 'prov-1',
+        mirror_config_id: 'mirror-1',
+        provider_id: 'p1',
+        upstream_namespace: 'hashicorp',
+        upstream_type: 'aws',
+        last_synced_at: '2025-07-01T08:00:00Z',
+        last_sync_version: '5.10.0',
+        sync_enabled: true,
+        created_at: '2025-06-01T00:00:00Z',
+        versions: [],
+      },
+    ])
+    const user = userEvent.setup()
+    renderWithProviders(<MirrorsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Upstream Public')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByText('View Details'))
+    await waitFor(() => {
+      expect(
+        screen.getByText('Providers — Upstream Public'),
+      ).toBeInTheDocument()
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('hashicorp')).toBeInTheDocument()
+    })
+    expect(screen.getByText('aws')).toBeInTheDocument()
+    expect(screen.getByText('5.10.0')).toBeInTheDocument()
+  })
+
+  it('shows empty info alert in providers dialog when no providers synced', async () => {
+    listMirrorsMock.mockResolvedValue([baseMirror])
+    getMirrorProvidersMock.mockResolvedValue([])
+    const user = userEvent.setup()
+    renderWithProviders(<MirrorsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Upstream Public')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByText('View Details'))
+    await waitFor(() => {
+      expect(
+        screen.getByText('No providers have been synced yet.'),
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('opens sync history dialog and shows history entries', async () => {
+    listMirrorsMock.mockResolvedValue([baseMirror])
+    getMirrorStatusMock.mockResolvedValue({
+      mirror_config: baseMirror,
+      recent_syncs: [
+        {
+          id: 'sync-1',
+          mirror_config_id: 'mirror-1',
+          started_at: '2025-07-01T07:00:00Z',
+          completed_at: '2025-07-01T08:00:00Z',
+          status: 'success',
+          providers_synced: 5,
+          providers_failed: 0,
+        },
+        {
+          id: 'sync-2',
+          mirror_config_id: 'mirror-1',
+          started_at: '2025-06-30T07:00:00Z',
+          completed_at: '2025-06-30T07:30:00Z',
+          status: 'failed',
+          providers_synced: 2,
+          providers_failed: 3,
+          error_message: 'Rate limited by upstream',
+        },
+      ],
+    })
+    const user = userEvent.setup()
+    renderWithProviders(<MirrorsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Upstream Public')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByLabelText('View sync history'))
+    await waitFor(() => {
+      expect(
+        screen.getByText('Sync History — Upstream Public'),
+      ).toBeInTheDocument()
+    })
+
+    // Wait for history entries to appear
+    await waitFor(() => {
+      expect(screen.getByText('5')).toBeInTheDocument()
+    })
+    // The failed row has providers_failed=3
+    expect(screen.getByText('3')).toBeInTheDocument()
+  })
+
+  it('shows empty history message when no syncs exist', async () => {
+    listMirrorsMock.mockResolvedValue([baseMirror])
+    getMirrorStatusMock.mockResolvedValue({
+      mirror_config: baseMirror,
+      recent_syncs: [],
+    })
+    const user = userEvent.setup()
+    renderWithProviders(<MirrorsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Upstream Public')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByLabelText('View sync history'))
+    await waitFor(() => {
+      expect(
+        screen.getByText('No sync history available.'),
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('closes create dialog when Cancel is clicked', async () => {
+    listMirrorsMock.mockResolvedValue([])
+    const user = userEvent.setup()
+    renderWithProviders(<MirrorsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Add Mirror')).toBeInTheDocument()
+    })
+    await user.click(screen.getByText('Add Mirror'))
+    expect(screen.getByText('Add Provider Mirror')).toBeInTheDocument()
+
+    await user.click(screen.getByText('Cancel'))
+    await waitFor(() => {
+      expect(screen.queryByText('Add Provider Mirror')).not.toBeInTheDocument()
+    })
+  })
+
+  it('auto-opens create dialog when ?action=add is in URL', async () => {
+    listMirrorsMock.mockResolvedValue([])
+    renderWithProviders(<MirrorsPage />, {
+      initialEntries: ['/admin/mirrors?action=add'],
+    })
+    await waitFor(() => {
+      expect(screen.getByText('Add Provider Mirror')).toBeInTheDocument()
+    })
+  })
+
+  it('shows error alert when create mutation fails', async () => {
+    listMirrorsMock.mockResolvedValue([])
+    createMirrorMock.mockRejectedValue(new Error('Server error'))
+    const user = userEvent.setup()
+    renderWithProviders(<MirrorsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Add Mirror')).toBeInTheDocument()
+    })
+    await user.click(screen.getByText('Add Mirror'))
+
+    const nameInput = screen.getByLabelText('Name *')
+    await user.type(nameInput, 'Bad Mirror')
+
+    await user.click(screen.getByText('Create'))
+    await waitFor(() => {
+      expect(screen.getByText('Server error')).toBeInTheDocument()
+    })
+  })
+
+  it('shows error alert when trigger sync fails', async () => {
+    listMirrorsMock.mockResolvedValue([baseMirror])
+    triggerMirrorSyncMock.mockRejectedValue(new Error('Sync unavailable'))
+    const user = userEvent.setup()
+    renderWithProviders(<MirrorsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Upstream Public')).toBeInTheDocument()
+    })
+    await user.click(screen.getByLabelText('Sync mirror'))
+    await waitFor(() => {
+      expect(screen.getByText('Sync unavailable')).toBeInTheDocument()
+    })
+  })
+
+  it('shows error alert when update mutation fails', async () => {
+    listMirrorsMock.mockResolvedValue([baseMirror])
+    updateMirrorMock.mockRejectedValue(new Error('Update failed'))
+    const user = userEvent.setup()
+    renderWithProviders(<MirrorsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Upstream Public')).toBeInTheDocument()
+    })
+    await user.click(screen.getByLabelText('Edit mirror'))
+    await user.click(screen.getByText('Update'))
+    await waitFor(() => {
+      expect(screen.getByText('Update failed')).toBeInTheDocument()
+    })
+  })
+
+  it('shows error alert when delete mutation fails', async () => {
+    listMirrorsMock.mockResolvedValue([baseMirror])
+    deleteMirrorMock.mockRejectedValue(new Error('Delete failed'))
+    const user = userEvent.setup()
+    renderWithProviders(<MirrorsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Upstream Public')).toBeInTheDocument()
+    })
+    await user.click(screen.getByLabelText('Delete mirror'))
+    await user.click(screen.getByRole('button', { name: 'Delete' }))
+    await waitFor(() => {
+      expect(screen.getByText('Delete failed')).toBeInTheDocument()
+    })
+  })
+
+  it('shows pagination when more than 10 mirrors exist', async () => {
+    const manyMirrors = Array.from({ length: 12 }, (_, i) => ({
+      id: `m-${i}`,
+      name: `Mirror ${i}`,
+      upstream_registry_url: 'https://registry.terraform.io',
+      enabled: true,
+      sync_interval_hours: 24,
+      created_at: '2025-07-01T00:00:00Z',
+      updated_at: '2025-07-01T00:00:00Z',
+    }))
+    listMirrorsMock.mockResolvedValue(manyMirrors)
+    renderWithProviders(<MirrorsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Mirror 0')).toBeInTheDocument()
+    })
+    // First page shows 10 items; mirrors 10 and 11 are on page 2
+    expect(screen.queryByText('Mirror 10')).not.toBeInTheDocument()
+    // Pagination controls should be present
+    expect(screen.getByText('1–10 of 12')).toBeInTheDocument()
+  })
+
+  it('expands provider row to show version sub-table in providers dialog', async () => {
+    listMirrorsMock.mockResolvedValue([baseMirror])
+    getMirrorProvidersMock.mockResolvedValue([
+      {
+        id: 'prov-1',
+        mirror_config_id: 'mirror-1',
+        provider_id: 'p1',
+        upstream_namespace: 'hashicorp',
+        upstream_type: 'aws',
+        last_synced_at: '2025-07-01T08:00:00Z',
+        last_sync_version: '5.10.0',
+        sync_enabled: true,
+        created_at: '2025-06-01T00:00:00Z',
+        versions: [
+          {
+            id: 'v1',
+            mirrored_provider_id: 'prov-1',
+            provider_version_id: 'pv1',
+            upstream_version: '5.10.0',
+            synced_at: '2025-07-01T08:00:00Z',
+            shasum_verified: true,
+            gpg_verified: false,
+            platforms: [
+              {
+                id: 'plat-1',
+                provider_version_id: 'pv1',
+                os: 'linux',
+                arch: 'amd64',
+                filename: 'terraform-provider-aws_5.10.0_linux_amd64.zip',
+                shasum: 'abc123def456abc123def456abc123de',
+              },
+            ],
+          },
+        ],
+      },
+    ])
+    const user = userEvent.setup()
+    renderWithProviders(<MirrorsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Upstream Public')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByText('View Details'))
+    await waitFor(() => {
+      expect(screen.getByText('hashicorp')).toBeInTheDocument()
+    })
+
+    // Expand the provider row to show versions
+    const toggleVersionsBtn = screen.getByLabelText('Toggle versions')
+    await user.click(toggleVersionsBtn)
+
+    // The version row shows the upstream_version in a monospace caption
+    await waitFor(() => {
+      // Both the card-level "5.10.0" and the version row render it
+      expect(screen.getAllByText('5.10.0').length).toBeGreaterThanOrEqual(2)
+    })
+
+    // Expand the version row to show platforms
+    const togglePlatformsBtn = screen.getByLabelText('Toggle platforms')
+    await user.click(togglePlatformsBtn)
+    await waitFor(() => {
+      expect(screen.getByText('linux')).toBeInTheDocument()
+    })
+    expect(screen.getByText('amd64')).toBeInTheDocument()
+    expect(
+      screen.getByText('terraform-provider-aws_5.10.0_linux_amd64.zip'),
+    ).toBeInTheDocument()
+  })
+
+  it('shows default status chip for unknown sync status', async () => {
+    const unknownStatusMirror = {
+      id: 'mirror-unknown',
+      name: 'Unknown Status Mirror',
+      upstream_registry_url: 'https://registry.terraform.io',
+      enabled: true,
+      sync_interval_hours: 24,
+      last_sync_status: 'partial' as 'success',
+      created_at: '2025-07-02T00:00:00Z',
+      updated_at: '2025-07-02T00:00:00Z',
+    }
+    listMirrorsMock.mockResolvedValue([unknownStatusMirror])
+    renderWithProviders(<MirrorsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Unknown Status Mirror')).toBeInTheDocument()
+    })
+    // The default case renders the raw status text
+    expect(screen.getByText('partial')).toBeInTheDocument()
+  })
+
+  it('shows "Never" for last sync when mirror has never been synced', async () => {
+    listMirrorsMock.mockResolvedValue([neverSyncedMirror])
+    renderWithProviders(<MirrorsPage />)
+    await waitFor(() => {
+      expect(screen.getByText(/Last sync: Never/)).toBeInTheDocument()
+    })
+  })
+
+  it('handles getMirrorProviders failure gracefully', async () => {
+    listMirrorsMock.mockResolvedValue([baseMirror])
+    getMirrorProvidersMock.mockRejectedValue(new Error('Network error'))
+    const user = userEvent.setup()
+    renderWithProviders(<MirrorsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Upstream Public')).toBeInTheDocument()
+    })
+    await user.click(screen.getByText('View Details'))
+    // When providers fetch fails, it shows "No providers have been synced yet." (empty fallback)
+    await waitFor(() => {
+      expect(
+        screen.getByText('No providers have been synced yet.'),
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('handles getMirrorStatus failure gracefully in history dialog', async () => {
+    listMirrorsMock.mockResolvedValue([baseMirror])
+    getMirrorStatusMock.mockRejectedValue(new Error('Network error'))
+    const user = userEvent.setup()
+    renderWithProviders(<MirrorsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Upstream Public')).toBeInTheDocument()
+    })
+    await user.click(screen.getByLabelText('View sync history'))
+    // When status fetch fails, it falls back to empty history
+    await waitFor(() => {
+      expect(
+        screen.getByText('No sync history available.'),
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('closes history dialog when Close button is clicked', async () => {
+    listMirrorsMock.mockResolvedValue([baseMirror])
+    getMirrorStatusMock.mockResolvedValue({
+      mirror_config: baseMirror,
+      recent_syncs: [],
+    })
+    const user = userEvent.setup()
+    renderWithProviders(<MirrorsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Upstream Public')).toBeInTheDocument()
+    })
+    await user.click(screen.getByLabelText('View sync history'))
+    await waitFor(() => {
+      expect(screen.getByText('Sync History — Upstream Public')).toBeInTheDocument()
+    })
+    await user.click(screen.getByText('Close'))
+    await waitFor(() => {
+      expect(screen.queryByText('Sync History — Upstream Public')).not.toBeInTheDocument()
+    })
+  })
+
+  it('closes providers dialog when Close button is clicked', async () => {
+    listMirrorsMock.mockResolvedValue([baseMirror])
+    getMirrorProvidersMock.mockResolvedValue([])
+    const user = userEvent.setup()
+    renderWithProviders(<MirrorsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Upstream Public')).toBeInTheDocument()
+    })
+    await user.click(screen.getByText('View Details'))
+    await waitFor(() => {
+      expect(screen.getByText('Providers — Upstream Public')).toBeInTheDocument()
+    })
+    await user.click(screen.getByText('Close'))
+    await waitFor(() => {
+      expect(screen.queryByText('Providers — Upstream Public')).not.toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/pages/admin/__tests__/ModuleUploadPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/ModuleUploadPage.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+    useLocation: () => ({ state: null, pathname: '/admin/upload/module', search: '', hash: '' }),
+  }
+})
+
+vi.mock('../../../services/api', () => ({
+  default: {
+    uploadModule: vi.fn(),
+    createModuleRecord: vi.fn(),
+  },
+}))
+
+vi.mock('../../../components/PublishFromSCMWizard', () => ({
+  default: () => <div data-testid="scm-wizard">SCM Wizard</div>,
+}))
+
+import ModuleUploadPage from '../../admin/ModuleUploadPage'
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <ModuleUploadPage />
+    </MemoryRouter>,
+  )
+}
+
+describe('ModuleUploadPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the page heading', () => {
+    renderPage()
+    expect(screen.getByText('Upload Module')).toBeInTheDocument()
+    expect(screen.getByText('Publish a Terraform module to your registry')).toBeInTheDocument()
+  })
+
+  it('shows method chooser by default', () => {
+    renderPage()
+    expect(screen.getByText('How would you like to publish this module?')).toBeInTheDocument()
+    expect(screen.getByText('Upload from File')).toBeInTheDocument()
+    expect(screen.getByText('Link from SCM Repository')).toBeInTheDocument()
+  })
+
+  it('switches to upload form when Upload from File is clicked', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    await user.click(screen.getByText('Upload from File'))
+    expect(screen.getByText('Upload Terraform Module')).toBeInTheDocument()
+    expect(screen.getByLabelText(/Namespace/)).toBeInTheDocument()
+    expect(screen.getByLabelText(/Module Name/)).toBeInTheDocument()
+  })
+
+  it('switches to SCM form when Link from SCM is clicked', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    await user.click(screen.getByText('Link from SCM Repository'))
+    expect(screen.getByText('Link Module to SCM Repository')).toBeInTheDocument()
+  })
+
+  it('shows requirements in the upload form', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    await user.click(screen.getByText('Upload from File'))
+    expect(screen.getByText(/Requirements:/)).toBeInTheDocument()
+  })
+
+  it('has back button in upload form', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    await user.click(screen.getByText('Upload from File'))
+    await user.click(screen.getByText('Back'))
+    expect(screen.getByText('How would you like to publish this module?')).toBeInTheDocument()
+  })
+
+  it('has back button in SCM form', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    await user.click(screen.getByText('Link from SCM Repository'))
+    await user.click(screen.getByText('Back'))
+    expect(screen.getByText('How would you like to publish this module?')).toBeInTheDocument()
+  })
+
+  it('disables upload button when no file selected', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    await user.click(screen.getByText('Upload from File'))
+    const uploadButton = screen.getByRole('button', { name: /Upload Module/i })
+    expect(uploadButton).toBeDisabled()
+  })
+
+  it('disables SCM continue button when required fields empty', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    await user.click(screen.getByText('Link from SCM Repository'))
+    const continueButton = screen.getByRole('button', { name: /Continue to Repository Selection/i })
+    expect(continueButton).toBeDisabled()
+  })
+})

--- a/frontend/src/pages/admin/__tests__/OIDCSettingsPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/OIDCSettingsPage.test.tsx
@@ -1,0 +1,277 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { OIDCConfigResponse, Organization } from '../../../types'
+
+const getAdminOIDCConfigMock = vi.fn()
+const updateOIDCGroupMappingMock = vi.fn()
+const listOrganizationsMock = vi.fn()
+
+vi.mock('../../../services/api', () => ({
+  default: {
+    getAdminOIDCConfig: (...args: unknown[]) => getAdminOIDCConfigMock(...args),
+    updateOIDCGroupMapping: (...args: unknown[]) => updateOIDCGroupMappingMock(...args),
+    listOrganizations: (...args: unknown[]) => listOrganizationsMock(...args),
+  },
+}))
+
+import OIDCSettingsPage from '../OIDCSettingsPage'
+
+function renderWithProviders(ui: React.ReactElement) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>)
+}
+
+const fakeConfig: OIDCConfigResponse = {
+  id: 'oidc-1',
+  name: 'Corporate IDP',
+  provider_type: 'azure',
+  issuer_url: 'https://login.example.com',
+  client_id: 'client-abc-123',
+  redirect_url: 'https://registry.example.com/callback',
+  scopes: ['openid', 'profile'],
+  is_active: true,
+  group_claim_name: 'groups',
+  default_role: 'viewer',
+  group_mappings: [
+    { group: 'platform-admins', organization: 'infra-team', role: 'admin' },
+    { group: 'developers', organization: 'dev-org', role: 'publisher' },
+  ],
+  created_at: '2025-01-01T00:00:00Z',
+  updated_at: '2025-06-01T00:00:00Z',
+}
+
+const fakeOrgs: Organization[] = [
+  { id: 'org-1', name: 'infra-team', display_name: 'Infra Team', created_at: '2025-01-01T00:00:00Z', updated_at: '2025-01-01T00:00:00Z' },
+  { id: 'org-2', name: 'dev-org', display_name: 'Dev Org', created_at: '2025-01-01T00:00:00Z', updated_at: '2025-01-01T00:00:00Z' },
+]
+
+describe('OIDCSettingsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    listOrganizationsMock.mockResolvedValue(fakeOrgs)
+  })
+
+  it('shows loading spinner while fetching', () => {
+    getAdminOIDCConfigMock.mockReturnValue(new Promise(() => { }))
+    renderWithProviders(<OIDCSettingsPage />)
+    expect(screen.getByRole('progressbar')).toBeInTheDocument()
+  })
+
+  it('renders heading and description after load', async () => {
+    getAdminOIDCConfigMock.mockResolvedValue(fakeConfig)
+    renderWithProviders(<OIDCSettingsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('OIDC Groups')).toBeInTheDocument()
+    })
+    expect(
+      screen.getByText(/Configure group claim mapping from your identity provider/)
+    ).toBeInTheDocument()
+  })
+
+  it('renders active OIDC provider summary', async () => {
+    getAdminOIDCConfigMock.mockResolvedValue(fakeConfig)
+    renderWithProviders(<OIDCSettingsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Active OIDC Provider')).toBeInTheDocument()
+    })
+    expect(screen.getByText('azure')).toBeInTheDocument()
+    expect(screen.getByText('https://login.example.com')).toBeInTheDocument()
+    expect(screen.getByText('client-abc-123')).toBeInTheDocument()
+    expect(screen.getByText('Active')).toBeInTheDocument()
+  })
+
+  it('shows Inactive chip when provider is not active', async () => {
+    getAdminOIDCConfigMock.mockResolvedValue({ ...fakeConfig, is_active: false })
+    renderWithProviders(<OIDCSettingsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Inactive')).toBeInTheDocument()
+    })
+  })
+
+  it('populates group claim name and default role from config', async () => {
+    getAdminOIDCConfigMock.mockResolvedValue(fakeConfig)
+    renderWithProviders(<OIDCSettingsPage />)
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('groups')).toBeInTheDocument()
+    })
+  })
+
+  it('renders group mappings table with data', async () => {
+    getAdminOIDCConfigMock.mockResolvedValue(fakeConfig)
+    renderWithProviders(<OIDCSettingsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('platform-admins')).toBeInTheDocument()
+    })
+    expect(screen.getByText('infra-team')).toBeInTheDocument()
+    expect(screen.getByText('developers')).toBeInTheDocument()
+    expect(screen.getByText('dev-org')).toBeInTheDocument()
+    // Table headers
+    expect(screen.getByText('IdP Group')).toBeInTheDocument()
+    expect(screen.getByText('Organization')).toBeInTheDocument()
+  })
+
+  it('shows empty message when no group mappings', async () => {
+    getAdminOIDCConfigMock.mockResolvedValue({
+      ...fakeConfig,
+      group_mappings: [],
+    })
+    renderWithProviders(<OIDCSettingsPage />)
+    await waitFor(() => {
+      expect(
+        screen.getByText(/No group mappings configured/)
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('opens add mapping dialog and adds a new mapping', async () => {
+    getAdminOIDCConfigMock.mockResolvedValue({
+      ...fakeConfig,
+      group_mappings: [],
+    })
+    const user = userEvent.setup()
+    renderWithProviders(<OIDCSettingsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Add Mapping')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByText('Add Mapping'))
+    expect(screen.getByText('Add Group Mapping')).toBeInTheDocument()
+
+    // Fill in the group field
+    const groupInput = screen.getByLabelText('IdP Group')
+    await user.type(groupInput, 'qa-engineers')
+
+    // Fill in the organization field
+    const orgInput = screen.getByLabelText('Organization')
+    await user.type(orgInput, 'qa-org')
+
+    // Click Add
+    const addButton = screen.getByRole('button', { name: 'Add' })
+    await user.click(addButton)
+
+    // Mapping should appear in the table
+    await waitFor(() => {
+      expect(screen.getByText('qa-engineers')).toBeInTheDocument()
+    })
+  })
+
+  it('opens edit dialog for existing mapping', async () => {
+    getAdminOIDCConfigMock.mockResolvedValue(fakeConfig)
+    const user = userEvent.setup()
+    renderWithProviders(<OIDCSettingsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('platform-admins')).toBeInTheDocument()
+    })
+
+    const editButtons = screen.getAllByLabelText('Edit claim mapping')
+    await user.click(editButtons[0])
+
+    expect(screen.getByText('Edit Group Mapping')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('platform-admins')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Update' })).toBeInTheDocument()
+  })
+
+  it('opens delete confirmation and removes a mapping', async () => {
+    getAdminOIDCConfigMock.mockResolvedValue(fakeConfig)
+    const user = userEvent.setup()
+    renderWithProviders(<OIDCSettingsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('platform-admins')).toBeInTheDocument()
+    })
+
+    const deleteButtons = screen.getAllByLabelText('Delete claim mapping')
+    await user.click(deleteButtons[0])
+
+    // Confirm dialog should appear
+    expect(screen.getByText('Remove Group Mapping')).toBeInTheDocument()
+    expect(screen.getByText(/Remove the mapping for group/)).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Remove' }))
+
+    // The mapping should be gone
+    await waitFor(() => {
+      expect(screen.queryByText('platform-admins')).not.toBeInTheDocument()
+    })
+    // The other mapping should still be there
+    expect(screen.getByText('developers')).toBeInTheDocument()
+  })
+
+  it('calls save mutation and shows success message', async () => {
+    getAdminOIDCConfigMock.mockResolvedValue(fakeConfig)
+    updateOIDCGroupMappingMock.mockResolvedValue(fakeConfig)
+    const user = userEvent.setup()
+    renderWithProviders(<OIDCSettingsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Save Changes')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByText('Save Changes'))
+
+    await waitFor(() => {
+      expect(updateOIDCGroupMappingMock).toHaveBeenCalledWith({
+        group_claim_name: 'groups',
+        group_mappings: fakeConfig.group_mappings,
+        default_role: 'viewer',
+      })
+    })
+    await waitFor(() => {
+      expect(
+        screen.getByText('Group mapping settings saved successfully.')
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('shows error alert when save mutation fails', async () => {
+    getAdminOIDCConfigMock.mockResolvedValue(fakeConfig)
+    updateOIDCGroupMappingMock.mockRejectedValue({
+      response: { data: { error: 'Permission denied' } },
+    })
+    const user = userEvent.setup()
+    renderWithProviders(<OIDCSettingsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Save Changes')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByText('Save Changes'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Permission denied')).toBeInTheDocument()
+    })
+  })
+
+  it('shows error when query fails to load config', async () => {
+    getAdminOIDCConfigMock.mockRejectedValue({
+      response: { data: { error: 'Unauthorized access' } },
+    })
+    renderWithProviders(<OIDCSettingsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Unauthorized access')).toBeInTheDocument()
+    })
+  })
+
+  it('cancel button closes the add dialog without adding', async () => {
+    getAdminOIDCConfigMock.mockResolvedValue({
+      ...fakeConfig,
+      group_mappings: [],
+    })
+    const user = userEvent.setup()
+    renderWithProviders(<OIDCSettingsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Add Mapping')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByText('Add Mapping'))
+    expect(screen.getByText('Add Group Mapping')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    await waitFor(() => {
+      expect(screen.queryByText('Add Group Mapping')).not.toBeInTheDocument()
+    })
+    expect(screen.getByText(/No group mappings configured/)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/admin/__tests__/OrganizationsPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/OrganizationsPage.test.tsx
@@ -1,0 +1,115 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter } from 'react-router-dom'
+
+const listOrganizationsMock = vi.fn()
+vi.mock('../../../services/api', () => ({
+  default: {
+    listOrganizations: (...args: unknown[]) => listOrganizationsMock(...args),
+  },
+}))
+
+vi.mock('../../../contexts/AuthContext', () => ({
+  useAuth: () => ({ allowedScopes: ['admin'], user: { id: 'u1' } }),
+}))
+
+import OrganizationsPage from '../OrganizationsPage'
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  })
+}
+
+function renderPage() {
+  const queryClient = createQueryClient()
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <OrganizationsPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+const fakeOrgs = [
+  {
+    id: 'org-1',
+    name: 'acme-corp',
+    display_name: 'Acme Corporation',
+    created_at: '2025-03-15T10:00:00Z',
+    updated_at: '2025-03-15T10:00:00Z',
+  },
+  {
+    id: 'org-2',
+    name: 'globex',
+    display_name: 'Globex Inc',
+    created_at: '2025-04-20T08:00:00Z',
+    updated_at: '2025-04-20T08:00:00Z',
+  },
+]
+
+describe('OrganizationsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows loading spinner initially', () => {
+    listOrganizationsMock.mockReturnValue(new Promise(() => { }))
+    renderPage()
+    expect(screen.getByRole('progressbar')).toBeInTheDocument()
+  })
+
+  it('renders heading and description after load', async () => {
+    listOrganizationsMock.mockResolvedValue(fakeOrgs)
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('Organizations')).toBeInTheDocument()
+    })
+    expect(
+      screen.getByText('Manage organizations and their members'),
+    ).toBeInTheDocument()
+  })
+
+  it('shows org table with data', async () => {
+    listOrganizationsMock.mockResolvedValue(fakeOrgs)
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('acme-corp')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Acme Corporation')).toBeInTheDocument()
+    expect(screen.getByText('globex')).toBeInTheDocument()
+    expect(screen.getByText('Globex Inc')).toBeInTheDocument()
+    // Table headers
+    expect(screen.getByText('Name')).toBeInTheDocument()
+    expect(screen.getByText('Display Name')).toBeInTheDocument()
+    expect(screen.getByText('Created')).toBeInTheDocument()
+  })
+
+  it('shows Add Organization button', async () => {
+    listOrganizationsMock.mockResolvedValue(fakeOrgs)
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('Add Organization')).toBeInTheDocument()
+    })
+  })
+
+  it('shows empty state when no organizations exist', async () => {
+    listOrganizationsMock.mockResolvedValue([])
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('No organizations found')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Create First Organization')).toBeInTheDocument()
+  })
+
+  it('shows empty state when API fails', async () => {
+    listOrganizationsMock.mockRejectedValue(new Error('Network error'))
+    renderPage()
+    // Error alert is suppressed in DEV mode; component falls through to empty state
+    await waitFor(() => {
+      expect(screen.getByText('No organizations found')).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/pages/admin/__tests__/ProviderUploadPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/ProviderUploadPage.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  }
+})
+
+vi.mock('../../../services/api', () => ({
+  default: {
+    uploadProvider: vi.fn(),
+  },
+}))
+
+import ProviderUploadPage from '../../admin/ProviderUploadPage'
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <ProviderUploadPage />
+    </MemoryRouter>,
+  )
+}
+
+describe('ProviderUploadPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the page heading', () => {
+    renderPage()
+    expect(screen.getByText('Upload Provider')).toBeInTheDocument()
+    expect(screen.getByText('Add a Terraform provider to your registry')).toBeInTheDocument()
+  })
+
+  it('shows method chooser by default', () => {
+    renderPage()
+    expect(screen.getByText('How would you like to add this provider?')).toBeInTheDocument()
+    expect(screen.getByText('Manual Upload')).toBeInTheDocument()
+    expect(screen.getByText('Provider Mirror')).toBeInTheDocument()
+  })
+
+  it('switches to upload form when Manual Upload is clicked', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    await user.click(screen.getByText('Manual Upload'))
+    expect(screen.getByText('Upload Terraform Provider')).toBeInTheDocument()
+    expect(screen.getByLabelText(/Namespace/)).toBeInTheDocument()
+    expect(screen.getByLabelText(/Provider Name/)).toBeInTheDocument()
+    expect(screen.getByLabelText(/Version/)).toBeInTheDocument()
+  })
+
+  it('shows requirements section in upload form', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    await user.click(screen.getByText('Manual Upload'))
+    expect(screen.getByText(/Requirements:/)).toBeInTheDocument()
+  })
+
+  it('navigates to mirrors when Provider Mirror is clicked', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    await user.click(screen.getByText('Provider Mirror'))
+    expect(mockNavigate).toHaveBeenCalledWith('/admin/mirrors?action=add')
+  })
+
+  it('has a back button in upload form', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    await user.click(screen.getByText('Manual Upload'))
+    expect(screen.getByText('Back')).toBeInTheDocument()
+  })
+
+  it('goes back to chooser when Back is clicked', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    await user.click(screen.getByText('Manual Upload'))
+    await user.click(screen.getByText('Back'))
+    expect(screen.getByText('How would you like to add this provider?')).toBeInTheDocument()
+  })
+
+  it('disables upload button when no file selected', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    await user.click(screen.getByText('Manual Upload'))
+    const uploadButton = screen.getByRole('button', { name: /Upload Provider/i })
+    expect(uploadButton).toBeDisabled()
+  })
+})

--- a/frontend/src/pages/admin/__tests__/RolesPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/RolesPage.test.tsx
@@ -1,0 +1,129 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+// Mock api
+const listRoleTemplatesMock = vi.fn()
+vi.mock('../../../services/api', () => ({
+  default: {
+    listRoleTemplates: (...args: unknown[]) => listRoleTemplatesMock(...args),
+  },
+}))
+
+import RolesPage from '../../admin/RolesPage'
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  })
+}
+
+function renderPage() {
+  const queryClient = createQueryClient()
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <RolesPage />
+    </QueryClientProvider>,
+  )
+}
+
+const fakeRoles = [
+  {
+    id: 'r-1',
+    name: 'viewer',
+    display_name: 'Viewer',
+    description: 'Read-only access to modules and providers',
+    scopes: ['modules:read', 'providers:read'],
+    is_system: true,
+    created_at: '2025-01-01T00:00:00Z',
+    updated_at: '2025-01-01T00:00:00Z',
+  },
+  {
+    id: 'r-2',
+    name: 'admin',
+    display_name: 'Administrator',
+    description: 'Full access to all features',
+    scopes: ['admin'],
+    is_system: true,
+    created_at: '2025-01-01T00:00:00Z',
+    updated_at: '2025-02-01T00:00:00Z',
+  },
+  {
+    id: 'r-3',
+    name: 'publisher',
+    display_name: 'Publisher',
+    description: 'Can upload modules and providers',
+    scopes: ['modules:read', 'modules:write', 'providers:read', 'providers:write'],
+    is_system: true,
+    created_at: '2025-01-01T00:00:00Z',
+    updated_at: '2025-01-01T00:00:00Z',
+  },
+]
+
+describe('RolesPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows loading spinner initially', () => {
+    listRoleTemplatesMock.mockReturnValue(new Promise(() => {}))
+    renderPage()
+    expect(screen.getByRole('progressbar')).toBeInTheDocument()
+  })
+
+  it('renders heading and description after loading', async () => {
+    listRoleTemplatesMock.mockResolvedValue(fakeRoles)
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('Roles & Permissions')).toBeInTheDocument()
+    })
+    expect(screen.getByText(/View the available roles/)).toBeInTheDocument()
+  })
+
+  it('renders the scope reference table', async () => {
+    listRoleTemplatesMock.mockResolvedValue(fakeRoles)
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('Available Scopes Reference')).toBeInTheDocument()
+    })
+    // Multiple elements may exist since scopes appear in both reference table and role details
+    expect(screen.getAllByText('Modules Read').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getAllByText('Administrator').length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('renders role template list', async () => {
+    listRoleTemplatesMock.mockResolvedValue(fakeRoles)
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('Role Templates')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Viewer')).toBeInTheDocument()
+    expect(screen.getByText('Publisher')).toBeInTheDocument()
+  })
+
+  it('shows scope count for each role', async () => {
+    listRoleTemplatesMock.mockResolvedValue(fakeRoles)
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('2 scopes')).toBeInTheDocument() // viewer
+      expect(screen.getByText('1 scope')).toBeInTheDocument()  // admin
+      expect(screen.getByText('4 scopes')).toBeInTheDocument() // publisher
+    })
+  })
+
+  it('shows no roles found when empty', async () => {
+    listRoleTemplatesMock.mockResolvedValue([])
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('No roles found.')).toBeInTheDocument()
+    })
+  })
+
+  it('shows error when API fails', async () => {
+    listRoleTemplatesMock.mockRejectedValue(new Error('Network error'))
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('Failed to load roles. Please try again.')).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/pages/admin/__tests__/SecurityScanningPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/SecurityScanningPage.test.tsx
@@ -1,0 +1,138 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+// Mock api
+const getScanningConfigMock = vi.fn()
+const getScanningStatsMock = vi.fn()
+vi.mock('../../../services/api', () => ({
+  default: {
+    getScanningConfig: (...args: unknown[]) => getScanningConfigMock(...args),
+    getScanningStats: (...args: unknown[]) => getScanningStatsMock(...args),
+  },
+}))
+
+import SecurityScanningPage from '../../admin/SecurityScanningPage'
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  })
+}
+
+function renderPage() {
+  const queryClient = createQueryClient()
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <SecurityScanningPage />
+    </QueryClientProvider>,
+  )
+}
+
+const fakeConfig = {
+  enabled: true,
+  tool: 'trivy',
+  expected_version: '0.50.0',
+  severity_threshold: 'HIGH',
+  timeout: '5m',
+  worker_count: 2,
+  scan_interval_mins: 60,
+}
+
+const fakeStats = {
+  total: 25,
+  pending: 2,
+  clean: 18,
+  findings: 3,
+  error: 2,
+  recent_scans: [
+    {
+      id: 's-1',
+      namespace: 'hashicorp',
+      module_name: 'consul',
+      system: 'aws',
+      module_version: '1.0.0',
+      scanner: 'trivy',
+      status: 'clean',
+      critical_count: 0,
+      high_count: 0,
+      medium_count: 1,
+      low_count: 3,
+      scanned_at: new Date().toISOString(),
+    },
+  ],
+}
+
+describe('SecurityScanningPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows loading spinner initially', () => {
+    getScanningConfigMock.mockReturnValue(new Promise(() => {}))
+    getScanningStatsMock.mockReturnValue(new Promise(() => {}))
+    renderPage()
+    expect(screen.getByRole('progressbar')).toBeInTheDocument()
+  })
+
+  it('renders page heading', () => {
+    getScanningConfigMock.mockReturnValue(new Promise(() => {}))
+    getScanningStatsMock.mockReturnValue(new Promise(() => {}))
+    renderPage()
+    expect(screen.getByText('Security Scanning')).toBeInTheDocument()
+  })
+
+  it('renders configuration section after load', async () => {
+    getScanningConfigMock.mockResolvedValue(fakeConfig)
+    getScanningStatsMock.mockResolvedValue(fakeStats)
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('Configuration')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Enabled')).toBeInTheDocument()
+    // 'trivy' appears in both config and recent scans table
+    expect(screen.getAllByText('trivy').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getByText('0.50.0')).toBeInTheDocument()
+    expect(screen.getByText('HIGH')).toBeInTheDocument()
+  })
+
+  it('renders summary stats', async () => {
+    getScanningConfigMock.mockResolvedValue(fakeConfig)
+    getScanningStatsMock.mockResolvedValue(fakeStats)
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('Total Scans')).toBeInTheDocument()
+    })
+    expect(screen.getByText('25')).toBeInTheDocument()
+    expect(screen.getByText('18')).toBeInTheDocument()
+  })
+
+  it('renders recent scans table', async () => {
+    getScanningConfigMock.mockResolvedValue(fakeConfig)
+    getScanningStatsMock.mockResolvedValue(fakeStats)
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('Recent Scans')).toBeInTheDocument()
+    })
+    expect(screen.getByText('hashicorp/consul/aws')).toBeInTheDocument()
+    expect(screen.getByText('1.0.0')).toBeInTheDocument()
+  })
+
+  it('shows error when API fails', async () => {
+    getScanningConfigMock.mockRejectedValue(new Error('fail'))
+    getScanningStatsMock.mockRejectedValue(new Error('fail'))
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('Failed to load scanning data.')).toBeInTheDocument()
+    })
+  })
+
+  it('shows no scans message when empty', async () => {
+    getScanningConfigMock.mockResolvedValue(fakeConfig)
+    getScanningStatsMock.mockResolvedValue({ ...fakeStats, recent_scans: [] })
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('No scans recorded yet.')).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/pages/admin/__tests__/StoragePage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/StoragePage.test.tsx
@@ -1,0 +1,515 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { StorageConfigResponse } from '../../../types'
+
+const getSetupStatusMock = vi.fn()
+const listStorageConfigsMock = vi.fn()
+const listStorageMigrationsMock = vi.fn()
+const testStorageConfigMock = vi.fn()
+const createStorageConfigMock = vi.fn()
+const activateStorageConfigMock = vi.fn()
+const deleteStorageConfigMock = vi.fn()
+
+vi.mock('../../../services/api', () => ({
+  default: {
+    getSetupStatus: (...args: unknown[]) => getSetupStatusMock(...args),
+    listStorageConfigs: (...args: unknown[]) => listStorageConfigsMock(...args),
+    listStorageMigrations: (...args: unknown[]) => listStorageMigrationsMock(...args),
+    testStorageConfig: (...args: unknown[]) => testStorageConfigMock(...args),
+    createStorageConfig: (...args: unknown[]) => createStorageConfigMock(...args),
+    activateStorageConfig: (...args: unknown[]) => activateStorageConfigMock(...args),
+    deleteStorageConfig: (...args: unknown[]) => deleteStorageConfigMock(...args),
+  },
+}))
+
+vi.mock('../../../components/StorageMigrationWizard', () => ({
+  default: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="migration-wizard">Migration Wizard</div> : null,
+}))
+
+import StoragePage from '../StoragePage'
+
+function renderWithProviders(ui: React.ReactElement) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>)
+}
+
+const fakeLocalConfig = {
+  id: 'cfg-1',
+  backend_type: 'local' as const,
+  is_active: true,
+  local_base_path: './data/storage',
+  local_serve_directly: true,
+  azure_account_key_set: false,
+  s3_access_key_id_set: false,
+  s3_secret_access_key_set: false,
+  gcs_credentials_json_set: false,
+  created_at: '2025-06-01T12:00:00Z',
+  updated_at: '2025-06-01T12:00:00Z',
+}
+
+const fakeS3Config = {
+  id: 'cfg-2',
+  backend_type: 's3' as const,
+  is_active: false,
+  s3_bucket: 'my-bucket',
+  s3_region: 'us-east-1',
+  s3_auth_method: 'default',
+  azure_account_key_set: false,
+  s3_access_key_id_set: false,
+  s3_secret_access_key_set: false,
+  gcs_credentials_json_set: false,
+  created_at: '2025-06-02T10:00:00Z',
+  updated_at: '2025-06-02T10:00:00Z',
+}
+
+const fakeAzureConfig = {
+  id: 'cfg-3',
+  backend_type: 'azure' as const,
+  is_active: false,
+  azure_account_name: 'myaccount',
+  azure_container_name: 'mycontainer',
+  azure_account_key_set: true,
+  s3_access_key_id_set: false,
+  s3_secret_access_key_set: false,
+  gcs_credentials_json_set: false,
+  created_at: '2025-06-03T10:00:00Z',
+  updated_at: '2025-06-03T10:00:00Z',
+}
+
+const fakeGcsConfig = {
+  id: 'cfg-4',
+  backend_type: 'gcs' as const,
+  is_active: false,
+  gcs_bucket: 'gcs-bucket',
+  gcs_auth_method: 'default',
+  azure_account_key_set: false,
+  s3_access_key_id_set: false,
+  s3_secret_access_key_set: false,
+  gcs_credentials_json_set: false,
+  created_at: '2025-06-04T10:00:00Z',
+  updated_at: '2025-06-04T10:00:00Z',
+}
+
+const fakeMigration = {
+  id: 'mig-1',
+  source_config_id: 'cfg-1',
+  target_config_id: 'cfg-2',
+  status: 'completed' as const,
+  total_artifacts: 10,
+  migrated_artifacts: 10,
+  failed_artifacts: 0,
+  started_at: '2025-06-05T08:00:00Z',
+  completed_at: '2025-06-05T08:30:00Z',
+  created_at: '2025-06-05T08:00:00Z',
+}
+
+/** Helper: mock API for setup-required state (shows wizard) */
+function mockSetupRequired() {
+  getSetupStatusMock.mockResolvedValue({ setup_required: true, storage_configured: false })
+  listStorageConfigsMock.mockResolvedValue([])
+  listStorageMigrationsMock.mockResolvedValue([])
+}
+
+/** Helper: mock API for existing configs state */
+function mockExistingConfigs(
+  configs: StorageConfigResponse[] = [fakeLocalConfig, fakeS3Config],
+  migrations: typeof fakeMigration[] = [],
+) {
+  getSetupStatusMock.mockResolvedValue({ setup_required: false, storage_configured: true })
+  listStorageConfigsMock.mockResolvedValue(configs)
+  listStorageMigrationsMock.mockResolvedValue(migrations)
+}
+
+describe('StoragePage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // ---- Loading state ----
+
+  it('shows loading spinner while fetching', () => {
+    getSetupStatusMock.mockReturnValue(new Promise(() => { }))
+    renderWithProviders(<StoragePage />)
+    expect(screen.getByRole('progressbar')).toBeInTheDocument()
+  })
+
+  // ---- Setup Wizard view ----
+
+  it('renders setup wizard heading when setup is required', async () => {
+    mockSetupRequired()
+    renderWithProviders(<StoragePage />)
+    await waitFor(() => {
+      expect(screen.getByText('Storage Configuration')).toBeInTheDocument()
+    })
+    expect(
+      screen.getByText(/Configure where the registry will store module and provider files/)
+    ).toBeInTheDocument()
+  })
+
+  it('shows stepper with three steps in setup wizard', async () => {
+    mockSetupRequired()
+    renderWithProviders(<StoragePage />)
+    await waitFor(() => {
+      expect(screen.getByText('Select Backend')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Configure Settings')).toBeInTheDocument()
+    expect(screen.getByText('Review & Save')).toBeInTheDocument()
+  })
+
+  it('renders all four backend selection cards', async () => {
+    mockSetupRequired()
+    renderWithProviders(<StoragePage />)
+    await waitFor(() => {
+      expect(screen.getByText('Local File System')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Azure Blob Storage')).toBeInTheDocument()
+    expect(screen.getByText('Amazon S3 / S3-Compatible')).toBeInTheDocument()
+    expect(screen.getByText('Google Cloud Storage')).toBeInTheDocument()
+  })
+
+  it('navigates to step 2 and shows local settings form by default', async () => {
+    mockSetupRequired()
+    const user = userEvent.setup()
+    renderWithProviders(<StoragePage />)
+    await waitFor(() => {
+      expect(screen.getByText('Next')).toBeInTheDocument()
+    })
+    await user.click(screen.getByText('Next'))
+    expect(screen.getByLabelText(/Base Path/)).toBeInTheDocument()
+    expect(
+      screen.getByText(/Serve files directly/)
+    ).toBeInTheDocument()
+  })
+
+  it('shows Azure settings when Azure backend is selected', async () => {
+    mockSetupRequired()
+    const user = userEvent.setup()
+    renderWithProviders(<StoragePage />)
+    await waitFor(() => {
+      expect(screen.getByText('Azure Blob Storage')).toBeInTheDocument()
+    })
+    await user.click(screen.getByText('Azure Blob Storage'))
+    await user.click(screen.getByText('Next'))
+    expect(screen.getByLabelText(/Account Name/)).toBeInTheDocument()
+    expect(screen.getByLabelText(/Account Key/)).toBeInTheDocument()
+    expect(screen.getByLabelText(/Container Name/)).toBeInTheDocument()
+  })
+
+  it('shows S3 settings when S3 backend is selected', async () => {
+    mockSetupRequired()
+    const user = userEvent.setup()
+    renderWithProviders(<StoragePage />)
+    await waitFor(() => {
+      expect(screen.getByText('Amazon S3 / S3-Compatible')).toBeInTheDocument()
+    })
+    await user.click(screen.getByText('Amazon S3 / S3-Compatible'))
+    await user.click(screen.getByText('Next'))
+    expect(screen.getByLabelText(/Bucket/)).toBeInTheDocument()
+    expect(screen.getByLabelText(/^Region/)).toBeInTheDocument()
+    expect(screen.getAllByText('Authentication Method').length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('shows GCS settings when GCS backend is selected', async () => {
+    mockSetupRequired()
+    const user = userEvent.setup()
+    renderWithProviders(<StoragePage />)
+    await waitFor(() => {
+      expect(screen.getByText('Google Cloud Storage')).toBeInTheDocument()
+    })
+    await user.click(screen.getByText('Google Cloud Storage'))
+    await user.click(screen.getByText('Next'))
+    expect(screen.getByLabelText(/Bucket/)).toBeInTheDocument()
+    expect(screen.getByLabelText(/Project ID/)).toBeInTheDocument()
+  })
+
+  it('navigates to review step and shows configuration summary', async () => {
+    mockSetupRequired()
+    const user = userEvent.setup()
+    renderWithProviders(<StoragePage />)
+    await waitFor(() => {
+      expect(screen.getByText('Next')).toBeInTheDocument()
+    })
+    // Step 0 -> Step 1
+    await user.click(screen.getByText('Next'))
+    // Step 1 -> Step 2 (review)
+    await user.click(screen.getByText('Next'))
+    expect(screen.getByText('Configuration Summary')).toBeInTheDocument()
+    expect(screen.getByText('Local File System')).toBeInTheDocument()
+    expect(screen.getByText('Test Configuration')).toBeInTheDocument()
+    expect(screen.getByText('Save Configuration')).toBeInTheDocument()
+  })
+
+  it('can go back from review to settings step', async () => {
+    mockSetupRequired()
+    const user = userEvent.setup()
+    renderWithProviders(<StoragePage />)
+    await waitFor(() => {
+      expect(screen.getByText('Next')).toBeInTheDocument()
+    })
+    await user.click(screen.getByText('Next'))
+    await user.click(screen.getByText('Next'))
+    expect(screen.getByText('Configuration Summary')).toBeInTheDocument()
+    await user.click(screen.getByText('Back'))
+    expect(screen.getByLabelText(/Base Path/)).toBeInTheDocument()
+  })
+
+  it('calls createStorageConfig when Save Configuration is clicked', async () => {
+    mockSetupRequired()
+    createStorageConfigMock.mockResolvedValue({
+      id: 'new-cfg',
+      backend_type: 'local',
+      is_active: true,
+    })
+    const user = userEvent.setup()
+    renderWithProviders(<StoragePage />)
+    await waitFor(() => {
+      expect(screen.getByText('Next')).toBeInTheDocument()
+    })
+    await user.click(screen.getByText('Next'))
+    await user.click(screen.getByText('Next'))
+    await user.click(screen.getByText('Save Configuration'))
+    await waitFor(() => {
+      expect(createStorageConfigMock).toHaveBeenCalledTimes(1)
+    })
+    expect(createStorageConfigMock).toHaveBeenCalledWith(
+      expect.objectContaining({ backend_type: 'local' })
+    )
+  })
+
+  it('shows success alert after saving configuration', async () => {
+    mockSetupRequired()
+    createStorageConfigMock.mockResolvedValue({ id: 'new-cfg', backend_type: 'local' })
+    const user = userEvent.setup()
+    renderWithProviders(<StoragePage />)
+    await waitFor(() => {
+      expect(screen.getByText('Next')).toBeInTheDocument()
+    })
+    await user.click(screen.getByText('Next'))
+    await user.click(screen.getByText('Next'))
+    await user.click(screen.getByText('Save Configuration'))
+    await waitFor(() => {
+      expect(screen.getByText('Storage configuration saved successfully!')).toBeInTheDocument()
+    })
+  })
+
+  it('shows error alert when save fails', async () => {
+    mockSetupRequired()
+    createStorageConfigMock.mockRejectedValue(new Error('Server error'))
+    const user = userEvent.setup()
+    renderWithProviders(<StoragePage />)
+    await waitFor(() => {
+      expect(screen.getByText('Next')).toBeInTheDocument()
+    })
+    await user.click(screen.getByText('Next'))
+    await user.click(screen.getByText('Next'))
+    await user.click(screen.getByText('Save Configuration'))
+    await waitFor(() => {
+      expect(screen.getByText('Server error')).toBeInTheDocument()
+    })
+  })
+
+  it('calls testStorageConfig from review step', async () => {
+    mockSetupRequired()
+    testStorageConfigMock.mockResolvedValue({ success: true, message: 'OK' })
+    const user = userEvent.setup()
+    renderWithProviders(<StoragePage />)
+    await waitFor(() => {
+      expect(screen.getByText('Next')).toBeInTheDocument()
+    })
+    await user.click(screen.getByText('Next'))
+    await user.click(screen.getByText('Next'))
+    await user.click(screen.getByText('Test Configuration'))
+    await waitFor(() => {
+      expect(testStorageConfigMock).toHaveBeenCalledTimes(1)
+    })
+    await waitFor(() => {
+      expect(screen.getByText('Storage configuration is valid!')).toBeInTheDocument()
+    })
+  })
+
+  // ---- Existing Configs view ----
+
+  it('renders existing configs heading when setup is complete', async () => {
+    mockExistingConfigs()
+    renderWithProviders(<StoragePage />)
+    await waitFor(() => {
+      expect(screen.getByText('Storage Settings')).toBeInTheDocument()
+    })
+  })
+
+  it('shows info alert about data loss when changing backends', async () => {
+    mockExistingConfigs()
+    renderWithProviders(<StoragePage />)
+    await waitFor(() => {
+      expect(screen.getByText(/Changing storage backends after initial setup may result in data loss/)).toBeInTheDocument()
+    })
+  })
+
+  it('renders config cards with backend labels and active/inactive chips', async () => {
+    mockExistingConfigs()
+    renderWithProviders(<StoragePage />)
+    await waitFor(() => {
+      expect(screen.getByText('Local File System')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Amazon S3 / S3-Compatible')).toBeInTheDocument()
+    expect(screen.getByText('Active')).toBeInTheDocument()
+    expect(screen.getByText('Inactive')).toBeInTheDocument()
+  })
+
+  it('shows config-specific details on cards', async () => {
+    mockExistingConfigs([fakeLocalConfig, fakeS3Config, fakeAzureConfig, fakeGcsConfig])
+    renderWithProviders(<StoragePage />)
+    await waitFor(() => {
+      expect(screen.getByText(/\.\/data\/storage/)).toBeInTheDocument()
+    })
+    expect(screen.getByText(/my-bucket/)).toBeInTheDocument()
+    expect(screen.getByText(/us-east-1/)).toBeInTheDocument()
+    expect(screen.getByText(/myaccount/)).toBeInTheDocument()
+    expect(screen.getByText(/mycontainer/)).toBeInTheDocument()
+    expect(screen.getByText(/gcs-bucket/)).toBeInTheDocument()
+  })
+
+  it('shows activate and delete buttons only for inactive configs', async () => {
+    mockExistingConfigs()
+    renderWithProviders(<StoragePage />)
+    await waitFor(() => {
+      expect(screen.getByText('Local File System')).toBeInTheDocument()
+    })
+    // Active config should not have activate or delete buttons
+    expect(screen.queryByLabelText('Activate Local File System')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Delete Local File System')).not.toBeInTheDocument()
+    // Inactive S3 config should have both
+    expect(screen.getByLabelText('Activate Amazon S3 / S3-Compatible')).toBeInTheDocument()
+    expect(screen.getByLabelText('Delete Amazon S3 / S3-Compatible')).toBeInTheDocument()
+  })
+
+  it('calls activateStorageConfig when activate button is clicked', async () => {
+    mockExistingConfigs()
+    activateStorageConfigMock.mockResolvedValue({ message: 'Activated', config: fakeS3Config })
+    const user = userEvent.setup()
+    renderWithProviders(<StoragePage />)
+    await waitFor(() => {
+      expect(screen.getByLabelText('Activate Amazon S3 / S3-Compatible')).toBeInTheDocument()
+    })
+    await user.click(screen.getByLabelText('Activate Amazon S3 / S3-Compatible'))
+    await waitFor(() => {
+      expect(activateStorageConfigMock).toHaveBeenCalledWith('cfg-2')
+    })
+  })
+
+  it('calls deleteStorageConfig after confirmation', async () => {
+    mockExistingConfigs()
+    deleteStorageConfigMock.mockResolvedValue(undefined)
+    const confirmMock = vi.fn().mockReturnValue(true)
+    vi.stubGlobal('confirm', confirmMock)
+    const user = userEvent.setup()
+    renderWithProviders(<StoragePage />)
+    await waitFor(() => {
+      expect(screen.getByLabelText('Delete Amazon S3 / S3-Compatible')).toBeInTheDocument()
+    })
+    await user.click(screen.getByLabelText('Delete Amazon S3 / S3-Compatible'))
+    expect(confirmMock).toHaveBeenCalledWith(
+      'Are you sure you want to delete this storage configuration?'
+    )
+    await waitFor(() => {
+      expect(deleteStorageConfigMock).toHaveBeenCalledWith('cfg-2')
+    })
+    vi.unstubAllGlobals()
+  })
+
+  it('does not delete when confirmation is cancelled', async () => {
+    mockExistingConfigs()
+    const confirmMock = vi.fn().mockReturnValue(false)
+    vi.stubGlobal('confirm', confirmMock)
+    const user = userEvent.setup()
+    renderWithProviders(<StoragePage />)
+    await waitFor(() => {
+      expect(screen.getByLabelText('Delete Amazon S3 / S3-Compatible')).toBeInTheDocument()
+    })
+    await user.click(screen.getByLabelText('Delete Amazon S3 / S3-Compatible'))
+    expect(deleteStorageConfigMock).not.toHaveBeenCalled()
+    vi.unstubAllGlobals()
+  })
+
+  it('shows test connection button for each config and calls testStorageConfig', async () => {
+    mockExistingConfigs()
+    testStorageConfigMock.mockResolvedValue({ success: true, message: 'OK' })
+    const user = userEvent.setup()
+    renderWithProviders(<StoragePage />)
+    await waitFor(() => {
+      expect(screen.getByLabelText('Test Local File System')).toBeInTheDocument()
+    })
+    await user.click(screen.getByLabelText('Test Local File System'))
+    await waitFor(() => {
+      expect(testStorageConfigMock).toHaveBeenCalledWith(
+        expect.objectContaining({ backend_type: 'local', local_base_path: './data/storage' })
+      )
+    })
+  })
+
+  it('shows Migrate Data button when two or more configs exist', async () => {
+    mockExistingConfigs([fakeLocalConfig, fakeS3Config])
+    renderWithProviders(<StoragePage />)
+    await waitFor(() => {
+      expect(screen.getByText('Migrate Data')).toBeInTheDocument()
+    })
+  })
+
+  it('hides Migrate Data button when fewer than two configs', async () => {
+    mockExistingConfigs([fakeLocalConfig])
+    renderWithProviders(<StoragePage />)
+    await waitFor(() => {
+      expect(screen.getByText('Storage Settings')).toBeInTheDocument()
+    })
+    expect(screen.queryByText('Migrate Data')).not.toBeInTheDocument()
+  })
+
+  it('opens migration wizard when Migrate Data is clicked', async () => {
+    mockExistingConfigs([fakeLocalConfig, fakeS3Config])
+    const user = userEvent.setup()
+    renderWithProviders(<StoragePage />)
+    await waitFor(() => {
+      expect(screen.getByText('Migrate Data')).toBeInTheDocument()
+    })
+    await user.click(screen.getByText('Migrate Data'))
+    expect(screen.getByTestId('migration-wizard')).toBeInTheDocument()
+  })
+
+  it('renders migration history when migrations exist', async () => {
+    mockExistingConfigs([fakeLocalConfig, fakeS3Config], [fakeMigration])
+    renderWithProviders(<StoragePage />)
+    await waitFor(() => {
+      expect(screen.getByText('Migration History')).toBeInTheDocument()
+    })
+  })
+
+  it('shows migration row details in migration history table', async () => {
+    mockExistingConfigs([fakeLocalConfig, fakeS3Config], [fakeMigration])
+    const user = userEvent.setup()
+    renderWithProviders(<StoragePage />)
+    await waitFor(() => {
+      expect(screen.getByText('Migration History')).toBeInTheDocument()
+    })
+    // Expand the accordion
+    await user.click(screen.getByText('Migration History'))
+    // Check table headers
+    expect(screen.getByText('Source')).toBeInTheDocument()
+    expect(screen.getByText('Target')).toBeInTheDocument()
+    // Check migration data
+    expect(screen.getByText('completed')).toBeInTheDocument()
+    expect(screen.getByText('10 / 10')).toBeInTheDocument()
+  })
+
+  it('shows Refresh button in existing configs view', async () => {
+    mockExistingConfigs()
+    renderWithProviders(<StoragePage />)
+    await waitFor(() => {
+      expect(screen.getByText('Refresh')).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/pages/admin/__tests__/UsersPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/UsersPage.test.tsx
@@ -1,0 +1,141 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+// ---- Mocks ----
+
+const listUsersMock = vi.fn()
+const searchUsersMock = vi.fn()
+const listRoleTemplatesMock = vi.fn()
+const getUserMembershipsMock = vi.fn()
+
+vi.mock('../../../services/api', () => ({
+  default: {
+    listUsers: (...args: unknown[]) => listUsersMock(...args),
+    searchUsers: (...args: unknown[]) => searchUsersMock(...args),
+    listRoleTemplates: (...args: unknown[]) => listRoleTemplatesMock(...args),
+    getUserMemberships: (...args: unknown[]) => getUserMembershipsMock(...args),
+  },
+}))
+
+import UsersPage from '../../admin/UsersPage'
+
+// ---- Helpers ----
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        gcTime: 0,
+      },
+    },
+  })
+}
+
+function renderPage() {
+  const queryClient = createQueryClient()
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <UsersPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+const fakeUsersResponse = {
+  users: [
+    {
+      id: 'u1',
+      email: 'alice@example.com',
+      name: 'Alice Smith',
+      role_template_name: 'admin',
+      created_at: '2025-01-01T00:00:00Z',
+      updated_at: '2025-06-01T00:00:00Z',
+    },
+    {
+      id: 'u2',
+      email: 'bob@example.com',
+      name: 'Bob Jones',
+      role_template_name: 'viewer',
+      created_at: '2025-02-01T00:00:00Z',
+      updated_at: '2025-06-01T00:00:00Z',
+    },
+  ],
+  pagination: { total: 2, page: 1, per_page: 20 },
+}
+
+// ---- Tests ----
+
+describe('UsersPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows loading spinner initially', () => {
+    listUsersMock.mockReturnValue(new Promise(() => { }))
+    renderPage()
+    expect(screen.getByRole('progressbar')).toBeInTheDocument()
+  })
+
+  it('renders heading after data loads', async () => {
+    listUsersMock.mockResolvedValue(fakeUsersResponse)
+    getUserMembershipsMock.mockResolvedValue([])
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('Users')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Manage user accounts and permissions')).toBeInTheDocument()
+  })
+
+  it('renders user table with email and name data', async () => {
+    listUsersMock.mockResolvedValue(fakeUsersResponse)
+    getUserMembershipsMock.mockResolvedValue([])
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('Alice Smith')).toBeInTheDocument()
+    })
+    expect(screen.getByText('alice@example.com')).toBeInTheDocument()
+    expect(screen.getByText('Bob Jones')).toBeInTheDocument()
+    expect(screen.getByText('bob@example.com')).toBeInTheDocument()
+  })
+
+  it('shows search field', async () => {
+    listUsersMock.mockResolvedValue(fakeUsersResponse)
+    getUserMembershipsMock.mockResolvedValue([])
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('Search users...')).toBeInTheDocument()
+    })
+  })
+
+  it('shows empty state when no users returned', async () => {
+    listUsersMock.mockResolvedValue({
+      users: [],
+      pagination: { total: 0, page: 1, per_page: 20 },
+    })
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('No users found')).toBeInTheDocument()
+    })
+  })
+
+  it('shows Add User button', async () => {
+    listUsersMock.mockResolvedValue(fakeUsersResponse)
+    getUserMembershipsMock.mockResolvedValue([])
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /add user/i })).toBeInTheDocument()
+    })
+  })
+
+  it('shows error state when API fails', async () => {
+    listUsersMock.mockRejectedValue(new Error('Network error'))
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText(/Failed to load users/)).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/services/__tests__/api.test.ts
+++ b/frontend/src/services/__tests__/api.test.ts
@@ -313,4 +313,1281 @@ describe('ApiClient', () => {
       expect(typeof client.getVersionInfo).toBe('function')
     })
   })
+
+  // ─── Auth ─────────────────────────────────────────────────────────────────
+  describe('auth methods', () => {
+    it('refreshToken calls POST /api/v1/auth/refresh', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { token: 'new' } })
+      const result = await client.refreshToken()
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/auth/refresh')
+      expect(result.token).toBe('new')
+    })
+
+    it('getCurrentUser calls GET /api/v1/auth/me', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { user: { id: 'u1', email: 'a@b.com' } } })
+      const result = await client.getCurrentUser()
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/auth/me')
+      expect(result.id).toBe('u1')
+    })
+
+    it('getCurrentUserWithRole returns user, role_template, allowed_scopes', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { user: { id: 'u1' }, role_template: { id: 'r1' }, allowed_scopes: ['admin'] },
+        })
+      const result = await client.getCurrentUserWithRole()
+      expect(result.user.id).toBe('u1')
+      expect(result.role_template?.id).toBe('r1')
+      expect(result.allowed_scopes).toEqual(['admin'])
+    })
+
+    it('getCurrentUserWithRole defaults missing fields', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { user: { id: 'u1' } },
+        })
+      const result = await client.getCurrentUserWithRole()
+      expect(result.role_template).toBeNull()
+      expect(result.allowed_scopes).toEqual([])
+    })
+
+    it('devLogin calls POST /api/v1/dev/login', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { token: 'dev-tok' } })
+      const result = await client.devLogin()
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/dev/login')
+      expect(result.token).toBe('dev-tok')
+    })
+
+    it('getDevStatus calls GET /api/v1/dev/status', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { dev_mode: true } })
+      const result = await client.getDevStatus()
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/dev/status')
+      expect(result.dev_mode).toBe(true)
+    })
+
+    it('listUsersForImpersonation calls GET /api/v1/dev/users', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { users: [], dev_mode: true } })
+      const result = await client.listUsersForImpersonation()
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/dev/users')
+      expect(result.dev_mode).toBe(true)
+    })
+
+    it('impersonateUser calls POST /api/v1/dev/impersonate/:id', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { token: 'imp-tok', message: 'ok' } })
+      const result = await client.impersonateUser('u1')
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/dev/impersonate/u1')
+      expect(result.token).toBe('imp-tok')
+    })
+  })
+
+  // ─── Modules ──────────────────────────────────────────────────────────────
+  describe('module methods', () => {
+    it('getModuleVersions', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { versions: [] } })
+      await client.getModuleVersions('hashicorp', 'consul', 'aws')
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/v1/modules/hashicorp/consul/aws/versions')
+    })
+
+    it('createModuleRecord', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { id: 'm1' } })
+      const result = await client.createModuleRecord({ namespace: 'ns', name: 'mod', system: 'aws' })
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/admin/modules/create', { namespace: 'ns', name: 'mod', system: 'aws' })
+      expect(result.id).toBe('m1')
+    })
+
+    it('uploadModule sends FormData', async () => {
+      const client = await getApiClient()
+      const fd = new FormData()
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { ok: true } })
+      await client.uploadModule(fd)
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/modules', fd, expect.objectContaining({ headers: { 'Content-Type': 'multipart/form-data' } }))
+    })
+
+    it('getModule', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { id: 'm1' } })
+      await client.getModule('ns', 'mod', 'aws')
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/modules/ns/mod/aws')
+    })
+
+    it('deleteModule', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+      await client.deleteModule('ns', 'mod', 'aws')
+      expect(mockAxiosInstance.delete).toHaveBeenCalledWith('/api/v1/modules/ns/mod/aws')
+    })
+
+    it('deleteModuleVersion', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+      await client.deleteModuleVersion('ns', 'mod', 'aws', '1.0.0')
+      expect(mockAxiosInstance.delete).toHaveBeenCalledWith('/api/v1/modules/ns/mod/aws/versions/1.0.0')
+    })
+
+    it('deprecateModuleVersion with message', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+      await client.deprecateModuleVersion('ns', 'mod', 'aws', '1.0.0', 'old')
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/modules/ns/mod/aws/versions/1.0.0/deprecate', { message: 'old' })
+    })
+
+    it('deprecateModuleVersion without message', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+      await client.deprecateModuleVersion('ns', 'mod', 'aws', '1.0.0')
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/modules/ns/mod/aws/versions/1.0.0/deprecate', {})
+    })
+
+    it('undeprecateModuleVersion', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+      await client.undeprecateModuleVersion('ns', 'mod', 'aws', '1.0.0')
+      expect(mockAxiosInstance.delete).toHaveBeenCalledWith('/api/v1/modules/ns/mod/aws/versions/1.0.0/deprecate')
+    })
+
+    it('deprecateModule', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+      await client.deprecateModule('ns', 'mod', 'aws', { message: 'eol' })
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/modules/ns/mod/aws/deprecate', { message: 'eol' })
+    })
+
+    it('undeprecateModule', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+      await client.undeprecateModule('ns', 'mod', 'aws')
+      expect(mockAxiosInstance.delete).toHaveBeenCalledWith('/api/v1/modules/ns/mod/aws/deprecate')
+    })
+
+    it('updateModule', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+      await client.updateModule('m1', { description: 'new desc' })
+      expect(mockAxiosInstance.put).toHaveBeenCalledWith('/api/v1/admin/modules/m1', { description: 'new desc' })
+    })
+
+    it('getModuleScan', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { status: 'clean' } })
+      await client.getModuleScan('ns', 'mod', 'aws', '1.0.0')
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/modules/ns/mod/aws/versions/1.0.0/scan')
+    })
+
+    it('getModuleDocs', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { content: '' } })
+      await client.getModuleDocs('ns', 'mod', 'aws', '1.0.0')
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/modules/ns/mod/aws/versions/1.0.0/docs')
+    })
+  })
+
+  // ─── Providers ────────────────────────────────────────────────────────────
+  describe('provider methods', () => {
+    it('getProviderVersions', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { versions: [] } })
+      await client.getProviderVersions('hashicorp', 'aws')
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/v1/providers/hashicorp/aws/versions')
+    })
+
+    it('uploadProvider sends FormData', async () => {
+      const client = await getApiClient()
+      const fd = new FormData()
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+      await client.uploadProvider(fd)
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/providers', fd, expect.objectContaining({ headers: { 'Content-Type': 'multipart/form-data' } }))
+    })
+
+    it('getProvider', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { id: 'p1' } })
+      await client.getProvider('hashicorp', 'aws')
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/providers/hashicorp/aws')
+    })
+
+    it('deleteProvider', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+      await client.deleteProvider('hashicorp', 'aws')
+      expect(mockAxiosInstance.delete).toHaveBeenCalledWith('/api/v1/providers/hashicorp/aws')
+    })
+
+    it('deleteProviderVersion', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+      await client.deleteProviderVersion('hashicorp', 'aws', '5.0.0')
+      expect(mockAxiosInstance.delete).toHaveBeenCalledWith('/api/v1/providers/hashicorp/aws/versions/5.0.0')
+    })
+
+    it('deprecateProviderVersion with message', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+      await client.deprecateProviderVersion('hashicorp', 'aws', '5.0.0', 'old')
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/providers/hashicorp/aws/versions/5.0.0/deprecate', { message: 'old' })
+    })
+
+    it('deprecateProviderVersion without message', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+      await client.deprecateProviderVersion('hashicorp', 'aws', '5.0.0')
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/providers/hashicorp/aws/versions/5.0.0/deprecate', {})
+    })
+
+    it('undeprecateProviderVersion', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+      await client.undeprecateProviderVersion('hashicorp', 'aws', '5.0.0')
+      expect(mockAxiosInstance.delete).toHaveBeenCalledWith('/api/v1/providers/hashicorp/aws/versions/5.0.0/deprecate')
+    })
+
+    it('getProviderDocs with all params', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { docs: [] } })
+      await client.getProviderDocs('hashicorp', 'aws', '5.0.0', 'resources', 'en', 10, 0)
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith(
+        '/api/v1/providers/hashicorp/aws/versions/5.0.0/docs',
+        { params: { category: 'resources', language: 'en', limit: 10, offset: 0 } },
+      )
+    })
+
+    it('getProviderDocs without optional params', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { docs: [] } })
+      await client.getProviderDocs('hashicorp', 'aws', '5.0.0')
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith(
+        '/api/v1/providers/hashicorp/aws/versions/5.0.0/docs',
+        { params: {} },
+      )
+    })
+
+    it('getProviderDocContent', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { content: '# Doc' } })
+      await client.getProviderDocContent('hashicorp', 'aws', '5.0.0', 'resources', 'aws_instance')
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/providers/hashicorp/aws/versions/5.0.0/docs/resources/aws_instance')
+    })
+  })
+
+  // ─── Users ────────────────────────────────────────────────────────────────
+  describe('user methods', () => {
+    it('searchUsers', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { users: [{ id: 'u1', email: 'a@b.com', name: 'A', created_at: '', updated_at: '' }], pagination: {} },
+        })
+      const result = await client.searchUsers('test', 1, 10)
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/users/search', { params: { q: 'test', page: 1, per_page: 10 } })
+      expect(result.users[0].id).toBe('u1')
+    })
+
+    it('getUser', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { user: { id: 'u1', email: 'a@b.com', name: 'A', created_at: '', updated_at: '' } },
+        })
+      const result = await client.getUser('u1')
+      expect(result.id).toBe('u1')
+    })
+
+    it('createUser', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { user: { id: 'u2', email: 'b@b.com', name: 'B', created_at: '', updated_at: '' } },
+        })
+      const result = await client.createUser({ email: 'b@b.com', name: 'B' })
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/users', { email: 'b@b.com', name: 'B' })
+      expect(result.id).toBe('u2')
+    })
+
+    it('updateUser', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { user: { id: 'u1', email: 'a@b.com', name: 'Updated', created_at: '', updated_at: '' } },
+        })
+      const result = await client.updateUser('u1', { name: 'Updated' })
+      expect(mockAxiosInstance.put).toHaveBeenCalledWith('/api/v1/users/u1', { name: 'Updated' })
+      expect(result.name).toBe('Updated')
+    })
+
+    it('deleteUser', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { ok: true } })
+      await client.deleteUser('u1')
+      expect(mockAxiosInstance.delete).toHaveBeenCalledWith('/api/v1/users/u1')
+    })
+
+    it('getUserMemberships', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { memberships: [{ org_id: 'o1' }] } })
+      const result = await client.getUserMemberships('u1')
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/users/u1/memberships')
+      expect(result).toHaveLength(1)
+    })
+
+    it('getCurrentUserMemberships', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { memberships: [] } })
+      await client.getCurrentUserMemberships()
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/users/me/memberships')
+    })
+
+    it('transformUser handles PascalCase fields', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { user: { ID: 'u1', Email: 'a@b.com', Name: 'A', CreatedAt: '2025-01-01', UpdatedAt: '2025-01-01', RoleTemplateID: 'r1' } },
+        })
+      const result = await client.getUser('u1')
+      expect(result.id).toBe('u1')
+      expect(result.email).toBe('a@b.com')
+      expect(result.role_template_id).toBe('r1')
+    })
+  })
+
+  // ─── Organizations ────────────────────────────────────────────────────────
+  describe('organization methods', () => {
+    it('listOrganizations', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { organizations: [{ id: 'o1', name: 'org1', display_name: 'Org 1', created_at: '', updated_at: '' }] },
+        })
+      const result = await client.listOrganizations(1, 20)
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/organizations', { params: { page: 1, per_page: 20 } })
+      expect(result).toHaveLength(1)
+    })
+
+    it('searchOrganizations', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { organizations: [{ id: 'o1', name: 'org1', display_name: 'Org 1', created_at: '', updated_at: '' }] },
+        })
+      const result = await client.searchOrganizations('org', 1, 10)
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/organizations/search', { params: { q: 'org', page: 1, per_page: 10 } })
+      expect(result).toHaveLength(1)
+    })
+
+    it('getOrganization', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { organization: { id: 'o1', name: 'org1', display_name: 'Org 1', created_at: '', updated_at: '' } },
+        })
+      const result = await client.getOrganization('o1')
+      expect(result.id).toBe('o1')
+    })
+
+    it('createOrganization', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          status: 201,
+          data: { organization: { id: 'o2', name: 'new', display_name: 'New', created_at: '', updated_at: '' } },
+        })
+      const result = await client.createOrganization({ name: 'new', display_name: 'New' })
+      expect(result.id).toBe('o2')
+    })
+
+    it('updateOrganization', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { organization: { id: 'o1', name: 'org1', display_name: 'Updated', created_at: '', updated_at: '' } },
+        })
+      const result = await client.updateOrganization('o1', { display_name: 'Updated' })
+      expect(result.display_name).toBe('Updated')
+    })
+
+    it('deleteOrganization', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+      await client.deleteOrganization('o1')
+      expect(mockAxiosInstance.delete).toHaveBeenCalledWith('/api/v1/organizations/o1')
+    })
+
+    it('addOrganizationMember', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+      await client.addOrganizationMember('o1', { user_id: 'u1' })
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/organizations/o1/members', { user_id: 'u1' })
+    })
+
+    it('updateOrganizationMember', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+      await client.updateOrganizationMember('o1', 'u1', { role_template_id: 'r1' })
+      expect(mockAxiosInstance.put).toHaveBeenCalledWith('/api/v1/organizations/o1/members/u1', { role_template_id: 'r1' })
+    })
+
+    it('removeOrganizationMember', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+      await client.removeOrganizationMember('o1', 'u1')
+      expect(mockAxiosInstance.delete).toHaveBeenCalledWith('/api/v1/organizations/o1/members/u1')
+    })
+
+    it('listOrganizationMembers', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { members: [{ user_id: 'u1' }] } })
+      const result = await client.listOrganizationMembers('o1')
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/organizations/o1/members')
+      expect(result).toHaveLength(1)
+    })
+
+    it('transformOrganization throws for undefined org', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { organization: undefined },
+        })
+      await expect(client.getOrganization('bad')).rejects.toThrow('Cannot transform undefined organization')
+    })
+  })
+
+  // ─── API Keys ─────────────────────────────────────────────────────────────
+  describe('API key methods', () => {
+    it('listAPIKeys without org filter', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { keys: [{ id: 'k1', name: 'key1', scopes: [], created_at: '' }] },
+        })
+      const result = await client.listAPIKeys()
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/apikeys', { params: {} })
+      expect(result).toHaveLength(1)
+    })
+
+    it('listAPIKeys with org filter', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { keys: [] } })
+      await client.listAPIKeys('org-1')
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/apikeys', { params: { organization_id: 'org-1' } })
+    })
+
+    it('listAPIKeys normalizes PascalCase keys', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { keys: [{ ID: 'k1', Name: 'mykey', Scopes: ['read'], CreatedAt: '2025-01-01' }] },
+        })
+      const result = await client.listAPIKeys()
+      expect(result[0].id).toBe('k1')
+      expect(result[0].name).toBe('mykey')
+      expect(result[0].scopes).toEqual(['read'])
+    })
+
+    it('createAPIKey', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { key: 'secret', id: 'k1' } })
+      const data = { name: 'key1', organization_id: 'o1', scopes: ['read'] }
+      await client.createAPIKey(data)
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/apikeys', data)
+    })
+
+    it('getAPIKey', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { id: 'k1' } })
+      await client.getAPIKey('k1')
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/apikeys/k1')
+    })
+
+    it('updateAPIKey', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+      await client.updateAPIKey('k1', { name: 'updated' })
+      expect(mockAxiosInstance.put).toHaveBeenCalledWith('/api/v1/apikeys/k1', { name: 'updated' })
+    })
+
+    it('deleteAPIKey', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+      await client.deleteAPIKey('k1')
+      expect(mockAxiosInstance.delete).toHaveBeenCalledWith('/api/v1/apikeys/k1')
+    })
+
+    it('rotateAPIKey', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { new_key: 'secret2' } })
+      await client.rotateAPIKey('k1', 24)
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/apikeys/k1/rotate', { grace_period_hours: 24 })
+    })
+  })
+
+  // ─── SCM Providers ────────────────────────────────────────────────────────
+  describe('SCM provider methods', () => {
+    it('listSCMProviders', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: [] })
+      await client.listSCMProviders()
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/scm-providers', { params: {} })
+    })
+
+    it('listSCMProviders with org', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: [] })
+      await client.listSCMProviders('org-1')
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/scm-providers', { params: { organization_id: 'org-1' } })
+    })
+
+    it('createSCMProvider', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { id: 'scm-1' } })
+      await client.createSCMProvider({ organization_id: 'o1', provider_type: 'github', name: 'GH' })
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/scm-providers', expect.objectContaining({ provider_type: 'github' }))
+    })
+
+    it('getSCMProvider', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { id: 'scm-1' } })
+      await client.getSCMProvider('scm-1')
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/scm-providers/scm-1')
+    })
+
+    it('updateSCMProvider', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+      await client.updateSCMProvider('scm-1', { name: 'Updated' })
+      expect(mockAxiosInstance.put).toHaveBeenCalledWith('/api/v1/scm-providers/scm-1', { name: 'Updated' })
+    })
+
+    it('deleteSCMProvider', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+      await client.deleteSCMProvider('scm-1')
+      expect(mockAxiosInstance.delete).toHaveBeenCalledWith('/api/v1/scm-providers/scm-1')
+    })
+
+    it('initiateSCMOAuth', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { redirect_url: 'https://github.com/oauth' } })
+      await client.initiateSCMOAuth('scm-1')
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/scm-providers/scm-1/oauth/authorize')
+    })
+
+    it('refreshSCMToken', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+      await client.refreshSCMToken('scm-1')
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/scm-providers/scm-1/oauth/refresh')
+    })
+
+    it('getSCMTokenStatus', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { connected: true } })
+      const result = await client.getSCMTokenStatus('scm-1')
+      expect(result.connected).toBe(true)
+    })
+
+    it('listSCMRepositories', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { repositories: [] } })
+      await client.listSCMRepositories('scm-1', 'search')
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/scm-providers/scm-1/repositories', { params: { search: 'search' } })
+    })
+
+    it('listSCMRepositoryTags', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { tags: [] } })
+      await client.listSCMRepositoryTags('scm-1', 'owner', 'repo')
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/scm-providers/scm-1/repositories/owner/repo/tags')
+    })
+
+    it('listSCMRepositoryBranches', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { branches: [] } })
+      await client.listSCMRepositoryBranches('scm-1', 'owner', 'repo')
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/scm-providers/scm-1/repositories/owner/repo/branches')
+    })
+
+    it('revokeSCMToken', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+      await client.revokeSCMToken('scm-1')
+      expect(mockAxiosInstance.delete).toHaveBeenCalledWith('/api/v1/scm-providers/scm-1/oauth/token')
+    })
+
+    it('saveSCMToken', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+      await client.saveSCMToken('scm-1', 'token123')
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/scm-providers/scm-1/token', { access_token: 'token123' })
+    })
+  })
+
+  // ─── Module SCM Linking ───────────────────────────────────────────────────
+  describe('module SCM linking', () => {
+    it('linkModuleToSCM', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+      await client.linkModuleToSCM('m1', { provider_id: 'scm-1', repository_owner: 'org', repository_name: 'repo' })
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/admin/modules/m1/scm', expect.objectContaining({ provider_id: 'scm-1' }))
+    })
+
+    it('getModuleSCMInfo', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { linked: true } })
+      await client.getModuleSCMInfo('m1')
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/modules/m1/scm')
+    })
+
+    it('updateModuleSCMLink', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+      await client.updateModuleSCMLink('m1', { auto_publish_enabled: true })
+      expect(mockAxiosInstance.put).toHaveBeenCalledWith('/api/v1/admin/modules/m1/scm', { auto_publish_enabled: true })
+    })
+
+    it('unlinkModuleFromSCM', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+      await client.unlinkModuleFromSCM('m1')
+      expect(mockAxiosInstance.delete).toHaveBeenCalledWith('/api/v1/admin/modules/m1/scm')
+    })
+
+    it('triggerManualSync', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+      await client.triggerManualSync('m1', { tag_name: 'v1.0.0' })
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/admin/modules/m1/scm/sync', { tag_name: 'v1.0.0' })
+    })
+
+    it('triggerManualSync without data', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+      await client.triggerManualSync('m1')
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/admin/modules/m1/scm/sync', {})
+    })
+
+    it('getWebhookEvents', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { events: [] } })
+      await client.getWebhookEvents('m1')
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/modules/m1/scm/events')
+    })
+  })
+
+  // ─── Scanning ─────────────────────────────────────────────────────────────
+  describe('scanning methods', () => {
+    it('getScanningConfig', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { enabled: true } })
+      await client.getScanningConfig()
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/scanning/config')
+    })
+
+    it('getScanningStats', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { total: 10 } })
+      await client.getScanningStats()
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/scanning/stats')
+    })
+  })
+
+  // ─── Dashboard ────────────────────────────────────────────────────────────
+  describe('dashboard methods', () => {
+    it('getDashboardStats', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { modules: {} } })
+      await client.getDashboardStats()
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/stats/dashboard')
+    })
+  })
+
+  // ─── Mirrors ──────────────────────────────────────────────────────────────
+  describe('mirror methods', () => {
+    it('listMirrors', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { mirrors: [{ id: 'mir-1' }] } })
+      const result = await client.listMirrors()
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/mirrors', { params: {} })
+      expect(result).toHaveLength(1)
+    })
+
+    it('listMirrors enabledOnly', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { mirrors: [] } })
+      await client.listMirrors(true)
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/mirrors', { params: { enabled: 'true' } })
+    })
+
+    it('getMirror', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { id: 'mir-1' } })
+      await client.getMirror('mir-1')
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/mirrors/mir-1')
+    })
+
+    it('createMirror', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { id: 'mir-2' } })
+      await client.createMirror({ name: 'test', upstream_registry_url: 'https://registry.terraform.io' })
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/admin/mirrors', expect.objectContaining({ name: 'test' }))
+    })
+
+    it('updateMirror', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+      await client.updateMirror('mir-1', { name: 'updated' })
+      expect(mockAxiosInstance.put).toHaveBeenCalledWith('/api/v1/admin/mirrors/mir-1', { name: 'updated' })
+    })
+
+    it('deleteMirror', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+      await client.deleteMirror('mir-1')
+      expect(mockAxiosInstance.delete).toHaveBeenCalledWith('/api/v1/admin/mirrors/mir-1')
+    })
+
+    it('triggerMirrorSync', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+      await client.triggerMirrorSync('mir-1', { namespace: 'hashicorp' })
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/admin/mirrors/mir-1/sync', { namespace: 'hashicorp' })
+    })
+
+    it('getMirrorStatus', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { status: 'idle' } })
+      await client.getMirrorStatus('mir-1')
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/mirrors/mir-1/status')
+    })
+
+    it('getMirrorProviders', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { providers: ['hashicorp/aws'] } })
+      const result = await client.getMirrorProviders('mir-1')
+      expect(result).toEqual(['hashicorp/aws'])
+    })
+  })
+
+  // ─── Roles ────────────────────────────────────────────────────────────────
+  describe('role template methods', () => {
+    it('listRoleTemplates', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: [{ id: 'r1' }] })
+      const result = await client.listRoleTemplates()
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/role-templates')
+      expect(result).toHaveLength(1)
+    })
+
+    it('getRoleTemplate', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { id: 'r1' } })
+      await client.getRoleTemplate('r1')
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/role-templates/r1')
+    })
+
+    it('createRoleTemplate', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { id: 'r2' } })
+      await client.createRoleTemplate({ name: 'editor', display_name: 'Editor', scopes: ['write'] })
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/admin/role-templates', expect.objectContaining({ name: 'editor' }))
+    })
+
+    it('updateRoleTemplate', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+      await client.updateRoleTemplate('r1', { display_name: 'Updated' })
+      expect(mockAxiosInstance.put).toHaveBeenCalledWith('/api/v1/admin/role-templates/r1', { display_name: 'Updated' })
+    })
+
+    it('deleteRoleTemplate', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+      await client.deleteRoleTemplate('r1')
+      expect(mockAxiosInstance.delete).toHaveBeenCalledWith('/api/v1/admin/role-templates/r1')
+    })
+  })
+
+  // ─── Approvals ────────────────────────────────────────────────────────────
+  describe('approval methods', () => {
+    it('listApprovalRequests', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: [{ id: 'a1' }] })
+      const result = await client.listApprovalRequests({ status: 'pending' })
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/approvals', { params: { status: 'pending' } })
+      expect(result).toHaveLength(1)
+    })
+
+    it('listApprovalRequests without filters', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: [] })
+      await client.listApprovalRequests()
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/approvals', { params: {} })
+    })
+
+    it('getApprovalRequest', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { id: 'a1' } })
+      await client.getApprovalRequest('a1')
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/approvals/a1')
+    })
+
+    it('createApprovalRequest', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { id: 'a2' } })
+      await client.createApprovalRequest({ mirror_config_id: 'mir-1', provider_namespace: 'hashicorp' })
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/admin/approvals', expect.objectContaining({ provider_namespace: 'hashicorp' }))
+    })
+
+    it('reviewApproval', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+      await client.reviewApproval('a1', { status: 'approved', notes: 'lgtm' })
+      expect(mockAxiosInstance.put).toHaveBeenCalledWith('/api/v1/admin/approvals/a1/review', { status: 'approved', notes: 'lgtm' })
+    })
+  })
+
+  // ─── Mirror Policies ──────────────────────────────────────────────────────
+  describe('mirror policy methods', () => {
+    it('listMirrorPolicies', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: [{ id: 'p1' }] })
+      await client.listMirrorPolicies()
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/policies', { params: {} })
+    })
+
+    it('listMirrorPolicies with org', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: [] })
+      await client.listMirrorPolicies('org-1')
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/policies', { params: { organization_id: 'org-1' } })
+    })
+
+    it('getMirrorPolicy', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { id: 'p1' } })
+      await client.getMirrorPolicy('p1')
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/policies/p1')
+    })
+
+    it('createMirrorPolicy', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { id: 'p2' } })
+      await client.createMirrorPolicy({ name: 'allow-all', policy_type: 'allow' })
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/admin/policies', expect.objectContaining({ name: 'allow-all' }))
+    })
+
+    it('updateMirrorPolicy', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+      await client.updateMirrorPolicy('p1', { name: 'updated' })
+      expect(mockAxiosInstance.put).toHaveBeenCalledWith('/api/v1/admin/policies/p1', { name: 'updated' })
+    })
+
+    it('deleteMirrorPolicy', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+      await client.deleteMirrorPolicy('p1')
+      expect(mockAxiosInstance.delete).toHaveBeenCalledWith('/api/v1/admin/policies/p1')
+    })
+
+    it('evaluateMirrorPolicy', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { allowed: true } })
+      await client.evaluateMirrorPolicy({ registry: 'https://registry.terraform.io', namespace: 'hashicorp', provider: 'aws' }, 'org-1')
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith(
+        '/api/v1/admin/policies/evaluate',
+        { registry: 'https://registry.terraform.io', namespace: 'hashicorp', provider: 'aws' },
+        { params: { organization_id: 'org-1' } },
+      )
+    })
+  })
+
+  // ─── Storage ──────────────────────────────────────────────────────────────
+  describe('storage methods', () => {
+    it('getSetupStatus', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { setup_required: false } })
+      await client.getSetupStatus()
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/setup/status')
+    })
+
+    it('listStorageConfigs', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: [{ id: 's1' }] })
+      await client.listStorageConfigs()
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/storage/configs')
+    })
+
+    it('getStorageConfig', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { id: 's1' } })
+      await client.getStorageConfig('s1')
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/storage/configs/s1')
+    })
+
+    it('createStorageConfig', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { id: 's2' } })
+      await client.createStorageConfig({ backend_type: 's3' } as never)
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/storage/configs', expect.objectContaining({ backend_type: 's3' }))
+    })
+
+    it('updateStorageConfig', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+      await client.updateStorageConfig('s1', { backend_type: 's3' } as never)
+      expect(mockAxiosInstance.put).toHaveBeenCalledWith('/api/v1/storage/configs/s1', expect.objectContaining({ backend_type: 's3' }))
+    })
+
+    it('deleteStorageConfig', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+      await client.deleteStorageConfig('s1')
+      expect(mockAxiosInstance.delete).toHaveBeenCalledWith('/api/v1/storage/configs/s1')
+    })
+
+    it('activateStorageConfig', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { message: 'activated' } })
+      await client.activateStorageConfig('s1')
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/storage/configs/s1/activate')
+    })
+
+    it('testStorageConfig', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { success: true, message: 'ok' } })
+      await client.testStorageConfig({ backend_type: 'local' } as never)
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/storage/configs/test', expect.objectContaining({ backend_type: 'local' }))
+    })
+
+    it('planStorageMigration', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { items: 10 } })
+      await client.planStorageMigration('s1', 's2')
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/admin/storage/migrations/plan', { source_config_id: 's1', target_config_id: 's2' })
+    })
+
+    it('startStorageMigration', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { id: 'mig-1' } })
+      await client.startStorageMigration('s1', 's2')
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/admin/storage/migrations', { source_config_id: 's1', target_config_id: 's2' })
+    })
+
+    it('getStorageMigration', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { id: 'mig-1' } })
+      await client.getStorageMigration('mig-1')
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/storage/migrations/mig-1')
+    })
+
+    it('cancelStorageMigration', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { id: 'mig-1', status: 'cancelled' } })
+      await client.cancelStorageMigration('mig-1')
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/admin/storage/migrations/mig-1/cancel')
+    })
+
+    it('listStorageMigrations', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: [{ id: 'mig-1' }] })
+      await client.listStorageMigrations()
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/storage/migrations')
+    })
+  })
+
+  // ─── Setup Wizard ─────────────────────────────────────────────────────────
+  describe('setup wizard methods', () => {
+    it('testOIDCConfig', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { success: true } })
+      await client.testOIDCConfig('tok', { issuer_url: 'https://auth.example.com', client_id: 'id', client_secret: 'secret' } as never)
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/setup/oidc/test', expect.anything(), expect.objectContaining({ headers: { Authorization: 'SetupToken tok' } }))
+    })
+
+    it('saveOIDCConfig', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+      await client.saveOIDCConfig('tok', { issuer_url: 'https://auth.example.com' } as never)
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/setup/oidc', expect.anything(), expect.objectContaining({ headers: { Authorization: 'SetupToken tok' } }))
+    })
+
+    it('getAdminOIDCConfig', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { issuer_url: 'https://auth.example.com' } })
+      await client.getAdminOIDCConfig()
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/oidc/config')
+    })
+
+    it('updateOIDCGroupMapping', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+      await client.updateOIDCGroupMapping({ group_claim_name: 'groups' } as never)
+      expect(mockAxiosInstance.put).toHaveBeenCalledWith('/api/v1/admin/oidc/group-mapping', expect.objectContaining({ group_claim_name: 'groups' }))
+    })
+
+    it('testSetupStorageConfig', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { success: true } })
+      await client.testSetupStorageConfig('tok', { backend_type: 'local' } as never)
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/setup/storage/test', expect.anything(), expect.objectContaining({ headers: { Authorization: 'SetupToken tok' } }))
+    })
+
+    it('saveSetupStorageConfig', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { message: 'saved' } })
+      await client.saveSetupStorageConfig('tok', { backend_type: 'local' } as never)
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/setup/storage', expect.anything(), expect.objectContaining({ headers: { Authorization: 'SetupToken tok' } }))
+    })
+
+    it('testScanningConfig', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { success: true } })
+      await client.testScanningConfig('tok', { enabled: true } as never)
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/setup/scanning/test', expect.anything(), expect.objectContaining({ headers: { Authorization: 'SetupToken tok' } }))
+    })
+
+    it('saveScanningConfig', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { message: 'saved' } })
+      await client.saveScanningConfig('tok', { enabled: true } as never)
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/setup/scanning', expect.anything(), expect.objectContaining({ headers: { Authorization: 'SetupToken tok' } }))
+    })
+
+    it('configureAdmin', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+      await client.configureAdmin('tok', { admin_email: 'admin@example.com' } as never)
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/setup/admin', expect.anything(), expect.objectContaining({ headers: { Authorization: 'SetupToken tok' } }))
+    })
+
+    it('completeSetup', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { success: true } })
+      await client.completeSetup('tok')
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/setup/complete', {}, expect.objectContaining({ headers: { Authorization: 'SetupToken tok' } }))
+    })
+  })
+
+  // ─── Terraform Mirrors Admin ──────────────────────────────────────────────
+  describe('terraform mirror admin methods', () => {
+    it('listPublicTerraformMirrorConfigs', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: [{ name: 'tf' }] })
+      const result = await client.listPublicTerraformMirrorConfigs()
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/terraform/binaries')
+      expect(result).toHaveLength(1)
+    })
+
+    it('listPublicTerraformMirrorConfigs handles non-array', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: null })
+      const result = await client.listPublicTerraformMirrorConfigs()
+      expect(result).toEqual([])
+    })
+
+    it('listTerraformMirrorConfigs', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { configs: [] } })
+      await client.listTerraformMirrorConfigs()
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/terraform-mirrors')
+    })
+
+    it('createTerraformMirrorConfig', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { id: 'tc-1' } })
+      await client.createTerraformMirrorConfig({ name: 'test', tool: 'terraform' } as never)
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/admin/terraform-mirrors', expect.objectContaining({ name: 'test' }))
+    })
+
+    it('getTerraformMirrorConfig', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { id: 'tc-1' } })
+      await client.getTerraformMirrorConfig('tc-1')
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/terraform-mirrors/tc-1')
+    })
+
+    it('getTerraformMirrorStatus', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { status: 'idle' } })
+      await client.getTerraformMirrorStatus('tc-1')
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/terraform-mirrors/tc-1/status')
+    })
+
+    it('updateTerraformMirrorConfig', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+      await client.updateTerraformMirrorConfig('tc-1', { name: 'updated' } as never)
+      expect(mockAxiosInstance.put).toHaveBeenCalledWith('/api/v1/admin/terraform-mirrors/tc-1', expect.objectContaining({ name: 'updated' }))
+    })
+
+    it('deleteTerraformMirrorConfig', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+      await client.deleteTerraformMirrorConfig('tc-1')
+      expect(mockAxiosInstance.delete).toHaveBeenCalledWith('/api/v1/admin/terraform-mirrors/tc-1')
+    })
+
+    it('triggerTerraformMirrorSync', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { message: 'started' } })
+      await client.triggerTerraformMirrorSync('tc-1')
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/admin/terraform-mirrors/tc-1/sync', {})
+    })
+
+    it('listTerraformVersions', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { versions: [] } })
+      await client.listTerraformVersions('tc-1', { synced: true })
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/terraform-mirrors/tc-1/versions', { params: { synced: 'true' } })
+    })
+
+    it('listTerraformVersions without filter', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { versions: [] } })
+      await client.listTerraformVersions('tc-1')
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/terraform-mirrors/tc-1/versions', { params: {} })
+    })
+
+    it('getTerraformVersion', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { version: '1.5.0' } })
+      await client.getTerraformVersion('tc-1', '1.5.0')
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/terraform-mirrors/tc-1/versions/1.5.0')
+    })
+
+    it('deleteTerraformVersion', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+      await client.deleteTerraformVersion('tc-1', '1.5.0')
+      expect(mockAxiosInstance.delete).toHaveBeenCalledWith('/api/v1/admin/terraform-mirrors/tc-1/versions/1.5.0')
+    })
+
+    it('deprecateTerraformVersion', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+      await client.deprecateTerraformVersion('tc-1', '1.5.0')
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/admin/terraform-mirrors/tc-1/versions/1.5.0/deprecate', {})
+    })
+
+    it('undeprecateTerraformVersion', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+      await client.undeprecateTerraformVersion('tc-1', '1.5.0')
+      expect(mockAxiosInstance.delete).toHaveBeenCalledWith('/api/v1/admin/terraform-mirrors/tc-1/versions/1.5.0/deprecate')
+    })
+
+    it('listTerraformVersionPlatforms returns array from data', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: [{ os: 'linux', arch: 'amd64' }] })
+      const result = await client.listTerraformVersionPlatforms('tc-1', '1.5.0')
+      expect(result).toHaveLength(1)
+    })
+
+    it('listTerraformVersionPlatforms returns platforms from nested', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { platforms: [{ os: 'linux' }] } })
+      const result = await client.listTerraformVersionPlatforms('tc-1', '1.5.0')
+      expect(result).toHaveLength(1)
+    })
+
+    it('getTerraformMirrorHistory', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { history: [] } })
+      await client.getTerraformMirrorHistory('tc-1', 10)
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/terraform-mirrors/tc-1/history', { params: { limit: 10 } })
+    })
+  })
+
+  // ─── Terraform Mirrors Public ─────────────────────────────────────────────
+  describe('terraform mirror public methods', () => {
+    it('listPublicTerraformVersions', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { versions: [] } })
+      await client.listPublicTerraformVersions('terraform')
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/terraform/binaries/terraform/versions')
+    })
+
+    it('getPublicLatestTerraformVersion', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { version: '1.9.0' } })
+      await client.getPublicLatestTerraformVersion('terraform')
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/terraform/binaries/terraform/versions/latest')
+    })
+
+    it('getPublicTerraformVersion', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { version: '1.5.0' } })
+      await client.getPublicTerraformVersion('terraform', '1.5.0')
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/terraform/binaries/terraform/versions/1.5.0')
+    })
+
+    it('getTerraformBinaryDownload', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { download_url: 'https://...' } })
+      await client.getTerraformBinaryDownload('terraform', '1.5.0', 'linux', 'amd64')
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/terraform/binaries/terraform/versions/1.5.0/linux/amd64')
+    })
+  })
+
+  // ─── Audit Logs ───────────────────────────────────────────────────────────
+  describe('audit log methods', () => {
+    it('listAuditLogs with filters', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { logs: [], pagination: {} } })
+      await client.listAuditLogs({ page: 1, per_page: 25, resource_type: 'module' })
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/audit-logs', { params: { page: 1, per_page: 25, resource_type: 'module' } })
+    })
+
+    it('getAuditLog', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { id: 'log-1' } })
+      await client.getAuditLog('log-1')
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/audit-logs/log-1')
+    })
+
+    it('exportAuditLogsCSV creates download', async () => {
+      const client = await getApiClient()
+      const createElementSpy = vi.spyOn(document, 'createElement')
+      const revokeURLSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => { })
+      const createURLSpy = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:url')
+      const clickSpy = vi.fn()
+      createElementSpy.mockReturnValue({ click: clickSpy, href: '', download: '' } as unknown as HTMLAnchorElement)
+
+      client.exportAuditLogsCSV([
+        { id: 'l1', created_at: '2025-01-01', action: 'create', resource_type: 'module' } as never,
+      ])
+
+      expect(createURLSpy).toHaveBeenCalled()
+      expect(clickSpy).toHaveBeenCalled()
+      expect(revokeURLSpy).toHaveBeenCalledWith('blob:url')
+
+      createElementSpy.mockRestore()
+      revokeURLSpy.mockRestore()
+      createURLSpy.mockRestore()
+    })
+
+    it('exportAuditLogsJSON creates download', async () => {
+      const client = await getApiClient()
+      const createElementSpy = vi.spyOn(document, 'createElement')
+      const revokeURLSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => { })
+      const createURLSpy = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:url')
+      const clickSpy = vi.fn()
+      createElementSpy.mockReturnValue({ click: clickSpy, href: '', download: '' } as unknown as HTMLAnchorElement)
+
+      client.exportAuditLogsJSON([
+        { id: 'l1', action: 'create' } as never,
+      ])
+
+      expect(createURLSpy).toHaveBeenCalled()
+      expect(clickSpy).toHaveBeenCalled()
+
+      createElementSpy.mockRestore()
+      revokeURLSpy.mockRestore()
+      createURLSpy.mockRestore()
+    })
+  })
+
+  // ─── Version Info ─────────────────────────────────────────────────────────
+  describe('version info', () => {
+    it('getVersionInfo', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: { version: '1.0.0' } })
+      const result = await client.getVersionInfo()
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/version')
+      expect(result.version).toBe('1.0.0')
+    })
+  })
 })

--- a/frontend/src/services/__tests__/performanceReporting.test.ts
+++ b/frontend/src/services/__tests__/performanceReporting.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { flush, reportNavigation, destroy, init } from '../performanceReporting'
+
+// Mock web-vitals to avoid actual browser API usage
+vi.mock('web-vitals', () => ({
+  onCLS: vi.fn(),
+  onFCP: vi.fn(),
+  onLCP: vi.fn(),
+  onTTFB: vi.fn(),
+  onINP: vi.fn(),
+}))
+
+describe('performanceReporting', () => {
+  beforeEach(() => {
+    destroy()
+    vi.useFakeTimers()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    destroy()
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  describe('flush', () => {
+    it('does nothing when buffer is empty', () => {
+      const sendBeaconSpy = vi.spyOn(navigator, 'sendBeacon').mockReturnValue(true)
+      flush()
+      expect(sendBeaconSpy).not.toHaveBeenCalled()
+    })
+
+    it('does nothing when dsn is null', () => {
+      // Without calling init(), dsn is null
+      reportNavigation('/test', 100)
+      const sendBeaconSpy = vi.spyOn(navigator, 'sendBeacon').mockReturnValue(true)
+      flush()
+      // sendBeacon shouldn't be called because dsn is null
+      expect(sendBeaconSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('reportNavigation', () => {
+    it('enqueues a navigation entry', () => {
+      // reportNavigation pushes to buffer even without dsn
+      reportNavigation('/admin/users', 150.5)
+      // We can verify the log in dev mode
+      expect(console.log).toHaveBeenCalledWith(
+        expect.stringContaining('[Perf] Navigation')
+      )
+    })
+
+    it('logs the route name and duration in dev mode', () => {
+      reportNavigation('/modules', 42.3)
+      expect(console.log).toHaveBeenCalledWith(
+        expect.stringContaining('/modules')
+      )
+    })
+  })
+
+  describe('init', () => {
+    it('logs initialization message without DSN', () => {
+      init()
+      expect(console.log).toHaveBeenCalledWith(
+        '[Perf] No DSN configured — metrics logged to console only'
+      )
+    })
+
+    it('registers web vitals callbacks', async () => {
+      init()
+      // Allow the dynamic import to resolve
+      await vi.dynamicImportSettled()
+      const webVitals = await import('web-vitals')
+      expect(webVitals.onCLS).toHaveBeenCalled()
+      expect(webVitals.onFCP).toHaveBeenCalled()
+      expect(webVitals.onLCP).toHaveBeenCalled()
+      expect(webVitals.onTTFB).toHaveBeenCalled()
+      expect(webVitals.onINP).toHaveBeenCalled()
+    })
+
+    it('sets up flush interval', () => {
+      const setIntervalSpy = vi.spyOn(globalThis, 'setInterval')
+      init()
+      expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 10_000)
+    })
+  })
+
+  describe('destroy', () => {
+    it('clears the flush interval', () => {
+      init()
+      const clearIntervalSpy = vi.spyOn(globalThis, 'clearInterval')
+      destroy()
+      expect(clearIntervalSpy).toHaveBeenCalled()
+    })
+
+    it('is safe to call multiple times', () => {
+      destroy()
+      destroy()
+      // No errors thrown
+    })
+  })
+})

--- a/frontend/src/services/__tests__/queryKeys.test.ts
+++ b/frontend/src/services/__tests__/queryKeys.test.ts
@@ -7,27 +7,46 @@ describe('queryKeys', () => {
       expect(queryKeys.modules._def).toEqual(['modules'])
     })
 
-    it('produces unique search keys for different parameters', () => {
-      const key1 = queryKeys.modules.search({ query: 'vpc', limit: 10, offset: 0, viewMode: 'grid' })
-      const key2 = queryKeys.modules.search({ query: 'ecs', limit: 10, offset: 0, viewMode: 'grid' })
-      const key3 = queryKeys.modules.search({ query: 'vpc', limit: 20, offset: 0, viewMode: 'grid' })
-
-      expect(key1).not.toEqual(key2) // different query
-      expect(key1).not.toEqual(key3) // different limit
-    })
-
-    it('produces identical keys for identical parameters', () => {
-      const params = { query: 'vpc', limit: 10, offset: 0, viewMode: 'grid' }
-      const key1 = queryKeys.modules.search(params)
-      const key2 = queryKeys.modules.search({ ...params })
-
-      expect(key1).toEqual(key2)
-    })
-
-    it('search key starts with the _def hierarchy', () => {
-      const key = queryKeys.modules.search({ query: 'test', limit: 10, offset: 0, viewMode: 'grid' })
+    it('search key includes params', () => {
+      const key = queryKeys.modules.search({ query: 'vpc', limit: 10, offset: 0, viewMode: 'grid' })
       expect(key[0]).toBe('modules')
       expect(key[1]).toBe('search')
+      expect(key[2]).toEqual({ query: 'vpc', limit: 10, offset: 0, viewMode: 'grid' })
+    })
+
+    it('search key with sort and order', () => {
+      const key = queryKeys.modules.search({ query: 'test', limit: 20, offset: 10, viewMode: 'list', sort: 'name', order: 'asc' })
+      expect(key[2]).toMatchObject({ sort: 'name', order: 'asc' })
+    })
+
+    it('detail key includes namespace/name/system', () => {
+      const key = queryKeys.modules.detail('hashicorp', 'consul', 'aws')
+      expect(key).toEqual(['modules', 'detail', 'hashicorp', 'consul', 'aws'])
+    })
+
+    it('versions key includes namespace/name/system', () => {
+      const key = queryKeys.modules.versions('hashicorp', 'consul', 'aws')
+      expect(key).toEqual(['modules', 'versions', 'hashicorp', 'consul', 'aws'])
+    })
+
+    it('scm key includes moduleId', () => {
+      const key = queryKeys.modules.scm('mod-123')
+      expect(key).toEqual(['modules', 'scm', 'mod-123'])
+    })
+
+    it('scan key includes namespace/name/system/version', () => {
+      const key = queryKeys.modules.scan('hashicorp', 'consul', 'aws', '1.0.0')
+      expect(key).toEqual(['modules', 'scan', 'hashicorp', 'consul', 'aws', '1.0.0'])
+    })
+
+    it('docs key includes namespace/name/system/version', () => {
+      const key = queryKeys.modules.docs('hashicorp', 'consul', 'aws', '1.0.0')
+      expect(key).toEqual(['modules', 'docs', 'hashicorp', 'consul', 'aws', '1.0.0'])
+    })
+
+    it('webhookEvents key includes moduleId', () => {
+      const key = queryKeys.modules.webhookEvents('mod-456')
+      expect(key).toEqual(['modules', 'webhookEvents', 'mod-456'])
     })
   })
 
@@ -36,43 +55,218 @@ describe('queryKeys', () => {
       expect(queryKeys.providers._def).toEqual(['providers'])
     })
 
-    it('produces unique search keys for different parameters', () => {
-      const key1 = queryKeys.providers.search({ query: 'aws', limit: 10, offset: 0 })
-      const key2 = queryKeys.providers.search({ query: 'gcp', limit: 10, offset: 0 })
-
-      expect(key1).not.toEqual(key2)
-    })
-
-    it('search key includes hierarchy prefix', () => {
-      const key = queryKeys.providers.search({ query: 'azure', limit: 10, offset: 0 })
+    it('search key includes params', () => {
+      const key = queryKeys.providers.search({ query: 'aws', limit: 10, offset: 0, sort: 'name', order: 'asc' })
       expect(key[0]).toBe('providers')
       expect(key[1]).toBe('search')
+      expect(key[2]).toMatchObject({ query: 'aws', sort: 'name', order: 'asc' })
+    })
+
+    it('detail key includes namespace/type', () => {
+      const key = queryKeys.providers.detail('hashicorp', 'aws')
+      expect(key).toEqual(['providers', 'detail', 'hashicorp', 'aws'])
+    })
+
+    it('versions key includes namespace/type', () => {
+      const key = queryKeys.providers.versions('hashicorp', 'aws')
+      expect(key).toEqual(['providers', 'versions', 'hashicorp', 'aws'])
     })
   })
 
   describe('dashboard', () => {
-    it('has a stable _def key', () => {
-      expect(queryKeys.dashboard._def).toEqual(['dashboard'])
-    })
-
-    it('stats key is derived from _def', () => {
-      const key = queryKeys.dashboard.stats()
-      expect(key[0]).toBe('dashboard')
-      expect(key[1]).toBe('stats')
-    })
-
-    it('stats key is stable across calls', () => {
-      const key1 = queryKeys.dashboard.stats()
-      const key2 = queryKeys.dashboard.stats()
-      expect(key1).toEqual(key2)
+    it('stats key is stable', () => {
+      expect(queryKeys.dashboard.stats()).toEqual(['dashboard', 'stats'])
     })
   })
 
-  describe('key uniqueness across domains', () => {
-    it('different domains produce non-overlapping key prefixes', () => {
-      expect(queryKeys.modules._def).not.toEqual(queryKeys.providers._def)
-      expect(queryKeys.modules._def).not.toEqual(queryKeys.dashboard._def)
-      expect(queryKeys.providers._def).not.toEqual(queryKeys.dashboard._def)
+  describe('users', () => {
+    it('has a stable _def key', () => {
+      expect(queryKeys.users._def).toEqual(['users'])
+    })
+
+    it('list key includes params', () => {
+      const key = queryKeys.users.list({ page: 1, perPage: 20, search: 'john' })
+      expect(key).toEqual(['users', 'list', { page: 1, perPage: 20, search: 'john' }])
+    })
+
+    it('list key works without params', () => {
+      const key = queryKeys.users.list()
+      expect(key).toEqual(['users', 'list', undefined])
+    })
+
+    it('detail key includes id', () => {
+      expect(queryKeys.users.detail('u-123')).toEqual(['users', 'detail', 'u-123'])
+    })
+
+    it('memberships key includes userId', () => {
+      expect(queryKeys.users.memberships('u-123')).toEqual(['users', 'memberships', 'u-123'])
+    })
+  })
+
+  describe('organizations', () => {
+    it('has a stable _def key', () => {
+      expect(queryKeys.organizations._def).toEqual(['organizations'])
+    })
+
+    it('list key includes params', () => {
+      const key = queryKeys.organizations.list({ page: 2, perPage: 10 })
+      expect(key).toEqual(['organizations', 'list', { page: 2, perPage: 10 }])
+    })
+
+    it('detail key includes id', () => {
+      expect(queryKeys.organizations.detail('org-1')).toEqual(['organizations', 'detail', 'org-1'])
+    })
+
+    it('members key includes orgId', () => {
+      expect(queryKeys.organizations.members('org-1')).toEqual(['organizations', 'members', 'org-1'])
+    })
+  })
+
+  describe('apiKeys', () => {
+    it('has a stable _def key', () => {
+      expect(queryKeys.apiKeys._def).toEqual(['apiKeys'])
+    })
+
+    it('list key includes organizationId', () => {
+      expect(queryKeys.apiKeys.list('org-1')).toEqual(['apiKeys', 'list', 'org-1'])
+    })
+
+    it('list key works without organizationId', () => {
+      expect(queryKeys.apiKeys.list()).toEqual(['apiKeys', 'list', undefined])
+    })
+
+    it('memberships key includes userId', () => {
+      expect(queryKeys.apiKeys.memberships('u-1')).toEqual(['apiKeys', 'memberships', 'u-1'])
+    })
+  })
+
+  describe('scmProviders', () => {
+    it('has a stable _def key', () => {
+      expect(queryKeys.scmProviders._def).toEqual(['scmProviders'])
+    })
+
+    it('list key includes organizationId', () => {
+      expect(queryKeys.scmProviders.list('org-1')).toEqual(['scmProviders', 'list', 'org-1'])
+    })
+
+    it('tokenStatus key includes providerId', () => {
+      expect(queryKeys.scmProviders.tokenStatus('scm-1')).toEqual(['scmProviders', 'tokenStatus', 'scm-1'])
+    })
+
+    it('memberships key includes userId', () => {
+      expect(queryKeys.scmProviders.memberships('u-1')).toEqual(['scmProviders', 'memberships', 'u-1'])
+    })
+  })
+
+  describe('auditLogs', () => {
+    it('has a stable _def key', () => {
+      expect(queryKeys.auditLogs._def).toEqual(['auditLogs'])
+    })
+
+    it('list key includes params', () => {
+      const params = { action: 'create', resource: 'module' }
+      expect(queryKeys.auditLogs.list(params)).toEqual(['auditLogs', 'list', params])
+    })
+  })
+
+  describe('storageConfigs', () => {
+    it('list key is stable', () => {
+      expect(queryKeys.storageConfigs.list()).toEqual(['storageConfigs', 'list'])
+    })
+
+    it('setupStatus key is stable', () => {
+      expect(queryKeys.storageConfigs.setupStatus()).toEqual(['storageConfigs', 'setupStatus'])
+    })
+  })
+
+  describe('storageMigrations', () => {
+    it('list key is stable', () => {
+      expect(queryKeys.storageMigrations.list()).toEqual(['storageMigrations', 'list'])
+    })
+
+    it('detail key includes id', () => {
+      expect(queryKeys.storageMigrations.detail('mig-1')).toEqual(['storageMigrations', 'detail', 'mig-1'])
+    })
+  })
+
+  describe('mirrors', () => {
+    it('list key is stable', () => {
+      expect(queryKeys.mirrors.list()).toEqual(['mirrors', 'list'])
+    })
+
+    it('providers key includes mirrorId', () => {
+      expect(queryKeys.mirrors.providers('m-1')).toEqual(['mirrors', 'providers', 'm-1'])
+    })
+  })
+
+  describe('roles', () => {
+    it('list key is stable', () => {
+      expect(queryKeys.roles.list()).toEqual(['roles', 'list'])
+    })
+  })
+
+  describe('approvals', () => {
+    it('list key includes status param', () => {
+      expect(queryKeys.approvals.list({ status: 'pending' })).toEqual(['approvals', 'list', { status: 'pending' }])
+    })
+
+    it('list key works without params', () => {
+      expect(queryKeys.approvals.list()).toEqual(['approvals', 'list', undefined])
+    })
+  })
+
+  describe('policies', () => {
+    it('list key includes organizationId', () => {
+      expect(queryKeys.policies.list('org-1')).toEqual(['policies', 'list', 'org-1'])
+    })
+  })
+
+  describe('oidcConfig', () => {
+    it('get key is stable', () => {
+      expect(queryKeys.oidcConfig.get()).toEqual(['oidcConfig', 'get'])
+    })
+  })
+
+  describe('terraformMirrors', () => {
+    it('list key is stable', () => {
+      expect(queryKeys.terraformMirrors.list()).toEqual(['terraformMirrors', 'list'])
+    })
+
+    it('status key includes configId', () => {
+      expect(queryKeys.terraformMirrors.status('cfg-1')).toEqual(['terraformMirrors', 'status', 'cfg-1'])
+    })
+
+    it('versions key includes configId', () => {
+      expect(queryKeys.terraformMirrors.versions('cfg-1')).toEqual(['terraformMirrors', 'versions', 'cfg-1'])
+    })
+
+    it('history key includes configId', () => {
+      expect(queryKeys.terraformMirrors.history('cfg-1')).toEqual(['terraformMirrors', 'history', 'cfg-1'])
+    })
+  })
+
+  describe('key uniqueness across all domains', () => {
+    it('all top-level _def keys are unique', () => {
+      const allDefs = [
+        queryKeys.modules._def,
+        queryKeys.providers._def,
+        queryKeys.dashboard._def,
+        queryKeys.users._def,
+        queryKeys.organizations._def,
+        queryKeys.apiKeys._def,
+        queryKeys.scmProviders._def,
+        queryKeys.auditLogs._def,
+        queryKeys.storageConfigs._def,
+        queryKeys.storageMigrations._def,
+        queryKeys.mirrors._def,
+        queryKeys.roles._def,
+        queryKeys.approvals._def,
+        queryKeys.policies._def,
+        queryKeys.oidcConfig._def,
+        queryKeys.terraformMirrors._def,
+      ]
+      const prefixes = allDefs.map(d => d[0])
+      expect(new Set(prefixes).size).toBe(prefixes.length)
     })
   })
 })

--- a/frontend/src/utils/__tests__/scopes.test.ts
+++ b/frontend/src/utils/__tests__/scopes.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+import { getScopeInfo, getScopeColor } from '../scopes'
+
+describe('getScopeInfo', () => {
+  it('returns scope metadata for a known scope', () => {
+    const info = getScopeInfo('modules:read')
+    expect(info.value).toBe('modules:read')
+    expect(info.label).toBe('Modules Read')
+    expect(info.description).toBe('View modules and versions')
+  })
+
+  it('returns admin scope info', () => {
+    const info = getScopeInfo('admin')
+    expect(info.value).toBe('admin')
+    expect(info.label).toBe('Administrator')
+  })
+
+  it('returns fallback for unknown scope', () => {
+    const info = getScopeInfo('custom:unknown')
+    expect(info.value).toBe('custom:unknown')
+    expect(info.label).toBe('custom:unknown')
+    expect(info.description).toBe('Unknown scope')
+  })
+
+  it('returns correct info for mirrors:manage', () => {
+    const info = getScopeInfo('mirrors:manage')
+    expect(info.label).toBe('Mirrors Manage')
+  })
+})
+
+describe('getScopeColor', () => {
+  it('returns error for admin scope', () => {
+    expect(getScopeColor('admin')).toBe('error')
+  })
+
+  it('returns warning for :write scopes', () => {
+    expect(getScopeColor('modules:write')).toBe('warning')
+    expect(getScopeColor('users:write')).toBe('warning')
+  })
+
+  it('returns warning for :manage scopes', () => {
+    expect(getScopeColor('mirrors:manage')).toBe('warning')
+    expect(getScopeColor('scm:manage')).toBe('warning')
+  })
+
+  it('returns success for :read scopes', () => {
+    expect(getScopeColor('modules:read')).toBe('success')
+    expect(getScopeColor('audit:read')).toBe('success')
+  })
+
+  it('returns default for unrecognized patterns', () => {
+    expect(getScopeColor('something')).toBe('default')
+    expect(getScopeColor('')).toBe('default')
+  })
+})

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -4,6 +4,9 @@ import { resolve } from 'path'
 
 export default defineConfig({
   plugins: [react()],
+  define: {
+    __APP_VERSION__: JSON.stringify('0.0.0-test'),
+  },
   resolve: {
     alias: {
       '@': resolve(__dirname, './src'),
@@ -14,6 +17,7 @@ export default defineConfig({
     setupFiles: './src/setupTests.ts',
     globals: true,
     unstubGlobals: true,
+    testTimeout: 15_000,
     coverage: {
       provider: 'v8',
       reporter: ['text', 'text-summary', 'lcov', 'json-summary'],
@@ -28,10 +32,10 @@ export default defineConfig({
         'src/**/*.d.ts',
       ],
       thresholds: {
-        statements: 8,
-        branches: 8,
-        functions: 8,
-        lines: 8,
+        statements: 42,
+        branches: 37,
+        functions: 36,
+        lines: 43,
       },
     },
   },


### PR DESCRIPTION
## Summary
- Adds 28 new unit test files covering components, pages, admin pages, services, and utilities
- Extends 2 existing test files (api.test.ts, queryKeys.test.ts) with additional test cases
- Fixes TypeScript errors in 7 test files (missing properties, wrong field names, unused imports)
- Sets vitest testTimeout to 15s for parallel execution stability
- Adjusts coverage thresholds to 42/37/36/43% (~5% below actual)
- Line coverage: 15% → 51%

## Changelog
- feat: add comprehensive unit tests raising line coverage from 15% to 51%

## Test plan
- [x] `npx vitest run` — 723 tests pass (48 test files, 0 failures)
- [x] `npx vitest run --coverage` — all thresholds met (49.76/44.87/42.16/51.29%)
- [x] `npx tsc --noEmit` — no TypeScript errors
- [x] `npm run lint` — no lint warnings
- [x] `npm run build` — builds successfully