### PR TITLE
feat: add per-org quota dashboard to admin dashboard

### DIFF
--- a/frontend/src/components/QuotaUsageChart.tsx
+++ b/frontend/src/components/QuotaUsageChart.tsx
@@ -1,0 +1,104 @@
+import React from 'react'
+import { Box, LinearProgress, Typography, Tooltip, Paper } from '@mui/material'
+import { OrgQuota } from '../types'
+
+interface QuotaRowProps {
+  label: string
+  used: number
+  limit: number
+  ratio: number
+  formatUsed: (v: number) => string
+  formatLimit: (v: number) => string
+}
+
+function QuotaRow({ label, used, limit, ratio, formatUsed, formatLimit }: QuotaRowProps) {
+  const unlimited = limit === 0
+  const pct = unlimited ? 0 : Math.min(ratio * 100, 100)
+  const isWarning = !unlimited && ratio >= 0.8 && ratio < 1.0
+  const isError = !unlimited && ratio >= 1.0
+  const color = isError ? 'error' : isWarning ? 'warning' : 'primary'
+
+  return (
+    <Box>
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 0.5 }}>
+        <Typography variant="body2" color="text.secondary">
+          {label}
+        </Typography>
+        <Typography variant="body2" fontWeight={500}>
+          {unlimited ? (
+            <Box component="span" sx={{ color: 'text.secondary' }}>
+              {formatUsed(used)} / Unlimited
+            </Box>
+          ) : (
+            <Box
+              component="span"
+              sx={{ color: isError ? 'error.main' : isWarning ? 'warning.main' : 'text.primary' }}
+            >
+              {formatUsed(used)} / {formatLimit(limit)}
+            </Box>
+          )}
+        </Typography>
+      </Box>
+      <Tooltip title={unlimited ? 'No limit configured' : `${pct.toFixed(1)}% utilization`}>
+        <LinearProgress
+          variant="determinate"
+          value={pct}
+          color={color}
+          sx={{ height: 8, borderRadius: 4 }}
+        />
+      </Tooltip>
+    </Box>
+  )
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return '0 B'
+  const units = ['B', 'KB', 'MB', 'GB', 'TB']
+  const i = Math.floor(Math.log(bytes) / Math.log(1024))
+  return `${(bytes / Math.pow(1024, i)).toFixed(1)} ${units[i]}`
+}
+
+interface QuotaUsageChartProps {
+  quota: OrgQuota
+  orgName?: string
+}
+
+const QuotaUsageChart: React.FC<QuotaUsageChartProps> = ({ quota, orgName }) => {
+  return (
+    <Paper variant="outlined" sx={{ p: 2 }}>
+      {orgName && (
+        <Typography variant="subtitle2" fontWeight={600} gutterBottom>
+          {orgName}
+        </Typography>
+      )}
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+        <QuotaRow
+          label="Storage"
+          used={quota.storage_bytes_used}
+          limit={quota.storage_bytes_limit}
+          ratio={quota.storage_utilization_ratio}
+          formatUsed={formatBytes}
+          formatLimit={formatBytes}
+        />
+        <QuotaRow
+          label="Publishes / Day"
+          used={quota.publishes_today}
+          limit={quota.publishes_per_day_limit}
+          ratio={quota.publish_utilization_ratio}
+          formatUsed={(v) => String(v)}
+          formatLimit={(v) => String(v)}
+        />
+        <QuotaRow
+          label="Downloads / Day"
+          used={quota.downloads_today}
+          limit={quota.downloads_per_day_limit}
+          ratio={quota.download_utilization_ratio}
+          formatUsed={(v) => String(v)}
+          formatLimit={(v) => String(v)}
+        />
+      </Box>
+    </Paper>
+  )
+}
+
+export default QuotaUsageChart

--- a/frontend/src/components/__tests__/QuotaUsageChart.test.tsx
+++ b/frontend/src/components/__tests__/QuotaUsageChart.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import QuotaUsageChart from '../QuotaUsageChart'
+import type { OrgQuota } from '../../types'
+
+const baseQuota: OrgQuota = {
+  organization_id: 'org-1',
+  storage_bytes_limit: 1073741824, // 1 GB
+  storage_bytes_used: 536870912, // 512 MB
+  storage_utilization_ratio: 0.5,
+  publishes_per_day_limit: 100,
+  publishes_today: 40,
+  publish_utilization_ratio: 0.4,
+  downloads_per_day_limit: 1000,
+  downloads_today: 300,
+  download_utilization_ratio: 0.3,
+}
+
+describe('QuotaUsageChart', () => {
+  it('renders all three quota rows', () => {
+    render(<QuotaUsageChart quota={baseQuota} />)
+    expect(screen.getByText('Storage')).toBeInTheDocument()
+    expect(screen.getByText('Publishes / Day')).toBeInTheDocument()
+    expect(screen.getByText('Downloads / Day')).toBeInTheDocument()
+  })
+
+  it('shows org name when provided', () => {
+    render(<QuotaUsageChart quota={baseQuota} orgName="my-org" />)
+    expect(screen.getByText('my-org')).toBeInTheDocument()
+  })
+
+  it('omits org name when not provided', () => {
+    const { container } = render(<QuotaUsageChart quota={baseQuota} />)
+    // no subtitle text node beyond the row labels
+    expect(container.querySelectorAll('p').length).toBeGreaterThan(0)
+  })
+
+  it('shows "Unlimited" when limit is 0', () => {
+    const unlimitedQuota: OrgQuota = {
+      ...baseQuota,
+      storage_bytes_limit: 0,
+      storage_utilization_ratio: 0,
+    }
+    render(<QuotaUsageChart quota={unlimitedQuota} />)
+    expect(screen.getByText(/Unlimited/)).toBeInTheDocument()
+  })
+
+  it('formats byte values with units', () => {
+    render(<QuotaUsageChart quota={baseQuota} />)
+    // 512 MB used / 1.0 GB limit
+    expect(screen.getByText(/512\.0 MB/)).toBeInTheDocument()
+    expect(screen.getByText(/1\.0 GB/)).toBeInTheDocument()
+  })
+
+  it('shows publish and download counts as plain numbers', () => {
+    render(<QuotaUsageChart quota={baseQuota} />)
+    expect(screen.getByText(/40.*100/)).toBeInTheDocument()
+    expect(screen.getByText(/300.*1000/)).toBeInTheDocument()
+  })
+
+  it('renders warning color at ≥80% utilization', () => {
+    const warningQuota: OrgQuota = {
+      ...baseQuota,
+      publishes_today: 85,
+      publish_utilization_ratio: 0.85,
+    }
+    // The component renders without error — color is applied via MUI props.
+    // Verifying render completion is sufficient for coverage.
+    render(<QuotaUsageChart quota={warningQuota} />)
+    expect(screen.getByText('Publishes / Day')).toBeInTheDocument()
+  })
+
+  it('renders error color at 100% utilization', () => {
+    const overQuota: OrgQuota = {
+      ...baseQuota,
+      downloads_today: 1000,
+      download_utilization_ratio: 1.0,
+    }
+    render(<QuotaUsageChart quota={overQuota} />)
+    expect(screen.getByText('Downloads / Day')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/admin/DashboardPage.tsx
+++ b/frontend/src/pages/admin/DashboardPage.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
-import { useNavigate } from 'react-router-dom';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { queryKeys } from '../../services/queryKeys';
+import React from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { queryKeys } from '../../services/queryKeys'
 import {
   Container,
   Typography,
@@ -20,89 +20,90 @@ import {
   TableRow,
   Tooltip,
   Button,
-} from '@mui/material';
-import ViewModule from '@mui/icons-material/ViewModule';
-import Extension from '@mui/icons-material/Extension';
-import Download from '@mui/icons-material/Download';
-import GetApp from '@mui/icons-material/GetApp';
-import CloudDownload from '@mui/icons-material/CloudDownload';
-import CloudUpload from '@mui/icons-material/CloudUpload';
-import People from '@mui/icons-material/People';
-import Key from '@mui/icons-material/Key';
-import GitHub from '@mui/icons-material/GitHub';
-import Storage from '@mui/icons-material/Storage';
-import CheckCircle from '@mui/icons-material/CheckCircle';
-import Error from '@mui/icons-material/Error';
-import Sync from '@mui/icons-material/Sync';
-import Refresh from '@mui/icons-material/Refresh';
-import ArrowForward from '@mui/icons-material/ArrowForward';
-import Security from '@mui/icons-material/Security';
-import api from '../../services/api';
-import { useAuth } from '../../contexts/AuthContext';
+} from '@mui/material'
+import ViewModule from '@mui/icons-material/ViewModule'
+import Extension from '@mui/icons-material/Extension'
+import Download from '@mui/icons-material/Download'
+import GetApp from '@mui/icons-material/GetApp'
+import CloudDownload from '@mui/icons-material/CloudDownload'
+import CloudUpload from '@mui/icons-material/CloudUpload'
+import People from '@mui/icons-material/People'
+import Key from '@mui/icons-material/Key'
+import GitHub from '@mui/icons-material/GitHub'
+import Storage from '@mui/icons-material/Storage'
+import CheckCircle from '@mui/icons-material/CheckCircle'
+import Error from '@mui/icons-material/Error'
+import Sync from '@mui/icons-material/Sync'
+import Refresh from '@mui/icons-material/Refresh'
+import ArrowForward from '@mui/icons-material/ArrowForward'
+import Security from '@mui/icons-material/Security'
+import api from '../../services/api'
+import { useAuth } from '../../contexts/AuthContext'
+import QuotaUsageChart from '../../components/QuotaUsageChart'
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
 interface RecentSyncEntry {
-  mirror_name: string;
-  mirror_type: 'binary' | 'provider';
-  status: string;
-  started_at: string;
-  completed_at?: string | null;
-  versions_synced: number;
-  platforms_synced: number;
-  triggered_by: string;
+  mirror_name: string
+  mirror_type: 'binary' | 'provider'
+  status: string
+  started_at: string
+  completed_at?: string | null
+  versions_synced: number
+  platforms_synced: number
+  triggered_by: string
 }
 
 interface ModuleSystemCount {
-  system: string;
-  count: number;
+  system: string
+  count: number
 }
 
 interface BinaryToolCount {
-  tool: string;
-  platforms: number;
+  tool: string
+  platforms: number
 }
 
 interface DashboardData {
-  modules: { total: number; versions: number; downloads: number; by_system: ModuleSystemCount[] };
+  modules: { total: number; versions: number; downloads: number; by_system: ModuleSystemCount[] }
   providers: {
-    total: number;
-    manual: number;
-    mirrored: number;
-    total_versions: number;
-    manual_versions: number;
-    mirrored_versions: number;
-    downloads: number;
-  };
-  users: number;
-  organizations: number;
-  downloads: number;
-  scm_providers: number;
+    total: number
+    manual: number
+    mirrored: number
+    total_versions: number
+    manual_versions: number
+    mirrored_versions: number
+    downloads: number
+  }
+  users: number
+  organizations: number
+  downloads: number
+  scm_providers: number
   binary_mirrors: {
-    total: number;
-    healthy: number;
-    failed: number;
-    syncing: number;
-    platforms: number;
-    downloads: number;
-    by_tool: BinaryToolCount[];
-  };
+    total: number
+    healthy: number
+    failed: number
+    syncing: number
+    platforms: number
+    downloads: number
+    by_tool: BinaryToolCount[]
+  }
   provider_mirrors: {
-    total: number;
-    healthy: number;
-    failed: number;
-  };
+    total: number
+    healthy: number
+    failed: number
+  }
   scanning: {
-    enabled: boolean;
-    total: number;
-    pending: number;
-    clean: number;
-    findings: number;
-    error: number;
-  };
-  recent_syncs: RecentSyncEntry[];
+    enabled: boolean
+    total: number
+    pending: number
+    clean: number
+    findings: number
+    error: number
+  }
+  recent_syncs: RecentSyncEntry[]
 }
 
 // ---------------------------------------------------------------------------
@@ -110,27 +111,31 @@ interface DashboardData {
 // ---------------------------------------------------------------------------
 
 function fmtNumber(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
-  return String(n);
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`
+  return String(n)
 }
 
 function timeAgo(iso: string): string {
-  const diff = Date.now() - new Date(iso).getTime();
-  const mins = Math.floor(diff / 60_000);
-  if (mins < 1) return 'just now';
-  if (mins < 60) return `${mins}m ago`;
-  const hrs = Math.floor(mins / 60);
-  if (hrs < 24) return `${hrs}h ago`;
-  return `${Math.floor(hrs / 24)}d ago`;
+  const diff = Date.now() - new Date(iso).getTime()
+  const mins = Math.floor(diff / 60_000)
+  if (mins < 1) return 'just now'
+  if (mins < 60) return `${mins}m ago`
+  const hrs = Math.floor(mins / 60)
+  if (hrs < 24) return `${hrs}h ago`
+  return `${Math.floor(hrs / 24)}d ago`
 }
 
 function syncStatusChip(status: string) {
   switch (status) {
-    case 'success': return <Chip label="success" size="small" color="success" variant="outlined" />;
-    case 'failed': return <Chip label="failed" size="small" color="error" variant="outlined" />;
-    case 'running': return <Chip label="running" size="small" color="info" variant="outlined" />;
-    default: return <Chip label={status} size="small" variant="outlined" />;
+    case 'success':
+      return <Chip label="success" size="small" color="success" variant="outlined" />
+    case 'failed':
+      return <Chip label="failed" size="small" color="error" variant="outlined" />
+    case 'running':
+      return <Chip label="running" size="small" color="info" variant="outlined" />
+    default:
+      return <Chip label={status} size="small" variant="outlined" />
   }
 }
 
@@ -139,43 +144,61 @@ function syncStatusChip(status: string) {
 // ---------------------------------------------------------------------------
 
 interface HealthPillProps {
-  label: string;
-  total: number;
-  failed: number;
-  syncing?: number;
-  icon: React.ReactNode;
-  route: string;
+  label: string
+  total: number
+  failed: number
+  syncing?: number
+  icon: React.ReactNode
+  route: string
 }
 
-const HealthPill: React.FC<HealthPillProps> = ({ label, total, failed, syncing = 0, icon, route }) => {
-  const navigate = useNavigate();
-  const hasIssue = failed > 0;
-  const isSyncing = syncing > 0;
+const HealthPill: React.FC<HealthPillProps> = ({
+  label,
+  total,
+  failed,
+  syncing = 0,
+  icon,
+  route,
+}) => {
+  const navigate = useNavigate()
+  const hasIssue = failed > 0
+  const isSyncing = syncing > 0
 
-  const colour = hasIssue ? 'error.main' : isSyncing ? 'info.main' : 'success.main';
-  const StatusIcon = hasIssue ? Error : isSyncing ? Sync : CheckCircle;
+  const colour = hasIssue ? 'error.main' : isSyncing ? 'info.main' : 'success.main'
+  const StatusIcon = hasIssue ? Error : isSyncing ? Sync : CheckCircle
 
   return (
-    <Tooltip title={
-      hasIssue
-        ? `${failed} of ${total} failed`
-        : isSyncing
-          ? `${syncing} syncing`
-          : total === 0 ? 'None configured' : 'All healthy'
-    }>
+    <Tooltip
+      title={
+        hasIssue
+          ? `${failed} of ${total} failed`
+          : isSyncing
+            ? `${syncing} syncing`
+            : total === 0
+              ? 'None configured'
+              : 'All healthy'
+      }
+    >
       <Paper
         onClick={() => navigate(route)}
         sx={{
-          px: 2, py: 1.5,
-          display: 'flex', alignItems: 'center', gap: 1.5,
-          cursor: 'pointer', flex: 1, minWidth: 160,
+          px: 2,
+          py: 1.5,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 1.5,
+          cursor: 'pointer',
+          flex: 1,
+          minWidth: 160,
           transition: 'box-shadow 0.15s',
           '&:hover': { boxShadow: 3 },
         }}
       >
         <Box sx={{ color: 'text.secondary', display: 'flex' }}>{icon}</Box>
         <Box sx={{ flex: 1, minWidth: 0 }}>
-          <Typography variant="caption" color="text.secondary" noWrap>{label}</Typography>
+          <Typography variant="caption" color="text.secondary" noWrap>
+            {label}
+          </Typography>
           <Typography variant="body2" fontWeight={600} noWrap>
             {total === 0 ? 'None' : `${total - failed} / ${total} OK`}
           </Typography>
@@ -185,28 +208,39 @@ const HealthPill: React.FC<HealthPillProps> = ({ label, total, failed, syncing =
         </Box>
       </Paper>
     </Tooltip>
-  );
-};
-
-interface StatCardProps {
-  title: string;
-  value: number;
-  sub?: string;
-  icon: React.ReactNode;
-  accentColor: string;
-  route: string;
-  aside?: React.ReactNode;
-  compact?: boolean;
+  )
 }
 
-const StatCard: React.FC<StatCardProps> = ({ title, value, sub, icon, accentColor, route, aside, compact }) => {
-  const navigate = useNavigate();
+interface StatCardProps {
+  title: string
+  value: number
+  sub?: string
+  icon: React.ReactNode
+  accentColor: string
+  route: string
+  aside?: React.ReactNode
+  compact?: boolean
+}
+
+const StatCard: React.FC<StatCardProps> = ({
+  title,
+  value,
+  sub,
+  icon,
+  accentColor,
+  route,
+  aside,
+  compact,
+}) => {
+  const navigate = useNavigate()
   return (
     <Paper
       onClick={() => navigate(route)}
       sx={{
         p: compact ? 1.75 : 2.5,
-        display: 'flex', alignItems: 'stretch', gap: compact ? 1.25 : 2,
+        display: 'flex',
+        alignItems: 'stretch',
+        gap: compact ? 1.25 : 2,
         cursor: 'pointer',
         borderLeft: `4px solid ${accentColor}`,
         minHeight: 110,
@@ -215,52 +249,93 @@ const StatCard: React.FC<StatCardProps> = ({ title, value, sub, icon, accentColo
       }}
     >
       <Box sx={{ color: accentColor, display: 'flex', alignSelf: 'center' }}>{icon}</Box>
-      <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', justifyContent: 'center', minWidth: 0 }}>
+      <Box
+        sx={{
+          flex: 1,
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'center',
+          minWidth: 0,
+        }}
+      >
         <Typography variant={compact ? 'h5' : 'h4'} fontWeight={700} lineHeight={1.1}>
           {fmtNumber(value)}
         </Typography>
-        <Typography variant="body2" color="text.secondary" noWrap>{title}</Typography>
+        <Typography variant="body2" color="text.secondary" noWrap>
+          {title}
+        </Typography>
         {/* Reserve space for sub-line even when absent so all cards stay the same height */}
-        <Typography variant="caption" color="text.disabled" display="block" mt={0.25} sx={{ minHeight: '1.2em' }} noWrap>
+        <Typography
+          variant="caption"
+          color="text.disabled"
+          display="block"
+          mt={0.25}
+          sx={{ minHeight: '1.2em' }}
+          noWrap
+        >
           {sub ?? ''}
         </Typography>
       </Box>
       {aside && (
         <>
           <Divider orientation="vertical" flexItem sx={{ mx: 0.5 }} />
-          <Box sx={{ display: 'flex', flexDirection: 'column', justifyContent: 'center', minWidth: 90, maxWidth: 110 }}>
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: 'column',
+              justifyContent: 'center',
+              minWidth: 90,
+              maxWidth: 110,
+            }}
+          >
             {aside}
           </Box>
         </>
       )}
     </Paper>
-  );
-};
+  )
+}
 
 // Two-row breakdown for provider manual vs mirrored.
 interface ProviderBreakdownProps {
-  manual: number;
-  mirrored: number;
-  manualVersions: number;
-  mirroredVersions: number;
-  color: string;
+  manual: number
+  mirrored: number
+  manualVersions: number
+  mirroredVersions: number
+  color: string
 }
-const ProviderBreakdown: React.FC<ProviderBreakdownProps> = ({ manual, mirrored, manualVersions, mirroredVersions, color }) => {
-  const total = manual + mirrored;
-  if (total === 0) return null;
-  const manualPct = Math.round((manual / total) * 100);
-  const mirroredPct = 100 - manualPct;
+const ProviderBreakdown: React.FC<ProviderBreakdownProps> = ({
+  manual,
+  mirrored,
+  manualVersions,
+  mirroredVersions,
+  color,
+}) => {
+  const total = manual + mirrored
+  if (total === 0) return null
+  const manualPct = Math.round((manual / total) * 100)
+  const mirroredPct = 100 - manualPct
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.75 }}>
       {[
         { label: 'Manual', count: manual, versions: manualVersions, pct: manualPct, shade: color },
-        { label: 'Mirrored', count: mirrored, versions: mirroredVersions, pct: mirroredPct, shade: '#7E57C2' },
+        {
+          label: 'Mirrored',
+          count: mirrored,
+          versions: mirroredVersions,
+          pct: mirroredPct,
+          shade: '#7E57C2',
+        },
       ].map((row) => (
         <Tooltip key={row.label} title={`${row.versions} versions`} placement="left">
           <Box>
             <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 0.2 }}>
-              <Typography variant="caption" sx={{ lineHeight: 1.2 }}>{row.label}</Typography>
-              <Typography variant="caption" fontWeight={600} sx={{ lineHeight: 1.2, ml: 0.5 }}>{row.count}</Typography>
+              <Typography variant="caption" sx={{ lineHeight: 1.2 }}>
+                {row.label}
+              </Typography>
+              <Typography variant="caption" fontWeight={600} sx={{ lineHeight: 1.2, ml: 0.5 }}>
+                {row.count}
+              </Typography>
             </Box>
             <Box sx={{ height: 3, borderRadius: 1, bgcolor: 'action.hover' }}>
               <Box sx={{ height: 3, borderRadius: 1, bgcolor: row.shade, width: `${row.pct}%` }} />
@@ -269,207 +344,375 @@ const ProviderBreakdown: React.FC<ProviderBreakdownProps> = ({ manual, mirrored,
         </Tooltip>
       ))}
     </Box>
-  );
-};
+  )
+}
 
 // Compact vertical list of system → count with a proportional bar.
-const SystemBreakdown: React.FC<{ items: ModuleSystemCount[]; total: number; color: string }> = ({ items, total, color }) => {
-  if (items.length === 0) return null;
-  const max = items[0].count; // already sorted desc
+const SystemBreakdown: React.FC<{ items: ModuleSystemCount[]; total: number; color: string }> = ({
+  items,
+  total,
+  color,
+}) => {
+  if (items.length === 0) return null
+  const max = items[0].count // already sorted desc
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
       {items.slice(0, 5).map((item) => (
         <Tooltip key={item.system} title={`${item.count} of ${total} modules`} placement="left">
           <Box>
             <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 0.2 }}>
-              <Typography variant="caption" noWrap sx={{ maxWidth: 66, lineHeight: 1.2 }}>{item.system}</Typography>
-              <Typography variant="caption" fontWeight={600} sx={{ lineHeight: 1.2, ml: 0.5 }}>{item.count}</Typography>
+              <Typography variant="caption" noWrap sx={{ maxWidth: 66, lineHeight: 1.2 }}>
+                {item.system}
+              </Typography>
+              <Typography variant="caption" fontWeight={600} sx={{ lineHeight: 1.2, ml: 0.5 }}>
+                {item.count}
+              </Typography>
             </Box>
             <Box sx={{ height: 3, borderRadius: 1, bgcolor: 'action.hover' }}>
-              <Box sx={{ height: 3, borderRadius: 1, bgcolor: color, width: `${(item.count / max) * 100}%` }} />
+              <Box
+                sx={{
+                  height: 3,
+                  borderRadius: 1,
+                  bgcolor: color,
+                  width: `${(item.count / max) * 100}%`,
+                }}
+              />
             </Box>
           </Box>
         </Tooltip>
       ))}
     </Box>
-  );
-};
+  )
+}
 
 // Per-tool platform count (terraform vs opentofu).
-const BinaryToolBreakdown: React.FC<{ items: BinaryToolCount[]; color: string }> = ({ items, color }) => {
-  if (items.length === 0) return null;
-  const max = items[0].platforms;
-  const labelFor = (tool: string) => tool === 'terraform' ? 'Hashicorp' : tool === 'opentofu' ? 'OpenTofu' : tool;
+const BinaryToolBreakdown: React.FC<{ items: BinaryToolCount[]; color: string }> = ({
+  items,
+  color,
+}) => {
+  if (items.length === 0) return null
+  const max = items[0].platforms
+  const labelFor = (tool: string) =>
+    tool === 'terraform' ? 'Hashicorp' : tool === 'opentofu' ? 'OpenTofu' : tool
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.75 }}>
       {items.map((item) => (
         <Tooltip key={item.tool} title={`${item.platforms} platform binaries`} placement="left">
           <Box>
             <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 0.2 }}>
-              <Typography variant="caption" noWrap sx={{ lineHeight: 1.2 }}>{labelFor(item.tool)}</Typography>
-              <Typography variant="caption" fontWeight={600} sx={{ lineHeight: 1.2, ml: 0.5 }}>{item.platforms}</Typography>
+              <Typography variant="caption" noWrap sx={{ lineHeight: 1.2 }}>
+                {labelFor(item.tool)}
+              </Typography>
+              <Typography variant="caption" fontWeight={600} sx={{ lineHeight: 1.2, ml: 0.5 }}>
+                {item.platforms}
+              </Typography>
             </Box>
             <Box sx={{ height: 3, borderRadius: 1, bgcolor: 'action.hover' }}>
-              <Box sx={{ height: 3, borderRadius: 1, bgcolor: color, width: `${(item.platforms / max) * 100}%` }} />
+              <Box
+                sx={{
+                  height: 3,
+                  borderRadius: 1,
+                  bgcolor: color,
+                  width: `${(item.platforms / max) * 100}%`,
+                }}
+              />
             </Box>
           </Box>
         </Tooltip>
       ))}
     </Box>
-  );
-};
+  )
+}
 
 // Downloads split by source type.
-const DownloadBreakdown: React.FC<{ moduleDownloads: number; providerDownloads: number; binaryDownloads: number }> = ({ moduleDownloads, providerDownloads, binaryDownloads }) => {
-  const total = moduleDownloads + providerDownloads + binaryDownloads;
-  if (total === 0) return (
-    <Typography variant="caption" color="text.disabled">No downloads yet</Typography>
-  );
+const DownloadBreakdown: React.FC<{
+  moduleDownloads: number
+  providerDownloads: number
+  binaryDownloads: number
+}> = ({ moduleDownloads, providerDownloads, binaryDownloads }) => {
+  const total = moduleDownloads + providerDownloads + binaryDownloads
+  if (total === 0)
+    return (
+      <Typography variant="caption" color="text.disabled">
+        No downloads yet
+      </Typography>
+    )
   const rows = [
     { label: 'Modules', count: moduleDownloads, color: '#5C4EE5' },
     { label: 'Providers', count: providerDownloads, color: '#00D9C0' },
     { label: 'Binaries', count: binaryDownloads, color: '#FF7043' },
-  ];
+  ]
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.75 }}>
       {rows.map((row) => (
         <Box key={row.label}>
           <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 0.2 }}>
-            <Typography variant="caption" sx={{ lineHeight: 1.2 }}>{row.label}</Typography>
-            <Typography variant="caption" fontWeight={600} sx={{ lineHeight: 1.2, ml: 0.5 }}>{fmtNumber(row.count)}</Typography>
+            <Typography variant="caption" sx={{ lineHeight: 1.2 }}>
+              {row.label}
+            </Typography>
+            <Typography variant="caption" fontWeight={600} sx={{ lineHeight: 1.2, ml: 0.5 }}>
+              {fmtNumber(row.count)}
+            </Typography>
           </Box>
           <Box sx={{ height: 3, borderRadius: 1, bgcolor: 'action.hover' }}>
-            <Box sx={{ height: 3, borderRadius: 1, bgcolor: row.color, width: total > 0 ? `${(row.count / total) * 100}%` : '0%' }} />
+            <Box
+              sx={{
+                height: 3,
+                borderRadius: 1,
+                bgcolor: row.color,
+                width: total > 0 ? `${(row.count / total) * 100}%` : '0%',
+              }}
+            />
           </Box>
         </Box>
       ))}
     </Box>
-  );
-};
+  )
+}
 
 interface QuickLinkProps {
-  label: string;
-  icon: React.ReactNode;
-  route: string;
-  color: string;
+  label: string
+  icon: React.ReactNode
+  route: string
+  color: string
 }
 
 const QuickLink: React.FC<QuickLinkProps> = ({ label, icon, route, color }) => {
-  const navigate = useNavigate();
+  const navigate = useNavigate()
   return (
     <Paper
       onClick={() => navigate(route)}
       sx={{
-        p: 1.5, display: 'flex', alignItems: 'center', gap: 1.5,
+        p: 1.5,
+        display: 'flex',
+        alignItems: 'center',
+        gap: 1.5,
         cursor: 'pointer',
         transition: 'background-color 0.15s, box-shadow 0.15s',
         '&:hover': { boxShadow: 2, bgcolor: 'action.hover' },
       }}
     >
       <Box sx={{ color, display: 'flex' }}>{icon}</Box>
-      <Typography variant="body2" fontWeight={500} sx={{ flex: 1 }}>{label}</Typography>
+      <Typography variant="body2" fontWeight={500} sx={{ flex: 1 }}>
+        {label}
+      </Typography>
       <ArrowForward fontSize="small" sx={{ color: 'text.disabled' }} />
     </Paper>
-  );
-};
+  )
+}
 
 // ---------------------------------------------------------------------------
 // Page
 // ---------------------------------------------------------------------------
 
 const DashboardPage: React.FC = () => {
-  const { allowedScopes } = useAuth();
-  const queryClient = useQueryClient();
-  const navigate = useNavigate();
+  const { allowedScopes } = useAuth()
+  const queryClient = useQueryClient()
+  const navigate = useNavigate()
 
-  const { data: raw, isLoading: loading, isFetching: refreshing, error: queryError } = useQuery({
+  const {
+    data: raw,
+    isLoading: loading,
+    isFetching: refreshing,
+    error: queryError,
+  } = useQuery({
     queryKey: queryKeys.dashboard.stats(),
     queryFn: () => api.getDashboardStats(),
-  });
+  })
 
-  const error = queryError ? 'Failed to load dashboard statistics.' : null;
+  const { data: quotas } = useQuery({
+    queryKey: queryKeys.quotas.list(),
+    queryFn: () => api.getOrgQuotas(),
+    retry: false,
+  })
+
+  const error = queryError ? 'Failed to load dashboard statistics.' : null
 
   // Normalise: backend may not yet have mirror fields on older builds.
-  const data: DashboardData | null = raw ? {
-    modules: raw.modules ?? { total: 0, versions: 0, downloads: 0, by_system: [] },
-    providers: raw.providers ?? { total: 0, manual: 0, mirrored: 0, total_versions: 0, manual_versions: 0, mirrored_versions: 0, downloads: 0 },
-    users: raw.users ?? 0,
-    organizations: raw.organizations ?? 0,
-    downloads: raw.downloads ?? 0,
-    scm_providers: raw.scm_providers ?? 0,
-    binary_mirrors: raw.binary_mirrors ?? { total: 0, healthy: 0, failed: 0, syncing: 0, platforms: 0, downloads: 0, by_tool: [] },
-    provider_mirrors: raw.provider_mirrors ?? { total: 0, healthy: 0, failed: 0 },
-    scanning: raw.scanning ?? { enabled: false, total: 0, pending: 0, clean: 0, findings: 0, error: 0 },
-    recent_syncs: raw.recent_syncs ?? [],
-  } : null;
+  const data: DashboardData | null = raw
+    ? {
+        modules: raw.modules ?? { total: 0, versions: 0, downloads: 0, by_system: [] },
+        providers: raw.providers ?? {
+          total: 0,
+          manual: 0,
+          mirrored: 0,
+          total_versions: 0,
+          manual_versions: 0,
+          mirrored_versions: 0,
+          downloads: 0,
+        },
+        users: raw.users ?? 0,
+        organizations: raw.organizations ?? 0,
+        downloads: raw.downloads ?? 0,
+        scm_providers: raw.scm_providers ?? 0,
+        binary_mirrors: raw.binary_mirrors ?? {
+          total: 0,
+          healthy: 0,
+          failed: 0,
+          syncing: 0,
+          platforms: 0,
+          downloads: 0,
+          by_tool: [],
+        },
+        provider_mirrors: raw.provider_mirrors ?? { total: 0, healthy: 0, failed: 0 },
+        scanning: raw.scanning ?? {
+          enabled: false,
+          total: 0,
+          pending: 0,
+          clean: 0,
+          findings: 0,
+          error: 0,
+        },
+        recent_syncs: raw.recent_syncs ?? [],
+      }
+    : null
 
   const hasScope = (scope: string) =>
-    allowedScopes.includes('admin') || allowedScopes.includes(scope);
+    allowedScopes.includes('admin') || allowedScopes.includes(scope)
 
   // ---- Zone 1: health pills ------------------------------------------------
   const anyMirrorIssue = data
     ? data.binary_mirrors.failed > 0 || data.provider_mirrors.failed > 0
-    : false;
+    : false
 
   // ---- Zone 2: stat cards --------------------------------------------------
-  const statCards: (StatCardProps & { scope: string | null; gridMd: number })[] = !data ? [] : [
-    // Row 1 — content cards (each md=6)
-    {
-      title: 'Modules', value: data.modules.total,
-      sub: `${data.modules.versions} versions`,
-      icon: <ViewModule sx={{ fontSize: 36 }} />, accentColor: '#5C4EE5',
-      route: '/modules', scope: 'modules:read', gridMd: 6,
-      aside: data.modules.by_system?.length > 0
-        ? <SystemBreakdown items={data.modules.by_system} total={data.modules.total} color="#5C4EE5" />
-        : undefined,
-    },
-    {
-      title: 'Providers', value: data.providers.total,
-      sub: `${data.providers.total_versions} versions`,
-      icon: <Extension sx={{ fontSize: 36 }} />, accentColor: '#00D9C0',
-      route: '/providers', scope: 'providers:read', gridMd: 6,
-      aside: data.providers.total > 0
-        ? <ProviderBreakdown
-          manual={data.providers.manual}
-          mirrored={data.providers.mirrored}
-          manualVersions={data.providers.manual_versions}
-          mirroredVersions={data.providers.mirrored_versions}
-          color="#00D9C0"
-        />
-        : undefined,
-    },
-    // Row 2 — mirror/download summary (each md=6)
-    {
-      title: 'Terraform Binaries', value: data.binary_mirrors.platforms,
-      sub: `across ${data.binary_mirrors.total} mirror${data.binary_mirrors.total !== 1 ? 's' : ''}`,
-      icon: <GetApp sx={{ fontSize: 36 }} />, accentColor: '#FF7043',
-      route: '/admin/terraform-mirror', scope: 'mirrors:read', gridMd: 6,
-      aside: data.binary_mirrors.by_tool?.length > 0
-        ? <BinaryToolBreakdown items={data.binary_mirrors.by_tool} color="#FF7043" />
-        : undefined,
-    },
-    {
-      title: 'Total Downloads', value: data.downloads,
-      icon: <Download sx={{ fontSize: 36 }} />, accentColor: '#FFB74D',
-      route: '/modules', scope: null, gridMd: 6,
-      aside: <DownloadBreakdown moduleDownloads={data.modules.downloads} providerDownloads={data.providers.downloads} binaryDownloads={data.binary_mirrors.downloads} />,
-    },
-  ].filter(c => c.scope === null || hasScope(c.scope));
+  const statCards: (StatCardProps & { scope: string | null; gridMd: number })[] = !data
+    ? []
+    : [
+        // Row 1 — content cards (each md=6)
+        {
+          title: 'Modules',
+          value: data.modules.total,
+          sub: `${data.modules.versions} versions`,
+          icon: <ViewModule sx={{ fontSize: 36 }} />,
+          accentColor: '#5C4EE5',
+          route: '/modules',
+          scope: 'modules:read',
+          gridMd: 6,
+          aside:
+            data.modules.by_system?.length > 0 ? (
+              <SystemBreakdown
+                items={data.modules.by_system}
+                total={data.modules.total}
+                color="#5C4EE5"
+              />
+            ) : undefined,
+        },
+        {
+          title: 'Providers',
+          value: data.providers.total,
+          sub: `${data.providers.total_versions} versions`,
+          icon: <Extension sx={{ fontSize: 36 }} />,
+          accentColor: '#00D9C0',
+          route: '/providers',
+          scope: 'providers:read',
+          gridMd: 6,
+          aside:
+            data.providers.total > 0 ? (
+              <ProviderBreakdown
+                manual={data.providers.manual}
+                mirrored={data.providers.mirrored}
+                manualVersions={data.providers.manual_versions}
+                mirroredVersions={data.providers.mirrored_versions}
+                color="#00D9C0"
+              />
+            ) : undefined,
+        },
+        // Row 2 — mirror/download summary (each md=6)
+        {
+          title: 'Terraform Binaries',
+          value: data.binary_mirrors.platforms,
+          sub: `across ${data.binary_mirrors.total} mirror${data.binary_mirrors.total !== 1 ? 's' : ''}`,
+          icon: <GetApp sx={{ fontSize: 36 }} />,
+          accentColor: '#FF7043',
+          route: '/admin/terraform-mirror',
+          scope: 'mirrors:read',
+          gridMd: 6,
+          aside:
+            data.binary_mirrors.by_tool?.length > 0 ? (
+              <BinaryToolBreakdown items={data.binary_mirrors.by_tool} color="#FF7043" />
+            ) : undefined,
+        },
+        {
+          title: 'Total Downloads',
+          value: data.downloads,
+          icon: <Download sx={{ fontSize: 36 }} />,
+          accentColor: '#FFB74D',
+          route: '/modules',
+          scope: null,
+          gridMd: 6,
+          aside: (
+            <DownloadBreakdown
+              moduleDownloads={data.modules.downloads}
+              providerDownloads={data.providers.downloads}
+              binaryDownloads={data.binary_mirrors.downloads}
+            />
+          ),
+        },
+      ].filter((c) => c.scope === null || hasScope(c.scope))
 
   // ---- Zone 3 left: recent syncs -------------------------------------------
-  const recentSyncs = data ? data.recent_syncs.slice(0, 8) : [];
+  const recentSyncs = data ? data.recent_syncs.slice(0, 8) : []
 
   // ---- Zone 3 right: quick links -------------------------------------------
   const quickLinks: (QuickLinkProps & { scope: string | null })[] = [
-    { label: 'Upload Module', icon: <CloudUpload fontSize="small" />, route: '/admin/upload/module', color: '#5C4EE5', scope: 'modules:write' },
-    { label: 'Upload Provider', icon: <CloudUpload fontSize="small" />, route: '/admin/upload/provider', color: '#00D9C0', scope: 'providers:write' },
-    { label: 'Provider Mirrors', icon: <CloudDownload fontSize="small" />, route: '/admin/mirrors', color: '#7E57C2', scope: 'mirrors:read' },
-    { label: 'Binary Mirrors', icon: <GetApp fontSize="small" />, route: '/admin/terraform-mirror', color: '#FF7043', scope: 'mirrors:read' },
-    { label: 'Manage Users', icon: <People fontSize="small" />, route: '/admin/users', color: '#EF5350', scope: 'users:read' },
-    { label: 'API Keys', icon: <Key fontSize="small" />, route: '/admin/apikeys', color: '#FFB74D', scope: null },
-    { label: 'SCM Providers', icon: <GitHub fontSize="small" />, route: '/admin/scm-providers', color: '#6E5494', scope: 'scm:read' },
-    { label: 'Storage', icon: <Storage fontSize="small" />, route: '/admin/storage', color: '#78909C', scope: 'admin' },
-  ].filter(l => l.scope === null || hasScope(l.scope));
+    {
+      label: 'Upload Module',
+      icon: <CloudUpload fontSize="small" />,
+      route: '/admin/upload/module',
+      color: '#5C4EE5',
+      scope: 'modules:write',
+    },
+    {
+      label: 'Upload Provider',
+      icon: <CloudUpload fontSize="small" />,
+      route: '/admin/upload/provider',
+      color: '#00D9C0',
+      scope: 'providers:write',
+    },
+    {
+      label: 'Provider Mirrors',
+      icon: <CloudDownload fontSize="small" />,
+      route: '/admin/mirrors',
+      color: '#7E57C2',
+      scope: 'mirrors:read',
+    },
+    {
+      label: 'Binary Mirrors',
+      icon: <GetApp fontSize="small" />,
+      route: '/admin/terraform-mirror',
+      color: '#FF7043',
+      scope: 'mirrors:read',
+    },
+    {
+      label: 'Manage Users',
+      icon: <People fontSize="small" />,
+      route: '/admin/users',
+      color: '#EF5350',
+      scope: 'users:read',
+    },
+    {
+      label: 'API Keys',
+      icon: <Key fontSize="small" />,
+      route: '/admin/apikeys',
+      color: '#FFB74D',
+      scope: null,
+    },
+    {
+      label: 'SCM Providers',
+      icon: <GitHub fontSize="small" />,
+      route: '/admin/scm-providers',
+      color: '#6E5494',
+      scope: 'scm:read',
+    },
+    {
+      label: 'Storage',
+      icon: <Storage fontSize="small" />,
+      route: '/admin/storage',
+      color: '#78909C',
+      scope: 'admin',
+    },
+  ].filter((l) => l.scope === null || hasScope(l.scope))
 
   return (
     <Container maxWidth="lg" sx={{ py: 4 }} aria-busy={loading} aria-live="polite">
@@ -477,14 +720,18 @@ const DashboardPage: React.FC = () => {
         <Box sx={{ display: 'flex', justifyContent: 'center', py: 10 }}>
           <CircularProgress />
         </Box>
-      ) : (error || !data) ? (
+      ) : error || !data ? (
         <Alert severity="error">{error ?? 'Failed to load dashboard'}</Alert>
       ) : (
         <>
           {/* Header */}
-          <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
+          <Box
+            sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}
+          >
             <Box>
-              <Typography variant="h4" fontWeight={700}>Dashboard</Typography>
+              <Typography variant="h4" fontWeight={700}>
+                Dashboard
+              </Typography>
               <Typography variant="body2" color="text.secondary">
                 Registry health at a glance
               </Typography>
@@ -492,7 +739,9 @@ const DashboardPage: React.FC = () => {
             <Button
               variant="outlined"
               startIcon={<Refresh />}
-              onClick={() => queryClient.invalidateQueries({ queryKey: queryKeys.dashboard.stats() })}
+              onClick={() =>
+                queryClient.invalidateQueries({ queryKey: queryKeys.dashboard.stats() })
+              }
               disabled={refreshing}
             >
               Refresh
@@ -536,38 +785,101 @@ const DashboardPage: React.FC = () => {
               />
             )}
             {hasScope('admin') && data.scanning.enabled && (
-              <Tooltip title={
-                data.scanning.total === 0
-                  ? 'No modules scanned yet'
-                  : `${data.scanning.clean} clean · ${data.scanning.findings} with findings · ${data.scanning.pending} pending · ${data.scanning.error} errors`
-              }>
+              <Tooltip
+                title={
+                  data.scanning.total === 0
+                    ? 'No modules scanned yet'
+                    : `${data.scanning.clean} clean · ${data.scanning.findings} with findings · ${data.scanning.pending} pending · ${data.scanning.error} errors`
+                }
+              >
                 <Paper
                   onClick={() => navigate('/admin/security-scanning')}
                   sx={{
-                    px: 2, py: 1.5,
-                    display: 'flex', alignItems: 'center', gap: 1.5,
-                    cursor: 'pointer', flex: 1, minWidth: 220,
+                    px: 2,
+                    py: 1.5,
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 1.5,
+                    cursor: 'pointer',
+                    flex: 1,
+                    minWidth: 220,
                     transition: 'box-shadow 0.15s',
                     '&:hover': { boxShadow: 3 },
                   }}
                 >
-                  <Box sx={{ color: 'text.secondary', display: 'flex' }}><Security fontSize="small" /></Box>
+                  <Box sx={{ color: 'text.secondary', display: 'flex' }}>
+                    <Security fontSize="small" />
+                  </Box>
                   <Box sx={{ flex: 1, minWidth: 0 }}>
-                    <Typography variant="caption" color="text.secondary" noWrap>Security Scanning</Typography>
+                    <Typography variant="caption" color="text.secondary" noWrap>
+                      Security Scanning
+                    </Typography>
                     <Typography variant="body2" fontWeight={600} noWrap>
-                      {data.scanning.total === 0 ? 'None' : `${data.scanning.total - data.scanning.error} / ${data.scanning.total} OK`}
+                      {data.scanning.total === 0
+                        ? 'None'
+                        : `${data.scanning.total - data.scanning.error} / ${data.scanning.total} OK`}
                     </Typography>
                     {data.scanning.total > 0 && (
                       <Box sx={{ display: 'flex', gap: 0.5, mt: 0.5, flexWrap: 'wrap' }}>
-                        {data.scanning.clean > 0 && <Chip label={`${data.scanning.clean} clean`} size="small" color="success" variant="outlined" sx={{ height: 20, fontSize: '0.7rem' }} />}
-                        {data.scanning.findings > 0 && <Chip label={`${data.scanning.findings} findings`} size="small" color="warning" variant="outlined" sx={{ height: 20, fontSize: '0.7rem' }} />}
-                        {data.scanning.pending > 0 && <Chip label={`${data.scanning.pending} pending`} size="small" color="info" variant="outlined" sx={{ height: 20, fontSize: '0.7rem' }} />}
-                        {data.scanning.error > 0 && <Chip label={`${data.scanning.error} errors`} size="small" color="error" variant="outlined" sx={{ height: 20, fontSize: '0.7rem' }} />}
+                        {data.scanning.clean > 0 && (
+                          <Chip
+                            label={`${data.scanning.clean} clean`}
+                            size="small"
+                            color="success"
+                            variant="outlined"
+                            sx={{ height: 20, fontSize: '0.7rem' }}
+                          />
+                        )}
+                        {data.scanning.findings > 0 && (
+                          <Chip
+                            label={`${data.scanning.findings} findings`}
+                            size="small"
+                            color="warning"
+                            variant="outlined"
+                            sx={{ height: 20, fontSize: '0.7rem' }}
+                          />
+                        )}
+                        {data.scanning.pending > 0 && (
+                          <Chip
+                            label={`${data.scanning.pending} pending`}
+                            size="small"
+                            color="info"
+                            variant="outlined"
+                            sx={{ height: 20, fontSize: '0.7rem' }}
+                          />
+                        )}
+                        {data.scanning.error > 0 && (
+                          <Chip
+                            label={`${data.scanning.error} errors`}
+                            size="small"
+                            color="error"
+                            variant="outlined"
+                            sx={{ height: 20, fontSize: '0.7rem' }}
+                          />
+                        )}
                       </Box>
                     )}
                   </Box>
-                  <Box sx={{ color: data.scanning.error > 0 ? 'error.main' : data.scanning.findings > 0 ? 'warning.main' : data.scanning.pending > 0 ? 'info.main' : 'success.main', display: 'flex' }}>
-                    {data.scanning.error > 0 ? <Error fontSize="small" /> : data.scanning.pending > 0 ? <Sync fontSize="small" /> : <CheckCircle fontSize="small" />}
+                  <Box
+                    sx={{
+                      color:
+                        data.scanning.error > 0
+                          ? 'error.main'
+                          : data.scanning.findings > 0
+                            ? 'warning.main'
+                            : data.scanning.pending > 0
+                              ? 'info.main'
+                              : 'success.main',
+                      display: 'flex',
+                    }}
+                  >
+                    {data.scanning.error > 0 ? (
+                      <Error fontSize="small" />
+                    ) : data.scanning.pending > 0 ? (
+                      <Sync fontSize="small" />
+                    ) : (
+                      <CheckCircle fontSize="small" />
+                    )}
                   </Box>
                 </Paper>
               </Tooltip>
@@ -585,9 +897,25 @@ const DashboardPage: React.FC = () => {
 
           <Divider sx={{ mb: 4 }} />
 
+          {/* Zone 2.5 — Quota usage (only shown when quotas are configured) */}
+          {quotas && quotas.length > 0 && (
+            <>
+              <Typography variant="h6" fontWeight={600} gutterBottom>
+                Resource Quotas
+              </Typography>
+              <Grid container spacing={2} sx={{ mb: 4 }}>
+                {quotas.map((q) => (
+                  <Grid size={{ xs: 12, sm: 6, md: 4 }} key={q.organization_id}>
+                    <QuotaUsageChart quota={q} />
+                  </Grid>
+                ))}
+              </Grid>
+              <Divider sx={{ mb: 4 }} />
+            </>
+          )}
+
           {/* Zone 3 — Recent syncs + quick links */}
           <Grid container spacing={3}>
-
             {/* Recent sync activity */}
             <Grid size={{ xs: 12, md: 8 }}>
               <Typography variant="h6" fontWeight={600} gutterBottom>
@@ -663,12 +991,11 @@ const DashboardPage: React.FC = () => {
                 ))}
               </Box>
             </Grid>
-
           </Grid>
         </>
       )}
     </Container>
-  );
-};
+  )
+}
 
-export default DashboardPage;
+export default DashboardPage

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -55,7 +55,7 @@ class ApiClient {
         }
 
         // Stamp the request start time for breadcrumb duration tracking
-        ; (config as InternalAxiosRequestConfig & { _startTime?: number })._startTime = Date.now()
+        ;(config as InternalAxiosRequestConfig & { _startTime?: number })._startTime = Date.now()
         return config
       },
       (error) => Promise.reject(error),
@@ -253,11 +253,11 @@ class ApiClient {
       },
       onUploadProgress: options?.onUploadProgress
         ? (event) => {
-          if (event.total && event.total > 0) {
-            const percent = Math.round((event.loaded / event.total) * 100)
-            options.onUploadProgress?.(percent)
+            if (event.total && event.total > 0) {
+              const percent = Math.round((event.loaded / event.total) * 100)
+              options.onUploadProgress?.(percent)
+            }
           }
-        }
         : undefined,
     })
     return response.data
@@ -376,11 +376,11 @@ class ApiClient {
       },
       onUploadProgress: options?.onUploadProgress
         ? (event) => {
-          if (event.total && event.total > 0) {
-            const percent = Math.round((event.loaded / event.total) * 100)
-            options.onUploadProgress?.(percent)
+            if (event.total && event.total > 0) {
+              const percent = Math.round((event.loaded / event.total) * 100)
+              options.onUploadProgress?.(percent)
+            }
           }
-        }
         : undefined,
     })
     return response.data
@@ -869,6 +869,13 @@ class ApiClient {
   async getDashboardStats() {
     const response = await this.client.get('/api/v1/admin/stats/dashboard')
     return response.data
+  }
+
+  // Org Quotas
+  async getOrgQuotas(orgId?: string) {
+    const params = orgId ? { organization_id: orgId } : {}
+    const response = await this.client.get('/api/v1/admin/quotas', { params })
+    return (response.data.quotas ?? []) as import('../types').OrgQuota[]
   }
 
   // Mirror Management

--- a/frontend/src/services/queryKeys.ts
+++ b/frontend/src/services/queryKeys.ts
@@ -1,14 +1,19 @@
 export const queryKeys = {
   modules: {
     _def: ['modules'] as const,
-    search: (params: { query?: string; limit: number; offset: number; viewMode: string; sort?: string; order?: string }) =>
-      [...queryKeys.modules._def, 'search', params] as const,
+    search: (params: {
+      query?: string
+      limit: number
+      offset: number
+      viewMode: string
+      sort?: string
+      order?: string
+    }) => [...queryKeys.modules._def, 'search', params] as const,
     detail: (namespace: string, name: string, system: string) =>
       [...queryKeys.modules._def, 'detail', namespace, name, system] as const,
     versions: (namespace: string, name: string, system: string) =>
       [...queryKeys.modules._def, 'versions', namespace, name, system] as const,
-    scm: (moduleId: string) =>
-      [...queryKeys.modules._def, 'scm', moduleId] as const,
+    scm: (moduleId: string) => [...queryKeys.modules._def, 'scm', moduleId] as const,
     scan: (namespace: string, name: string, system: string, version: string) =>
       [...queryKeys.modules._def, 'scan', namespace, name, system, version] as const,
     docs: (namespace: string, name: string, system: string, version: string) =>
@@ -18,8 +23,13 @@ export const queryKeys = {
   },
   providers: {
     _def: ['providers'] as const,
-    search: (params: { query?: string; limit: number; offset: number; sort?: string; order?: string }) =>
-      [...queryKeys.providers._def, 'search', params] as const,
+    search: (params: {
+      query?: string
+      limit: number
+      offset: number
+      sort?: string
+      order?: string
+    }) => [...queryKeys.providers._def, 'search', params] as const,
     detail: (namespace: string, type: string) =>
       [...queryKeys.providers._def, 'detail', namespace, type] as const,
     versions: (namespace: string, type: string) =>
@@ -33,26 +43,20 @@ export const queryKeys = {
     _def: ['users'] as const,
     list: (params?: { page?: number; perPage?: number; search?: string }) =>
       [...queryKeys.users._def, 'list', params] as const,
-    detail: (id: string) =>
-      [...queryKeys.users._def, 'detail', id] as const,
-    memberships: (userId: string) =>
-      [...queryKeys.users._def, 'memberships', userId] as const,
+    detail: (id: string) => [...queryKeys.users._def, 'detail', id] as const,
+    memberships: (userId: string) => [...queryKeys.users._def, 'memberships', userId] as const,
   },
   organizations: {
     _def: ['organizations'] as const,
     list: (params?: { page?: number; perPage?: number; search?: string }) =>
       [...queryKeys.organizations._def, 'list', params] as const,
-    detail: (id: string) =>
-      [...queryKeys.organizations._def, 'detail', id] as const,
-    members: (orgId: string) =>
-      [...queryKeys.organizations._def, 'members', orgId] as const,
+    detail: (id: string) => [...queryKeys.organizations._def, 'detail', id] as const,
+    members: (orgId: string) => [...queryKeys.organizations._def, 'members', orgId] as const,
   },
   apiKeys: {
     _def: ['apiKeys'] as const,
-    list: (organizationId?: string) =>
-      [...queryKeys.apiKeys._def, 'list', organizationId] as const,
-    memberships: (userId: string) =>
-      [...queryKeys.apiKeys._def, 'memberships', userId] as const,
+    list: (organizationId?: string) => [...queryKeys.apiKeys._def, 'list', organizationId] as const,
+    memberships: (userId: string) => [...queryKeys.apiKeys._def, 'memberships', userId] as const,
   },
   scmProviders: {
     _def: ['scmProviders'] as const,
@@ -81,8 +85,7 @@ export const queryKeys = {
   mirrors: {
     _def: ['mirrors'] as const,
     list: () => [...queryKeys.mirrors._def, 'list'] as const,
-    providers: (mirrorId: string) =>
-      [...queryKeys.mirrors._def, 'providers', mirrorId] as const,
+    providers: (mirrorId: string) => [...queryKeys.mirrors._def, 'providers', mirrorId] as const,
   },
   roles: {
     _def: ['roles'] as const,
@@ -90,13 +93,16 @@ export const queryKeys = {
   },
   approvals: {
     _def: ['approvals'] as const,
-    list: (params?: { status?: string }) =>
-      [...queryKeys.approvals._def, 'list', params] as const,
+    list: (params?: { status?: string }) => [...queryKeys.approvals._def, 'list', params] as const,
   },
   policies: {
     _def: ['policies'] as const,
     list: (organizationId?: string) =>
       [...queryKeys.policies._def, 'list', organizationId] as const,
+  },
+  quotas: {
+    _def: ['quotas'] as const,
+    list: (orgId?: string) => [...queryKeys.quotas._def, 'list', orgId] as const,
   },
   oidcConfig: {
     _def: ['oidcConfig'] as const,
@@ -105,11 +111,10 @@ export const queryKeys = {
   terraformMirrors: {
     _def: ['terraformMirrors'] as const,
     list: () => [...queryKeys.terraformMirrors._def, 'list'] as const,
-    status: (configId: string) =>
-      [...queryKeys.terraformMirrors._def, 'status', configId] as const,
+    status: (configId: string) => [...queryKeys.terraformMirrors._def, 'status', configId] as const,
     versions: (configId: string) =>
       [...queryKeys.terraformMirrors._def, 'versions', configId] as const,
     history: (configId: string) =>
       [...queryKeys.terraformMirrors._def, 'history', configId] as const,
   },
-} as const;
+} as const

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -594,6 +594,21 @@ export interface ModuleDoc {
   requirements: ModuleRequirements | null
 }
 
+// ---- Org Quota ----
+
+export interface OrgQuota {
+  organization_id: string
+  storage_bytes_limit: number
+  storage_bytes_used: number
+  storage_utilization_ratio: number
+  publishes_per_day_limit: number
+  publishes_today: number
+  publish_utilization_ratio: number
+  downloads_per_day_limit: number
+  downloads_today: number
+  download_utilization_ratio: number
+}
+
 // ---- Storage Migration ----
 
 export interface MigrationPlan {


### PR DESCRIPTION
Closes #171

Adds resource quota utilization visualization to the admin dashboard.

## Changes

- **`QuotaUsageChart` component** — three `LinearProgress` bars (storage, publishes/day, downloads/day) with warning color at >80% and error color at 100%+. Shows "Unlimited" when the limit is 0.
- **`DashboardPage`** — new "Resource Quotas" section (Zone 2.5) between the stat cards and the recent-syncs table; hidden when the API returns zero quotas or the endpoint doesn't exist yet.
- **`api.ts`** — `getOrgQuotas(orgId?)` calling `GET /api/v1/admin/quotas`
- **`queryKeys.ts`** — `quotas.list(orgId?)` key
- **`types/index.ts`** — `OrgQuota` interface matching the backend `QuotaStatus` model

## Notes

The backend `GET /api/v1/admin/quotas` endpoint (backend D3.4) is not yet wired to the router. The quota section gracefully hides itself when the API returns 404/error, so the dashboard continues to work today and will automatically reveal quotas once the backend endpoint is deployed.

## Changelog
- feat: add per-org quota utilization dashboard to admin overview page