### PR TITLE
fix: handle rate-limited auth probes and prevent duplicate exchange-token requests

### DIFF
--- a/frontend/src/pages/CallbackPage.tsx
+++ b/frontend/src/pages/CallbackPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import {
   Container,
@@ -16,9 +16,13 @@ const CallbackPage: React.FC = () => {
   const [searchParams] = useSearchParams();
   const { setToken } = useAuth();
   const [error, setError] = useState<string | null>(null);
+  const exchangedRef = useRef(false);
 
   useEffect(() => {
     const handleCallback = async () => {
+      // Guard against duplicate calls (e.g. React StrictMode double-mount in dev)
+      if (exchangedRef.current) return;
+      exchangedRef.current = true;
       const errorParam = searchParams.get('error');
       const errorDescription = searchParams.get('error_description');
 

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -43,6 +43,9 @@ async function probeProvider(id: ProviderId): Promise<boolean> {
       method: 'GET',
       redirect: 'manual',
     });
+    // 429 means rate-limited — the provider may still be configured, so treat
+    // it as available to avoid hiding login buttons after a burst of requests.
+    if (res.status === 429) return true;
     return res.type === 'opaqueredirect' || res.status === 0;
   } catch {
     return false;
@@ -90,28 +93,11 @@ const LoginPage: React.FC = () => {
     }
   };
 
-  const handleProviderLogin = async (provider: ProviderId) => {
+  const handleProviderLogin = (provider: ProviderId) => {
     setLoginError(null);
-    try {
-      const res = await fetch(`/api/v1/auth/login?provider=${provider}`, {
-        method: 'GET',
-        redirect: 'manual',
-      });
-      if (res.type === 'opaqueredirect' || res.status === 0) {
-        api.login(provider);
-        return;
-      }
-      let message = `${provider === 'oidc' ? 'OIDC' : 'Azure AD'} provider is not configured. Contact your administrator.`;
-      try {
-        const body = await res.json();
-        if (body?.error) message = body.error;
-      } catch {
-        // ignore parse errors
-      }
-      setLoginError(message);
-    } catch {
-      api.login(provider);
-    }
+    // Provider availability was already confirmed by probeProvider() — go
+    // straight to the redirect to avoid consuming an extra rate-limit token.
+    api.login(provider);
   };
 
   const availableCount = Object.values(providerAvailable).filter(Boolean).length;

--- a/frontend/src/pages/__tests__/LoginPage.test.tsx
+++ b/frontend/src/pages/__tests__/LoginPage.test.tsx
@@ -114,19 +114,21 @@ describe('LoginPage', () => {
     await waitFor(() => expect(mockApiLogin).toHaveBeenCalledWith('oidc'))
   })
 
-  it('shows inline error Alert when provider login returns non-redirect error body', async () => {
-    let probesDone = false
-    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input: Request | URL | string) => {
-      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
-      if (!probesDone && url.includes('provider=')) {
-        return { type: 'opaqueredirect', status: 0 } as Response
-      }
-      return { type: 'basic', status: 400, json: async () => ({ error: 'OIDC not configured' }) } as unknown as Response
-    })
+  it('triggers api.login directly when OIDC button is clicked (no extra fetch)', async () => {
+    mockProviderProbes({ oidc: 'ok', azuread: 'fail' })
     renderLoginPage()
     const btn = await screen.findByRole('button', { name: 'Sign in with SSO' })
-    probesDone = true
+    const fetchCallsBefore = vi.mocked(globalThis.fetch).mock.calls.length
     await act(async () => { await userEvent.click(btn) })
-    expect(await screen.findByText('OIDC not configured')).toBeInTheDocument()
+    // handleProviderLogin should NOT make another fetch — just call api.login
+    expect(vi.mocked(globalThis.fetch).mock.calls.length).toBe(fetchCallsBefore)
+    expect(mockApiLogin).toHaveBeenCalledWith('oidc')
+  })
+
+  it('treats 429 rate-limited probes as available providers', async () => {
+    mockProviderProbes({ oidc: { status: 429 }, azuread: 'fail' })
+    renderLoginPage()
+    expect(await screen.findByRole('button', { name: 'Sign in with SSO' })).toBeInTheDocument()
+    expect(screen.queryByTestId('no-providers-alert')).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
Closes #144

## Summary
- `probeProvider()` now treats HTTP 429 as "provider available" to avoid hiding login buttons when the auth rate limiter fires
- `handleProviderLogin()` no longer makes a redundant fetch before calling `api.login()`, saving one rate-limit token per click
- `CallbackPage` guards against duplicate exchange-token requests via ref

## Changelog
- fix: handle rate-limited auth probes to prevent false "No SSO providers configured" message
- fix: remove redundant fetch in login handler to reduce auth rate limit consumption
- fix: prevent duplicate exchange-token requests in callback page

## Test plan
- [ ] All 856 unit tests pass
- [ ] Lint clean (zero warnings)
- [ ] Manual test: login page shows SSO button even after rate limit exhaustion
- [ ] Manual test: clicking login does not fire duplicate requests