### PR TITLE
fix(setup): setup wizard now triggers for features added after initial setup

### DIFF
--- a/frontend/src/contexts/SetupWizardContext.tsx
+++ b/frontend/src/contexts/SetupWizardContext.tsx
@@ -153,7 +153,7 @@ export const SetupWizardProvider: React.FC<SetupWizardProviderProps> = ({
       setLoading(true);
       const status = await api.getSetupStatus();
       setSetupStatus(status);
-      if (status.setup_completed) {
+      if (status.setup_completed && !status.pending_feature_setup) {
         onSetupCompleted();
         return;
       }
@@ -163,6 +163,11 @@ export const SetupWizardProvider: React.FC<SetupWizardProviderProps> = ({
       if (status.storage_configured) setStorageSaved(true);
       if (status.scanning_configured) setScanningSaved(true);
       if (status.admin_configured) setAdminSaved(true);
+      // In pending-feature mode, jump directly to the first unconfigured step.
+      // Steps: 0=Token, 1=OIDC, 2=Storage, 3=Scanning, 4=Admin, 5=Complete
+      if (status.pending_feature_setup) {
+        if (!status.scanning_configured) setActiveStep(0);
+      }
       setOidcForm((prev) => {
         if (prev.redirect_url) return prev;
         const baseUrl = window.location.origin;

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -39,6 +39,7 @@ import QuickApiKeyDialog from '../components/QuickApiKeyDialog';
 
 interface HomeStats {
   setupRequired: boolean;
+  pendingFeatureSetup: boolean;
   moduleCount: number | null;
   moduleNames: { namespace: string; name: string; system: string }[];
   providerCount: number | null;
@@ -49,6 +50,7 @@ interface HomeStats {
 
 const initialStats: HomeStats = {
   setupRequired: false,
+  pendingFeatureSetup: false,
   moduleCount: null,
   moduleNames: [],
   providerCount: null,
@@ -97,6 +99,7 @@ const HomePage: React.FC = () => {
       setStats({
         loading: false,
         setupRequired: setup.status === 'fulfilled' ? (setup.value.setup_required ?? false) : false,
+        pendingFeatureSetup: setup.status === 'fulfilled' ? (setup.value.pending_feature_setup ?? false) : false,
         moduleCount: mods.status === 'fulfilled' ? (mods.value.meta?.total ?? null) : null,
         moduleNames: mods.status === 'fulfilled' ? (mods.value.modules ?? []).slice(0, 3) : [],
         providerCount: provs.status === 'fulfilled' ? (provs.value.meta?.total ?? null) : null,
@@ -149,14 +152,15 @@ const HomePage: React.FC = () => {
           icon={<WarningAmberIcon />}
           action={
             <Button color="inherit" size="small" onClick={() => navigate('/setup')} sx={{ fontWeight: 600 }}>
-              Start Setup
+              {stats.pendingFeatureSetup ? 'Configure Features' : 'Start Setup'}
             </Button>
           }
           sx={{ borderRadius: 0 }}
         >
-          <AlertTitle>Setup Required</AlertTitle>
-          This registry has not been configured yet. Complete the setup wizard to configure
-          authentication, storage, and the initial admin account.
+          <AlertTitle>{stats.pendingFeatureSetup ? 'Feature Configuration Required' : 'Setup Required'}</AlertTitle>
+          {stats.pendingFeatureSetup
+            ? 'New features have been added that require configuration. Complete the setup wizard to enable them.'
+            : 'This registry has not been configured yet. Complete the setup wizard to configure authentication, storage, and the initial admin account.'}
         </Alert>
       )}
 

--- a/frontend/src/pages/SetupWizardPage.tsx
+++ b/frontend/src/pages/SetupWizardPage.tsx
@@ -24,7 +24,7 @@ const stepComponents: Record<number, React.FC> = {
 const SetupWizardShell: React.FC = () => {
   const { loading, setupStatus, activeStep, error, setError, success, setSuccess } = useSetupWizard();
 
-  if (!loading && setupStatus?.setup_completed) return null;
+  if (!loading && setupStatus?.setup_completed && !setupStatus?.pending_feature_setup) return null;
 
   const StepComponent = stepComponents[activeStep];
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -309,6 +309,7 @@ export interface SetupStatus {
   oidc_configured?: boolean;
   scanning_configured?: boolean;
   admin_configured?: boolean;
+  pending_feature_setup?: boolean;
 }
 
 // Setup Wizard — Security Scanning configuration


### PR DESCRIPTION
Frontend companion to sethbacon/terraform-registry-backend#215. Existing registries that completed setup before scanning was added now see the setup wizard for unconfigured features.

## Changelog
- fix(setup): setup wizard now triggers for features added after initial setup — existing registries that completed setup before scanning was added now see a "Feature Configuration Required" banner and can configure scanning via the wizard
- fix(setup): `SetupWizardContext` no longer navigates away when `pending_feature_setup` is true
- fix(setup): `SetupWizardPage` renders the wizard shell in pending-feature mode instead of returning null
- fix(setup): HomePage banner shows contextual messaging ("Feature Configuration Required" vs "Setup Required") based on setup state