### PR TITLE
feat: add scanner auto-install to setup wizard

### DIFF
--- a/frontend/src/contexts/SetupWizardContext.tsx
+++ b/frontend/src/contexts/SetupWizardContext.tsx
@@ -1,6 +1,13 @@
-import React, { createContext, useCallback, useContext, useEffect, useState, ReactNode } from 'react';
-import api from '../services/api';
-import { getErrorMessage } from '../utils/errors';
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+  ReactNode,
+} from 'react'
+import api from '../services/api'
+import { getErrorMessage } from '../utils/errors'
 import type {
   SetupStatus,
   OIDCConfigInput,
@@ -10,99 +17,103 @@ import type {
   SetupTestResult,
   ScanningConfigInput,
   ScanningTestResult,
-} from '../types';
+  ScanningInstallResult,
+} from '../types'
 
 export interface SetupWizardContextValue {
   // status
-  loading: boolean;
-  setupStatus: SetupStatus | null;
-  reloadStatus: () => Promise<void>;
+  loading: boolean
+  setupStatus: SetupStatus | null
+  reloadStatus: () => Promise<void>
 
   // shared
-  activeStep: number;
-  goToStep: (n: number) => void;
-  error: string | null;
-  setError: (v: string | null) => void;
-  success: string | null;
-  setSuccess: (v: string | null) => void;
+  activeStep: number
+  goToStep: (n: number) => void
+  error: string | null
+  setError: (v: string | null) => void
+  success: string | null
+  setSuccess: (v: string | null) => void
 
   // step 0: token
-  setupToken: string;
-  setSetupToken: (v: string) => void;
-  tokenValidating: boolean;
-  tokenValid: boolean;
-  validateToken: () => Promise<void>;
+  setupToken: string
+  setSetupToken: (v: string) => void
+  tokenValidating: boolean
+  tokenValid: boolean
+  validateToken: () => Promise<void>
 
   // step 1: auth method + oidc
-  authMethod: 'oidc' | 'ldap';
-  setAuthMethod: (v: 'oidc' | 'ldap') => void;
+  authMethod: 'oidc' | 'ldap'
+  setAuthMethod: (v: 'oidc' | 'ldap') => void
 
-  oidcForm: OIDCConfigInput;
-  setOidcForm: (f: OIDCConfigInput) => void;
-  oidcTesting: boolean;
-  oidcTestResult: SetupTestResult | null;
-  oidcSaving: boolean;
-  oidcSaved: boolean;
-  testOIDC: () => Promise<void>;
-  saveOIDC: () => Promise<void>;
+  oidcForm: OIDCConfigInput
+  setOidcForm: (f: OIDCConfigInput) => void
+  oidcTesting: boolean
+  oidcTestResult: SetupTestResult | null
+  oidcSaving: boolean
+  oidcSaved: boolean
+  testOIDC: () => Promise<void>
+  saveOIDC: () => Promise<void>
 
   // step 1: ldap (alternative to oidc)
-  ldapForm: LDAPConfigInput;
-  setLdapForm: (f: LDAPConfigInput) => void;
-  ldapTesting: boolean;
-  ldapTestResult: SetupTestResult | null;
-  ldapSaving: boolean;
-  ldapSaved: boolean;
-  testLDAP: () => Promise<void>;
-  saveLDAP: () => Promise<void>;
+  ldapForm: LDAPConfigInput
+  setLdapForm: (f: LDAPConfigInput) => void
+  ldapTesting: boolean
+  ldapTestResult: SetupTestResult | null
+  ldapSaving: boolean
+  ldapSaved: boolean
+  testLDAP: () => Promise<void>
+  saveLDAP: () => Promise<void>
 
   // step 2: storage
-  storageForm: StorageConfigInput;
-  setStorageForm: (f: StorageConfigInput) => void;
-  changeStorageBackend: (type: StorageBackendType) => void;
-  storageTesting: boolean;
-  storageTestResult: SetupTestResult | null;
-  storageSaving: boolean;
-  storageSaved: boolean;
-  testStorage: () => Promise<void>;
-  saveStorage: () => Promise<void>;
+  storageForm: StorageConfigInput
+  setStorageForm: (f: StorageConfigInput) => void
+  changeStorageBackend: (type: StorageBackendType) => void
+  storageTesting: boolean
+  storageTestResult: SetupTestResult | null
+  storageSaving: boolean
+  storageSaved: boolean
+  testStorage: () => Promise<void>
+  saveStorage: () => Promise<void>
 
   // step 3: scanning
-  scanningForm: ScanningConfigInput;
-  setScanningForm: (f: ScanningConfigInput) => void;
-  scanningTesting: boolean;
-  scanningTestResult: ScanningTestResult | null;
-  setScanningTestResult: (r: ScanningTestResult | null) => void;
-  scanningSaving: boolean;
-  scanningSaved: boolean;
-  setScanningSaved: (v: boolean) => void;
-  testScanning: () => Promise<void>;
-  saveScanning: () => Promise<void>;
+  scanningForm: ScanningConfigInput
+  setScanningForm: (f: ScanningConfigInput) => void
+  scanningTesting: boolean
+  scanningTestResult: ScanningTestResult | null
+  setScanningTestResult: (r: ScanningTestResult | null) => void
+  scanningSaving: boolean
+  scanningSaved: boolean
+  setScanningSaved: (v: boolean) => void
+  testScanning: () => Promise<void>
+  saveScanning: () => Promise<void>
+  scanningInstalling: boolean
+  scanningInstallResult: ScanningInstallResult | null
+  installScanner: (version?: string) => Promise<void>
 
   // step 4: admin
-  adminEmail: string;
-  setAdminEmail: (v: string) => void;
-  adminSaving: boolean;
-  adminSaved: boolean;
-  saveAdmin: () => Promise<void>;
+  adminEmail: string
+  setAdminEmail: (v: string) => void
+  adminSaving: boolean
+  adminSaved: boolean
+  saveAdmin: () => Promise<void>
 
   // step 5: complete
-  completing: boolean;
-  completeSetup: () => Promise<void>;
+  completing: boolean
+  completeSetup: () => Promise<void>
 }
 
-const SetupWizardContext = createContext<SetupWizardContextValue | undefined>(undefined);
+const SetupWizardContext = createContext<SetupWizardContextValue | undefined>(undefined)
 
 export const useSetupWizard = (): SetupWizardContextValue => {
-  const ctx = useContext(SetupWizardContext);
-  if (!ctx) throw new Error('useSetupWizard must be used within a SetupWizardProvider');
-  return ctx;
-};
+  const ctx = useContext(SetupWizardContext)
+  if (!ctx) throw new Error('useSetupWizard must be used within a SetupWizardProvider')
+  return ctx
+}
 
 interface SetupWizardProviderProps {
-  children: ReactNode;
-  onSetupCompleted: () => void;
-  onSetupFinalized: () => void;
+  children: ReactNode
+  onSetupCompleted: () => void
+  onSetupFinalized: () => void
 }
 
 export const SetupWizardProvider: React.FC<SetupWizardProviderProps> = ({
@@ -110,19 +121,19 @@ export const SetupWizardProvider: React.FC<SetupWizardProviderProps> = ({
   onSetupCompleted,
   onSetupFinalized,
 }) => {
-  const [activeStep, setActiveStep] = useState(0);
-  const [setupStatus, setSetupStatus] = useState<SetupStatus | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [success, setSuccess] = useState<string | null>(null);
+  const [activeStep, setActiveStep] = useState(0)
+  const [setupStatus, setSetupStatus] = useState<SetupStatus | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState<string | null>(null)
 
   // Step 0: token
-  const [setupToken, setSetupToken] = useState('');
-  const [tokenValidating, setTokenValidating] = useState(false);
-  const [tokenValid, setTokenValid] = useState(false);
+  const [setupToken, setSetupToken] = useState('')
+  const [tokenValidating, setTokenValidating] = useState(false)
+  const [tokenValid, setTokenValid] = useState(false)
 
   // Step 1: Auth method
-  const [authMethod, setAuthMethod] = useState<'oidc' | 'ldap'>('oidc');
+  const [authMethod, setAuthMethod] = useState<'oidc' | 'ldap'>('oidc')
 
   // Step 1: OIDC
   const [oidcForm, setOidcForm] = useState<OIDCConfigInput>({
@@ -133,309 +144,401 @@ export const SetupWizardProvider: React.FC<SetupWizardProviderProps> = ({
     client_secret: '',
     redirect_url: '',
     scopes: ['openid', 'email', 'profile'],
-  });
-  const [oidcTesting, setOidcTesting] = useState(false);
-  const [oidcTestResult, setOidcTestResult] = useState<SetupTestResult | null>(null);
-  const [oidcSaving, setOidcSaving] = useState(false);
-  const [oidcSaved, setOidcSaved] = useState(false);
+  })
+  const [oidcTesting, setOidcTesting] = useState(false)
+  const [oidcTestResult, setOidcTestResult] = useState<SetupTestResult | null>(null)
+  const [oidcSaving, setOidcSaving] = useState(false)
+  const [oidcSaved, setOidcSaved] = useState(false)
 
   // Step 1: LDAP (alternative)
   const [ldapForm, setLdapForm] = useState<LDAPConfigInput>({
-    host: '', port: 389, use_tls: false, start_tls: true, insecure_skip_verify: false,
-    bind_dn: '', bind_password: '', base_dn: '', user_filter: '(sAMAccountName=%s)',
-    user_attr_email: 'mail', user_attr_name: 'displayName',
-    group_base_dn: '', group_filter: '', group_member_attr: 'member',
-  });
-  const [ldapTesting, setLdapTesting] = useState(false);
-  const [ldapTestResult, setLdapTestResult] = useState<SetupTestResult | null>(null);
-  const [ldapSaving, setLdapSaving] = useState(false);
-  const [ldapSaved, setLdapSaved] = useState(false);
+    host: '',
+    port: 389,
+    use_tls: false,
+    start_tls: true,
+    insecure_skip_verify: false,
+    bind_dn: '',
+    bind_password: '',
+    base_dn: '',
+    user_filter: '(sAMAccountName=%s)',
+    user_attr_email: 'mail',
+    user_attr_name: 'displayName',
+    group_base_dn: '',
+    group_filter: '',
+    group_member_attr: 'member',
+  })
+  const [ldapTesting, setLdapTesting] = useState(false)
+  const [ldapTestResult, setLdapTestResult] = useState<SetupTestResult | null>(null)
+  const [ldapSaving, setLdapSaving] = useState(false)
+  const [ldapSaved, setLdapSaved] = useState(false)
 
   // Step 2: storage
   const [storageForm, setStorageForm] = useState<StorageConfigInput>({
     backend_type: 'local',
     local_base_path: './data/storage',
     local_serve_directly: true,
-  });
-  const [storageTesting, setStorageTesting] = useState(false);
-  const [storageTestResult, setStorageTestResult] = useState<SetupTestResult | null>(null);
-  const [storageSaving, setStorageSaving] = useState(false);
-  const [storageSaved, setStorageSaved] = useState(false);
+  })
+  const [storageTesting, setStorageTesting] = useState(false)
+  const [storageTestResult, setStorageTestResult] = useState<SetupTestResult | null>(null)
+  const [storageSaving, setStorageSaving] = useState(false)
+  const [storageSaved, setStorageSaved] = useState(false)
 
   // Step 3: scanning
-  const [scanningForm, setScanningForm] = useState<ScanningConfigInput>({ enabled: false, tool: 'trivy', binary_path: '' });
-  const [scanningTesting, setScanningTesting] = useState(false);
-  const [scanningTestResult, setScanningTestResult] = useState<ScanningTestResult | null>(null);
-  const [scanningSaving, setScanningSaving] = useState(false);
-  const [scanningSaved, setScanningSaved] = useState(false);
+  const [scanningForm, setScanningForm] = useState<ScanningConfigInput>({
+    enabled: false,
+    tool: 'trivy',
+    binary_path: '',
+  })
+  const [scanningTesting, setScanningTesting] = useState(false)
+  const [scanningTestResult, setScanningTestResult] = useState<ScanningTestResult | null>(null)
+  const [scanningSaving, setScanningSaving] = useState(false)
+  const [scanningSaved, setScanningSaved] = useState(false)
+  const [scanningInstalling, setScanningInstalling] = useState(false)
+  const [scanningInstallResult, setScanningInstallResult] = useState<ScanningInstallResult | null>(
+    null,
+  )
 
   // Step 4: admin
-  const [adminEmail, setAdminEmail] = useState('');
-  const [adminSaving, setAdminSaving] = useState(false);
-  const [adminSaved, setAdminSaved] = useState(false);
+  const [adminEmail, setAdminEmail] = useState('')
+  const [adminSaving, setAdminSaving] = useState(false)
+  const [adminSaved, setAdminSaved] = useState(false)
 
   // Step 5: complete
-  const [completing, setCompleting] = useState(false);
+  const [completing, setCompleting] = useState(false)
 
   const reloadStatus = useCallback(async () => {
     try {
-      setLoading(true);
-      const status = await api.getSetupStatus();
-      setSetupStatus(status);
+      setLoading(true)
+      const status = await api.getSetupStatus()
+      setSetupStatus(status)
       if (status.setup_completed && !status.pending_feature_setup) {
-        onSetupCompleted();
-        return;
+        onSetupCompleted()
+        return
       }
       // Initialize saved-flags from backend status so features configured in
       // a previous session (or before a new feature was added) show as complete.
-      if (status.oidc_configured) setOidcSaved(true);
-      if (status.ldap_configured) setLdapSaved(true);
-      if (status.auth_method) setAuthMethod(status.auth_method);
-      if (status.storage_configured) setStorageSaved(true);
-      if (status.scanning_configured) setScanningSaved(true);
-      if (status.admin_configured) setAdminSaved(true);
+      if (status.oidc_configured) setOidcSaved(true)
+      if (status.ldap_configured) setLdapSaved(true)
+      if (status.auth_method) setAuthMethod(status.auth_method)
+      if (status.storage_configured) setStorageSaved(true)
+      if (status.scanning_configured) setScanningSaved(true)
+      if (status.admin_configured) setAdminSaved(true)
       // In pending-feature mode, jump directly to the first unconfigured step.
       // Steps: 0=Token, 1=OIDC, 2=Storage, 3=Scanning, 4=Admin, 5=Complete
       if (status.pending_feature_setup) {
-        if (!status.scanning_configured) setActiveStep(0);
+        if (!status.scanning_configured) setActiveStep(0)
       }
       setOidcForm((prev) => {
-        if (prev.redirect_url) return prev;
-        const baseUrl = window.location.origin;
-        return { ...prev, redirect_url: `${baseUrl}/api/v1/auth/callback` };
-      });
+        if (prev.redirect_url) return prev
+        const baseUrl = window.location.origin
+        return { ...prev, redirect_url: `${baseUrl}/api/v1/auth/callback` }
+      })
     } catch {
-      setError('Failed to check setup status');
+      setError('Failed to check setup status')
     } finally {
-      setLoading(false);
+      setLoading(false)
     }
-  }, [onSetupCompleted]);
+  }, [onSetupCompleted])
 
-  useEffect(() => { reloadStatus(); }, [reloadStatus]);
+  useEffect(() => {
+    reloadStatus()
+  }, [reloadStatus])
 
   const goToStep = useCallback((n: number) => {
-    setActiveStep(n);
-    setError(null);
-    setSuccess(null);
-  }, []);
+    setActiveStep(n)
+    setError(null)
+    setSuccess(null)
+  }, [])
 
   const validateToken = async () => {
     try {
-      setTokenValidating(true);
-      setError(null);
-      const result = await api.validateSetupToken(setupToken.trim());
+      setTokenValidating(true)
+      setError(null)
+      const result = await api.validateSetupToken(setupToken.trim())
       if (result.valid) {
-        setTokenValid(true);
-        setSuccess('Setup token verified successfully');
+        setTokenValid(true)
+        setSuccess('Setup token verified successfully')
         // In pending-feature mode, skip already-configured steps and jump to
         // the first unconfigured feature step.
         if (setupStatus?.pending_feature_setup) {
-          if (!scanningSaved) { setActiveStep(3); }
-          else { setActiveStep(5); }
+          if (!scanningSaved) {
+            setActiveStep(3)
+          } else {
+            setActiveStep(5)
+          }
         } else {
-          setActiveStep(1);
+          setActiveStep(1)
         }
       }
     } catch (err: unknown) {
-      setError(getErrorMessage(err, 'Invalid setup token'));
-      setTokenValid(false);
+      setError(getErrorMessage(err, 'Invalid setup token'))
+      setTokenValid(false)
     } finally {
-      setTokenValidating(false);
+      setTokenValidating(false)
     }
-  };
+  }
 
   const testOIDC = async () => {
     try {
-      setOidcTesting(true);
-      setError(null);
-      setOidcTestResult(null);
-      const result = await api.testOIDCConfig(setupToken, oidcForm);
-      setOidcTestResult(result);
-      if (!result.success) setError(result.message);
+      setOidcTesting(true)
+      setError(null)
+      setOidcTestResult(null)
+      const result = await api.testOIDCConfig(setupToken, oidcForm)
+      setOidcTestResult(result)
+      if (!result.success) setError(result.message)
     } catch (err: unknown) {
-      setError(getErrorMessage(err, 'OIDC test failed'));
+      setError(getErrorMessage(err, 'OIDC test failed'))
     } finally {
-      setOidcTesting(false);
+      setOidcTesting(false)
     }
-  };
+  }
 
   const saveOIDC = async () => {
     try {
-      setOidcSaving(true);
-      setError(null);
-      await api.saveOIDCConfig(setupToken, oidcForm);
-      setOidcSaved(true);
-      setSuccess('OIDC provider configured successfully');
+      setOidcSaving(true)
+      setError(null)
+      await api.saveOIDCConfig(setupToken, oidcForm)
+      setOidcSaved(true)
+      setSuccess('OIDC provider configured successfully')
     } catch (err: unknown) {
-      setError(getErrorMessage(err, 'Failed to save OIDC configuration'));
+      setError(getErrorMessage(err, 'Failed to save OIDC configuration'))
     } finally {
-      setOidcSaving(false);
+      setOidcSaving(false)
     }
-  };
+  }
 
   const testLDAP = async () => {
     try {
-      setLdapTesting(true);
-      setError(null);
-      setLdapTestResult(null);
-      const result = await api.testLDAPConfig(setupToken, ldapForm);
-      setLdapTestResult(result);
-      if (!result.success) setError(result.message);
+      setLdapTesting(true)
+      setError(null)
+      setLdapTestResult(null)
+      const result = await api.testLDAPConfig(setupToken, ldapForm)
+      setLdapTestResult(result)
+      if (!result.success) setError(result.message)
     } catch (err: unknown) {
-      setError(getErrorMessage(err, 'LDAP test failed'));
+      setError(getErrorMessage(err, 'LDAP test failed'))
     } finally {
-      setLdapTesting(false);
+      setLdapTesting(false)
     }
-  };
+  }
 
   const saveLDAP = async () => {
     try {
-      setLdapSaving(true);
-      setError(null);
-      await api.saveLDAPConfig(setupToken, ldapForm);
-      setLdapSaved(true);
-      setSuccess('LDAP configuration saved successfully');
+      setLdapSaving(true)
+      setError(null)
+      await api.saveLDAPConfig(setupToken, ldapForm)
+      setLdapSaved(true)
+      setSuccess('LDAP configuration saved successfully')
     } catch (err: unknown) {
-      setError(getErrorMessage(err, 'Failed to save LDAP configuration'));
+      setError(getErrorMessage(err, 'Failed to save LDAP configuration'))
     } finally {
-      setLdapSaving(false);
+      setLdapSaving(false)
     }
-  };
+  }
 
   const saveStorage = async () => {
     try {
-      setStorageSaving(true);
-      setError(null);
-      await api.saveSetupStorageConfig(setupToken, storageForm);
-      setStorageSaved(true);
-      setSuccess('Storage backend configured successfully');
+      setStorageSaving(true)
+      setError(null)
+      await api.saveSetupStorageConfig(setupToken, storageForm)
+      setStorageSaved(true)
+      setSuccess('Storage backend configured successfully')
     } catch (err: unknown) {
-      setError(getErrorMessage(err, 'Failed to save storage configuration'));
+      setError(getErrorMessage(err, 'Failed to save storage configuration'))
     } finally {
-      setStorageSaving(false);
+      setStorageSaving(false)
     }
-  };
+  }
 
   const testStorage = async () => {
     try {
-      setStorageTesting(true);
-      setError(null);
-      setStorageTestResult(null);
-      const result = await api.testSetupStorageConfig(setupToken, storageForm);
-      setStorageTestResult(result);
+      setStorageTesting(true)
+      setError(null)
+      setStorageTestResult(null)
+      const result = await api.testSetupStorageConfig(setupToken, storageForm)
+      setStorageTestResult(result)
       if (!result.success) {
-        setError(result.message);
+        setError(result.message)
       } else {
-        await saveStorage();
+        await saveStorage()
       }
     } catch (err: unknown) {
-      setError(getErrorMessage(err, 'Storage test failed'));
+      setError(getErrorMessage(err, 'Storage test failed'))
     } finally {
-      setStorageTesting(false);
+      setStorageTesting(false)
     }
-  };
+  }
 
   const changeStorageBackend = (type: StorageBackendType) => {
-    const newForm: StorageConfigInput = { backend_type: type };
+    const newForm: StorageConfigInput = { backend_type: type }
     switch (type) {
       case 'local':
-        newForm.local_base_path = './data/storage';
-        newForm.local_serve_directly = true;
-        break;
+        newForm.local_base_path = './data/storage'
+        newForm.local_serve_directly = true
+        break
       case 'azure':
-        newForm.azure_account_name = '';
-        newForm.azure_account_key = '';
-        newForm.azure_container_name = '';
-        break;
+        newForm.azure_account_name = ''
+        newForm.azure_account_key = ''
+        newForm.azure_container_name = ''
+        break
       case 's3':
-        newForm.s3_region = '';
-        newForm.s3_bucket = '';
-        newForm.s3_auth_method = 'access_key';
-        newForm.s3_access_key_id = '';
-        newForm.s3_secret_access_key = '';
-        break;
+        newForm.s3_region = ''
+        newForm.s3_bucket = ''
+        newForm.s3_auth_method = 'access_key'
+        newForm.s3_access_key_id = ''
+        newForm.s3_secret_access_key = ''
+        break
       case 'gcs':
-        newForm.gcs_bucket = '';
-        newForm.gcs_project_id = '';
-        newForm.gcs_auth_method = 'credentials_file';
-        break;
+        newForm.gcs_bucket = ''
+        newForm.gcs_project_id = ''
+        newForm.gcs_auth_method = 'credentials_file'
+        break
     }
-    setStorageForm(newForm);
-    setStorageTestResult(null);
-    setStorageSaved(false);
-  };
+    setStorageForm(newForm)
+    setStorageTestResult(null)
+    setStorageSaved(false)
+  }
 
   const testScanning = async () => {
     try {
-      setScanningTesting(true);
-      setError(null);
-      setScanningTestResult(null);
-      const result = await api.testScanningConfig(setupToken, scanningForm);
-      setScanningTestResult(result);
-      if (!result.success) setError(result.message);
+      setScanningTesting(true)
+      setError(null)
+      setScanningTestResult(null)
+      const result = await api.testScanningConfig(setupToken, scanningForm)
+      setScanningTestResult(result)
+      if (!result.success) setError(result.message)
     } catch (err: unknown) {
-      setError(getErrorMessage(err, 'Scanning test failed'));
+      setError(getErrorMessage(err, 'Scanning test failed'))
     } finally {
-      setScanningTesting(false);
+      setScanningTesting(false)
     }
-  };
+  }
 
   const saveScanning = async () => {
     try {
-      setScanningSaving(true);
-      setError(null);
-      await api.saveScanningConfig(setupToken, scanningForm);
-      setScanningSaved(true);
-      setSuccess('Security scanning configured successfully');
+      setScanningSaving(true)
+      setError(null)
+      await api.saveScanningConfig(setupToken, scanningForm)
+      setScanningSaved(true)
+      setSuccess('Security scanning configured successfully')
     } catch (err: unknown) {
-      setError(getErrorMessage(err, 'Failed to save scanning configuration'));
+      setError(getErrorMessage(err, 'Failed to save scanning configuration'))
     } finally {
-      setScanningSaving(false);
+      setScanningSaving(false)
     }
-  };
+  }
+
+  const installScanner = async (version?: string) => {
+    try {
+      setScanningInstalling(true)
+      setError(null)
+      setScanningInstallResult(null)
+      const result = await api.installScanningTool(setupToken, { tool: scanningForm.tool, version })
+      setScanningInstallResult(result)
+      if (result.success) {
+        setScanningForm({ ...scanningForm, binary_path: result.binary_path })
+        setSuccess(`${result.tool} ${result.version} installed successfully`)
+      } else {
+        setError(result.error || 'Scanner installation failed')
+      }
+    } catch (err: unknown) {
+      setError(getErrorMessage(err, 'Scanner installation failed'))
+    } finally {
+      setScanningInstalling(false)
+    }
+  }
 
   const saveAdmin = async () => {
     try {
-      setAdminSaving(true);
-      setError(null);
-      await api.configureAdmin(setupToken, { email: adminEmail.trim().toLowerCase() });
-      setAdminSaved(true);
-      setSuccess('Admin user configured successfully');
+      setAdminSaving(true)
+      setError(null)
+      await api.configureAdmin(setupToken, { email: adminEmail.trim().toLowerCase() })
+      setAdminSaved(true)
+      setSuccess('Admin user configured successfully')
     } catch (err: unknown) {
-      setError(getErrorMessage(err, 'Failed to configure admin user'));
+      setError(getErrorMessage(err, 'Failed to configure admin user'))
     } finally {
-      setAdminSaving(false);
+      setAdminSaving(false)
     }
-  };
+  }
 
   const completeSetup = async () => {
     try {
-      setCompleting(true);
-      setError(null);
-      const result = await api.completeSetup(setupToken);
-      setSuccess(result.message);
-      setTimeout(onSetupFinalized, 3000);
+      setCompleting(true)
+      setError(null)
+      const result = await api.completeSetup(setupToken)
+      setSuccess(result.message)
+      setTimeout(onSetupFinalized, 3000)
     } catch (err: unknown) {
-      setError(getErrorMessage(err, 'Failed to complete setup'));
+      setError(getErrorMessage(err, 'Failed to complete setup'))
     } finally {
-      setCompleting(false);
+      setCompleting(false)
     }
-  };
+  }
 
   const value: SetupWizardContextValue = {
-    loading, setupStatus, reloadStatus,
-    activeStep, goToStep, error, setError, success, setSuccess,
-    setupToken, setSetupToken, tokenValidating, tokenValid, validateToken,
-    authMethod, setAuthMethod,
-    oidcForm, setOidcForm, oidcTesting, oidcTestResult, oidcSaving, oidcSaved, testOIDC, saveOIDC,
-    ldapForm, setLdapForm, ldapTesting, ldapTestResult, ldapSaving, ldapSaved, testLDAP, saveLDAP,
-    storageForm, setStorageForm, changeStorageBackend,
-    storageTesting, storageTestResult, storageSaving, storageSaved, testStorage, saveStorage,
-    scanningForm, setScanningForm, scanningTesting, scanningTestResult, setScanningTestResult,
-    scanningSaving, scanningSaved, setScanningSaved, testScanning, saveScanning,
-    adminEmail, setAdminEmail, adminSaving, adminSaved, saveAdmin,
-    completing, completeSetup,
-  };
+    loading,
+    setupStatus,
+    reloadStatus,
+    activeStep,
+    goToStep,
+    error,
+    setError,
+    success,
+    setSuccess,
+    setupToken,
+    setSetupToken,
+    tokenValidating,
+    tokenValid,
+    validateToken,
+    authMethod,
+    setAuthMethod,
+    oidcForm,
+    setOidcForm,
+    oidcTesting,
+    oidcTestResult,
+    oidcSaving,
+    oidcSaved,
+    testOIDC,
+    saveOIDC,
+    ldapForm,
+    setLdapForm,
+    ldapTesting,
+    ldapTestResult,
+    ldapSaving,
+    ldapSaved,
+    testLDAP,
+    saveLDAP,
+    storageForm,
+    setStorageForm,
+    changeStorageBackend,
+    storageTesting,
+    storageTestResult,
+    storageSaving,
+    storageSaved,
+    testStorage,
+    saveStorage,
+    scanningForm,
+    setScanningForm,
+    scanningTesting,
+    scanningTestResult,
+    setScanningTestResult,
+    scanningSaving,
+    scanningSaved,
+    setScanningSaved,
+    testScanning,
+    saveScanning,
+    scanningInstalling,
+    scanningInstallResult,
+    installScanner,
+    adminEmail,
+    setAdminEmail,
+    adminSaving,
+    adminSaved,
+    saveAdmin,
+    completing,
+    completeSetup,
+  }
 
-  return <SetupWizardContext.Provider value={value}>{children}</SetupWizardContext.Provider>;
-};
+  return <SetupWizardContext.Provider value={value}>{children}</SetupWizardContext.Provider>
+}

--- a/frontend/src/contexts/__tests__/SetupWizardContext.test.tsx
+++ b/frontend/src/contexts/__tests__/SetupWizardContext.test.tsx
@@ -1,7 +1,7 @@
-import { render, act, waitFor, renderHook } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { SetupWizardProvider, useSetupWizard } from '../SetupWizardContext';
-import React from 'react';
+import { render, act, waitFor, renderHook } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { SetupWizardProvider, useSetupWizard } from '../SetupWizardContext'
+import React from 'react'
 
 const mockApi = vi.hoisted(() => ({
   getSetupStatus: vi.fn(),
@@ -14,99 +14,170 @@ const mockApi = vi.hoisted(() => ({
   saveSetupStorageConfig: vi.fn(),
   testScanningConfig: vi.fn(),
   saveScanningConfig: vi.fn(),
+  installScanningTool: vi.fn(),
   configureAdmin: vi.fn(),
   completeSetup: vi.fn(),
-}));
+}))
 
-vi.mock('../../services/api', () => ({ default: mockApi }));
+vi.mock('../../services/api', () => ({ default: mockApi }))
 
 function wrapper({ children }: { children: React.ReactNode }) {
   return (
-    <SetupWizardProvider onSetupCompleted={() => { }} onSetupFinalized={() => { }}>
+    <SetupWizardProvider onSetupCompleted={() => {}} onSetupFinalized={() => {}}>
       {children}
     </SetupWizardProvider>
-  );
+  )
 }
 
 describe('SetupWizardContext (roadmap 1.3)', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
-    mockApi.getSetupStatus.mockResolvedValue({ setup_completed: false });
-  });
+    vi.clearAllMocks()
+    mockApi.getSetupStatus.mockResolvedValue({ setup_completed: false })
+  })
 
   it('throws when used outside provider', () => {
-    const err = vi.spyOn(console, 'error').mockImplementation(() => { });
-    expect(() => renderHook(() => useSetupWizard())).toThrow(/must be used within a SetupWizardProvider/);
-    err.mockRestore();
-  });
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {})
+    expect(() => renderHook(() => useSetupWizard())).toThrow(
+      /must be used within a SetupWizardProvider/,
+    )
+    err.mockRestore()
+  })
 
   it('reloadStatus loads initial status and does not redirect on incomplete setup', async () => {
-    const { result } = renderHook(() => useSetupWizard(), { wrapper });
-    await waitFor(() => expect(result.current.loading).toBe(false));
-    expect(mockApi.getSetupStatus).toHaveBeenCalled();
-    expect(result.current.setupStatus?.setup_completed).toBe(false);
-    expect(result.current.activeStep).toBe(0);
-  });
+    const { result } = renderHook(() => useSetupWizard(), { wrapper })
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(mockApi.getSetupStatus).toHaveBeenCalled()
+    expect(result.current.setupStatus?.setup_completed).toBe(false)
+    expect(result.current.activeStep).toBe(0)
+  })
 
   it('redirects via onSetupCompleted when setup already complete', async () => {
-    mockApi.getSetupStatus.mockResolvedValue({ setup_completed: true });
-    const onCompleted = vi.fn();
+    mockApi.getSetupStatus.mockResolvedValue({ setup_completed: true })
+    const onCompleted = vi.fn()
     render(
-      <SetupWizardProvider onSetupCompleted={onCompleted} onSetupFinalized={() => { }}>
+      <SetupWizardProvider onSetupCompleted={onCompleted} onSetupFinalized={() => {}}>
         <div />
       </SetupWizardProvider>,
-    );
-    await waitFor(() => expect(onCompleted).toHaveBeenCalled());
-  });
+    )
+    await waitFor(() => expect(onCompleted).toHaveBeenCalled())
+  })
 
   it('goToStep updates activeStep and clears error/success', async () => {
-    const { result } = renderHook(() => useSetupWizard(), { wrapper });
-    await waitFor(() => expect(result.current.loading).toBe(false));
-    act(() => { result.current.setError('err'); result.current.setSuccess('ok'); });
-    act(() => { result.current.goToStep(3); });
-    expect(result.current.activeStep).toBe(3);
-    expect(result.current.error).toBeNull();
-    expect(result.current.success).toBeNull();
-  });
+    const { result } = renderHook(() => useSetupWizard(), { wrapper })
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    act(() => {
+      result.current.setError('err')
+      result.current.setSuccess('ok')
+    })
+    act(() => {
+      result.current.goToStep(3)
+    })
+    expect(result.current.activeStep).toBe(3)
+    expect(result.current.error).toBeNull()
+    expect(result.current.success).toBeNull()
+  })
 
   it('validateToken advances to step 1 on success', async () => {
-    mockApi.validateSetupToken.mockResolvedValue({ valid: true });
-    const { result } = renderHook(() => useSetupWizard(), { wrapper });
-    await waitFor(() => expect(result.current.loading).toBe(false));
-    act(() => { result.current.setSetupToken('tfr_setup_abc'); });
-    await act(async () => { await result.current.validateToken(); });
-    expect(result.current.tokenValid).toBe(true);
-    expect(result.current.activeStep).toBe(1);
-  });
+    mockApi.validateSetupToken.mockResolvedValue({ valid: true })
+    const { result } = renderHook(() => useSetupWizard(), { wrapper })
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    act(() => {
+      result.current.setSetupToken('tfr_setup_abc')
+    })
+    await act(async () => {
+      await result.current.validateToken()
+    })
+    expect(result.current.tokenValid).toBe(true)
+    expect(result.current.activeStep).toBe(1)
+  })
 
   it('validateToken surfaces error on invalid token', async () => {
-    mockApi.validateSetupToken.mockRejectedValue(new Error('bad token'));
-    const { result } = renderHook(() => useSetupWizard(), { wrapper });
-    await waitFor(() => expect(result.current.loading).toBe(false));
-    act(() => { result.current.setSetupToken('bad'); });
-    await act(async () => { await result.current.validateToken(); });
-    expect(result.current.tokenValid).toBe(false);
-    expect(result.current.error).toBeTruthy();
-  });
+    mockApi.validateSetupToken.mockRejectedValue(new Error('bad token'))
+    const { result } = renderHook(() => useSetupWizard(), { wrapper })
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    act(() => {
+      result.current.setSetupToken('bad')
+    })
+    await act(async () => {
+      await result.current.validateToken()
+    })
+    expect(result.current.tokenValid).toBe(false)
+    expect(result.current.error).toBeTruthy()
+  })
 
   it('changeStorageBackend resets form per backend type', async () => {
-    const { result } = renderHook(() => useSetupWizard(), { wrapper });
-    await waitFor(() => expect(result.current.loading).toBe(false));
-    act(() => { result.current.changeStorageBackend('s3'); });
-    expect(result.current.storageForm.backend_type).toBe('s3');
-    expect(result.current.storageForm.s3_region).toBe('');
-    expect(result.current.storageForm.s3_auth_method).toBe('access_key');
-    act(() => { result.current.changeStorageBackend('gcs'); });
-    expect(result.current.storageForm.backend_type).toBe('gcs');
-    expect(result.current.storageForm.gcs_auth_method).toBe('credentials_file');
-  });
+    const { result } = renderHook(() => useSetupWizard(), { wrapper })
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    act(() => {
+      result.current.changeStorageBackend('s3')
+    })
+    expect(result.current.storageForm.backend_type).toBe('s3')
+    expect(result.current.storageForm.s3_region).toBe('')
+    expect(result.current.storageForm.s3_auth_method).toBe('access_key')
+    act(() => {
+      result.current.changeStorageBackend('gcs')
+    })
+    expect(result.current.storageForm.backend_type).toBe('gcs')
+    expect(result.current.storageForm.gcs_auth_method).toBe('credentials_file')
+  })
 
   it('saveOIDC flips oidcSaved on success', async () => {
-    mockApi.saveOIDCConfig.mockResolvedValue({});
-    const { result } = renderHook(() => useSetupWizard(), { wrapper });
-    await waitFor(() => expect(result.current.loading).toBe(false));
-    await act(async () => { await result.current.saveOIDC(); });
-    expect(result.current.oidcSaved).toBe(true);
-    expect(result.current.success).toMatch(/OIDC/i);
-  });
-});
+    mockApi.saveOIDCConfig.mockResolvedValue({})
+    const { result } = renderHook(() => useSetupWizard(), { wrapper })
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    await act(async () => {
+      await result.current.saveOIDC()
+    })
+    expect(result.current.oidcSaved).toBe(true)
+    expect(result.current.success).toMatch(/OIDC/i)
+  })
+
+  it('installScanner updates binary_path and sets result on success', async () => {
+    mockApi.installScanningTool.mockResolvedValue({
+      success: true,
+      tool: 'trivy',
+      version: '0.58.0',
+      binary_path: '/app/scanners/trivy',
+      sha256: 'abc123',
+      source_url: 'https://example.com',
+    })
+    const { result } = renderHook(() => useSetupWizard(), { wrapper })
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    await act(async () => {
+      await result.current.installScanner()
+    })
+    expect(result.current.scanningInstallResult?.success).toBe(true)
+    expect(result.current.scanningForm.binary_path).toBe('/app/scanners/trivy')
+    expect(result.current.scanningInstalling).toBe(false)
+  })
+
+  it('installScanner sets error on failure', async () => {
+    mockApi.installScanningTool.mockResolvedValue({
+      success: false,
+      tool: 'trivy',
+      version: '',
+      binary_path: '',
+      sha256: '',
+      source_url: '',
+      error: 'no matching asset',
+    })
+    const { result } = renderHook(() => useSetupWizard(), { wrapper })
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    await act(async () => {
+      await result.current.installScanner()
+    })
+    expect(result.current.scanningInstallResult?.success).toBe(false)
+    expect(result.current.error).toMatch(/no matching asset/)
+  })
+
+  it('installScanner handles network error', async () => {
+    mockApi.installScanningTool.mockRejectedValue(new Error('network error'))
+    const { result } = renderHook(() => useSetupWizard(), { wrapper })
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    await act(async () => {
+      await result.current.installScanner()
+    })
+    expect(result.current.error).toBeTruthy()
+    expect(result.current.scanningInstalling).toBe(false)
+  })
+})

--- a/frontend/src/pages/__tests__/SetupWizardPage.test.tsx
+++ b/frontend/src/pages/__tests__/SetupWizardPage.test.tsx
@@ -34,6 +34,7 @@ vi.mock('../../services/api', () => ({
     saveSetupStorageConfig: (...args: unknown[]) => saveSetupStorageConfigMock(...args),
     testScanningConfig: (...args: unknown[]) => testScanningConfigMock(...args),
     saveScanningConfig: (...args: unknown[]) => saveScanningConfigMock(...args),
+    installScanningTool: vi.fn(),
     configureAdmin: vi.fn(),
     completeSetup: vi.fn(),
   },
@@ -48,7 +49,7 @@ function renderPage() {
   return render(
     <MemoryRouter initialEntries={['/setup']}>
       <SetupWizardPage />
-    </MemoryRouter>
+    </MemoryRouter>,
   )
 }
 
@@ -188,256 +189,304 @@ describe('SetupWizardPage — Security Scanning step', () => {
 
   // ── Scanning step navigation ──
 
-  it('navigates from Storage to Security Scanning step', async () => {
-    renderPage()
-    await waitFor(() => {
-      expect(screen.getByRole('heading', { name: /Setup Token/i })).toBeInTheDocument()
-    })
+  it(
+    'navigates from Storage to Security Scanning step',
+    async () => {
+      renderPage()
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: /Setup Token/i })).toBeInTheDocument()
+      })
 
-    await advanceToStep(3)
+      await advanceToStep(3)
 
-    expect(screen.getByLabelText(/Enable security scanning/i)).toBeInTheDocument()
-  }, STEP3_TIMEOUT)
+      expect(screen.getByLabelText(/Enable security scanning/i)).toBeInTheDocument()
+    },
+    STEP3_TIMEOUT,
+  )
 
   // ── Scanning skip ──
 
-  it('shows Skip button when scanning is disabled', async () => {
-    renderPage()
-    await waitFor(() => {
-      expect(screen.getByRole('heading', { name: /Setup Token/i })).toBeInTheDocument()
-    })
+  it(
+    'shows Skip button when scanning is disabled',
+    async () => {
+      renderPage()
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: /Setup Token/i })).toBeInTheDocument()
+      })
 
-    await advanceToStep(3)
+      await advanceToStep(3)
 
-    expect(screen.getByRole('button', { name: /Skip/i })).toBeInTheDocument()
-  }, STEP3_TIMEOUT)
+      expect(screen.getByRole('button', { name: /Skip/i })).toBeInTheDocument()
+    },
+    STEP3_TIMEOUT,
+  )
 
-  it('skipping scanning advances to Admin step', async () => {
-    renderPage()
-    await waitFor(() => {
-      expect(screen.getByRole('heading', { name: /Setup Token/i })).toBeInTheDocument()
-    })
+  it(
+    'skipping scanning advances to Admin step',
+    async () => {
+      renderPage()
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: /Setup Token/i })).toBeInTheDocument()
+      })
 
-    const user = await advanceToStep(3)
+      const user = await advanceToStep(3)
 
-    await user.click(screen.getByRole('button', { name: /Skip/i }))
+      await user.click(screen.getByRole('button', { name: /Skip/i }))
 
-    await waitFor(() => {
-      expect(screen.getByText('Initial Admin User')).toBeInTheDocument()
-    })
-  }, STEP3_TIMEOUT)
+      await waitFor(() => {
+        expect(screen.getByText('Initial Admin User')).toBeInTheDocument()
+      })
+    },
+    STEP3_TIMEOUT,
+  )
 
   // ── Scanning enable/toggle ──
 
-  it('hides Skip button when scanning is enabled', async () => {
-    renderPage()
-    await waitFor(() => {
-      expect(screen.getByRole('heading', { name: /Setup Token/i })).toBeInTheDocument()
-    })
+  it(
+    'hides Skip button when scanning is enabled',
+    async () => {
+      renderPage()
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: /Setup Token/i })).toBeInTheDocument()
+      })
 
-    const user = await advanceToStep(3)
+      const user = await advanceToStep(3)
 
-    const toggle = screen.getByLabelText(/Enable security scanning/i)
-    await user.click(toggle)
+      const toggle = screen.getByLabelText(/Enable security scanning/i)
+      await user.click(toggle)
 
-    expect(screen.queryByRole('button', { name: /^Skip$/i })).not.toBeInTheDocument()
-  }, STEP3_TIMEOUT)
+      expect(screen.queryByRole('button', { name: /^Skip$/i })).not.toBeInTheDocument()
+    },
+    STEP3_TIMEOUT,
+  )
 
-  it('shows scanning fields when enabled', async () => {
-    renderPage()
-    await waitFor(() => {
-      expect(screen.getByRole('heading', { name: /Setup Token/i })).toBeInTheDocument()
-    })
+  it(
+    'shows scanning fields when enabled',
+    async () => {
+      renderPage()
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: /Setup Token/i })).toBeInTheDocument()
+      })
 
-    const user = await advanceToStep(3)
+      const user = await advanceToStep(3)
 
-    const toggle = screen.getByLabelText(/Enable security scanning/i)
-    await user.click(toggle)
+      const toggle = screen.getByLabelText(/Enable security scanning/i)
+      await user.click(toggle)
 
-    // MUI Select renders label text in multiple places; use getAllByText
-    await waitFor(() => {
-      expect(screen.getAllByText(/Scanning Tool/i).length).toBeGreaterThan(0)
-    })
-    expect(screen.getByLabelText(/Binary Path/i)).toBeInTheDocument()
-    expect(screen.getByLabelText(/Severity Threshold/i)).toBeInTheDocument()
-    // Verify Test and Save buttons are present
-    expect(screen.getByRole('button', { name: /Test Configuration/i })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /Save Scanning Configuration/i })).toBeInTheDocument()
-  }, STEP3_TIMEOUT)
+      // MUI Select renders label text in multiple places; use getAllByText
+      await waitFor(() => {
+        expect(screen.getAllByText(/Scanning Tool/i).length).toBeGreaterThan(0)
+      })
+      expect(screen.getByLabelText(/Binary Path/i)).toBeInTheDocument()
+      expect(screen.getByLabelText(/Severity Threshold/i)).toBeInTheDocument()
+      // Verify Test and Save buttons are present
+      expect(screen.getByRole('button', { name: /Test Configuration/i })).toBeInTheDocument()
+      expect(
+        screen.getByRole('button', { name: /Save Scanning Configuration/i }),
+      ).toBeInTheDocument()
+    },
+    STEP3_TIMEOUT,
+  )
 
   // ── Scanning test ──
 
-  it('calls testScanningConfig when Test Configuration is clicked', async () => {
-    testScanningConfigMock.mockResolvedValue({
-      success: true,
-      message: 'Trivy found and working',
-      tool: 'trivy',
-      version: '0.50.0',
-    })
+  it(
+    'calls testScanningConfig when Test Configuration is clicked',
+    async () => {
+      testScanningConfigMock.mockResolvedValue({
+        success: true,
+        message: 'Trivy found and working',
+        tool: 'trivy',
+        version: '0.50.0',
+      })
 
-    renderPage()
-    await waitFor(() => {
-      expect(screen.getByRole('heading', { name: /Setup Token/i })).toBeInTheDocument()
-    })
+      renderPage()
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: /Setup Token/i })).toBeInTheDocument()
+      })
 
-    const user = await advanceToStep(3)
-    await user.click(screen.getByLabelText(/Enable security scanning/i))
+      const user = await advanceToStep(3)
+      await user.click(screen.getByLabelText(/Enable security scanning/i))
 
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: /Test Configuration/i })).toBeInTheDocument()
-    })
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /Test Configuration/i })).toBeInTheDocument()
+      })
 
-    await user.click(screen.getByRole('button', { name: /Test Configuration/i }))
+      await user.click(screen.getByRole('button', { name: /Test Configuration/i }))
 
-    await waitFor(() => {
-      expect(testScanningConfigMock).toHaveBeenCalledTimes(1)
-    })
+      await waitFor(() => {
+        expect(testScanningConfigMock).toHaveBeenCalledTimes(1)
+      })
 
-    await waitFor(() => {
-      expect(screen.getByText(/Trivy found and working/)).toBeInTheDocument()
-    })
-  }, STEP3_TIMEOUT)
+      await waitFor(() => {
+        expect(screen.getByText(/Trivy found and working/)).toBeInTheDocument()
+      })
+    },
+    STEP3_TIMEOUT,
+  )
 
-  it('displays version info on successful test', async () => {
-    testScanningConfigMock.mockResolvedValue({
-      success: true,
-      message: 'Trivy found and working',
-      tool: 'trivy',
-      version: '0.50.0',
-    })
+  it(
+    'displays version info on successful test',
+    async () => {
+      testScanningConfigMock.mockResolvedValue({
+        success: true,
+        message: 'Trivy found and working',
+        tool: 'trivy',
+        version: '0.50.0',
+      })
 
-    renderPage()
-    await waitFor(() => {
-      expect(screen.getByRole('heading', { name: /Setup Token/i })).toBeInTheDocument()
-    })
+      renderPage()
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: /Setup Token/i })).toBeInTheDocument()
+      })
 
-    const user = await advanceToStep(3)
-    await user.click(screen.getByLabelText(/Enable security scanning/i))
+      const user = await advanceToStep(3)
+      await user.click(screen.getByLabelText(/Enable security scanning/i))
 
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: /Test Configuration/i })).toBeInTheDocument()
-    })
-    await user.click(screen.getByRole('button', { name: /Test Configuration/i }))
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /Test Configuration/i })).toBeInTheDocument()
+      })
+      await user.click(screen.getByRole('button', { name: /Test Configuration/i }))
 
-    await waitFor(() => {
-      expect(screen.getByText(/Detected version: 0\.50\.0/)).toBeInTheDocument()
-    })
-  }, STEP3_TIMEOUT)
+      await waitFor(() => {
+        expect(screen.getByText(/Detected version: 0\.50\.0/)).toBeInTheDocument()
+      })
+    },
+    STEP3_TIMEOUT,
+  )
 
-  it('shows error when scanning test fails', async () => {
-    testScanningConfigMock.mockResolvedValue({
-      success: false,
-      message: 'trivy binary not found',
-    })
+  it(
+    'shows error when scanning test fails',
+    async () => {
+      testScanningConfigMock.mockResolvedValue({
+        success: false,
+        message: 'trivy binary not found',
+      })
 
-    renderPage()
-    await waitFor(() => {
-      expect(screen.getByRole('heading', { name: /Setup Token/i })).toBeInTheDocument()
-    })
+      renderPage()
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: /Setup Token/i })).toBeInTheDocument()
+      })
 
-    const user = await advanceToStep(3)
-    await user.click(screen.getByLabelText(/Enable security scanning/i))
+      const user = await advanceToStep(3)
+      await user.click(screen.getByLabelText(/Enable security scanning/i))
 
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: /Test Configuration/i })).toBeInTheDocument()
-    })
-    await user.click(screen.getByRole('button', { name: /Test Configuration/i }))
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /Test Configuration/i })).toBeInTheDocument()
+      })
+      await user.click(screen.getByRole('button', { name: /Test Configuration/i }))
 
-    // The error message appears in both the scanning result area and the top-level alert
-    await waitFor(() => {
-      expect(screen.getAllByText(/trivy binary not found/).length).toBeGreaterThan(0)
-    })
-  }, STEP3_TIMEOUT)
+      // The error message appears in both the scanning result area and the top-level alert
+      await waitFor(() => {
+        expect(screen.getAllByText(/trivy binary not found/).length).toBeGreaterThan(0)
+      })
+    },
+    STEP3_TIMEOUT,
+  )
 
   // ── Scanning save ──
 
-  it('enables Save button only after successful test', async () => {
-    testScanningConfigMock.mockResolvedValue({
-      success: true,
-      message: 'Scanner OK',
-      tool: 'trivy',
-      version: '0.50.0',
-    })
-    saveScanningConfigMock.mockResolvedValue({ message: 'Scanning configured' })
+  it(
+    'enables Save button only after successful test',
+    async () => {
+      testScanningConfigMock.mockResolvedValue({
+        success: true,
+        message: 'Scanner OK',
+        tool: 'trivy',
+        version: '0.50.0',
+      })
+      saveScanningConfigMock.mockResolvedValue({ message: 'Scanning configured' })
 
-    renderPage()
-    await waitFor(() => {
-      expect(screen.getByRole('heading', { name: /Setup Token/i })).toBeInTheDocument()
-    })
+      renderPage()
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: /Setup Token/i })).toBeInTheDocument()
+      })
 
-    const user = await advanceToStep(3)
-    await user.click(screen.getByLabelText(/Enable security scanning/i))
+      const user = await advanceToStep(3)
+      await user.click(screen.getByLabelText(/Enable security scanning/i))
 
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: /Save Scanning Configuration/i })).toBeInTheDocument()
-    })
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: /Save Scanning Configuration/i }),
+        ).toBeInTheDocument()
+      })
 
-    // Save should be disabled before test
-    expect(screen.getByRole('button', { name: /Save Scanning Configuration/i })).toBeDisabled()
+      // Save should be disabled before test
+      expect(screen.getByRole('button', { name: /Save Scanning Configuration/i })).toBeDisabled()
 
-    // Run test
-    await user.click(screen.getByRole('button', { name: /Test Configuration/i }))
-    await waitFor(() => {
-      expect(screen.getByText(/Scanner OK/)).toBeInTheDocument()
-    })
+      // Run test
+      await user.click(screen.getByRole('button', { name: /Test Configuration/i }))
+      await waitFor(() => {
+        expect(screen.getByText(/Scanner OK/)).toBeInTheDocument()
+      })
 
-    // Now Save should be enabled
-    expect(screen.getByRole('button', { name: /Save Scanning Configuration/i })).toBeEnabled()
-  }, STEP3_TIMEOUT)
+      // Now Save should be enabled
+      expect(screen.getByRole('button', { name: /Save Scanning Configuration/i })).toBeEnabled()
+    },
+    STEP3_TIMEOUT,
+  )
 
-  it('calls saveScanningConfig and shows Next button after save', async () => {
-    testScanningConfigMock.mockResolvedValue({
-      success: true,
-      message: 'Scanner OK',
-      tool: 'trivy',
-      version: '0.50.0',
-    })
-    saveScanningConfigMock.mockResolvedValue({ message: 'Scanning configured' })
+  it(
+    'calls saveScanningConfig and shows Next button after save',
+    async () => {
+      testScanningConfigMock.mockResolvedValue({
+        success: true,
+        message: 'Scanner OK',
+        tool: 'trivy',
+        version: '0.50.0',
+      })
+      saveScanningConfigMock.mockResolvedValue({ message: 'Scanning configured' })
 
-    renderPage()
-    await waitFor(() => {
-      expect(screen.getByRole('heading', { name: /Setup Token/i })).toBeInTheDocument()
-    })
+      renderPage()
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: /Setup Token/i })).toBeInTheDocument()
+      })
 
-    const user = await advanceToStep(3)
-    await user.click(screen.getByLabelText(/Enable security scanning/i))
+      const user = await advanceToStep(3)
+      await user.click(screen.getByLabelText(/Enable security scanning/i))
 
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: /Test Configuration/i })).toBeInTheDocument()
-    })
-    await user.click(screen.getByRole('button', { name: /Test Configuration/i }))
-    await waitFor(() => {
-      expect(screen.getByText(/Scanner OK/)).toBeInTheDocument()
-    })
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /Test Configuration/i })).toBeInTheDocument()
+      })
+      await user.click(screen.getByRole('button', { name: /Test Configuration/i }))
+      await waitFor(() => {
+        expect(screen.getByText(/Scanner OK/)).toBeInTheDocument()
+      })
 
-    await user.click(screen.getByRole('button', { name: /Save Scanning Configuration/i }))
+      await user.click(screen.getByRole('button', { name: /Save Scanning Configuration/i }))
 
-    await waitFor(() => {
-      expect(saveScanningConfigMock).toHaveBeenCalledTimes(1)
-    })
+      await waitFor(() => {
+        expect(saveScanningConfigMock).toHaveBeenCalledTimes(1)
+      })
 
-    await waitFor(() => {
-      expect(screen.getByText(/Next: Configure Admin/)).toBeInTheDocument()
-    })
-  }, STEP3_TIMEOUT)
+      await waitFor(() => {
+        expect(screen.getByText(/Next: Configure Admin/)).toBeInTheDocument()
+      })
+    },
+    STEP3_TIMEOUT,
+  )
 
   // ── Back navigation ──
 
-  it('Back button on scanning step goes to Storage step', async () => {
-    renderPage()
-    await waitFor(() => {
-      expect(screen.getByRole('heading', { name: /Setup Token/i })).toBeInTheDocument()
-    })
+  it(
+    'Back button on scanning step goes to Storage step',
+    async () => {
+      renderPage()
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: /Setup Token/i })).toBeInTheDocument()
+      })
 
-    const user = await advanceToStep(3)
+      const user = await advanceToStep(3)
 
-    const backButton = screen.getByRole('button', { name: /Back/i })
-    await user.click(backButton)
+      const backButton = screen.getByRole('button', { name: /Back/i })
+      await user.click(backButton)
 
-    await waitFor(() => {
-      expect(screen.getByText('Storage Backend Configuration')).toBeInTheDocument()
-    })
-  }, STEP3_TIMEOUT)
+      await waitFor(() => {
+        expect(screen.getByText('Storage Backend Configuration')).toBeInTheDocument()
+      })
+    },
+    STEP3_TIMEOUT,
+  )
 
   // ── Setup status with scanning_configured ──
 

--- a/frontend/src/pages/setup/steps/ScanningStep.tsx
+++ b/frontend/src/pages/setup/steps/ScanningStep.tsx
@@ -1,32 +1,69 @@
-import React from 'react';
+import React, { useState } from 'react'
 import {
-  Box, Typography, Stack, FormControlLabel, Switch, Collapse, FormControl, InputLabel,
-  Select, MenuItem, TextField, Alert, Button, CircularProgress,
-} from '@mui/material';
-import ShieldIcon from '@mui/icons-material/Shield';
-import { useSetupWizard } from '../../../contexts/SetupWizardContext';
+  Box,
+  Typography,
+  Stack,
+  FormControlLabel,
+  Switch,
+  Collapse,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  TextField,
+  Alert,
+  Button,
+  CircularProgress,
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
+} from '@mui/material'
+import ShieldIcon from '@mui/icons-material/Shield'
+import DownloadIcon from '@mui/icons-material/Download'
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
+import { useSetupWizard } from '../../../contexts/SetupWizardContext'
+
+const INSTALLABLE_TOOLS = ['trivy', 'checkov', 'terrascan']
 
 const ScanningStep: React.FC = () => {
   const {
     setupStatus,
-    scanningForm, setScanningForm, scanningTesting, scanningTestResult, setScanningTestResult,
-    scanningSaving, scanningSaved, setScanningSaved, testScanning, saveScanning, goToStep,
-  } = useSetupWizard();
+    scanningForm,
+    setScanningForm,
+    scanningTesting,
+    scanningTestResult,
+    setScanningTestResult,
+    scanningSaving,
+    scanningSaved,
+    setScanningSaved,
+    testScanning,
+    saveScanning,
+    goToStep,
+    scanningInstalling,
+    scanningInstallResult,
+    installScanner,
+  } = useSetupWizard()
 
-  const isPending = setupStatus?.pending_feature_setup ?? false;
-  const backStep = isPending ? 0 : 2;
-  const nextStep = isPending ? 5 : 4;
-  const nextLabel = isPending ? 'Next: Review & Complete' : 'Next: Configure Admin';
+  const [pinnedVersion, setPinnedVersion] = useState('')
+
+  const isPending = setupStatus?.pending_feature_setup ?? false
+  const backStep = isPending ? 0 : 2
+  const nextStep = isPending ? 5 : 4
+  const nextLabel = isPending ? 'Next: Review & Complete' : 'Next: Configure Admin'
+
+  const canAutoInstall = INSTALLABLE_TOOLS.includes(scanningForm.tool)
 
   return (
     <Box>
       <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
         <ShieldIcon sx={{ mr: 1, color: 'primary.main' }} />
-        <Typography variant="h6" component="h2">Security Scanning</Typography>
+        <Typography variant="h6" component="h2">
+          Security Scanning
+        </Typography>
       </Box>
       <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
-        Optionally configure a security scanning tool to automatically scan Terraform
-        modules and providers for vulnerabilities when they are published.
+        Optionally configure a security scanning tool to automatically scan Terraform modules and
+        providers for vulnerabilities when they are published.
       </Typography>
 
       <Stack spacing={2}>
@@ -35,9 +72,9 @@ const ScanningStep: React.FC = () => {
             <Switch
               checked={scanningForm.enabled}
               onChange={(e) => {
-                setScanningForm({ ...scanningForm, enabled: e.target.checked });
-                setScanningTestResult(null);
-                setScanningSaved(false);
+                setScanningForm({ ...scanningForm, enabled: e.target.checked })
+                setScanningTestResult(null)
+                setScanningSaved(false)
               }}
             />
           }
@@ -52,9 +89,9 @@ const ScanningStep: React.FC = () => {
                 value={scanningForm.tool}
                 label="Scanning Tool"
                 onChange={(e) => {
-                  setScanningForm({ ...scanningForm, tool: e.target.value });
-                  setScanningTestResult(null);
-                  setScanningSaved(false);
+                  setScanningForm({ ...scanningForm, tool: e.target.value })
+                  setScanningTestResult(null)
+                  setScanningSaved(false)
                 }}
               >
                 <MenuItem value="trivy">Trivy</MenuItem>
@@ -64,6 +101,73 @@ const ScanningStep: React.FC = () => {
                 <MenuItem value="custom">Custom</MenuItem>
               </Select>
             </FormControl>
+
+            {canAutoInstall && (
+              <Box sx={{ border: 1, borderColor: 'divider', borderRadius: 1, p: 2 }}>
+                <Typography variant="subtitle2" sx={{ mb: 1 }}>
+                  <DownloadIcon sx={{ fontSize: 18, mr: 0.5, verticalAlign: 'text-bottom' }} />
+                  Auto-Install
+                </Typography>
+                <Typography variant="body2" color="text.secondary" sx={{ mb: 1.5 }}>
+                  Download the official release, verify the SHA256 checksum, and install the binary
+                  on the server.
+                </Typography>
+
+                <Accordion
+                  variant="outlined"
+                  disableGutters
+                  sx={{ mb: 1.5, '&:before': { display: 'none' } }}
+                >
+                  <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                    <Typography variant="body2">Advanced: pin a specific version</Typography>
+                  </AccordionSummary>
+                  <AccordionDetails>
+                    <TextField
+                      fullWidth
+                      size="small"
+                      label="Version (optional)"
+                      value={pinnedVersion}
+                      onChange={(e) => setPinnedVersion(e.target.value)}
+                      placeholder="e.g. 0.58.0"
+                      helperText="Leave blank to install the latest release."
+                    />
+                  </AccordionDetails>
+                </Accordion>
+
+                <Button
+                  variant="outlined"
+                  startIcon={scanningInstalling ? <CircularProgress size={18} /> : <DownloadIcon />}
+                  onClick={() => installScanner(pinnedVersion || undefined)}
+                  disabled={scanningInstalling}
+                >
+                  {scanningInstalling ? 'Installing…' : `Install ${scanningForm.tool}`}
+                </Button>
+
+                {scanningInstallResult && (
+                  <Alert
+                    severity={scanningInstallResult.success ? 'success' : 'error'}
+                    sx={{ mt: 1.5 }}
+                  >
+                    {scanningInstallResult.success ? (
+                      <>
+                        Installed{' '}
+                        <strong>
+                          {scanningInstallResult.tool} {scanningInstallResult.version}
+                        </strong>
+                        <Typography variant="body2" sx={{ mt: 0.5 }}>
+                          Path: <code>{scanningInstallResult.binary_path}</code>
+                        </Typography>
+                        <Typography variant="body2">
+                          SHA256: <code>{scanningInstallResult.sha256?.slice(0, 16)}…</code>
+                        </Typography>
+                      </>
+                    ) : (
+                      scanningInstallResult.error || 'Installation failed'
+                    )}
+                  </Alert>
+                )}
+              </Box>
+            )}
 
             <TextField
               fullWidth
@@ -78,7 +182,9 @@ const ScanningStep: React.FC = () => {
               fullWidth
               label="Severity Threshold (optional)"
               value={scanningForm.severity_threshold || ''}
-              onChange={(e) => setScanningForm({ ...scanningForm, severity_threshold: e.target.value })}
+              onChange={(e) =>
+                setScanningForm({ ...scanningForm, severity_threshold: e.target.value })
+              }
               placeholder="HIGH"
               helperText="Minimum severity to report (e.g. LOW, MEDIUM, HIGH, CRITICAL)"
             />
@@ -106,7 +212,7 @@ const ScanningStep: React.FC = () => {
               <Button
                 variant="contained"
                 onClick={saveScanning}
-                disabled={scanningSaving || (!scanningTestResult?.success)}
+                disabled={scanningSaving || !scanningTestResult?.success}
               >
                 {scanningSaving ? <CircularProgress size={20} sx={{ mr: 1 }} /> : null}
                 Save Scanning Configuration
@@ -116,13 +222,15 @@ const ScanningStep: React.FC = () => {
         </Collapse>
 
         <Stack direction="row" spacing={2}>
-          <Button variant="text" onClick={() => goToStep(backStep)}>&#8592; Back</Button>
+          <Button variant="text" onClick={() => goToStep(backStep)}>
+            &#8592; Back
+          </Button>
           {!scanningForm.enabled && (
             <Button
               variant="outlined"
               onClick={() => {
-                setScanningSaved(true);
-                goToStep(nextStep);
+                setScanningSaved(true)
+                goToStep(nextStep)
               }}
             >
               Skip
@@ -139,7 +247,7 @@ const ScanningStep: React.FC = () => {
         )}
       </Stack>
     </Box>
-  );
-};
+  )
+}
 
-export default ScanningStep;
+export default ScanningStep

--- a/frontend/src/pages/setup/steps/__tests__/ScanningStep.test.tsx
+++ b/frontend/src/pages/setup/steps/__tests__/ScanningStep.test.tsx
@@ -15,6 +15,17 @@ const mockCtx = {
   testScanning: vi.fn(),
   saveScanning: vi.fn(),
   goToStep: vi.fn(),
+  scanningInstalling: false,
+  scanningInstallResult: null as {
+    success: boolean
+    tool: string
+    version: string
+    binary_path: string
+    sha256: string
+    source_url: string
+    error?: string
+  } | null,
+  installScanner: vi.fn(),
 }
 
 vi.mock('../../../../contexts/SetupWizardContext', () => ({
@@ -32,6 +43,8 @@ beforeEach(() => {
     scanningTestResult: null,
     scanningSaving: false,
     scanningSaved: false,
+    scanningInstalling: false,
+    scanningInstallResult: null,
   })
 })
 
@@ -54,55 +67,103 @@ describe('ScanningStep', () => {
   })
 
   it('shows scanning fields when enabled', () => {
-    mockCtx.scanningForm = { enabled: true, tool: 'trivy', binary_path: '', severity_threshold: '' }
+    mockCtx.scanningForm = {
+      enabled: true,
+      tool: 'trivy',
+      binary_path: '',
+      severity_threshold: '',
+    }
     render(<ScanningStep />)
     expect(screen.getByLabelText('Binary Path')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /Test Configuration/i })).toBeInTheDocument()
   })
 
   it('hides Skip button when enabled', () => {
-    mockCtx.scanningForm = { enabled: true, tool: 'trivy', binary_path: '', severity_threshold: '' }
+    mockCtx.scanningForm = {
+      enabled: true,
+      tool: 'trivy',
+      binary_path: '',
+      severity_threshold: '',
+    }
     render(<ScanningStep />)
     expect(screen.queryByRole('button', { name: /Skip/i })).not.toBeInTheDocument()
   })
 
   it('calls testScanning on Test button click', async () => {
-    mockCtx.scanningForm = { enabled: true, tool: 'trivy', binary_path: '', severity_threshold: '' }
+    mockCtx.scanningForm = {
+      enabled: true,
+      tool: 'trivy',
+      binary_path: '',
+      severity_threshold: '',
+    }
     render(<ScanningStep />)
     await userEvent.setup().click(screen.getByRole('button', { name: /Test Configuration/i }))
     expect(mockCtx.testScanning).toHaveBeenCalledOnce()
   })
 
   it('disables Save button when test has not succeeded', () => {
-    mockCtx.scanningForm = { enabled: true, tool: 'trivy', binary_path: '', severity_threshold: '' }
+    mockCtx.scanningForm = {
+      enabled: true,
+      tool: 'trivy',
+      binary_path: '',
+      severity_threshold: '',
+    }
     render(<ScanningStep />)
     expect(screen.getByRole('button', { name: /Save Scanning/i })).toBeDisabled()
   })
 
   it('enables Save button after successful test', () => {
-    mockCtx.scanningForm = { enabled: true, tool: 'trivy', binary_path: '', severity_threshold: '' }
-    mockCtx.scanningTestResult = { success: true, message: 'Trivy found', version: '0.50.0' }
+    mockCtx.scanningForm = {
+      enabled: true,
+      tool: 'trivy',
+      binary_path: '',
+      severity_threshold: '',
+    }
+    mockCtx.scanningTestResult = {
+      success: true,
+      message: 'Trivy found',
+      version: '0.50.0',
+    }
     render(<ScanningStep />)
     expect(screen.getByRole('button', { name: /Save Scanning/i })).toBeEnabled()
   })
 
   it('shows test result alert on success', () => {
-    mockCtx.scanningForm = { enabled: true, tool: 'trivy', binary_path: '', severity_threshold: '' }
-    mockCtx.scanningTestResult = { success: true, message: 'Trivy found', version: '0.50.0' }
+    mockCtx.scanningForm = {
+      enabled: true,
+      tool: 'trivy',
+      binary_path: '',
+      severity_threshold: '',
+    }
+    mockCtx.scanningTestResult = {
+      success: true,
+      message: 'Trivy found',
+      version: '0.50.0',
+    }
     render(<ScanningStep />)
     expect(screen.getByText(/Trivy found/)).toBeInTheDocument()
     expect(screen.getByText(/0\.50\.0/)).toBeInTheDocument()
   })
 
   it('shows test result alert on error', () => {
-    mockCtx.scanningForm = { enabled: true, tool: 'trivy', binary_path: '', severity_threshold: '' }
+    mockCtx.scanningForm = {
+      enabled: true,
+      tool: 'trivy',
+      binary_path: '',
+      severity_threshold: '',
+    }
     mockCtx.scanningTestResult = { success: false, message: 'Trivy not found' }
     render(<ScanningStep />)
     expect(screen.getByText(/Trivy not found/)).toBeInTheDocument()
   })
 
   it('shows Next button when saved and enabled', () => {
-    mockCtx.scanningForm = { enabled: true, tool: 'trivy', binary_path: '', severity_threshold: '' }
+    mockCtx.scanningForm = {
+      enabled: true,
+      tool: 'trivy',
+      binary_path: '',
+      severity_threshold: '',
+    }
     mockCtx.scanningSaved = true
     render(<ScanningStep />)
     expect(screen.getByRole('button', { name: /Next: Configure Admin/i })).toBeInTheDocument()
@@ -130,17 +191,138 @@ describe('ScanningStep', () => {
   })
 
   it('disables Test button when scanningTesting', () => {
-    mockCtx.scanningForm = { enabled: true, tool: 'trivy', binary_path: '', severity_threshold: '' }
+    mockCtx.scanningForm = {
+      enabled: true,
+      tool: 'trivy',
+      binary_path: '',
+      severity_threshold: '',
+    }
     mockCtx.scanningTesting = true
     render(<ScanningStep />)
     expect(screen.getByRole('button', { name: /Test Configuration/i })).toBeDisabled()
   })
 
   it('disables Save button when scanningSaving', () => {
-    mockCtx.scanningForm = { enabled: true, tool: 'trivy', binary_path: '', severity_threshold: '' }
+    mockCtx.scanningForm = {
+      enabled: true,
+      tool: 'trivy',
+      binary_path: '',
+      severity_threshold: '',
+    }
     mockCtx.scanningSaving = true
     render(<ScanningStep />)
     expect(screen.getByRole('button', { name: /Save Scanning/i })).toBeDisabled()
+  })
+})
+
+describe('ScanningStep — auto-install', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    Object.assign(mockCtx, {
+      setupStatus: null,
+      scanningForm: {
+        enabled: true,
+        tool: 'trivy',
+        binary_path: '',
+        severity_threshold: '',
+      },
+      scanningTesting: false,
+      scanningTestResult: null,
+      scanningSaving: false,
+      scanningSaved: false,
+      scanningInstalling: false,
+      scanningInstallResult: null,
+    })
+  })
+
+  it('shows auto-install panel for installable tools', () => {
+    render(<ScanningStep />)
+    expect(screen.getByText('Auto-Install')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Install trivy/i })).toBeInTheDocument()
+  })
+
+  it('hides auto-install panel for snyk', () => {
+    mockCtx.scanningForm = {
+      enabled: true,
+      tool: 'snyk',
+      binary_path: '',
+      severity_threshold: '',
+    }
+    render(<ScanningStep />)
+    expect(screen.queryByText('Auto-Install')).not.toBeInTheDocument()
+  })
+
+  it('hides auto-install panel for custom', () => {
+    mockCtx.scanningForm = {
+      enabled: true,
+      tool: 'custom',
+      binary_path: '',
+      severity_threshold: '',
+    }
+    render(<ScanningStep />)
+    expect(screen.queryByText('Auto-Install')).not.toBeInTheDocument()
+  })
+
+  it('calls installScanner on Install button click', async () => {
+    render(<ScanningStep />)
+    await userEvent.setup().click(screen.getByRole('button', { name: /Install trivy/i }))
+    expect(mockCtx.installScanner).toHaveBeenCalledWith(undefined)
+  })
+
+  it('disables Install button when scanningInstalling', () => {
+    mockCtx.scanningInstalling = true
+    render(<ScanningStep />)
+    expect(screen.getByRole('button', { name: /Installing/i })).toBeDisabled()
+  })
+
+  it('shows success alert after install', () => {
+    mockCtx.scanningInstallResult = {
+      success: true,
+      tool: 'trivy',
+      version: '0.58.0',
+      binary_path: '/app/scanners/trivy',
+      sha256: 'abc123def456789012345678',
+      source_url: 'https://github.com/aquasecurity/trivy/releases',
+    }
+    render(<ScanningStep />)
+    expect(screen.getByText(/trivy 0\.58\.0/)).toBeInTheDocument()
+    expect(screen.getByText(/\/app\/scanners\/trivy/)).toBeInTheDocument()
+  })
+
+  it('shows error alert after failed install', () => {
+    mockCtx.scanningInstallResult = {
+      success: false,
+      tool: 'trivy',
+      version: '',
+      binary_path: '',
+      sha256: '',
+      source_url: '',
+      error: 'no matching asset for this OS/arch',
+    }
+    render(<ScanningStep />)
+    expect(screen.getByText(/no matching asset/)).toBeInTheDocument()
+  })
+
+  it('shows auto-install panel for checkov', () => {
+    mockCtx.scanningForm = {
+      enabled: true,
+      tool: 'checkov',
+      binary_path: '',
+      severity_threshold: '',
+    }
+    render(<ScanningStep />)
+    expect(screen.getByRole('button', { name: /Install checkov/i })).toBeInTheDocument()
+  })
+
+  it('shows auto-install panel for terrascan', () => {
+    mockCtx.scanningForm = {
+      enabled: true,
+      tool: 'terrascan',
+      binary_path: '',
+      severity_threshold: '',
+    }
+    render(<ScanningStep />)
+    expect(screen.getByRole('button', { name: /Install terrascan/i })).toBeInTheDocument()
   })
 })
 
@@ -149,11 +331,18 @@ describe('ScanningStep — pending feature setup', () => {
     vi.clearAllMocks()
     Object.assign(mockCtx, {
       setupStatus: { pending_feature_setup: true },
-      scanningForm: { enabled: false, tool: 'trivy', binary_path: '', severity_threshold: '' },
+      scanningForm: {
+        enabled: false,
+        tool: 'trivy',
+        binary_path: '',
+        severity_threshold: '',
+      },
       scanningTesting: false,
       scanningTestResult: null,
       scanningSaving: false,
       scanningSaved: false,
+      scanningInstalling: false,
+      scanningInstallResult: null,
     })
   })
 
@@ -170,7 +359,12 @@ describe('ScanningStep — pending feature setup', () => {
   })
 
   it('shows "Next: Review & Complete" label in pending mode', () => {
-    mockCtx.scanningForm = { enabled: true, tool: 'trivy', binary_path: '', severity_threshold: '' }
+    mockCtx.scanningForm = {
+      enabled: true,
+      tool: 'trivy',
+      binary_path: '',
+      severity_threshold: '',
+    }
     mockCtx.scanningSaved = true
     render(<ScanningStep />)
     expect(screen.getByRole('button', { name: /Next: Review & Complete/i })).toBeInTheDocument()

--- a/frontend/src/pages/setup/steps/__tests__/ScanningStep.test.tsx
+++ b/frontend/src/pages/setup/steps/__tests__/ScanningStep.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
@@ -212,6 +212,51 @@ describe('ScanningStep', () => {
     mockCtx.scanningSaving = true
     render(<ScanningStep />)
     expect(screen.getByRole('button', { name: /Save Scanning/i })).toBeDisabled()
+  })
+
+  it('calls setScanningForm when binary path changes', async () => {
+    mockCtx.scanningForm = {
+      enabled: true,
+      tool: 'trivy',
+      binary_path: '',
+      severity_threshold: '',
+    }
+    render(<ScanningStep />)
+    const input = screen.getByLabelText('Binary Path')
+    await userEvent.setup().type(input, '/usr/bin/trivy')
+    expect(mockCtx.setScanningForm).toHaveBeenCalled()
+  })
+
+  it('calls setScanningForm when severity threshold changes', async () => {
+    mockCtx.scanningForm = {
+      enabled: true,
+      tool: 'trivy',
+      binary_path: '',
+      severity_threshold: '',
+    }
+    render(<ScanningStep />)
+    const input = screen.getByLabelText(/Severity Threshold/i)
+    await userEvent.setup().type(input, 'HIGH')
+    expect(mockCtx.setScanningForm).toHaveBeenCalled()
+  })
+
+  it('calls setScanningForm when scanning tool is changed', async () => {
+    mockCtx.scanningForm = {
+      enabled: true,
+      tool: 'trivy',
+      binary_path: '',
+      severity_threshold: '',
+    }
+    render(<ScanningStep />)
+    // Open the MUI Select dropdown and pick a different tool
+    // MUI Select requires mouseDown on the element with role=combobox to open
+    const trigger = screen.getByRole('combobox')
+    fireEvent.mouseDown(trigger)
+    const listbox = within(screen.getByRole('listbox'))
+    fireEvent.click(listbox.getByText('Checkov'))
+    expect(mockCtx.setScanningForm).toHaveBeenCalled()
+    expect(mockCtx.setScanningTestResult).toHaveBeenCalledWith(null)
+    expect(mockCtx.setScanningSaved).toHaveBeenCalledWith(false)
   })
 })
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,21 +1,23 @@
-import axios, { AxiosInstance, AxiosError, InternalAxiosRequestConfig } from 'axios';
-import { addApiBreadcrumb } from './errorReporting';
+import axios, { AxiosInstance, AxiosError, InternalAxiosRequestConfig } from 'axios'
+import { addApiBreadcrumb } from './errorReporting'
 
 // In dev mode, use empty baseURL to use relative paths (goes through Vite proxy)
 // In production, use the configured URL or default to current origin
-const API_BASE_URL = import.meta.env.DEV ? '' : (import.meta.env.VITE_API_URL || '');
+const API_BASE_URL = import.meta.env.DEV ? '' : import.meta.env.VITE_API_URL || ''
 
 // Only use mock responses when explicitly enabled (e.g., when backend is not running)
-const USE_MOCK_DATA = import.meta.env.VITE_USE_MOCK_DATA === 'true';
+const USE_MOCK_DATA = import.meta.env.VITE_USE_MOCK_DATA === 'true'
 
 /** Read a cookie value by name. Returns empty string if not found. */
 function getCookie(name: string): string {
-  const match = document.cookie.match(new RegExp('(?:^|; )' + name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '=([^;]*)'));
-  return match ? decodeURIComponent(match[1]) : '';
+  const match = document.cookie.match(
+    new RegExp('(?:^|; )' + name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '=([^;]*)'),
+  )
+  return match ? decodeURIComponent(match[1]) : ''
 }
 
 class ApiClient {
-  private client: AxiosInstance;
+  private client: AxiosInstance
 
   constructor() {
     this.client = axios.create({
@@ -28,7 +30,7 @@ class ApiClient {
       // Only validate successful status codes (2xx and 3xx)
       // This ensures errors are properly caught by the error interceptor
       validateStatus: (status) => status >= 200 && status < 400,
-    });
+    })
 
     // Request interceptor to add CSRF token on mutating requests
     this.client.interceptors.request.use(
@@ -36,38 +38,38 @@ class ApiClient {
         // For backward compatibility: if an auth token is in localStorage (migration
         // period), include it as a Bearer header. Once all sessions have migrated to
         // HttpOnly cookies this block can be removed.
-        const legacyToken = localStorage.getItem('auth_token');
+        const legacyToken = localStorage.getItem('auth_token')
         if (legacyToken) {
-          config.headers.Authorization = `Bearer ${legacyToken}`;
+          config.headers.Authorization = `Bearer ${legacyToken}`
         }
 
         // Add CSRF token header on mutating requests. The backend sets a non-HttpOnly
         // "tfr_csrf" cookie; we read it and echo it in X-CSRF-Token so the server can
         // validate the double-submit pattern.
-        const method = (config.method || 'get').toUpperCase();
+        const method = (config.method || 'get').toUpperCase()
         if (method === 'POST' || method === 'PUT' || method === 'PATCH' || method === 'DELETE') {
-          const csrfToken = getCookie('tfr_csrf');
+          const csrfToken = getCookie('tfr_csrf')
           if (csrfToken) {
-            config.headers['X-CSRF-Token'] = csrfToken;
+            config.headers['X-CSRF-Token'] = csrfToken
           }
         }
 
         // Stamp the request start time for breadcrumb duration tracking
-        (config as InternalAxiosRequestConfig & { _startTime?: number })._startTime = Date.now();
-        return config;
+        ;(config as InternalAxiosRequestConfig & { _startTime?: number })._startTime = Date.now()
+        return config
       },
-      (error) => Promise.reject(error)
-    );
+      (error) => Promise.reject(error),
+    )
 
     // Response interceptor for error handling
     this.client.interceptors.response.use(
       (response) => {
-        return response;
+        return response
       },
       (error: AxiosError) => {
         // Only return mock data when explicitly enabled (for offline development)
         if (USE_MOCK_DATA) {
-          return this.getMockResponse(error.config?.url || '');
+          return this.getMockResponse(error.config?.url || '')
         }
 
         if (error.response?.status === 401) {
@@ -75,9 +77,10 @@ class ApiClient {
           // been revoked — this is not a user session failure. Let the error propagate
           // so the calling component (e.g. RepositoryBrowser) can show the reconnect
           // prompt rather than wiping the user's session and redirecting to /login.
-          const url = error.config?.url || '';
-          const isSCMOAuthFailure = url.includes('/scm-providers/') &&
-            (url.includes('/repositories') || url.includes('/tags') || url.includes('/branches'));
+          const url = error.config?.url || ''
+          const isSCMOAuthFailure =
+            url.includes('/scm-providers/') &&
+            (url.includes('/repositories') || url.includes('/tags') || url.includes('/branches'))
 
           if (!isSCMOAuthFailure) {
             // Only redirect when the user previously had an active session
@@ -85,56 +88,60 @@ class ApiClient {
             // probing endpoints like /auth/me — this is expected and should
             // NOT trigger a redirect so public pages remain accessible.
             const hadSession =
-              !!localStorage.getItem('auth_token') || !!localStorage.getItem('user');
-            localStorage.removeItem('auth_token');
-            localStorage.removeItem('user');
+              !!localStorage.getItem('auth_token') || !!localStorage.getItem('user')
+            localStorage.removeItem('auth_token')
+            localStorage.removeItem('user')
             if (hadSession) {
-              window.location.href = '/login';
+              window.location.href = '/login'
             }
           }
         }
-        return Promise.reject(error);
-      }
-    );
+        return Promise.reject(error)
+      },
+    )
 
     // Breadcrumb interceptor — records API calls for error reporting context
     this.client.interceptors.response.use(
       (response) => {
-        const cfg = response.config as InternalAxiosRequestConfig & { _startTime?: number };
-        const duration = cfg._startTime ? Date.now() - cfg._startTime : undefined;
-        addApiBreadcrumb(cfg.method ?? 'GET', cfg.url ?? '', response.status, duration);
-        return response;
+        const cfg = response.config as InternalAxiosRequestConfig & { _startTime?: number }
+        const duration = cfg._startTime ? Date.now() - cfg._startTime : undefined
+        addApiBreadcrumb(cfg.method ?? 'GET', cfg.url ?? '', response.status, duration)
+        return response
       },
       (error: AxiosError) => {
-        const cfg = (error.config ?? {}) as InternalAxiosRequestConfig & { _startTime?: number };
-        const duration = cfg._startTime ? Date.now() - cfg._startTime : undefined;
-        addApiBreadcrumb(cfg.method ?? 'GET', cfg.url ?? '', error.response?.status, duration);
-        return Promise.reject(error);
-      }
-    );
+        const cfg = (error.config ?? {}) as InternalAxiosRequestConfig & { _startTime?: number }
+        const duration = cfg._startTime ? Date.now() - cfg._startTime : undefined
+        addApiBreadcrumb(cfg.method ?? 'GET', cfg.url ?? '', error.response?.status, duration)
+        return Promise.reject(error)
+      },
+    )
   }
 
   private getMockResponse(url: string): { data: unknown; status: number } {
     // Mock responses for development when backend is not available
-    let mockData: { data: unknown } = { data: [] };
+    let mockData: { data: unknown } = { data: [] }
 
     if (url.includes('/modules') && !url.includes('/versions')) {
-      mockData.data = { modules: [], meta: { total: 0, limit: 10, offset: 0 } };
-    } else if (url.includes('/providers') && !url.includes('/versions') && !url.includes('/scm-providers')) {
-      mockData.data = { providers: [], meta: { total: 0, limit: 10, offset: 0 } };
+      mockData.data = { modules: [], meta: { total: 0, limit: 10, offset: 0 } }
+    } else if (
+      url.includes('/providers') &&
+      !url.includes('/versions') &&
+      !url.includes('/scm-providers')
+    ) {
+      mockData.data = { providers: [], meta: { total: 0, limit: 10, offset: 0 } }
     } else if (url.includes('/users')) {
-      mockData.data = { users: [], meta: { total: 0, limit: 10, offset: 0 } };
+      mockData.data = { users: [], meta: { total: 0, limit: 10, offset: 0 } }
     } else if (url.includes('/organizations')) {
-      mockData.data = [];
+      mockData.data = []
     } else if (url.includes('/apikeys')) {
-      mockData.data = [];
+      mockData.data = []
     } else if (url.includes('/scm-providers')) {
-      mockData.data = [];
+      mockData.data = []
     } else if (url.includes('/versions')) {
-      mockData.data = { versions: [] };
+      mockData.data = { versions: [] }
     }
 
-    return { data: mockData.data, status: 200 };
+    return { data: mockData.data, status: 200 }
   }
 
   // Authentication
@@ -143,13 +150,15 @@ class ApiClient {
    * Fetch the list of available authentication providers from the backend.
    * Returns providers with type, name, and optional id (for SAML IdPs).
    */
-  async getAuthProviders(): Promise<{ providers: Array<{ type: string; name: string; id?: string }> }> {
-    const response = await this.client.get('/api/v1/auth/providers');
-    return response.data;
+  async getAuthProviders(): Promise<{
+    providers: Array<{ type: string; name: string; id?: string }>
+  }> {
+    const response = await this.client.get('/api/v1/auth/providers')
+    return response.data
   }
 
   async login(provider: string) {
-    window.location.href = `${API_BASE_URL}/api/v1/auth/login?provider=${provider}`;
+    window.location.href = `${API_BASE_URL}/api/v1/auth/login?provider=${provider}`
   }
 
   /**
@@ -157,8 +166,8 @@ class ApiClient {
    * Returns a JWT token on success.
    */
   async ldapLogin(username: string, password: string): Promise<{ token: string }> {
-    const response = await this.client.post('/api/v1/auth/ldap/login', { username, password });
-    return response.data;
+    const response = await this.client.post('/api/v1/auth/ldap/login', { username, password })
+    return response.data
   }
 
   /**
@@ -169,206 +178,267 @@ class ApiClient {
    * stored client-side.
    */
   logout() {
-    window.location.href = `${API_BASE_URL}/api/v1/auth/logout`;
+    window.location.href = `${API_BASE_URL}/api/v1/auth/logout`
   }
 
   async refreshToken() {
-    const response = await this.client.post('/api/v1/auth/refresh');
-    return response.data;
+    const response = await this.client.post('/api/v1/auth/refresh')
+    return response.data
   }
 
   async getCurrentUser() {
-    const response = await this.client.get('/api/v1/auth/me');
-    return response.data.user;
+    const response = await this.client.get('/api/v1/auth/me')
+    return response.data.user
   }
 
   async getCurrentUserWithRole(): Promise<{
-    user: import('../types').User;
-    role_template: import('../types').RoleTemplateInfo | null;
-    allowed_scopes: string[];
+    user: import('../types').User
+    role_template: import('../types').RoleTemplateInfo | null
+    allowed_scopes: string[]
   }> {
-    const response = await this.client.get('/api/v1/auth/me');
+    const response = await this.client.get('/api/v1/auth/me')
     return {
       user: response.data.user,
       role_template: response.data.role_template || null,
       allowed_scopes: response.data.allowed_scopes || [],
-    };
+    }
   }
 
   // Modules
-  async searchModules(options?: { query?: string; limit?: number; offset?: number; page?: number; per_page?: number; sort?: string; order?: string }) {
-    const params: Record<string, string | number> = {};
+  async searchModules(options?: {
+    query?: string
+    limit?: number
+    offset?: number
+    page?: number
+    per_page?: number
+    sort?: string
+    order?: string
+  }) {
+    const params: Record<string, string | number> = {}
 
-    if (options?.query) params.q = options.query;
-    if (options?.limit) params.limit = options.limit;
-    if (options?.offset !== undefined) params.offset = options.offset;
-    if (options?.page) params.page = options.page;
-    if (options?.per_page) params.per_page = options.per_page;
-    if (options?.sort) params.sort = options.sort;
-    if (options?.order) params.order = options.order;
+    if (options?.query) params.q = options.query
+    if (options?.limit) params.limit = options.limit
+    if (options?.offset !== undefined) params.offset = options.offset
+    if (options?.page) params.page = options.page
+    if (options?.per_page) params.per_page = options.per_page
+    if (options?.sort) params.sort = options.sort
+    if (options?.order) params.order = options.order
 
-    const response = await this.client.get('/api/v1/modules/search', { params });
-    return response.data;
+    const response = await this.client.get('/api/v1/modules/search', { params })
+    return response.data
   }
 
   async getModuleVersions(namespace: string, name: string, system: string) {
-    const response = await this.client.get(
-      `/v1/modules/${namespace}/${name}/${system}/versions`
-    );
-    return response.data;
+    const response = await this.client.get(`/v1/modules/${namespace}/${name}/${system}/versions`)
+    return response.data
   }
 
   async createModuleRecord(data: {
-    namespace: string;
-    name: string;
-    system: string;
-    description?: string;
+    namespace: string
+    name: string
+    system: string
+    description?: string
   }): Promise<{ id: string; namespace: string; name: string; system: string }> {
-    const response = await this.client.post('/api/v1/admin/modules/create', data);
-    return response.data;
+    const response = await this.client.post('/api/v1/admin/modules/create', data)
+    return response.data
   }
 
-  async uploadModule(formData: FormData, options?: { onUploadProgress?: (percent: number) => void }) {
+  async uploadModule(
+    formData: FormData,
+    options?: { onUploadProgress?: (percent: number) => void },
+  ) {
     const response = await this.client.post('/api/v1/modules', formData, {
       headers: {
         'Content-Type': 'multipart/form-data',
       },
       onUploadProgress: options?.onUploadProgress
         ? (event) => {
-          if (event.total && event.total > 0) {
-            const percent = Math.round((event.loaded / event.total) * 100);
-            options.onUploadProgress?.(percent);
+            if (event.total && event.total > 0) {
+              const percent = Math.round((event.loaded / event.total) * 100)
+              options.onUploadProgress?.(percent)
+            }
           }
-        }
         : undefined,
-    });
-    return response.data;
+    })
+    return response.data
   }
 
   async getModule(namespace: string, name: string, system: string) {
-    const response = await this.client.get(`/api/v1/modules/${namespace}/${name}/${system}`);
-    return response.data;
+    const response = await this.client.get(`/api/v1/modules/${namespace}/${name}/${system}`)
+    return response.data
   }
 
   async deleteModule(namespace: string, name: string, system: string) {
-    const response = await this.client.delete(`/api/v1/modules/${namespace}/${name}/${system}`);
-    return response.data;
+    const response = await this.client.delete(`/api/v1/modules/${namespace}/${name}/${system}`)
+    return response.data
   }
 
   async deleteModuleVersion(namespace: string, name: string, system: string, version: string) {
-    const response = await this.client.delete(`/api/v1/modules/${namespace}/${name}/${system}/versions/${version}`);
-    return response.data;
+    const response = await this.client.delete(
+      `/api/v1/modules/${namespace}/${name}/${system}/versions/${version}`,
+    )
+    return response.data
   }
 
-  async deprecateModuleVersion(namespace: string, name: string, system: string, version: string, message?: string) {
+  async deprecateModuleVersion(
+    namespace: string,
+    name: string,
+    system: string,
+    version: string,
+    message?: string,
+  ) {
     const response = await this.client.post(
       `/api/v1/modules/${namespace}/${name}/${system}/versions/${version}/deprecate`,
-      message ? { message } : {}
-    );
-    return response.data;
+      message ? { message } : {},
+    )
+    return response.data
   }
 
   async undeprecateModuleVersion(namespace: string, name: string, system: string, version: string) {
-    const response = await this.client.delete(`/api/v1/modules/${namespace}/${name}/${system}/versions/${version}/deprecate`);
-    return response.data;
+    const response = await this.client.delete(
+      `/api/v1/modules/${namespace}/${name}/${system}/versions/${version}/deprecate`,
+    )
+    return response.data
   }
 
-  async deprecateModule(namespace: string, name: string, system: string, data: { message: string; successor_module_id?: string }) {
-    const response = await this.client.post(`/api/v1/modules/${namespace}/${name}/${system}/deprecate`, data);
-    return response.data;
+  async deprecateModule(
+    namespace: string,
+    name: string,
+    system: string,
+    data: { message: string; successor_module_id?: string },
+  ) {
+    const response = await this.client.post(
+      `/api/v1/modules/${namespace}/${name}/${system}/deprecate`,
+      data,
+    )
+    return response.data
   }
 
   async undeprecateModule(namespace: string, name: string, system: string) {
-    const response = await this.client.delete(`/api/v1/modules/${namespace}/${name}/${system}/deprecate`);
-    return response.data;
+    const response = await this.client.delete(
+      `/api/v1/modules/${namespace}/${name}/${system}/deprecate`,
+    )
+    return response.data
   }
 
   // Providers
-  async searchProviders(options?: { query?: string; limit?: number; offset?: number; page?: number; per_page?: number; sort?: string; order?: string }) {
-    const params: Record<string, string | number> = {};
+  async searchProviders(options?: {
+    query?: string
+    limit?: number
+    offset?: number
+    page?: number
+    per_page?: number
+    sort?: string
+    order?: string
+  }) {
+    const params: Record<string, string | number> = {}
 
-    if (options?.query) params.q = options.query;
-    if (options?.limit) params.limit = options.limit;
-    if (options?.offset !== undefined) params.offset = options.offset;
-    if (options?.page) params.page = options.page;
-    if (options?.per_page) params.per_page = options.per_page;
-    if (options?.sort) params.sort = options.sort;
-    if (options?.order) params.order = options.order;
+    if (options?.query) params.q = options.query
+    if (options?.limit) params.limit = options.limit
+    if (options?.offset !== undefined) params.offset = options.offset
+    if (options?.page) params.page = options.page
+    if (options?.per_page) params.per_page = options.per_page
+    if (options?.sort) params.sort = options.sort
+    if (options?.order) params.order = options.order
 
-    const response = await this.client.get('/api/v1/providers/search', { params });
-    return response.data;
+    const response = await this.client.get('/api/v1/providers/search', { params })
+    return response.data
   }
 
   async getProviderVersions(namespace: string, type: string) {
-    const response = await this.client.get(
-      `/v1/providers/${namespace}/${type}/versions`
-    );
-    return response.data;
+    const response = await this.client.get(`/v1/providers/${namespace}/${type}/versions`)
+    return response.data
   }
 
-  async uploadProvider(formData: FormData, options?: { onUploadProgress?: (percent: number) => void }) {
+  async uploadProvider(
+    formData: FormData,
+    options?: { onUploadProgress?: (percent: number) => void },
+  ) {
     const response = await this.client.post('/api/v1/providers', formData, {
       headers: {
         'Content-Type': 'multipart/form-data',
       },
       onUploadProgress: options?.onUploadProgress
         ? (event) => {
-          if (event.total && event.total > 0) {
-            const percent = Math.round((event.loaded / event.total) * 100);
-            options.onUploadProgress?.(percent);
+            if (event.total && event.total > 0) {
+              const percent = Math.round((event.loaded / event.total) * 100)
+              options.onUploadProgress?.(percent)
+            }
           }
-        }
         : undefined,
-    });
-    return response.data;
+    })
+    return response.data
   }
 
   async getProvider(namespace: string, type: string) {
-    const response = await this.client.get(`/api/v1/providers/${namespace}/${type}`);
-    return response.data;
+    const response = await this.client.get(`/api/v1/providers/${namespace}/${type}`)
+    return response.data
   }
 
   async deleteProvider(namespace: string, type: string) {
-    const response = await this.client.delete(`/api/v1/providers/${namespace}/${type}`);
-    return response.data;
+    const response = await this.client.delete(`/api/v1/providers/${namespace}/${type}`)
+    return response.data
   }
 
   async deleteProviderVersion(namespace: string, type: string, version: string) {
-    const response = await this.client.delete(`/api/v1/providers/${namespace}/${type}/versions/${version}`);
-    return response.data;
+    const response = await this.client.delete(
+      `/api/v1/providers/${namespace}/${type}/versions/${version}`,
+    )
+    return response.data
   }
 
-  async deprecateProviderVersion(namespace: string, type: string, version: string, message?: string) {
+  async deprecateProviderVersion(
+    namespace: string,
+    type: string,
+    version: string,
+    message?: string,
+  ) {
     const response = await this.client.post(
       `/api/v1/providers/${namespace}/${type}/versions/${version}/deprecate`,
-      message ? { message } : {}
-    );
-    return response.data;
+      message ? { message } : {},
+    )
+    return response.data
   }
 
   async undeprecateProviderVersion(namespace: string, type: string, version: string) {
-    const response = await this.client.delete(`/api/v1/providers/${namespace}/${type}/versions/${version}/deprecate`);
-    return response.data;
+    const response = await this.client.delete(
+      `/api/v1/providers/${namespace}/${type}/versions/${version}/deprecate`,
+    )
+    return response.data
   }
 
-  async getProviderDocs(namespace: string, type: string, version: string, category?: string, language?: string, limit?: number, offset?: number) {
-    const params: Record<string, string | number> = {};
-    if (category) params.category = category;
-    if (language) params.language = language;
-    if (limit !== undefined) params.limit = limit;
-    if (offset !== undefined) params.offset = offset;
+  async getProviderDocs(
+    namespace: string,
+    type: string,
+    version: string,
+    category?: string,
+    language?: string,
+    limit?: number,
+    offset?: number,
+  ) {
+    const params: Record<string, string | number> = {}
+    if (category) params.category = category
+    if (language) params.language = language
+    if (limit !== undefined) params.limit = limit
+    if (offset !== undefined) params.offset = offset
     const response = await this.client.get(
       `/api/v1/providers/${namespace}/${type}/versions/${version}/docs`,
-      { params }
-    );
-    return response.data;
+      { params },
+    )
+    return response.data
   }
 
-  async getProviderDocContent(namespace: string, type: string, version: string, category: string, slug: string) {
+  async getProviderDocContent(
+    namespace: string,
+    type: string,
+    version: string,
+    category: string,
+    slug: string,
+  ) {
     const response = await this.client.get(
-      `/api/v1/providers/${namespace}/${type}/versions/${version}/docs/${category}/${slug}`
-    );
-    return response.data;
+      `/api/v1/providers/${namespace}/${type}/versions/${version}/docs/${category}/${slug}`,
+    )
+    return response.data
   }
 
   // Helper to transform user from API format to frontend format
@@ -380,59 +450,60 @@ class ApiClient {
       oidc_sub: (user.OidcSub || user.oidc_sub) as string | undefined,
       role_template_id: (user.RoleTemplateID || user.role_template_id) as string | undefined,
       role_template_name: (user.RoleTemplateName || user.role_template_name) as string | undefined,
-      role_template_display_name: (user.RoleTemplateDisplayName || user.role_template_display_name) as string | undefined,
+      role_template_display_name: (user.RoleTemplateDisplayName ||
+        user.role_template_display_name) as string | undefined,
       created_at: (user.CreatedAt || user.created_at) as string,
       updated_at: (user.UpdatedAt || user.updated_at) as string,
-    };
+    }
   }
 
   // Users
   async listUsers(page = 1, perPage = 20) {
     const response = await this.client.get('/api/v1/users', {
       params: { page, per_page: perPage },
-    });
-    const users = response.data.users || [];
+    })
+    const users = response.data.users || []
     return {
       users: users.map((user: Record<string, unknown>) => this.transformUser(user)),
       pagination: response.data.pagination,
-    };
+    }
   }
 
   async searchUsers(query: string, page = 1, perPage = 20) {
     const response = await this.client.get('/api/v1/users/search', {
       params: { q: query, page, per_page: perPage },
-    });
-    const users = response.data.users || [];
+    })
+    const users = response.data.users || []
     return {
       users: users.map((user: Record<string, unknown>) => this.transformUser(user)),
       pagination: response.data.pagination,
-    };
+    }
   }
 
   async getUser(id: string) {
-    const response = await this.client.get(`/api/v1/users/${id}`);
-    return this.transformUser(response.data.user);
+    const response = await this.client.get(`/api/v1/users/${id}`)
+    return this.transformUser(response.data.user)
   }
 
   async createUser(data: { email: string; name: string }) {
-    const response = await this.client.post('/api/v1/users', data);
-    return this.transformUser(response.data.user);
+    const response = await this.client.post('/api/v1/users', data)
+    return this.transformUser(response.data.user)
   }
 
   async updateUser(id: string, data: { name?: string; email?: string }) {
-    const response = await this.client.put(`/api/v1/users/${id}`, data);
-    return this.transformUser(response.data.user);
+    const response = await this.client.put(`/api/v1/users/${id}`, data)
+    return this.transformUser(response.data.user)
   }
 
   async deleteUser(id: string) {
-    const response = await this.client.delete(`/api/v1/users/${id}`);
-    return response.data;
+    const response = await this.client.delete(`/api/v1/users/${id}`)
+    return response.data
   }
 
   // Helper to transform organization from API format to frontend format
   private transformOrganization(org: Record<string, unknown>) {
     if (!org) {
-      throw new Error('Cannot transform undefined organization');
+      throw new Error('Cannot transform undefined organization')
     }
     return {
       id: org.id as string,
@@ -440,103 +511,98 @@ class ApiClient {
       display_name: org.display_name as string,
       created_at: org.created_at as string,
       updated_at: org.updated_at as string,
-    };
+    }
   }
 
   // Organizations
   async listOrganizations(page = 1, perPage = 20) {
     const response = await this.client.get('/api/v1/organizations', {
       params: { page, per_page: perPage },
-    });
-    const orgs = response.data.organizations || [];
-    return orgs.map((org: Record<string, unknown>) => this.transformOrganization(org));
+    })
+    const orgs = response.data.organizations || []
+    return orgs.map((org: Record<string, unknown>) => this.transformOrganization(org))
   }
 
   async searchOrganizations(query: string, page = 1, perPage = 20) {
     const response = await this.client.get('/api/v1/organizations/search', {
       params: { q: query, page, per_page: perPage },
-    });
-    const orgs = response.data.organizations || [];
-    return orgs.map((org: Record<string, unknown>) => this.transformOrganization(org));
+    })
+    const orgs = response.data.organizations || []
+    return orgs.map((org: Record<string, unknown>) => this.transformOrganization(org))
   }
 
   async getOrganization(id: string) {
-    const response = await this.client.get(`/api/v1/organizations/${id}`);
-    return this.transformOrganization(response.data.organization);
+    const response = await this.client.get(`/api/v1/organizations/${id}`)
+    return this.transformOrganization(response.data.organization)
   }
 
   async createOrganization(data: { name: string; display_name: string }) {
-    const response = await this.client.post('/api/v1/organizations', data);
+    const response = await this.client.post('/api/v1/organizations', data)
     // Check if the response contains an error
     if (response.status !== 200 && response.status !== 201) {
-      throw new Error(response.data?.error || 'Failed to create organization');
+      throw new Error(response.data?.error || 'Failed to create organization')
     }
     if (!response.data.organization) {
-      throw new Error('Invalid response from server: missing organization data');
+      throw new Error('Invalid response from server: missing organization data')
     }
-    return this.transformOrganization(response.data.organization);
+    return this.transformOrganization(response.data.organization)
   }
 
-  async updateOrganization(id: string, data: { display_name: string; idp_type?: string | null; idp_name?: string | null }) {
-    const response = await this.client.put(`/api/v1/organizations/${id}`, data);
-    return this.transformOrganization(response.data.organization);
+  async updateOrganization(
+    id: string,
+    data: { display_name: string; idp_type?: string | null; idp_name?: string | null },
+  ) {
+    const response = await this.client.put(`/api/v1/organizations/${id}`, data)
+    return this.transformOrganization(response.data.organization)
   }
 
   async deleteOrganization(id: string) {
-    const response = await this.client.delete(`/api/v1/organizations/${id}`);
-    return response.data;
+    const response = await this.client.delete(`/api/v1/organizations/${id}`)
+    return response.data
   }
 
   async addOrganizationMember(orgId: string, data: { user_id: string; role_template_id?: string }) {
-    const response = await this.client.post(
-      `/api/v1/organizations/${orgId}/members`,
-      data
-    );
-    return response.data;
+    const response = await this.client.post(`/api/v1/organizations/${orgId}/members`, data)
+    return response.data
   }
 
   async updateOrganizationMember(
     orgId: string,
     userId: string,
-    data: { role_template_id?: string }
+    data: { role_template_id?: string },
   ) {
-    const response = await this.client.put(
-      `/api/v1/organizations/${orgId}/members/${userId}`,
-      data
-    );
-    return response.data;
+    const response = await this.client.put(`/api/v1/organizations/${orgId}/members/${userId}`, data)
+    return response.data
   }
 
   async removeOrganizationMember(orgId: string, userId: string) {
-    const response = await this.client.delete(
-      `/api/v1/organizations/${orgId}/members/${userId}`
-    );
-    return response.data;
+    const response = await this.client.delete(`/api/v1/organizations/${orgId}/members/${userId}`)
+    return response.data
   }
 
   async listOrganizationMembers(orgId: string) {
-    const response = await this.client.get(`/api/v1/organizations/${orgId}/members`);
-    return response.data.members || [];
+    const response = await this.client.get(`/api/v1/organizations/${orgId}/members`)
+    return response.data.members || []
   }
 
   async getUserMemberships(userId: string) {
-    const response = await this.client.get(`/api/v1/users/${userId}/memberships`);
-    return response.data.memberships || [];
+    const response = await this.client.get(`/api/v1/users/${userId}/memberships`)
+    return response.data.memberships || []
   }
 
   // Self-access endpoint for current user's memberships (no special scope required)
   async getCurrentUserMemberships() {
-    const response = await this.client.get('/api/v1/users/me/memberships');
-    return response.data.memberships || [];
+    const response = await this.client.get('/api/v1/users/me/memberships')
+    return response.data.memberships || []
   }
 
   // API Keys
   async listAPIKeys(organizationId?: string) {
     const response = await this.client.get('/api/v1/apikeys', {
       params: organizationId ? { organization_id: organizationId } : {},
-    });
+    })
 
-    const rawKeys = response.data?.keys || [];
+    const rawKeys = response.data?.keys || []
 
     // Normalize keys to frontend shape (support PascalCase from Go structs
     // or snake_case from explicit JSON mapping)
@@ -552,288 +618,304 @@ class ApiClient {
       expires_at: k.expires_at || k.ExpiresAt || null,
       last_used_at: k.last_used_at || k.LastUsedAt || null,
       created_at: k.created_at || k.CreatedAt || '',
-    }));
+    }))
 
-    return keys;
+    return keys
   }
 
   async createAPIKey(data: {
-    name: string;
-    organization_id: string;
-    description?: string;
-    scopes: string[];
-    expires_at?: string;
+    name: string
+    organization_id: string
+    description?: string
+    scopes: string[]
+    expires_at?: string
   }) {
-    const response = await this.client.post('/api/v1/apikeys', data);
-    return response.data;
+    const response = await this.client.post('/api/v1/apikeys', data)
+    return response.data
   }
 
   async getAPIKey(id: string) {
-    const response = await this.client.get(`/api/v1/apikeys/${id}`);
-    return response.data;
+    const response = await this.client.get(`/api/v1/apikeys/${id}`)
+    return response.data
   }
 
-  async updateAPIKey(
-    id: string,
-    data: { name?: string; scopes?: string[]; expires_at?: string }
-  ) {
-    const response = await this.client.put(`/api/v1/apikeys/${id}`, data);
-    return response.data;
+  async updateAPIKey(id: string, data: { name?: string; scopes?: string[]; expires_at?: string }) {
+    const response = await this.client.put(`/api/v1/apikeys/${id}`, data)
+    return response.data
   }
 
   async deleteAPIKey(id: string) {
-    const response = await this.client.delete(`/api/v1/apikeys/${id}`);
-    return response.data;
+    const response = await this.client.delete(`/api/v1/apikeys/${id}`)
+    return response.data
   }
 
   async rotateAPIKey(id: string, gracePeriodHours: number = 0) {
     const response = await this.client.post(`/api/v1/apikeys/${id}/rotate`, {
       grace_period_hours: gracePeriodHours,
-    });
-    return response.data;
+    })
+    return response.data
   }
 
   // SCM Provider Management
   async listSCMProviders(organizationId?: string) {
-    const params = organizationId ? { organization_id: organizationId } : {};
-    const response = await this.client.get('/api/v1/scm-providers', { params });
-    return response.data;
+    const params = organizationId ? { organization_id: organizationId } : {}
+    const response = await this.client.get('/api/v1/scm-providers', { params })
+    return response.data
   }
 
   async createSCMProvider(data: {
-    organization_id: string;
-    provider_type: string;
-    name: string;
-    base_url?: string | null;
-    client_id?: string;
-    client_secret?: string;
-    webhook_secret?: string;
+    organization_id: string
+    provider_type: string
+    name: string
+    base_url?: string | null
+    client_id?: string
+    client_secret?: string
+    webhook_secret?: string
   }) {
-    const response = await this.client.post('/api/v1/scm-providers', data);
-    return response.data;
+    const response = await this.client.post('/api/v1/scm-providers', data)
+    return response.data
   }
 
   async getSCMProvider(id: string) {
-    const response = await this.client.get(`/api/v1/scm-providers/${id}`);
-    return response.data;
+    const response = await this.client.get(`/api/v1/scm-providers/${id}`)
+    return response.data
   }
 
   async updateSCMProvider(
     id: string,
     data: {
-      name?: string;
-      base_url?: string | null;
-      tenant_id?: string | null;
-      client_id?: string;
-      client_secret?: string;
-      webhook_secret?: string;
-      is_active?: boolean;
-    }
+      name?: string
+      base_url?: string | null
+      tenant_id?: string | null
+      client_id?: string
+      client_secret?: string
+      webhook_secret?: string
+      is_active?: boolean
+    },
   ) {
-    const response = await this.client.put(`/api/v1/scm-providers/${id}`, data);
-    return response.data;
+    const response = await this.client.put(`/api/v1/scm-providers/${id}`, data)
+    return response.data
   }
 
   async deleteSCMProvider(id: string) {
-    const response = await this.client.delete(`/api/v1/scm-providers/${id}`);
-    return response.data;
+    const response = await this.client.delete(`/api/v1/scm-providers/${id}`)
+    return response.data
   }
 
   // SCM OAuth
   async initiateSCMOAuth(providerId: string) {
-    const response = await this.client.get(`/api/v1/scm-providers/${providerId}/oauth/authorize`);
-    return response.data;
+    const response = await this.client.get(`/api/v1/scm-providers/${providerId}/oauth/authorize`)
+    return response.data
   }
 
   async refreshSCMToken(providerId: string) {
-    const response = await this.client.post(`/api/v1/scm-providers/${providerId}/oauth/refresh`);
-    return response.data;
+    const response = await this.client.post(`/api/v1/scm-providers/${providerId}/oauth/refresh`)
+    return response.data
   }
 
   async getSCMTokenStatus(providerId: string): Promise<{
-    connected: boolean;
-    connected_at?: string;
-    expires_at?: string | null;
-    token_type?: string;
+    connected: boolean
+    connected_at?: string
+    expires_at?: string | null
+    token_type?: string
   }> {
-    const response = await this.client.get(`/api/v1/scm-providers/${providerId}/oauth/token`);
-    return response.data;
+    const response = await this.client.get(`/api/v1/scm-providers/${providerId}/oauth/token`)
+    return response.data
   }
 
   async listSCMRepositories(providerId: string, search?: string) {
-    const params = search ? { search } : {};
-    const response = await this.client.get(`/api/v1/scm-providers/${providerId}/repositories`, { params });
-    return response.data;
+    const params = search ? { search } : {}
+    const response = await this.client.get(`/api/v1/scm-providers/${providerId}/repositories`, {
+      params,
+    })
+    return response.data
   }
 
   async listSCMRepositoryTags(providerId: string, owner: string, repo: string) {
-    const response = await this.client.get(`/api/v1/scm-providers/${providerId}/repositories/${owner}/${repo}/tags`);
-    return response.data;
+    const response = await this.client.get(
+      `/api/v1/scm-providers/${providerId}/repositories/${owner}/${repo}/tags`,
+    )
+    return response.data
   }
 
   async listSCMRepositoryBranches(providerId: string, owner: string, repo: string) {
-    const response = await this.client.get(`/api/v1/scm-providers/${providerId}/repositories/${owner}/${repo}/branches`);
-    return response.data;
+    const response = await this.client.get(
+      `/api/v1/scm-providers/${providerId}/repositories/${owner}/${repo}/branches`,
+    )
+    return response.data
   }
 
   async revokeSCMToken(providerId: string) {
-    const response = await this.client.delete(`/api/v1/scm-providers/${providerId}/oauth/token`);
-    return response.data;
+    const response = await this.client.delete(`/api/v1/scm-providers/${providerId}/oauth/token`)
+    return response.data
   }
 
   async saveSCMToken(providerId: string, accessToken: string) {
     const response = await this.client.post(`/api/v1/scm-providers/${providerId}/token`, {
       access_token: accessToken,
-    });
-    return response.data;
+    })
+    return response.data
   }
 
   // Module SCM Linking
   async linkModuleToSCM(
     moduleId: string,
     data: {
-      provider_id: string;
-      repository_owner: string;
-      repository_name: string;
-      repository_path?: string;
-      default_branch?: string;
-      auto_publish_enabled?: boolean;
-      tag_pattern?: string;
-    }
+      provider_id: string
+      repository_owner: string
+      repository_name: string
+      repository_path?: string
+      default_branch?: string
+      auto_publish_enabled?: boolean
+      tag_pattern?: string
+    },
   ) {
-    const response = await this.client.post(`/api/v1/admin/modules/${moduleId}/scm`, data);
-    return response.data;
+    const response = await this.client.post(`/api/v1/admin/modules/${moduleId}/scm`, data)
+    return response.data
   }
 
   async getModuleSCMInfo(moduleId: string) {
-    const response = await this.client.get(`/api/v1/admin/modules/${moduleId}/scm`);
-    return response.data;
+    const response = await this.client.get(`/api/v1/admin/modules/${moduleId}/scm`)
+    return response.data
   }
 
   async updateModuleSCMLink(
     moduleId: string,
     data: {
-      repository_path?: string;
-      default_branch?: string;
-      auto_publish_enabled?: boolean;
-      tag_pattern?: string;
-    }
+      repository_path?: string
+      default_branch?: string
+      auto_publish_enabled?: boolean
+      tag_pattern?: string
+    },
   ) {
-    const response = await this.client.put(`/api/v1/admin/modules/${moduleId}/scm`, data);
-    return response.data;
+    const response = await this.client.put(`/api/v1/admin/modules/${moduleId}/scm`, data)
+    return response.data
   }
 
   async unlinkModuleFromSCM(moduleId: string) {
-    const response = await this.client.delete(`/api/v1/admin/modules/${moduleId}/scm`);
-    return response.data;
+    const response = await this.client.delete(`/api/v1/admin/modules/${moduleId}/scm`)
+    return response.data
   }
 
   async triggerManualSync(moduleId: string, data?: { tag_name?: string; commit_sha?: string }) {
-    const response = await this.client.post(`/api/v1/admin/modules/${moduleId}/scm/sync`, data || {});
-    return response.data;
+    const response = await this.client.post(
+      `/api/v1/admin/modules/${moduleId}/scm/sync`,
+      data || {},
+    )
+    return response.data
   }
 
   async getWebhookEvents(moduleId: string) {
-    const response = await this.client.get(`/api/v1/admin/modules/${moduleId}/scm/events`);
-    return response.data;
+    const response = await this.client.get(`/api/v1/admin/modules/${moduleId}/scm/events`)
+    return response.data
   }
 
   async updateModule(id: string, data: { description?: string; source?: string }) {
-    const response = await this.client.put(`/api/v1/admin/modules/${id}`, data);
-    return response.data;
+    const response = await this.client.put(`/api/v1/admin/modules/${id}`, data)
+    return response.data
   }
 
-  async getModuleScan(namespace: string, name: string, system: string, version: string): Promise<import('../types').ModuleScan> {
+  async getModuleScan(
+    namespace: string,
+    name: string,
+    system: string,
+    version: string,
+  ): Promise<import('../types').ModuleScan> {
     const response = await this.client.get(
-      `/api/v1/modules/${namespace}/${name}/${system}/versions/${version}/scan`
-    );
-    return response.data;
+      `/api/v1/modules/${namespace}/${name}/${system}/versions/${version}/scan`,
+    )
+    return response.data
   }
 
   async getScanningConfig(): Promise<import('../types').ScanningConfig> {
-    const response = await this.client.get('/api/v1/admin/scanning/config');
-    return response.data;
+    const response = await this.client.get('/api/v1/admin/scanning/config')
+    return response.data
   }
 
   async getScanningStats(): Promise<import('../types').ScanningStats> {
-    const response = await this.client.get('/api/v1/admin/scanning/stats');
-    return response.data;
+    const response = await this.client.get('/api/v1/admin/scanning/stats')
+    return response.data
   }
 
-  async getModuleDocs(namespace: string, name: string, system: string, version: string): Promise<import('../types').ModuleDoc> {
+  async getModuleDocs(
+    namespace: string,
+    name: string,
+    system: string,
+    version: string,
+  ): Promise<import('../types').ModuleDoc> {
     const response = await this.client.get(
-      `/api/v1/modules/${namespace}/${name}/${system}/versions/${version}/docs`
-    );
-    return response.data;
+      `/api/v1/modules/${namespace}/${name}/${system}/versions/${version}/docs`,
+    )
+    return response.data
   }
 
   // Dashboard Stats
   async getDashboardStats() {
-    const response = await this.client.get('/api/v1/admin/stats/dashboard');
-    return response.data;
+    const response = await this.client.get('/api/v1/admin/stats/dashboard')
+    return response.data
   }
 
   // Mirror Management
   async listMirrors(enabledOnly = false) {
-    const params = enabledOnly ? { enabled: 'true' } : {};
-    const response = await this.client.get('/api/v1/admin/mirrors', { params });
-    return response.data.mirrors || [];
+    const params = enabledOnly ? { enabled: 'true' } : {}
+    const response = await this.client.get('/api/v1/admin/mirrors', { params })
+    return response.data.mirrors || []
   }
 
   async getMirror(id: string) {
-    const response = await this.client.get(`/api/v1/admin/mirrors/${id}`);
-    return response.data;
+    const response = await this.client.get(`/api/v1/admin/mirrors/${id}`)
+    return response.data
   }
 
   async createMirror(data: {
-    name: string;
-    description?: string;
-    upstream_registry_url: string;
-    organization_id?: string;
-    namespace_filter?: string[];
-    provider_filter?: string[];
-    enabled?: boolean;
-    sync_interval_hours?: number;
+    name: string
+    description?: string
+    upstream_registry_url: string
+    organization_id?: string
+    namespace_filter?: string[]
+    provider_filter?: string[]
+    enabled?: boolean
+    sync_interval_hours?: number
   }) {
-    const response = await this.client.post('/api/v1/admin/mirrors', data);
-    return response.data;
+    const response = await this.client.post('/api/v1/admin/mirrors', data)
+    return response.data
   }
 
   async updateMirror(
     id: string,
     data: {
-      name?: string;
-      description?: string;
-      upstream_registry_url?: string;
-      organization_id?: string;
-      namespace_filter?: string[];
-      provider_filter?: string[];
-      enabled?: boolean;
-      sync_interval_hours?: number;
-    }
+      name?: string
+      description?: string
+      upstream_registry_url?: string
+      organization_id?: string
+      namespace_filter?: string[]
+      provider_filter?: string[]
+      enabled?: boolean
+      sync_interval_hours?: number
+    },
   ) {
-    const response = await this.client.put(`/api/v1/admin/mirrors/${id}`, data);
-    return response.data;
+    const response = await this.client.put(`/api/v1/admin/mirrors/${id}`, data)
+    return response.data
   }
 
   async deleteMirror(id: string) {
-    const response = await this.client.delete(`/api/v1/admin/mirrors/${id}`);
-    return response.data;
+    const response = await this.client.delete(`/api/v1/admin/mirrors/${id}`)
+    return response.data
   }
 
   async triggerMirrorSync(id: string, data?: { namespace?: string; provider_name?: string }) {
-    const response = await this.client.post(`/api/v1/admin/mirrors/${id}/sync`, data || {});
-    return response.data;
+    const response = await this.client.post(`/api/v1/admin/mirrors/${id}/sync`, data || {})
+    return response.data
   }
 
   async getMirrorStatus(id: string) {
-    const response = await this.client.get(`/api/v1/admin/mirrors/${id}/status`);
-    return response.data;
+    const response = await this.client.get(`/api/v1/admin/mirrors/${id}/status`)
+    return response.data
   }
 
   async getMirrorProviders(id: string) {
-    const response = await this.client.get(`/api/v1/admin/mirrors/${id}/providers`);
-    return response.data.providers ?? [];
+    const response = await this.client.get(`/api/v1/admin/mirrors/${id}/providers`)
+    return response.data.providers ?? []
   }
 
   // ============================================================================
@@ -841,41 +923,41 @@ class ApiClient {
   // ============================================================================
 
   async listRoleTemplates() {
-    const response = await this.client.get('/api/v1/admin/role-templates');
-    return response.data || [];
+    const response = await this.client.get('/api/v1/admin/role-templates')
+    return response.data || []
   }
 
   async getRoleTemplate(id: string) {
-    const response = await this.client.get(`/api/v1/admin/role-templates/${id}`);
-    return response.data;
+    const response = await this.client.get(`/api/v1/admin/role-templates/${id}`)
+    return response.data
   }
 
   async createRoleTemplate(data: {
-    name: string;
-    display_name: string;
-    description?: string;
-    scopes: string[];
+    name: string
+    display_name: string
+    description?: string
+    scopes: string[]
   }) {
-    const response = await this.client.post('/api/v1/admin/role-templates', data);
-    return response.data;
+    const response = await this.client.post('/api/v1/admin/role-templates', data)
+    return response.data
   }
 
   async updateRoleTemplate(
     id: string,
     data: {
-      name?: string;
-      display_name?: string;
-      description?: string;
-      scopes?: string[];
-    }
+      name?: string
+      display_name?: string
+      description?: string
+      scopes?: string[]
+    },
   ) {
-    const response = await this.client.put(`/api/v1/admin/role-templates/${id}`, data);
-    return response.data;
+    const response = await this.client.put(`/api/v1/admin/role-templates/${id}`, data)
+    return response.data
   }
 
   async deleteRoleTemplate(id: string) {
-    const response = await this.client.delete(`/api/v1/admin/role-templates/${id}`);
-    return response.data;
+    const response = await this.client.delete(`/api/v1/admin/role-templates/${id}`)
+    return response.data
   }
 
   // ============================================================================
@@ -883,31 +965,31 @@ class ApiClient {
   // ============================================================================
 
   async listApprovalRequests(options?: { organization_id?: string; status?: string }) {
-    const params: Record<string, string> = {};
-    if (options?.organization_id) params.organization_id = options.organization_id;
-    if (options?.status) params.status = options.status;
-    const response = await this.client.get('/api/v1/admin/approvals', { params });
-    return response.data || [];
+    const params: Record<string, string> = {}
+    if (options?.organization_id) params.organization_id = options.organization_id
+    if (options?.status) params.status = options.status
+    const response = await this.client.get('/api/v1/admin/approvals', { params })
+    return response.data || []
   }
 
   async getApprovalRequest(id: string) {
-    const response = await this.client.get(`/api/v1/admin/approvals/${id}`);
-    return response.data;
+    const response = await this.client.get(`/api/v1/admin/approvals/${id}`)
+    return response.data
   }
 
   async createApprovalRequest(data: {
-    mirror_config_id: string;
-    provider_namespace: string;
-    provider_name?: string;
-    reason?: string;
+    mirror_config_id: string
+    provider_namespace: string
+    provider_name?: string
+    reason?: string
   }) {
-    const response = await this.client.post('/api/v1/admin/approvals', data);
-    return response.data;
+    const response = await this.client.post('/api/v1/admin/approvals', data)
+    return response.data
   }
 
   async reviewApproval(id: string, data: { status: 'approved' | 'rejected'; notes?: string }) {
-    const response = await this.client.put(`/api/v1/admin/approvals/${id}/review`, data);
-    return response.data;
+    const response = await this.client.put(`/api/v1/admin/approvals/${id}/review`, data)
+    return response.data
   }
 
   // ============================================================================
@@ -915,63 +997,66 @@ class ApiClient {
   // ============================================================================
 
   async listMirrorPolicies(organizationId?: string) {
-    const params = organizationId ? { organization_id: organizationId } : {};
-    const response = await this.client.get('/api/v1/admin/policies', { params });
-    return response.data || [];
+    const params = organizationId ? { organization_id: organizationId } : {}
+    const response = await this.client.get('/api/v1/admin/policies', { params })
+    return response.data || []
   }
 
   async getMirrorPolicy(id: string) {
-    const response = await this.client.get(`/api/v1/admin/policies/${id}`);
-    return response.data;
+    const response = await this.client.get(`/api/v1/admin/policies/${id}`)
+    return response.data
   }
 
   async createMirrorPolicy(data: {
-    organization_id?: string;
-    name: string;
-    description?: string;
-    policy_type: 'allow' | 'deny';
-    upstream_registry?: string;
-    namespace_pattern?: string;
-    provider_pattern?: string;
-    priority?: number;
-    is_active?: boolean;
-    requires_approval?: boolean;
+    organization_id?: string
+    name: string
+    description?: string
+    policy_type: 'allow' | 'deny'
+    upstream_registry?: string
+    namespace_pattern?: string
+    provider_pattern?: string
+    priority?: number
+    is_active?: boolean
+    requires_approval?: boolean
   }) {
-    const response = await this.client.post('/api/v1/admin/policies', data);
-    return response.data;
+    const response = await this.client.post('/api/v1/admin/policies', data)
+    return response.data
   }
 
   async updateMirrorPolicy(
     id: string,
     data: {
-      name?: string;
-      description?: string;
-      policy_type?: 'allow' | 'deny';
-      upstream_registry?: string;
-      namespace_pattern?: string;
-      provider_pattern?: string;
-      priority?: number;
-      is_active?: boolean;
-      requires_approval?: boolean;
-    }
+      name?: string
+      description?: string
+      policy_type?: 'allow' | 'deny'
+      upstream_registry?: string
+      namespace_pattern?: string
+      provider_pattern?: string
+      priority?: number
+      is_active?: boolean
+      requires_approval?: boolean
+    },
   ) {
-    const response = await this.client.put(`/api/v1/admin/policies/${id}`, data);
-    return response.data;
+    const response = await this.client.put(`/api/v1/admin/policies/${id}`, data)
+    return response.data
   }
 
   async deleteMirrorPolicy(id: string) {
-    const response = await this.client.delete(`/api/v1/admin/policies/${id}`);
-    return response.data;
+    const response = await this.client.delete(`/api/v1/admin/policies/${id}`)
+    return response.data
   }
 
-  async evaluateMirrorPolicy(data: {
-    registry: string;
-    namespace: string;
-    provider: string;
-  }, organizationId?: string) {
-    const params = organizationId ? { organization_id: organizationId } : {};
-    const response = await this.client.post('/api/v1/admin/policies/evaluate', data, { params });
-    return response.data;
+  async evaluateMirrorPolicy(
+    data: {
+      registry: string
+      namespace: string
+      provider: string
+    },
+    organizationId?: string,
+  ) {
+    const params = organizationId ? { organization_id: organizationId } : {}
+    const response = await this.client.post('/api/v1/admin/policies/evaluate', data, { params })
+    return response.data
   }
 
   // ============================================================================
@@ -979,39 +1064,39 @@ class ApiClient {
   // ============================================================================
 
   async getDevStatus(): Promise<{ dev_mode: boolean; message?: string }> {
-    const response = await this.client.get('/api/v1/dev/status');
-    return response.data;
+    const response = await this.client.get('/api/v1/dev/status')
+    return response.data
   }
 
   async devLogin(): Promise<{ token: string; user: Record<string, unknown>; expires_in: number }> {
-    const response = await this.client.post('/api/v1/dev/login');
-    return response.data;
+    const response = await this.client.post('/api/v1/dev/login')
+    return response.data
   }
 
   async listUsersForImpersonation(): Promise<{
     users: Array<{
-      id: string;
-      email: string;
-      name: string;
-      primary_role: string;
-    }>;
-    dev_mode: boolean;
+      id: string
+      email: string
+      name: string
+      primary_role: string
+    }>
+    dev_mode: boolean
   }> {
-    const response = await this.client.get('/api/v1/dev/users');
-    return response.data;
+    const response = await this.client.get('/api/v1/dev/users')
+    return response.data
   }
 
   async impersonateUser(userId: string): Promise<{
-    token: string;
+    token: string
     user: {
-      id: string;
-      email: string;
-      name: string;
-    };
-    message: string;
+      id: string
+      email: string
+      name: string
+    }
+    message: string
   }> {
-    const response = await this.client.post(`/api/v1/dev/impersonate/${userId}`);
-    return response.data;
+    const response = await this.client.post(`/api/v1/dev/impersonate/${userId}`)
+    return response.data
   }
 
   // ============================================================================
@@ -1025,167 +1110,177 @@ class ApiClient {
   private setupRequest(setupToken: string) {
     return {
       headers: { Authorization: `SetupToken ${setupToken}` },
-    };
+    }
   }
 
   async validateSetupToken(
-    setupToken: string
+    setupToken: string,
   ): Promise<import('../types').SetupValidateTokenResponse> {
     const response = await this.client.post(
       '/api/v1/setup/validate-token',
       {},
-      this.setupRequest(setupToken)
-    );
-    return response.data;
+      this.setupRequest(setupToken),
+    )
+    return response.data
   }
 
   async testOIDCConfig(
     setupToken: string,
-    data: import('../types').OIDCConfigInput
+    data: import('../types').OIDCConfigInput,
   ): Promise<import('../types').SetupTestResult> {
     const response = await this.client.post(
       '/api/v1/setup/oidc/test',
       data,
-      this.setupRequest(setupToken)
-    );
-    return response.data;
+      this.setupRequest(setupToken),
+    )
+    return response.data
   }
 
   async saveOIDCConfig(
     setupToken: string,
-    data: import('../types').OIDCConfigInput
+    data: import('../types').OIDCConfigInput,
   ): Promise<import('../types').OIDCConfigResponse> {
     const response = await this.client.post(
       '/api/v1/setup/oidc',
       data,
-      this.setupRequest(setupToken)
-    );
-    return response.data;
+      this.setupRequest(setupToken),
+    )
+    return response.data
   }
 
   async testLDAPConfig(
     setupToken: string,
-    data: import('../types').LDAPConfigInput
+    data: import('../types').LDAPConfigInput,
   ): Promise<import('../types').SetupTestResult> {
     const response = await this.client.post(
       '/api/v1/setup/ldap/test',
       data,
-      this.setupRequest(setupToken)
-    );
-    return response.data;
+      this.setupRequest(setupToken),
+    )
+    return response.data
   }
 
   async saveLDAPConfig(
     setupToken: string,
-    data: import('../types').LDAPConfigInput
+    data: import('../types').LDAPConfigInput,
   ): Promise<{ message: string; host: string; port: number }> {
     const response = await this.client.post(
       '/api/v1/setup/ldap',
       data,
-      this.setupRequest(setupToken)
-    );
-    return response.data;
+      this.setupRequest(setupToken),
+    )
+    return response.data
   }
 
   // Admin OIDC config endpoints
 
   async getAdminOIDCConfig(): Promise<import('../types').OIDCConfigResponse> {
-    const response = await this.client.get('/api/v1/admin/oidc/config');
-    return response.data;
+    const response = await this.client.get('/api/v1/admin/oidc/config')
+    return response.data
   }
 
   async updateOIDCGroupMapping(
-    data: import('../types').OIDCGroupMappingInput
+    data: import('../types').OIDCGroupMappingInput,
   ): Promise<import('../types').OIDCConfigResponse> {
-    const response = await this.client.put('/api/v1/admin/oidc/group-mapping', data);
-    return response.data;
+    const response = await this.client.put('/api/v1/admin/oidc/group-mapping', data)
+    return response.data
   }
 
   /**
    * Fetch SAML + LDAP group mapping configuration (read-only, from server config).
    */
   async getIdentityGroupMappings(): Promise<import('../types').IdentityGroupMappings> {
-    const response = await this.client.get('/api/v1/admin/identity/group-mappings');
-    return response.data;
+    const response = await this.client.get('/api/v1/admin/identity/group-mappings')
+    return response.data
   }
 
   /**
    * Fetch mTLS certificate mapping configuration (read-only, from server config).
    */
   async getMTLSConfig(): Promise<import('../types').MTLSConfigResponse> {
-    const response = await this.client.get('/api/v1/admin/mtls/config');
-    return response.data;
+    const response = await this.client.get('/api/v1/admin/mtls/config')
+    return response.data
   }
 
   async testSetupStorageConfig(
     setupToken: string,
-    data: import('../types').StorageConfigInput
+    data: import('../types').StorageConfigInput,
   ): Promise<import('../types').SetupTestResult> {
     const response = await this.client.post(
       '/api/v1/setup/storage/test',
       data,
-      this.setupRequest(setupToken)
-    );
-    return response.data;
+      this.setupRequest(setupToken),
+    )
+    return response.data
   }
 
   async saveSetupStorageConfig(
     setupToken: string,
-    data: import('../types').StorageConfigInput
+    data: import('../types').StorageConfigInput,
   ): Promise<{ message: string; config: import('../types').StorageConfigResponse }> {
     const response = await this.client.post(
       '/api/v1/setup/storage',
       data,
-      this.setupRequest(setupToken)
-    );
-    return response.data;
+      this.setupRequest(setupToken),
+    )
+    return response.data
   }
 
   async testScanningConfig(
     setupToken: string,
-    data: import('../types').ScanningConfigInput
+    data: import('../types').ScanningConfigInput,
   ): Promise<import('../types').ScanningTestResult> {
     const response = await this.client.post(
       '/api/v1/setup/scanning/test',
       data,
-      this.setupRequest(setupToken)
-    );
-    return response.data;
+      this.setupRequest(setupToken),
+    )
+    return response.data
   }
 
   async saveScanningConfig(
     setupToken: string,
-    data: import('../types').ScanningConfigInput
+    data: import('../types').ScanningConfigInput,
   ): Promise<{ message: string }> {
     const response = await this.client.post(
       '/api/v1/setup/scanning',
       data,
-      this.setupRequest(setupToken)
-    );
-    return response.data;
+      this.setupRequest(setupToken),
+    )
+    return response.data
+  }
+
+  async installScanningTool(
+    setupToken: string,
+    data: import('../types').ScanningInstallRequest,
+  ): Promise<import('../types').ScanningInstallResult> {
+    const response = await this.client.post(
+      '/api/v1/setup/scanning/install',
+      data,
+      this.setupRequest(setupToken),
+    )
+    return response.data
   }
 
   async configureAdmin(
     setupToken: string,
-    data: import('../types').ConfigureAdminInput
+    data: import('../types').ConfigureAdminInput,
   ): Promise<import('../types').ConfigureAdminResponse> {
     const response = await this.client.post(
       '/api/v1/setup/admin',
       data,
-      this.setupRequest(setupToken)
-    );
-    return response.data;
+      this.setupRequest(setupToken),
+    )
+    return response.data
   }
 
-  async completeSetup(
-    setupToken: string
-  ): Promise<import('../types').CompleteSetupResponse> {
+  async completeSetup(setupToken: string): Promise<import('../types').CompleteSetupResponse> {
     const response = await this.client.post(
       '/api/v1/setup/complete',
       {},
-      this.setupRequest(setupToken)
-    );
-    return response.data;
+      this.setupRequest(setupToken),
+    )
+    return response.data
   }
 
   // ============================================================================
@@ -1193,50 +1288,56 @@ class ApiClient {
   // ============================================================================
 
   async getSetupStatus(): Promise<import('../types').SetupStatus> {
-    const response = await this.client.get('/api/v1/setup/status');
-    return response.data;
+    const response = await this.client.get('/api/v1/setup/status')
+    return response.data
   }
 
   async getActiveStorageConfig(): Promise<import('../types').StorageConfigResponse> {
-    const response = await this.client.get('/api/v1/storage/config');
-    return response.data;
+    const response = await this.client.get('/api/v1/storage/config')
+    return response.data
   }
 
   async listStorageConfigs(): Promise<import('../types').StorageConfigResponse[]> {
-    const response = await this.client.get('/api/v1/storage/configs');
-    return response.data;
+    const response = await this.client.get('/api/v1/storage/configs')
+    return response.data
   }
 
   async getStorageConfig(id: string): Promise<import('../types').StorageConfigResponse> {
-    const response = await this.client.get(`/api/v1/storage/configs/${id}`);
-    return response.data;
+    const response = await this.client.get(`/api/v1/storage/configs/${id}`)
+    return response.data
   }
 
-  async createStorageConfig(data: import('../types').StorageConfigInput): Promise<import('../types').StorageConfigResponse> {
-    const response = await this.client.post('/api/v1/storage/configs', data);
-    return response.data;
+  async createStorageConfig(
+    data: import('../types').StorageConfigInput,
+  ): Promise<import('../types').StorageConfigResponse> {
+    const response = await this.client.post('/api/v1/storage/configs', data)
+    return response.data
   }
 
   async updateStorageConfig(
     id: string,
-    data: import('../types').StorageConfigInput
+    data: import('../types').StorageConfigInput,
   ): Promise<import('../types').StorageConfigResponse> {
-    const response = await this.client.put(`/api/v1/storage/configs/${id}`, data);
-    return response.data;
+    const response = await this.client.put(`/api/v1/storage/configs/${id}`, data)
+    return response.data
   }
 
   async deleteStorageConfig(id: string): Promise<void> {
-    await this.client.delete(`/api/v1/storage/configs/${id}`);
+    await this.client.delete(`/api/v1/storage/configs/${id}`)
   }
 
-  async activateStorageConfig(id: string): Promise<{ message: string; config: import('../types').StorageConfigResponse }> {
-    const response = await this.client.post(`/api/v1/storage/configs/${id}/activate`);
-    return response.data;
+  async activateStorageConfig(
+    id: string,
+  ): Promise<{ message: string; config: import('../types').StorageConfigResponse }> {
+    const response = await this.client.post(`/api/v1/storage/configs/${id}/activate`)
+    return response.data
   }
 
-  async testStorageConfig(data: import('../types').StorageConfigInput): Promise<{ success: boolean; message: string }> {
-    const response = await this.client.post('/api/v1/storage/configs/test', data);
-    return response.data;
+  async testStorageConfig(
+    data: import('../types').StorageConfigInput,
+  ): Promise<{ success: boolean; message: string }> {
+    const response = await this.client.post('/api/v1/storage/configs/test', data)
+    return response.data
   }
 
   // ============================================================================
@@ -1245,48 +1346,50 @@ class ApiClient {
 
   async planStorageMigration(
     sourceId: string,
-    targetId: string
+    targetId: string,
   ): Promise<import('../types').MigrationPlan> {
     const response = await this.client.post('/api/v1/admin/storage/migrations/plan', {
       source_config_id: sourceId,
       target_config_id: targetId,
-    });
-    return response.data;
+    })
+    return response.data
   }
 
   async startStorageMigration(
     sourceId: string,
-    targetId: string
+    targetId: string,
   ): Promise<import('../types').StorageMigration> {
     const response = await this.client.post('/api/v1/admin/storage/migrations', {
       source_config_id: sourceId,
       target_config_id: targetId,
-    });
-    return response.data;
+    })
+    return response.data
   }
 
   async getStorageMigration(id: string): Promise<import('../types').StorageMigration> {
-    const response = await this.client.get(`/api/v1/admin/storage/migrations/${id}`);
-    return response.data;
+    const response = await this.client.get(`/api/v1/admin/storage/migrations/${id}`)
+    return response.data
   }
 
   async cancelStorageMigration(id: string): Promise<import('../types').StorageMigration> {
-    const response = await this.client.post(`/api/v1/admin/storage/migrations/${id}/cancel`);
-    return response.data;
+    const response = await this.client.post(`/api/v1/admin/storage/migrations/${id}/cancel`)
+    return response.data
   }
 
   async listStorageMigrations(): Promise<import('../types').StorageMigration[]> {
-    const response = await this.client.get('/api/v1/admin/storage/migrations');
-    return response.data;
+    const response = await this.client.get('/api/v1/admin/storage/migrations')
+    return response.data
   }
 
   // ============================================================================
   // Terraform Binary Mirror — Public list (no auth required)
   // ============================================================================
 
-  async listPublicTerraformMirrorConfigs(): Promise<{ name: string; description?: string | null; tool: string }[]> {
-    const response = await this.client.get('/terraform/binaries');
-    return Array.isArray(response.data) ? response.data : [];
+  async listPublicTerraformMirrorConfigs(): Promise<
+    { name: string; description?: string | null; tool: string }[]
+  > {
+    const response = await this.client.get('/terraform/binaries')
+    return Array.isArray(response.data) ? response.data : []
   }
 
   // ============================================================================
@@ -1294,108 +1397,108 @@ class ApiClient {
   // All config-scoped endpoints take a configId (UUID) as their first argument.
   // ============================================================================
 
-  async listTerraformMirrorConfigs(): Promise<import('../types/terraform_mirror').TerraformMirrorConfigListResponse> {
-    const response = await this.client.get('/api/v1/admin/terraform-mirrors');
-    return response.data;
+  async listTerraformMirrorConfigs(): Promise<
+    import('../types/terraform_mirror').TerraformMirrorConfigListResponse
+  > {
+    const response = await this.client.get('/api/v1/admin/terraform-mirrors')
+    return response.data
   }
 
   async createTerraformMirrorConfig(
-    data: import('../types/terraform_mirror').CreateTerraformMirrorConfigRequest
+    data: import('../types/terraform_mirror').CreateTerraformMirrorConfigRequest,
   ): Promise<import('../types/terraform_mirror').TerraformMirrorConfig> {
-    const response = await this.client.post('/api/v1/admin/terraform-mirrors', data);
-    return response.data;
+    const response = await this.client.post('/api/v1/admin/terraform-mirrors', data)
+    return response.data
   }
 
   async getTerraformMirrorConfig(
-    configId: string
+    configId: string,
   ): Promise<import('../types/terraform_mirror').TerraformMirrorConfig> {
-    const response = await this.client.get(`/api/v1/admin/terraform-mirrors/${configId}`);
-    return response.data;
+    const response = await this.client.get(`/api/v1/admin/terraform-mirrors/${configId}`)
+    return response.data
   }
 
   async getTerraformMirrorStatus(
-    configId: string
+    configId: string,
   ): Promise<import('../types/terraform_mirror').TerraformMirrorStatusResponse> {
-    const response = await this.client.get(`/api/v1/admin/terraform-mirrors/${configId}/status`);
-    return response.data;
+    const response = await this.client.get(`/api/v1/admin/terraform-mirrors/${configId}/status`)
+    return response.data
   }
 
   async updateTerraformMirrorConfig(
     configId: string,
-    data: import('../types/terraform_mirror').UpdateTerraformMirrorConfigRequest
+    data: import('../types/terraform_mirror').UpdateTerraformMirrorConfigRequest,
   ): Promise<import('../types/terraform_mirror').TerraformMirrorConfig> {
-    const response = await this.client.put(`/api/v1/admin/terraform-mirrors/${configId}`, data);
-    return response.data;
+    const response = await this.client.put(`/api/v1/admin/terraform-mirrors/${configId}`, data)
+    return response.data
   }
 
   async deleteTerraformMirrorConfig(configId: string): Promise<void> {
-    await this.client.delete(`/api/v1/admin/terraform-mirrors/${configId}`);
+    await this.client.delete(`/api/v1/admin/terraform-mirrors/${configId}`)
   }
 
   async triggerTerraformMirrorSync(configId: string): Promise<{ message: string }> {
-    const response = await this.client.post(`/api/v1/admin/terraform-mirrors/${configId}/sync`, {});
-    return response.data;
+    const response = await this.client.post(`/api/v1/admin/terraform-mirrors/${configId}/sync`, {})
+    return response.data
   }
 
   async listTerraformVersions(
     configId: string,
-    options?: { synced?: boolean }
+    options?: { synced?: boolean },
   ): Promise<import('../types/terraform_mirror').TerraformVersionListResponse> {
-    const params: Record<string, string> = {};
-    if (options?.synced !== undefined) params.synced = String(options.synced);
-    const response = await this.client.get(
-      `/api/v1/admin/terraform-mirrors/${configId}/versions`,
-      { params }
-    );
-    return response.data;
+    const params: Record<string, string> = {}
+    if (options?.synced !== undefined) params.synced = String(options.synced)
+    const response = await this.client.get(`/api/v1/admin/terraform-mirrors/${configId}/versions`, {
+      params,
+    })
+    return response.data
   }
 
   async getTerraformVersion(
     configId: string,
-    version: string
+    version: string,
   ): Promise<import('../types/terraform_mirror').TerraformVersion> {
     const response = await this.client.get(
-      `/api/v1/admin/terraform-mirrors/${configId}/versions/${version}`
-    );
-    return response.data;
+      `/api/v1/admin/terraform-mirrors/${configId}/versions/${version}`,
+    )
+    return response.data
   }
 
   async deleteTerraformVersion(configId: string, version: string): Promise<void> {
-    await this.client.delete(`/api/v1/admin/terraform-mirrors/${configId}/versions/${version}`);
+    await this.client.delete(`/api/v1/admin/terraform-mirrors/${configId}/versions/${version}`)
   }
 
   async deprecateTerraformVersion(configId: string, version: string): Promise<void> {
     await this.client.post(
       `/api/v1/admin/terraform-mirrors/${configId}/versions/${version}/deprecate`,
-      {}
-    );
+      {},
+    )
   }
 
   async undeprecateTerraformVersion(configId: string, version: string): Promise<void> {
     await this.client.delete(
-      `/api/v1/admin/terraform-mirrors/${configId}/versions/${version}/deprecate`
-    );
+      `/api/v1/admin/terraform-mirrors/${configId}/versions/${version}/deprecate`,
+    )
   }
 
   async listTerraformVersionPlatforms(
     configId: string,
-    version: string
+    version: string,
   ): Promise<import('../types/terraform_mirror').TerraformVersionPlatform[]> {
     const response = await this.client.get(
-      `/api/v1/admin/terraform-mirrors/${configId}/versions/${version}/platforms`
-    );
-    return Array.isArray(response.data) ? response.data : (response.data.platforms ?? []);
+      `/api/v1/admin/terraform-mirrors/${configId}/versions/${version}/platforms`,
+    )
+    return Array.isArray(response.data) ? response.data : (response.data.platforms ?? [])
   }
 
   async getTerraformMirrorHistory(
     configId: string,
-    limit = 20
+    limit = 20,
   ): Promise<import('../types/terraform_mirror').TerraformSyncHistoryListResponse> {
-    const response = await this.client.get(
-      `/api/v1/admin/terraform-mirrors/${configId}/history`,
-      { params: { limit } }
-    );
-    return response.data;
+    const response = await this.client.get(`/api/v1/admin/terraform-mirrors/${configId}/history`, {
+      params: { limit },
+    })
+    return response.data
   }
 
   // ============================================================================
@@ -1404,33 +1507,37 @@ class ApiClient {
   // ============================================================================
 
   async listPublicTerraformVersions(
-    name: string
+    name: string,
   ): Promise<import('../types/terraform_mirror').TerraformVersionListResponse> {
-    const response = await this.client.get(`/terraform/binaries/${name}/versions`);
-    return response.data;
+    const response = await this.client.get(`/terraform/binaries/${name}/versions`)
+    return response.data
   }
 
-  async getPublicLatestTerraformVersion(name: string): Promise<import('../types/terraform_mirror').TerraformVersion> {
-    const response = await this.client.get(`/terraform/binaries/${name}/versions/latest`);
-    return response.data;
+  async getPublicLatestTerraformVersion(
+    name: string,
+  ): Promise<import('../types/terraform_mirror').TerraformVersion> {
+    const response = await this.client.get(`/terraform/binaries/${name}/versions/latest`)
+    return response.data
   }
 
   async getPublicTerraformVersion(
     name: string,
-    version: string
+    version: string,
   ): Promise<import('../types/terraform_mirror').TerraformVersion> {
-    const response = await this.client.get(`/terraform/binaries/${name}/versions/${version}`);
-    return response.data;
+    const response = await this.client.get(`/terraform/binaries/${name}/versions/${version}`)
+    return response.data
   }
 
   async getTerraformBinaryDownload(
     name: string,
     version: string,
     os: string,
-    arch: string
+    arch: string,
   ): Promise<import('../types/terraform_mirror').TerraformBinaryDownloadResponse> {
-    const response = await this.client.get(`/terraform/binaries/${name}/versions/${version}/${os}/${arch}`);
-    return response.data;
+    const response = await this.client.get(
+      `/terraform/binaries/${name}/versions/${version}/${os}/${arch}`,
+    )
+    return response.data
   }
 
   // ============================================================================
@@ -1438,56 +1545,70 @@ class ApiClient {
   // ============================================================================
 
   async listAuditLogs(opts?: {
-    page?: number;
-    per_page?: number;
-    action?: string;
-    resource_type?: string;
-    user_id?: string;
-    user_email?: string;
-    start_date?: string;
-    end_date?: string;
+    page?: number
+    per_page?: number
+    action?: string
+    resource_type?: string
+    user_id?: string
+    user_email?: string
+    start_date?: string
+    end_date?: string
   }): Promise<import('../types').AuditLogListResponse> {
-    const response = await this.client.get('/api/v1/admin/audit-logs', { params: opts });
-    return response.data;
+    const response = await this.client.get('/api/v1/admin/audit-logs', { params: opts })
+    return response.data
   }
 
   async getAuditLog(id: string): Promise<import('../types').AuditLog> {
-    const response = await this.client.get(`/api/v1/admin/audit-logs/${id}`);
-    return response.data;
+    const response = await this.client.get(`/api/v1/admin/audit-logs/${id}`)
+    return response.data
   }
 
   exportAuditLogsCSV(logs: import('../types').AuditLog[]): void {
-    const header = ['id', 'created_at', 'action', 'resource_type', 'resource_id', 'user_email', 'user_name', 'organization_id', 'ip_address'];
-    const rows = logs.map((l) => [
-      l.id,
-      l.created_at,
-      l.action,
-      l.resource_type ?? '',
-      l.resource_id ?? '',
-      l.user_email ?? '',
-      l.user_name ?? '',
-      l.organization_id ?? '',
-      l.ip_address ?? '',
-    ].map((v) => `"${String(v).replace(/"/g, '""')}"`).join(','));
-    const csv = [header.join(','), ...rows].join('\n');
-    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = `audit-logs-${new Date().toISOString().slice(0, 10)}.csv`;
-    a.click();
-    URL.revokeObjectURL(url);
+    const header = [
+      'id',
+      'created_at',
+      'action',
+      'resource_type',
+      'resource_id',
+      'user_email',
+      'user_name',
+      'organization_id',
+      'ip_address',
+    ]
+    const rows = logs.map((l) =>
+      [
+        l.id,
+        l.created_at,
+        l.action,
+        l.resource_type ?? '',
+        l.resource_id ?? '',
+        l.user_email ?? '',
+        l.user_name ?? '',
+        l.organization_id ?? '',
+        l.ip_address ?? '',
+      ]
+        .map((v) => `"${String(v).replace(/"/g, '""')}"`)
+        .join(','),
+    )
+    const csv = [header.join(','), ...rows].join('\n')
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = `audit-logs-${new Date().toISOString().slice(0, 10)}.csv`
+    a.click()
+    URL.revokeObjectURL(url)
   }
 
   exportAuditLogsJSON(logs: import('../types').AuditLog[]): void {
-    const json = JSON.stringify(logs, null, 2);
-    const blob = new Blob([json], { type: 'application/json' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = `audit-logs-${new Date().toISOString().slice(0, 10)}.json`;
-    a.click();
-    URL.revokeObjectURL(url);
+    const json = JSON.stringify(logs, null, 2)
+    const blob = new Blob([json], { type: 'application/json' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = `audit-logs-${new Date().toISOString().slice(0, 10)}.json`
+    a.click()
+    URL.revokeObjectURL(url)
   }
 
   // ============================================================================
@@ -1495,11 +1616,10 @@ class ApiClient {
   // ============================================================================
 
   async getVersionInfo(): Promise<import('../types').VersionInfo> {
-    const response = await this.client.get('/version');
-    return response.data;
+    const response = await this.client.get('/version')
+    return response.data
   }
 }
 
-const apiClient = new ApiClient();
-export default apiClient;
-
+const apiClient = new ApiClient()
+export default apiClient

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,506 +1,522 @@
 export interface User {
-  id: string;
-  email: string;
-  name: string;
-  username?: string; // Alias for name for UI purposes
-  role?: string; // Deprecated: use memberships for per-org roles
-  organization_name?: string; // Associated organization
-  oidc_sub?: string;
-  created_at: string;
-  updated_at: string;
+  id: string
+  email: string
+  name: string
+  username?: string // Alias for name for UI purposes
+  role?: string // Deprecated: use memberships for per-org roles
+  organization_name?: string // Associated organization
+  oidc_sub?: string
+  created_at: string
+  updated_at: string
 }
 
-export type { RoleTemplate } from './rbac';
+export type { RoleTemplate } from './rbac'
 
 export interface RoleTemplateInfo {
-  id?: string;
-  name: string;
-  display_name: string;
-  scopes?: string[];
+  id?: string
+  name: string
+  display_name: string
+  scopes?: string[]
 }
 
 export interface Organization {
-  id: string;
-  name: string;
-  display_name: string;
-  idp_type?: string | null;  // "oidc", "saml", "ldap", or null
-  idp_name?: string | null;  // IdP name within the type
-  created_at: string;
-  updated_at: string;
+  id: string
+  name: string
+  display_name: string
+  idp_type?: string | null // "oidc", "saml", "ldap", or null
+  idp_name?: string | null // IdP name within the type
+  created_at: string
+  updated_at: string
 }
 
 export interface OrganizationMember {
-  organization_id: string;
-  user_id: string;
-  role_template_id?: string;
-  created_at: string;
+  organization_id: string
+  user_id: string
+  role_template_id?: string
+  created_at: string
 }
 
 export interface OrganizationMemberWithUser {
-  organization_id: string;
-  user_id: string;
-  role_template_id?: string;
-  role_template_name?: string;
-  role_template_display_name?: string;
-  role_template_scopes?: string[];
-  created_at: string;
-  user_name: string;
-  user_email: string;
+  organization_id: string
+  user_id: string
+  role_template_id?: string
+  role_template_name?: string
+  role_template_display_name?: string
+  role_template_scopes?: string[]
+  created_at: string
+  user_name: string
+  user_email: string
 }
 
 export interface UserMembership {
-  organization_id: string;
-  organization_name: string;
-  role_template_id?: string;
-  role_template_name?: string;
-  role_template_display_name?: string;
-  role_template_scopes?: string[];
-  role_template?: RoleTemplateInfo;
-  created_at: string;
+  organization_id: string
+  organization_name: string
+  role_template_id?: string
+  role_template_name?: string
+  role_template_display_name?: string
+  role_template_scopes?: string[]
+  role_template?: RoleTemplateInfo
+  created_at: string
 }
 
 export interface APIKey {
-  id: string;
-  user_id?: string;
-  user_name?: string; // User name who created this key (joined from users table)
-  organization_id: string;
-  name: string;
-  description?: string;
-  key_prefix: string;
-  scopes: string[];
-  expires_at?: string;
-  last_used_at?: string;
-  created_at: string;
+  id: string
+  user_id?: string
+  user_name?: string // User name who created this key (joined from users table)
+  organization_id: string
+  name: string
+  description?: string
+  key_prefix: string
+  scopes: string[]
+  expires_at?: string
+  last_used_at?: string
+  created_at: string
 }
 
 export interface RotateAPIKeyResponse {
   new_key: {
-    id: string;
-    name: string;
-    key: string;
-    key_prefix: string;
-    scopes: string[];
-    expires_at?: string;
-    created_at: string;
-  };
-  old_key_status: string;
-  old_expires_at?: string;
+    id: string
+    name: string
+    key: string
+    key_prefix: string
+    scopes: string[]
+    expires_at?: string
+    created_at: string
+  }
+  old_key_status: string
+  old_expires_at?: string
 }
 
 export interface Module {
-  id: string;
-  namespace: string;
-  name: string;
-  system: string;
-  provider?: string; // Alias for system for backward compatibility
-  description?: string;
-  source?: string;
-  organization_id?: string;
-  organization_name?: string;
-  latest_version?: string; // Latest version string
-  download_count?: number; // Total downloads
-  versions?: ModuleVersion[]; // Embedded versions from getModule API
-  created_by?: string; // User ID who created this module
-  created_by_name?: string; // User name who created this module
-  created_at: string;
-  updated_at: string;
-  deprecated?: boolean;
-  deprecated_at?: string;
-  deprecation_message?: string;
-  successor_module_id?: string;
-  successor_module?: { namespace: string; name: string; system: string };
+  id: string
+  namespace: string
+  name: string
+  system: string
+  provider?: string // Alias for system for backward compatibility
+  description?: string
+  source?: string
+  organization_id?: string
+  organization_name?: string
+  latest_version?: string // Latest version string
+  download_count?: number // Total downloads
+  versions?: ModuleVersion[] // Embedded versions from getModule API
+  created_by?: string // User ID who created this module
+  created_by_name?: string // User name who created this module
+  created_at: string
+  updated_at: string
+  deprecated?: boolean
+  deprecated_at?: string
+  deprecation_message?: string
+  successor_module_id?: string
+  successor_module?: { namespace: string; name: string; system: string }
 }
 
 export interface ModuleVersion {
-  id: string;
-  module_id: string;
-  version: string;
-  storage_path?: string;
-  storage_backend?: string;
-  size_bytes?: number;
-  checksum?: string;
-  readme?: string;
-  download_count: number;
-  deprecated?: boolean;
-  deprecated_at?: string;
-  deprecation_message?: string;
-  published_by?: string; // User ID who published this version
-  published_by_name?: string; // User name who published this version
-  published_at?: string;
-  created_at?: string;
+  id: string
+  module_id: string
+  version: string
+  storage_path?: string
+  storage_backend?: string
+  size_bytes?: number
+  checksum?: string
+  readme?: string
+  download_count: number
+  deprecated?: boolean
+  deprecated_at?: string
+  deprecation_message?: string
+  published_by?: string // User ID who published this version
+  published_by_name?: string // User name who published this version
+  published_at?: string
+  created_at?: string
 }
 
 export interface Provider {
-  id: string;
-  namespace: string;
-  type: string;
-  description?: string;
-  source?: string;
-  organization_id: string;
-  organization_name?: string;
-  latest_version?: string; // Latest version string
-  download_count?: number; // Total downloads
-  created_by?: string; // User ID who created this provider
-  created_by_name?: string; // User name who created this provider
-  created_at: string;
-  updated_at: string;
+  id: string
+  namespace: string
+  type: string
+  description?: string
+  source?: string
+  organization_id: string
+  organization_name?: string
+  latest_version?: string // Latest version string
+  download_count?: number // Total downloads
+  created_by?: string // User ID who created this provider
+  created_by_name?: string // User name who created this provider
+  created_at: string
+  updated_at: string
 }
 
 export interface ProviderPlatform {
-  id: string;
-  provider_version_id: string;
-  os: string;
-  arch: string;
-  filename: string;
-  storage_path: string;
-  storage_backend: string;
-  size_bytes: number;
-  shasum: string;
-  download_count: number;
+  id: string
+  provider_version_id: string
+  os: string
+  arch: string
+  filename: string
+  storage_path: string
+  storage_backend: string
+  size_bytes: number
+  shasum: string
+  download_count: number
 }
 
 export interface ProviderVersion {
-  id: string;
-  provider_id: string;
-  version: string;
-  protocols: string[];
-  gpg_public_key: string;
-  shasums_url: string;
-  shasums_signature_url: string;
-  published_by?: string; // User ID who published this version
-  published_by_name?: string; // User name who published this version
-  published_at: string;
-  download_count?: number;
-  platforms?: ProviderPlatform[];
-  deprecated?: boolean;
-  deprecated_at?: string;
-  deprecation_message?: string;
-  created_at: string;
+  id: string
+  provider_id: string
+  version: string
+  protocols: string[]
+  gpg_public_key: string
+  shasums_url: string
+  shasums_signature_url: string
+  published_by?: string // User ID who published this version
+  published_by_name?: string // User name who published this version
+  published_at: string
+  download_count?: number
+  platforms?: ProviderPlatform[]
+  deprecated?: boolean
+  deprecated_at?: string
+  deprecation_message?: string
+  created_at: string
 }
 
 export interface ProviderDocEntry {
-  id: string;
-  title: string;
-  slug: string;
-  category: string;
-  subcategory?: string;
-  language: string;
+  id: string
+  title: string
+  slug: string
+  category: string
+  subcategory?: string
+  language: string
 }
 
 export interface ProviderDocsResponse {
-  docs: ProviderDocEntry[];
-  categories: string[];
-  total: number;
-  limit: number;
-  offset: number;
+  docs: ProviderDocEntry[]
+  categories: string[]
+  total: number
+  limit: number
+  offset: number
 }
 
 export interface ProviderDocContent {
-  content: string;
-  title: string;
-  category: string;
-  slug: string;
+  content: string
+  title: string
+  category: string
+  slug: string
 }
 
 export interface PaginationMeta {
-  page: number;
-  per_page: number;
-  total: number;
+  page: number
+  per_page: number
+  total: number
 }
 
 export interface AuthContextType {
-  user: User | null;
-  roleTemplate: RoleTemplateInfo | null; // Primary role template (backward compat)
-  allowedScopes: string[]; // Combined scopes across all org memberships
-  memberships?: UserMembership[]; // Per-org memberships with role templates
-  isAuthenticated: boolean;
-  isLoading: boolean;
-  sessionExpiresAt: Date | null;
-  sessionExpiresSoon: boolean;
-  login: (userOrProvider: User | 'oidc' | 'azuread') => Promise<void>;
-  logout: () => void;
-  refreshToken: () => Promise<void>;
-  setToken: (token: string) => void; // For dev mode impersonation
+  user: User | null
+  roleTemplate: RoleTemplateInfo | null // Primary role template (backward compat)
+  allowedScopes: string[] // Combined scopes across all org memberships
+  memberships?: UserMembership[] // Per-org memberships with role templates
+  isAuthenticated: boolean
+  isLoading: boolean
+  sessionExpiresAt: Date | null
+  sessionExpiresSoon: boolean
+  login: (userOrProvider: User | 'oidc' | 'azuread') => Promise<void>
+  logout: () => void
+  refreshToken: () => Promise<void>
+  setToken: (token: string) => void // For dev mode impersonation
 }
 
 // Storage Configuration Types
-export type StorageBackendType = 'local' | 'azure' | 's3' | 'gcs';
+export type StorageBackendType = 'local' | 'azure' | 's3' | 'gcs'
 
 export interface StorageConfigResponse {
-  id: string;
-  backend_type: StorageBackendType;
-  is_active: boolean;
+  id: string
+  backend_type: StorageBackendType
+  is_active: boolean
 
   // Local storage settings
-  local_base_path?: string;
-  local_serve_directly?: boolean;
+  local_base_path?: string
+  local_serve_directly?: boolean
 
   // Azure Blob Storage settings
-  azure_account_name?: string;
-  azure_account_key_set: boolean;
-  azure_container_name?: string;
-  azure_cdn_url?: string;
+  azure_account_name?: string
+  azure_account_key_set: boolean
+  azure_container_name?: string
+  azure_cdn_url?: string
 
   // S3 settings
-  s3_endpoint?: string;
-  s3_region?: string;
-  s3_bucket?: string;
-  s3_auth_method?: string;
-  s3_access_key_id_set: boolean;
-  s3_secret_access_key_set: boolean;
-  s3_role_arn?: string;
-  s3_role_session_name?: string;
-  s3_external_id?: string;
-  s3_web_identity_token_file?: string;
+  s3_endpoint?: string
+  s3_region?: string
+  s3_bucket?: string
+  s3_auth_method?: string
+  s3_access_key_id_set: boolean
+  s3_secret_access_key_set: boolean
+  s3_role_arn?: string
+  s3_role_session_name?: string
+  s3_external_id?: string
+  s3_web_identity_token_file?: string
 
   // GCS settings
-  gcs_bucket?: string;
-  gcs_project_id?: string;
-  gcs_auth_method?: string;
-  gcs_credentials_file?: string;
-  gcs_credentials_json_set: boolean;
-  gcs_endpoint?: string;
+  gcs_bucket?: string
+  gcs_project_id?: string
+  gcs_auth_method?: string
+  gcs_credentials_file?: string
+  gcs_credentials_json_set: boolean
+  gcs_endpoint?: string
 
   // Metadata
-  created_at: string;
-  updated_at: string;
+  created_at: string
+  updated_at: string
 }
 
 export interface StorageConfigInput {
-  backend_type: StorageBackendType;
+  backend_type: StorageBackendType
 
   // Local storage settings
-  local_base_path?: string;
-  local_serve_directly?: boolean;
+  local_base_path?: string
+  local_serve_directly?: boolean
 
   // Azure Blob Storage settings
-  azure_account_name?: string;
-  azure_account_key?: string;
-  azure_container_name?: string;
-  azure_cdn_url?: string;
+  azure_account_name?: string
+  azure_account_key?: string
+  azure_container_name?: string
+  azure_cdn_url?: string
 
   // S3 settings
-  s3_endpoint?: string;
-  s3_region?: string;
-  s3_bucket?: string;
-  s3_auth_method?: string;
-  s3_access_key_id?: string;
-  s3_secret_access_key?: string;
-  s3_role_arn?: string;
-  s3_role_session_name?: string;
-  s3_external_id?: string;
-  s3_web_identity_token_file?: string;
+  s3_endpoint?: string
+  s3_region?: string
+  s3_bucket?: string
+  s3_auth_method?: string
+  s3_access_key_id?: string
+  s3_secret_access_key?: string
+  s3_role_arn?: string
+  s3_role_session_name?: string
+  s3_external_id?: string
+  s3_web_identity_token_file?: string
 
   // GCS settings
-  gcs_bucket?: string;
-  gcs_project_id?: string;
-  gcs_auth_method?: string;
-  gcs_credentials_file?: string;
-  gcs_credentials_json?: string;
-  gcs_endpoint?: string;
+  gcs_bucket?: string
+  gcs_project_id?: string
+  gcs_auth_method?: string
+  gcs_credentials_file?: string
+  gcs_credentials_json?: string
+  gcs_endpoint?: string
 }
 
 export interface SetupStatus {
-  storage_configured: boolean;
-  setup_required: boolean;
-  storage_configured_at?: string;
+  storage_configured: boolean
+  setup_required: boolean
+  storage_configured_at?: string
   // Enhanced fields from setup wizard
-  setup_completed?: boolean;
-  oidc_configured?: boolean;
-  ldap_configured?: boolean;
-  auth_method?: 'oidc' | 'ldap';
-  scanning_configured?: boolean;
-  admin_configured?: boolean;
-  pending_feature_setup?: boolean;
+  setup_completed?: boolean
+  oidc_configured?: boolean
+  ldap_configured?: boolean
+  auth_method?: 'oidc' | 'ldap'
+  scanning_configured?: boolean
+  admin_configured?: boolean
+  pending_feature_setup?: boolean
 }
 
 // Setup Wizard — Security Scanning configuration
 export interface ScanningConfigInput {
-  enabled: boolean;
-  tool: string;
-  binary_path?: string;
-  severity_threshold?: string;
-  timeout?: string;
+  enabled: boolean
+  tool: string
+  binary_path?: string
+  severity_threshold?: string
+  timeout?: string
 }
 
 export interface ScanningTestResult {
-  success: boolean;
-  message: string;
-  tool?: string;
-  version?: string;
+  success: boolean
+  message: string
+  tool?: string
+  version?: string
+}
+
+// Setup Wizard / Admin — Scanner auto-install
+export interface ScanningInstallRequest {
+  tool: string
+  version?: string
+}
+
+export interface ScanningInstallResult {
+  success: boolean
+  tool: string
+  version: string
+  binary_path: string
+  sha256: string
+  source_url: string
+  error?: string
 }
 
 // Setup Wizard — LDAP configuration
 export interface LDAPConfigInput {
-  host: string;
-  port: number;
-  use_tls: boolean;
-  start_tls: boolean;
-  insecure_skip_verify: boolean;
-  bind_dn: string;
-  bind_password: string;
-  base_dn: string;
-  user_filter: string;
-  user_attr_email: string;
-  user_attr_name: string;
-  group_base_dn: string;
-  group_filter: string;
-  group_member_attr: string;
+  host: string
+  port: number
+  use_tls: boolean
+  start_tls: boolean
+  insecure_skip_verify: boolean
+  bind_dn: string
+  bind_password: string
+  base_dn: string
+  user_filter: string
+  user_attr_email: string
+  user_attr_name: string
+  group_base_dn: string
+  group_filter: string
+  group_member_attr: string
 }
 
 // Setup Wizard Types
 export interface OIDCConfigInput {
-  name?: string;
-  provider_type: 'generic_oidc' | 'azuread';
-  issuer_url: string;
-  client_id: string;
-  client_secret: string;
-  redirect_url: string;
-  scopes?: string[];
-  extra_config?: Record<string, string>;
+  name?: string
+  provider_type: 'generic_oidc' | 'azuread'
+  issuer_url: string
+  client_id: string
+  client_secret: string
+  redirect_url: string
+  scopes?: string[]
+  extra_config?: Record<string, string>
 }
 
 export interface OIDCGroupMapping {
-  group: string;
-  organization: string;
-  role: string;
+  group: string
+  organization: string
+  role: string
 }
 
 export interface OIDCGroupMappingInput {
-  group_claim_name: string;
-  group_mappings: OIDCGroupMapping[];
-  default_role: string;
+  group_claim_name: string
+  group_mappings: OIDCGroupMapping[]
+  default_role: string
 }
 
 export interface OIDCConfigResponse {
-  id: string;
-  name: string;
-  provider_type: string;
-  issuer_url: string;
-  client_id: string;
-  redirect_url: string;
-  scopes: string[];
-  is_active: boolean;
-  group_claim_name?: string;
-  group_mappings?: OIDCGroupMapping[];
-  default_role?: string;
-  created_at: string;
-  updated_at: string;
+  id: string
+  name: string
+  provider_type: string
+  issuer_url: string
+  client_id: string
+  redirect_url: string
+  scopes: string[]
+  is_active: boolean
+  group_claim_name?: string
+  group_mappings?: OIDCGroupMapping[]
+  default_role?: string
+  created_at: string
+  updated_at: string
 }
 
 // SAML + LDAP identity group mapping types (read-only from server config)
 export interface SAMLGroupMapping {
-  group: string;
-  organization: string;
-  role: string;
+  group: string
+  organization: string
+  role: string
 }
 
 export interface LDAPGroupMapping {
-  group_dn: string;
-  organization: string;
-  role: string;
+  group_dn: string
+  organization: string
+  role: string
 }
 
 export interface IdentityGroupMappings {
   saml?: {
-    group_attribute_name: string;
-    default_role: string;
-    group_mappings: SAMLGroupMapping[];
-  };
+    group_attribute_name: string
+    default_role: string
+    group_mappings: SAMLGroupMapping[]
+  }
   ldap?: {
-    default_role: string;
-    group_mappings: LDAPGroupMapping[];
-  };
+    default_role: string
+    group_mappings: LDAPGroupMapping[]
+  }
 }
 
 export interface MTLSSubjectMapping {
-  subject: string;
-  scopes: string[];
+  subject: string
+  scopes: string[]
 }
 
 export interface MTLSConfigResponse {
-  enabled: boolean;
-  client_ca_file: string;
-  mappings: MTLSSubjectMapping[];
+  enabled: boolean
+  client_ca_file: string
+  mappings: MTLSSubjectMapping[]
 }
 
 export interface SetupValidateTokenResponse {
-  valid: boolean;
-  message: string;
+  valid: boolean
+  message: string
 }
 
 export interface SetupTestResult {
-  success: boolean;
-  message: string;
-  issuer?: string; // For OIDC test
+  success: boolean
+  message: string
+  issuer?: string // For OIDC test
 }
 
 export interface ConfigureAdminInput {
-  email: string;
+  email: string
 }
 
 export interface ConfigureAdminResponse {
-  message: string;
-  email: string;
-  organization: string;
-  role: string;
+  message: string
+  email: string
+  organization: string
+  role: string
 }
 
 export interface CompleteSetupResponse {
-  message: string;
-  setup_completed: boolean;
+  message: string
+  setup_completed: boolean
 }
 
 export interface AuditLog {
-  id: string;
-  user_id: string | null;
-  user_email: string | null;
-  user_name: string | null;
-  organization_id: string | null;
-  action: string;
-  resource_type: string | null;
-  resource_id: string | null;
-  metadata: Record<string, unknown> | null;
-  ip_address: string | null;
-  created_at: string;
+  id: string
+  user_id: string | null
+  user_email: string | null
+  user_name: string | null
+  organization_id: string | null
+  action: string
+  resource_type: string | null
+  resource_id: string | null
+  metadata: Record<string, unknown> | null
+  ip_address: string | null
+  created_at: string
 }
 
 export interface AuditLogListResponse {
-  logs: AuditLog[];
-  pagination: PaginationMeta;
+  logs: AuditLog[]
+  pagination: PaginationMeta
 }
 
 export interface VersionInfo {
-  version: string;
-  build_date: string;
-  api_version: string;
+  version: string
+  build_date: string
+  api_version: string
   protocols: {
-    modules: string;
-    providers: string;
-    mirror: string;
-  };
+    modules: string
+    providers: string
+    mirror: string
+  }
 }
 
 // ---- Module Security Scan ----
 
-export type ModuleScanStatus = 'pending' | 'scanning' | 'clean' | 'findings' | 'error';
+export type ModuleScanStatus = 'pending' | 'scanning' | 'clean' | 'findings' | 'error'
 
 export interface ModuleScan {
-  id: string;
-  module_version_id: string;
-  scanner: string;
-  scanner_version: string | null;
-  expected_version: string | null;
-  status: ModuleScanStatus;
-  scanned_at: string | null;
-  critical_count: number;
-  high_count: number;
-  medium_count: number;
-  low_count: number;
-  raw_results: Record<string, unknown> | null;
-  error_message: string | null;
-  created_at: string;
-  updated_at: string;
+  id: string
+  module_version_id: string
+  scanner: string
+  scanner_version: string | null
+  expected_version: string | null
+  status: ModuleScanStatus
+  scanned_at: string | null
+  critical_count: number
+  high_count: number
+  medium_count: number
+  low_count: number
+  raw_results: Record<string, unknown> | null
+  error_message: string | null
+  created_at: string
+  updated_at: string
 }
 
 // ---- Module terraform-docs ----
@@ -508,95 +524,95 @@ export interface ModuleScan {
 // ---- Security Scanning Admin ----
 
 export interface ScanningConfig {
-  enabled: boolean;
-  tool: string;
-  expected_version?: string;
-  severity_threshold: string;
-  timeout: string;
-  worker_count: number;
-  scan_interval_mins: number;
+  enabled: boolean
+  tool: string
+  expected_version?: string
+  severity_threshold: string
+  timeout: string
+  worker_count: number
+  scan_interval_mins: number
 }
 
 export interface RecentScanEntry {
-  id: string;
-  module_version: string;
-  module_name: string;
-  namespace: string;
-  system: string;
-  scanner: string;
-  status: ModuleScanStatus;
-  critical_count: number;
-  high_count: number;
-  medium_count: number;
-  low_count: number;
-  scanned_at: string | null;
-  created_at: string;
+  id: string
+  module_version: string
+  module_name: string
+  namespace: string
+  system: string
+  scanner: string
+  status: ModuleScanStatus
+  critical_count: number
+  high_count: number
+  medium_count: number
+  low_count: number
+  scanned_at: string | null
+  created_at: string
 }
 
 export interface ScanningStats {
-  total: number;
-  pending: number;
-  scanning: number;
-  clean: number;
-  findings: number;
-  error: number;
-  recent_scans: RecentScanEntry[];
+  total: number
+  pending: number
+  scanning: number
+  clean: number
+  findings: number
+  error: number
+  recent_scans: RecentScanEntry[]
 }
 
 // ---- Module terraform-docs ----
 
 export interface ModuleInputVar {
-  name: string;
-  type: string;
-  description: string;
-  default: unknown;
-  required: boolean;
+  name: string
+  type: string
+  description: string
+  default: unknown
+  required: boolean
 }
 
 export interface ModuleOutputVal {
-  name: string;
-  description: string;
-  sensitive: boolean;
+  name: string
+  description: string
+  sensitive: boolean
 }
 
 export interface ModuleProviderReq {
-  name: string;
-  source: string;
-  version_constraints: string;
+  name: string
+  source: string
+  version_constraints: string
 }
 
 export interface ModuleRequirements {
-  required_version: string;
+  required_version: string
 }
 
 export interface ModuleDoc {
-  inputs: ModuleInputVar[];
-  outputs: ModuleOutputVal[];
-  providers: ModuleProviderReq[];
-  requirements: ModuleRequirements | null;
+  inputs: ModuleInputVar[]
+  outputs: ModuleOutputVal[]
+  providers: ModuleProviderReq[]
+  requirements: ModuleRequirements | null
 }
 
 // ---- Storage Migration ----
 
 export interface MigrationPlan {
-  source_config_id: string;
-  target_config_id: string;
-  total_artifacts: number;
-  total_modules: number;
-  total_providers: number;
-  estimated_size_bytes: number;
+  source_config_id: string
+  target_config_id: string
+  total_artifacts: number
+  total_modules: number
+  total_providers: number
+  estimated_size_bytes: number
 }
 
 export interface StorageMigration {
-  id: string;
-  source_config_id: string;
-  target_config_id: string;
-  status: 'pending' | 'running' | 'completed' | 'failed' | 'cancelled';
-  total_artifacts: number;
-  migrated_artifacts: number;
-  failed_artifacts: number;
-  error_message?: string;
-  started_at?: string;
-  completed_at?: string;
-  created_at: string;
+  id: string
+  source_config_id: string
+  target_config_id: string
+  status: 'pending' | 'running' | 'completed' | 'failed' | 'cancelled'
+  total_artifacts: number
+  migrated_artifacts: number
+  failed_artifacts: number
+  error_message?: string
+  started_at?: string
+  completed_at?: string
+  created_at: string
 }


### PR DESCRIPTION
## Summary
- Add auto-install panel to the Security Scanning setup wizard step
- Supports Trivy, Checkov, and Terrascan — downloads official release, verifies SHA256 checksum, installs binary
- Accordion UI for optional version pinning
- Auto-populates binary path on successful install
- Success/error alerts with version, path, and truncated SHA256

## Changes
- `types/index.ts` — Add `ScanningInstallRequest` and `ScanningInstallResult` types
- `services/api.ts` — Add `installScanningTool()` API method
- `contexts/SetupWizardContext.tsx` — Add `installScanner` action, `scanningInstalling`/`scanningInstallResult` state
- `pages/setup/steps/ScanningStep.tsx` — Add auto-install panel with version pinning accordion
- Tests updated across context, step component, and wizard integration

## Changelog
- feat: add scanner auto-install UI to setup wizard (Trivy, Checkov, Terrascan)

## Test plan
- [x] `npm run lint` passes
- [x] `npm run build` succeeds
- [x] ScanningStep unit tests pass (9 new auto-install tests)
- [x] SetupWizardContext unit tests pass (3 new install tests)
- [x] SetupWizardPage integration tests pass
- [ ] E2E: verify auto-install panel appears when scanning is enabled
- [ ] E2E: verify panel hidden for snyk/custom tool selections

Closes #159