### PR TITLE
fix: add horizontal padding to command palette group headings

### DIFF
--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -136,6 +136,19 @@ const CommandPalette: React.FC<CommandPaletteProps> = ({ open, onClose }) => {
             }}
           />
         </Box>
+        <Box
+          sx={{
+            '& [cmdk-group-heading]': {
+              px: 3,
+              py: 0.75,
+              fontSize: '0.7rem',
+              fontWeight: 600,
+              letterSpacing: '0.08em',
+              textTransform: 'uppercase',
+              color: 'text.disabled',
+            },
+          }}
+        >
         <Command.List
           style={{
             maxHeight: 400,
@@ -213,6 +226,7 @@ const CommandPalette: React.FC<CommandPaletteProps> = ({ open, onClose }) => {
             </Command.Group>
           )}
         </Command.List>
+        </Box>
       </Command>
     </Dialog>
   );


### PR DESCRIPTION
Closes #168

`[cmdk-group-heading]` elements ("Navigation", "Admin", etc.) had no horizontal padding override, leaving them flush against the modal edges while items had `px: 3`.

Wrapped `Command.List` in a `Box` with an `sx` rule targeting `[cmdk-group-heading]` — applies `px: 3`, a muted uppercase label style (0.7rem, 600 weight, `text.disabled` colour) consistent with cmdk convention.

## Changelog
- fix: command palette group headings now have consistent horizontal padding matching list items