### PR TITLE
feat: default Modules to Provider view + Name A-Z sort, persist view in URL

### DIFF
--- a/frontend/src/pages/ModulesPage.tsx
+++ b/frontend/src/pages/ModulesPage.tsx
@@ -55,8 +55,14 @@ function parseSortValue(value: string): { sort?: string; order?: string } {
 
 /** Build a combined sort value from separate sort/order URL params. */
 function buildSortValue(sort?: string | null, order?: string | null): string {
-  if (!sort) return 'relevance';
+  if (!sort) return 'name:asc';
+  if (sort === 'relevance') return 'relevance';
   return order ? `${sort}:${order}` : sort;
+}
+
+/** Parse a URL ?view= value into a validated ViewMode (grouped is the default). */
+function parseViewMode(value: string | null): ViewMode {
+  return value === 'grid' ? 'grid' : 'grouped';
 }
 
 /** Group an array of modules by their system (provider) field, alphabetically. */
@@ -118,7 +124,9 @@ const ModulesPage: React.FC = () => {
     setInputValue(urlQuery);
   }, [urlQuery]);
 
-  const [viewMode, setViewMode] = useState<ViewMode>('grid');
+  // View mode is URL-backed (?view=grid|grouped) so it survives reload and is shareable.
+  // Grouped is the default — only grid is persisted as a query param to keep URLs tidy.
+  const viewMode: ViewMode = parseViewMode(searchParams.get('view'));
   const limit = viewMode === 'grouped' ? 100 : 12;
 
   const { sort: apiSort, order: apiOrder } = parseSortValue(sortValue);
@@ -164,18 +172,16 @@ const ModulesPage: React.FC = () => {
 
   const handleSortChange = useCallback((event: SelectChangeEvent<string>) => {
     const newValue = event.target.value;
-    const { sort, order } = parseSortValue(newValue);
     setSearchParams((prev) => {
       const next = new URLSearchParams(prev);
-      if (sort) {
-        next.set('sort', sort);
-      } else {
-        next.delete('sort');
-      }
-      if (order) {
-        next.set('order', order);
-      } else {
+      if (newValue === 'relevance') {
+        // Default is name:asc, so Relevance must be persisted explicitly.
+        next.set('sort', 'relevance');
         next.delete('order');
+      } else {
+        const { sort, order } = parseSortValue(newValue);
+        if (sort) next.set('sort', sort); else next.delete('sort');
+        if (order) next.set('order', order); else next.delete('order');
       }
       // Reset to page 1 when sort changes
       next.delete('page');
@@ -185,10 +191,14 @@ const ModulesPage: React.FC = () => {
 
   const handleViewModeChange = useCallback((_event: React.MouseEvent<HTMLElement>, newMode: ViewMode | null) => {
     if (newMode) {
-      setViewMode(newMode);
-      // Reset to page 1 when view mode changes
       setSearchParams((prev) => {
         const next = new URLSearchParams(prev);
+        if (newMode === 'grouped') {
+          next.delete('view');
+        } else {
+          next.set('view', newMode);
+        }
+        // Reset to page 1 when view mode changes
         next.delete('page');
         return next;
       }, { replace: true });
@@ -329,11 +339,11 @@ const ModulesPage: React.FC = () => {
             No modules found
           </Typography>
           <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
-            {urlQuery || apiSort
+            {urlQuery || urlSort
               ? 'Try a different search query or sort option'
               : 'Upload your first module to get started'}
           </Typography>
-          {(urlQuery || apiSort) && (
+          {(urlQuery || urlSort) && (
             <Button
               variant="outlined"
               sx={{ mt: 2 }}

--- a/frontend/src/pages/ProvidersPage.tsx
+++ b/frontend/src/pages/ProvidersPage.tsx
@@ -45,7 +45,8 @@ function parseSortValue(value: string): { sort?: string; order?: string } {
 
 /** Build a combined sort value from separate sort/order URL params. */
 function buildSortValue(sort?: string | null, order?: string | null): string {
-  if (!sort) return 'relevance';
+  if (!sort) return 'name:asc';
+  if (sort === 'relevance') return 'relevance';
   return order ? `${sort}:${order}` : sort;
 }
 
@@ -137,18 +138,16 @@ const ProvidersPage: React.FC = () => {
 
   const handleSortChange = useCallback((event: SelectChangeEvent<string>) => {
     const newValue = event.target.value;
-    const { sort, order } = parseSortValue(newValue);
     setSearchParams((prev) => {
       const next = new URLSearchParams(prev);
-      if (sort) {
-        next.set('sort', sort);
-      } else {
-        next.delete('sort');
-      }
-      if (order) {
-        next.set('order', order);
-      } else {
+      if (newValue === 'relevance') {
+        // Default is name:asc, so Relevance must be persisted explicitly.
+        next.set('sort', 'relevance');
         next.delete('order');
+      } else {
+        const { sort, order } = parseSortValue(newValue);
+        if (sort) next.set('sort', sort); else next.delete('sort');
+        if (order) next.set('order', order); else next.delete('order');
       }
       next.delete('page');
       return next;
@@ -243,11 +242,11 @@ const ProvidersPage: React.FC = () => {
             No providers found
           </Typography>
           <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
-            {urlQuery || apiSort
+            {urlQuery || urlSort
               ? 'Try a different search query or sort option'
               : 'Upload your first provider to get started'}
           </Typography>
-          {(urlQuery || apiSort) && (
+          {(urlQuery || urlSort) && (
             <Button
               variant="outlined"
               sx={{ mt: 2 }}

--- a/frontend/src/pages/__tests__/ModulesPage.test.tsx
+++ b/frontend/src/pages/__tests__/ModulesPage.test.tsx
@@ -131,7 +131,8 @@ describe('ModulesPage', () => {
       modules: fakeModules,
       meta: { total: 50, limit: 12, offset: 12 },
     })
-    renderWithRoute('/modules?page=2')
+    // Force grid view so the paginated limit is 12 (grouped uses limit=100).
+    renderWithRoute('/modules?page=2&view=grid')
     // The API should be called with offset 12 (page 2, limit 12)
     await screen.findByText('Terraform Modules')
     expect(searchModulesMock).toHaveBeenCalledWith(
@@ -230,9 +231,66 @@ describe('ModulesPage', () => {
     expect(screen.getByRole('button', { name: /grouped by provider/i })).toBeInTheDocument()
   })
 
-  // -- Sort dropdown renders --
+  // -- View mode URL persistence --
 
-  it('renders the sort dropdown with correct default', async () => {
+  it('defaults to grouped view when no ?view= param is present', async () => {
+    renderWithRoute()
+    await screen.findByText('consul')
+    // Grouped view renders provider section headers (e.g. "Aws", "Azure")
+    expect(screen.getByText('Aws')).toBeInTheDocument()
+    expect(screen.getByText('Azure')).toBeInTheDocument()
+  })
+
+  it('reads initial view mode from URL ?view=grid param', async () => {
+    renderWithRoute('/modules?view=grid')
+    await screen.findByText('consul')
+    // Grid view does NOT render provider section headers
+    expect(screen.queryByText('Aws')).not.toBeInTheDocument()
+    expect(screen.queryByText('Azure')).not.toBeInTheDocument()
+  })
+
+  it('switching to grid view calls the API with the grid limit', async () => {
+    const user = userEvent.setup()
+    renderWithRoute()
+    await screen.findByText('consul')
+    await user.click(screen.getByRole('button', { name: /grid view/i }))
+    // Grid view uses limit=12; grouped uses limit=100.
+    await waitFor(() => {
+      const lastCall = searchModulesMock.mock.calls[searchModulesMock.mock.calls.length - 1][0]
+      expect(lastCall.limit).toBe(12)
+    })
+  })
+
+  it('switching from grid back to grouped uses the grouped limit', async () => {
+    const user = userEvent.setup()
+    renderWithRoute('/modules?view=grid')
+    await screen.findByText('consul')
+    await user.click(screen.getByRole('button', { name: /grouped by provider/i }))
+    await waitFor(() => {
+      const lastCall = searchModulesMock.mock.calls[searchModulesMock.mock.calls.length - 1][0]
+      expect(lastCall.limit).toBe(100)
+    })
+  })
+
+  // -- Sort default + persistence --
+
+  it('defaults to Name A-Z sort when no ?sort= is present', async () => {
+    renderWithRoute()
+    await screen.findByText('Terraform Modules')
+    const lastCall = searchModulesMock.mock.calls[searchModulesMock.mock.calls.length - 1][0]
+    expect(lastCall.sort).toBe('name')
+    expect(lastCall.order).toBe('asc')
+  })
+
+  it('treats explicit ?sort=relevance as no sort/order to the API', async () => {
+    renderWithRoute('/modules?sort=relevance')
+    await screen.findByText('Terraform Modules')
+    const lastCall = searchModulesMock.mock.calls[searchModulesMock.mock.calls.length - 1][0]
+    expect(lastCall.sort).toBeUndefined()
+    expect(lastCall.order).toBeUndefined()
+  })
+
+  it('renders the sort dropdown', async () => {
     renderWithRoute()
     await screen.findByText('consul')
     expect(screen.getByLabelText('Sort By')).toBeInTheDocument()

--- a/frontend/src/pages/__tests__/ProvidersPage.test.tsx
+++ b/frontend/src/pages/__tests__/ProvidersPage.test.tsx
@@ -227,14 +227,35 @@ describe('ProvidersPage', () => {
   it('changes the sort field via the dropdown', async () => {
     searchProvidersMock.mockResolvedValue({ providers: fakeProviders, meta: { total: 2 } })
     renderPage()
+    // Default is Name A-Z, so pick a different option to actually exercise the change.
     const sortSelect = screen.getByLabelText('Sort By')
     fireEvent.mouseDown(sortSelect)
-    const opt = await screen.findByRole('option', { name: /name a-z/i })
+    const opt = await screen.findByRole('option', { name: /newest/i })
     fireEvent.click(opt)
     await waitFor(() => {
       expect(searchProvidersMock).toHaveBeenCalledWith(
-        expect.objectContaining({ sort: 'name', order: 'asc' }),
+        expect.objectContaining({ sort: 'created_at', order: 'desc' }),
       )
+    })
+  })
+
+  it('defaults to Name A-Z sort when no ?sort= is present', async () => {
+    searchProvidersMock.mockResolvedValue({ providers: fakeProviders, meta: { total: 2 } })
+    renderPage()
+    await waitFor(() => {
+      const lastCall = searchProvidersMock.mock.calls[searchProvidersMock.mock.calls.length - 1][0]
+      expect(lastCall.sort).toBe('name')
+      expect(lastCall.order).toBe('asc')
+    })
+  })
+
+  it('treats explicit ?sort=relevance as no sort/order to the API', async () => {
+    searchProvidersMock.mockResolvedValue({ providers: fakeProviders, meta: { total: 2 } })
+    renderPage('/providers?sort=relevance')
+    await waitFor(() => {
+      const lastCall = searchProvidersMock.mock.calls[searchProvidersMock.mock.calls.length - 1][0]
+      expect(lastCall.sort).toBeUndefined()
+      expect(lastCall.order).toBeUndefined()
     })
   })
 


### PR DESCRIPTION
Closes #162

## Summary
- **Modules page** — default view mode is now **Provider** (grouped) instead of Grid. View mode is URL-backed (`?view=grid|grouped`) so it survives reload, back/forward, and is shareable — matching how sort and search are already handled.
- **Modules + Providers pages** — default sort is now **Name A-Z** instead of Relevance. Explicit Relevance is persisted as `?sort=relevance` so a clean URL applies the new default while users can still opt into backend default ordering.
- Empty-state logic ("Upload your first..." / "Clear filters") now keys off `urlSort` instead of the derived `apiSort`, so the fresh-registry hint still surfaces when no params are set.

## Behaviour matrix
| URL | Sort sent to API | View |
| --- | --- | --- |
| `/modules` | `sort=name&order=asc` | grouped |
| `/modules?view=grid` | `sort=name&order=asc` | grid |
| `/modules?sort=relevance` | (none) | grouped |
| `/modules?sort=downloads&order=desc&view=grid` | `sort=downloads&order=desc` | grid |
| `/providers` | `sort=name&order=asc` | n/a |
| `/providers?sort=relevance` | (none) | n/a |

## Tests
- Unit tests — full suite passes (1392 passed, 1 pre-existing unrelated flake in `SetupWizardPage.test.tsx` that passes in isolation).
- Added 7 new unit tests covering default view, `?view=` URL persistence, grid/grouped API-limit differences, default sort, and explicit `?sort=relevance` passthrough for both pages.
- Existing tests updated: `reads the initial page from URL ?page= param` now pins `view=grid` since the grouped default uses `limit=100`; `changes the sort field via the dropdown` on Providers now picks "Newest" (Name A-Z is the new default).
- `npm run lint` clean, `npm run build` succeeds.
- E2E specs for modules/providers don't assert on sort/view and remain valid; not rerun locally.

## Changelog
- feat: default Modules page to Provider view and Name A-Z sort
- feat: persist Modules view mode in the URL as `?view=grid|grouped`
- feat: default Providers page sort to Name A-Z; explicit Relevance is now persisted as `?sort=relevance`