### PR TITLE
feat: Phase 1 — Security hardening

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,32 @@
+name: Dependabot Auto-Merge
+
+# Auto-merge Dependabot security PRs that pass CI (patch-level bumps only).
+# This reduces toil for low-risk security fixes while requiring manual review
+# for minor/major version bumps.
+on:
+  pull_request:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    name: Auto-merge Dependabot (patch security)
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444e5e4fda8 # v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Auto-merge patch-level security updates
+        if: >-
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' &&
+          steps.metadata.outputs.dependency-type == 'direct:production'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="csp-nonce" content="__CSP_NONCE__" />
     <title>Terraform Registry</title>
     <!-- Removed temporary client-side redirect for /api-docs -->
   </head>

--- a/frontend/nginx-ecs.conf.template
+++ b/frontend/nginx-ecs.conf.template
@@ -27,8 +27,13 @@ server {
     add_header X-Frame-Options "DENY" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none';" always;
+    set $csp_nonce $request_id;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'nonce-$csp_nonce'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none';" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
+
+    # Inject CSP nonce into index.html
+    sub_filter_once on;
+    sub_filter '__CSP_NONCE__' '$csp_nonce';
 
     # Upload size limit (matches backend: 100MB modules, 500MB providers)
     client_max_body_size 500m;

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -20,9 +20,16 @@ server {
     add_header X-Frame-Options "DENY" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-    # CSP: unsafe-inline required for MUI/Emotion CSS-in-JS
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none';" always;
+    # CSP: nonce-based for style-src to avoid 'unsafe-inline' (MUI/Emotion uses nonce)
+    # The __CSP_NONCE__ placeholder is replaced per-request by the sub_filter below.
+    # In development (without nginx), 'unsafe-inline' is still needed — Vite injects styles directly.
+    set $csp_nonce $request_id;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'nonce-$csp_nonce'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none';" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
+
+    # Inject CSP nonce into index.html so the React app can read it
+    sub_filter_once on;
+    sub_filter '__CSP_NONCE__' '$csp_nonce';
 
     # Upload size limit (matches backend: 100MB modules, 500MB providers)
     client_max_body_size 500m;

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "terraform-registry-frontend",
       "version": "0.5.6",
       "dependencies": {
+        "@emotion/cache": "^11.14.0",
         "@emotion/react": "^11.11.3",
         "@emotion/styled": "^11.11.0",
         "@fortawesome/fontawesome-svg-core": "^7.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "format:check": "prettier --check 'src/**/*.{ts,tsx,css,json}'"
   },
   "dependencies": {
+    "@emotion/cache": "^11.14.0",
     "@emotion/react": "^11.11.3",
     "@emotion/styled": "^11.11.0",
     "@fortawesome/fontawesome-svg-core": "^7.2.0",

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,5 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
+import createCache from '@emotion/cache'
+import { CacheProvider } from '@emotion/react'
 import App from './App'
 import './index.css'
 import { init as initErrorReporting, captureError } from './services/errorReporting'
@@ -19,8 +21,22 @@ if (import.meta.env.DEV) {
   });
 }
 
+// Read CSP nonce from meta tag (injected by nginx sub_filter)
+const nonceMeta = document.querySelector('meta[name="csp-nonce"]')
+const nonce = nonceMeta?.getAttribute('content') || undefined
+// In production, __CSP_NONCE__ is replaced with the actual request_id by nginx.
+// In development, it stays as the literal string, so we treat it as absent.
+const resolvedNonce = nonce && nonce !== '__CSP_NONCE__' ? nonce : undefined
+
+const emotionCache = createCache({
+  key: 'css',
+  nonce: resolvedNonce,
+})
+
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
+    <CacheProvider value={emotionCache}>
+      <App />
+    </CacheProvider>
   </React.StrictMode>
 )


### PR DESCRIPTION
## Phase 1: Security Hardening

### Changes

**Dependency Management (A1.5)**
- Added dependabot-automerge.yml for patch-level security auto-merge

**CSP Hardening (F1.1, A1.3)**
- Removed cdn.jsdelivr.net from CSP in nginx-ecs.conf.template
- Implemented nonce-based CSP for style-src (nginx sub_filter + Emotion cache)
- Replaced unsafe-inline with nonce in both nginx configs

**Offline Audit (F1.2, A1.4)**
- All markdown rendering is npm-bundled, no external fetches
- No remaining external CDN asset references

### Dependencies
- Added @emotion/cache as direct dependency

## Changelog
- feat: add dependabot auto-merge workflow for patch security updates
- feat: implement CSP nonce-based styles, removing unsafe-inline
- feat: remove CDN references from nginx CSP policies