### PR TITLE
feat: policy evaluation results in module upload flow (F-E4.2)

### DIFF
--- a/frontend/src/components/PolicyResultsPanel.tsx
+++ b/frontend/src/components/PolicyResultsPanel.tsx
@@ -1,0 +1,89 @@
+import React, { useState } from 'react'
+import {
+  Box,
+  Paper,
+  Typography,
+  Divider,
+  Chip,
+  Stack,
+  Collapse,
+  IconButton,
+} from '@mui/material'
+import PolicyIcon from '@mui/icons-material/Policy'
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
+import ExpandLessIcon from '@mui/icons-material/ExpandLess'
+import { PolicyResult } from '../types'
+
+interface PolicyResultsPanelProps {
+  policyResult: PolicyResult
+}
+
+const PolicyResultsPanel: React.FC<PolicyResultsPanelProps> = ({ policyResult }) => {
+  const [expanded, setExpanded] = useState(policyResult.violations.length > 0)
+
+  const hasViolations = policyResult.violations.length > 0
+
+  const statusLabel = !policyResult.allowed ? 'BLOCK' : hasViolations ? 'WARN' : 'PASS'
+  const statusColor: 'error' | 'warning' | 'success' = !policyResult.allowed
+    ? 'error'
+    : hasViolations
+      ? 'warning'
+      : 'success'
+
+  return (
+    <Paper sx={{ p: 3 }}>
+      <Box display="flex" alignItems="center" gap={1} mb={1}>
+        <PolicyIcon fontSize="small" color="action" />
+        <Typography variant="h6">Policy Evaluation</Typography>
+      </Box>
+      <Divider sx={{ mb: 2 }} />
+      <Box mb={hasViolations ? 1.5 : 0}>
+        <Chip label={statusLabel} size="small" color={statusColor} />
+        <Typography variant="caption" color="text.secondary" sx={{ ml: 1 }}>
+          mode: {policyResult.mode}
+        </Typography>
+      </Box>
+      {hasViolations && (
+        <>
+          <Box
+            display="flex"
+            alignItems="center"
+            sx={{ cursor: 'pointer', mb: 0.5 }}
+            onClick={() => setExpanded(!expanded)}
+          >
+            <Typography variant="body2" fontWeight="medium">
+              {policyResult.violations.length} violation
+              {policyResult.violations.length !== 1 ? 's' : ''}
+            </Typography>
+            <IconButton size="small" sx={{ ml: 'auto' }}>
+              {expanded ? (
+                <ExpandLessIcon fontSize="small" />
+              ) : (
+                <ExpandMoreIcon fontSize="small" />
+              )}
+            </IconButton>
+          </Box>
+          <Collapse in={expanded}>
+            <Stack spacing={1} sx={{ mt: 1 }}>
+              {policyResult.violations.map((v, i) => (
+                <Box
+                  key={i}
+                  sx={{ pl: 1.5, borderLeft: 2, borderColor: `${statusColor}.main` }}
+                >
+                  <Typography variant="caption" fontWeight="medium" display="block">
+                    {v.rule}
+                  </Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    {v.message}
+                  </Typography>
+                </Box>
+              ))}
+            </Stack>
+          </Collapse>
+        </>
+      )}
+    </Paper>
+  )
+}
+
+export default PolicyResultsPanel

--- a/frontend/src/components/__tests__/PolicyResultsPanel.test.tsx
+++ b/frontend/src/components/__tests__/PolicyResultsPanel.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import PolicyResultsPanel from '../PolicyResultsPanel'
+import type { PolicyResult } from '../../types'
+
+const passResult: PolicyResult = {
+  allowed: true,
+  mode: 'warn',
+  violations: [],
+}
+
+const warnResult: PolicyResult = {
+  allowed: true,
+  mode: 'warn',
+  violations: [
+    { rule: 'no-debug', message: 'Debug output detected' },
+    { rule: 'size-limit', message: 'Module exceeds recommended size' },
+  ],
+}
+
+const blockResult: PolicyResult = {
+  allowed: false,
+  mode: 'block',
+  violations: [{ rule: 'required-tag', message: 'Required tag "owner" is missing' }],
+}
+
+describe('PolicyResultsPanel', () => {
+  it('renders PASS chip when allowed and no violations', () => {
+    render(<PolicyResultsPanel policyResult={passResult} />)
+    expect(screen.getByText('PASS')).toBeInTheDocument()
+  })
+
+  it('renders WARN chip when allowed but violations present', () => {
+    render(<PolicyResultsPanel policyResult={warnResult} />)
+    expect(screen.getByText('WARN')).toBeInTheDocument()
+  })
+
+  it('renders BLOCK chip when not allowed', () => {
+    render(<PolicyResultsPanel policyResult={blockResult} />)
+    expect(screen.getByText('BLOCK')).toBeInTheDocument()
+  })
+
+  it('shows mode label', () => {
+    render(<PolicyResultsPanel policyResult={passResult} />)
+    expect(screen.getByText('mode: warn')).toBeInTheDocument()
+  })
+
+  it('does not render violation list when no violations', () => {
+    render(<PolicyResultsPanel policyResult={passResult} />)
+    expect(screen.queryByText(/violation/)).not.toBeInTheDocument()
+  })
+
+  it('shows violation count when violations present', () => {
+    render(<PolicyResultsPanel policyResult={warnResult} />)
+    expect(screen.getByText('2 violations')).toBeInTheDocument()
+  })
+
+  it('shows singular "violation" for exactly one violation', () => {
+    render(<PolicyResultsPanel policyResult={blockResult} />)
+    expect(screen.getByText('1 violation')).toBeInTheDocument()
+  })
+
+  it('expands violation list by default when violations present', () => {
+    render(<PolicyResultsPanel policyResult={blockResult} />)
+    expect(screen.getByText('required-tag')).toBeInTheDocument()
+    expect(screen.getByText('Required tag "owner" is missing')).toBeInTheDocument()
+  })
+
+  it('shows all violations in expanded state', () => {
+    render(<PolicyResultsPanel policyResult={warnResult} />)
+    expect(screen.getByText('no-debug')).toBeInTheDocument()
+    expect(screen.getByText('Debug output detected')).toBeInTheDocument()
+    expect(screen.getByText('size-limit')).toBeInTheDocument()
+    expect(screen.getByText('Module exceeds recommended size')).toBeInTheDocument()
+  })
+
+  it('collapses and re-expands violation list on toggle click', () => {
+    render(<PolicyResultsPanel policyResult={warnResult} />)
+    const toggle = screen.getByText('2 violations').closest('div')!
+
+    // initially expanded — violation visible
+    expect(screen.getByText('no-debug')).toBeInTheDocument()
+
+    // collapse
+    fireEvent.click(toggle)
+    // after collapse the Collapse animation hides content but DOM may still be present;
+    // just verify the toggle is still clickable and re-expands
+    fireEvent.click(toggle)
+    expect(screen.getByText('no-debug')).toBeInTheDocument()
+  })
+
+  it('renders panel title', () => {
+    render(<PolicyResultsPanel policyResult={passResult} />)
+    expect(screen.getByText('Policy Evaluation')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/ApiDocumentation.tsx
+++ b/frontend/src/pages/ApiDocumentation.tsx
@@ -1,8 +1,8 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
-import SwaggerUI from 'swagger-ui-react';
-import 'swagger-ui-react/swagger-ui.css';
-import { Box, Typography, List, ListItem, ListItemButton, ListItemText, Paper } from '@mui/material';
-import { useTheme } from '@mui/material/styles';
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import SwaggerUI from 'swagger-ui-react'
+import 'swagger-ui-react/swagger-ui.css'
+import { Box, Typography, List, ListItem, ListItemButton, ListItemText, Paper } from '@mui/material'
+import { useTheme } from '@mui/material/styles'
 
 // swagger-ui-react's wrapper only forwards a fixed set of props to the
 // underlying SwaggerUIBundle.  tagsSorter is not one of them, so we inject
@@ -12,20 +12,22 @@ const TagsSorterPlugin = (): any => ({
   statePlugins: {
     spec: {
       wrapSelectors: {
-        taggedOperations: (origSelector: any) => (...args: any[]) => {
-          const taggedOps = origSelector(...args);
-          if (taggedOps && typeof taggedOps.sortBy === 'function') {
-            return taggedOps.sortBy(
-              (_val: any, key: string) => key,
-              (a: string, b: string) => a.localeCompare(b),
-            );
-          }
-          return taggedOps;
-        },
+        taggedOperations:
+          (origSelector: any) =>
+          (...args: any[]) => {
+            const taggedOps = origSelector(...args)
+            if (taggedOps && typeof taggedOps.sortBy === 'function') {
+              return taggedOps.sortBy(
+                (_val: any, key: string) => key,
+                (a: string, b: string) => a.localeCompare(b),
+              )
+            }
+            return taggedOps
+          },
       },
     },
   },
-});
+})
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
 // ---------------------------------------------------------------------------
@@ -44,7 +46,7 @@ const METHOD_COLORS: Record<string, string> = {
   patch: '#0a7fa0',
   head: '#5C4EE5',
   options: '#5C4EE5',
-};
+}
 
 /** Apply WCAG-compliant colours directly to Swagger UI DOM elements. */
 function enforceSwaggerA11yStyles(dark: boolean): void {
@@ -55,56 +57,56 @@ function enforceSwaggerA11yStyles(dark: boolean): void {
         `.swagger-ui .opblock.opblock-${method} .opblock-summary-method`,
       )
       .forEach((el) => {
-        el.style.setProperty('background', bg, 'important');
-        el.style.setProperty('color', '#fff', 'important');
-      });
+        el.style.setProperty('background', bg, 'important')
+        el.style.setProperty('color', '#fff', 'important')
+      })
   }
 
   // Version stamps — theme-aware contrast
-  const versionColor = dark ? '#ccc' : '#555';
-  const versionBg = dark ? '#333' : '#e8e8e8';
+  const versionColor = dark ? '#ccc' : '#555'
+  const versionBg = dark ? '#333' : '#e8e8e8'
   document.querySelectorAll<HTMLElement>('.swagger-ui pre.version').forEach((el) => {
-    el.style.setProperty('color', versionColor, 'important');
-    el.style.setProperty('background', versionBg, 'important');
-  });
+    el.style.setProperty('color', versionColor, 'important')
+    el.style.setProperty('background', versionBg, 'important')
+  })
 
   // URL field
-  const urlColor = dark ? '#8ab4f8' : '#3b6fb6';
+  const urlColor = dark ? '#8ab4f8' : '#3b6fb6'
   document.querySelectorAll<HTMLElement>('.swagger-ui span.url').forEach((el) => {
-    el.style.setProperty('color', urlColor, 'important');
-  });
+    el.style.setProperty('color', urlColor, 'important')
+  })
 
   // Info links (terms of service, contact, etc.)
-  const linkColor = dark ? '#8ab4f8' : '#3b6fb6';
+  const linkColor = dark ? '#8ab4f8' : '#3b6fb6'
   document
     .querySelectorAll<HTMLElement>('.swagger-ui .info a.link, .swagger-ui .info .link')
     .forEach((el) => {
-      el.style.setProperty('color', linkColor, 'important');
-    });
+      el.style.setProperty('color', linkColor, 'important')
+    })
 
   // Authorize button
-  const authColor = dark ? '#2ea77a' : '#00875a';
+  const authColor = dark ? '#2ea77a' : '#00875a'
   document.querySelectorAll<HTMLElement>('.swagger-ui .btn.authorize').forEach((btn) => {
-    btn.style.setProperty('border-color', authColor, 'important');
-    btn.style.setProperty('color', authColor, 'important');
-    const span = btn.querySelector<HTMLElement>('span');
-    if (span) span.style.setProperty('color', authColor, 'important');
-    const svg = btn.querySelector<SVGElement>('svg');
-    if (svg) svg.style.setProperty('fill', authColor, 'important');
-  });
+    btn.style.setProperty('border-color', authColor, 'important')
+    btn.style.setProperty('color', authColor, 'important')
+    const span = btn.querySelector<HTMLElement>('span')
+    if (span) span.style.setProperty('color', authColor, 'important')
+    const svg = btn.querySelector<SVGElement>('svg')
+    if (svg) svg.style.setProperty('fill', authColor, 'important')
+  })
 
   // Nested-interactive fix: replace <a> inside summary buttons with <span>
   document
     .querySelectorAll<HTMLAnchorElement>('.swagger-ui .opblock-summary-control a')
     .forEach((a) => {
-      const span = document.createElement('span');
-      span.className = a.className;
-      span.textContent = a.textContent;
+      const span = document.createElement('span')
+      span.className = a.className
+      span.textContent = a.textContent
       Array.from(a.attributes).forEach((attr) => {
-        if (attr.name.startsWith('data-')) span.setAttribute(attr.name, attr.value);
-      });
-      a.replaceWith(span);
-    });
+        if (attr.name.startsWith('data-')) span.setAttribute(attr.name, attr.value)
+      })
+      a.replaceWith(span)
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -241,7 +243,7 @@ const BASE_CSS = `
 
   /* remove the very wide left margin swagger-ui adds by default */
   .swagger-ui .wrapper { padding: 0; }
-`;
+`
 
 const LIGHT_EXTRA = `
   .swagger-ui .scheme-container { background: #fafafa; border-bottom: 1px solid #e0e0e0; }
@@ -283,7 +285,7 @@ const LIGHT_EXTRA = `
   .swagger-ui .tab li { color: #666; }
   .swagger-ui .markdown p,
   .swagger-ui .markdown li { color: #444; }
-`;
+`
 
 const DARK_EXTRA = `
   .swagger-ui,
@@ -358,152 +360,155 @@ const DARK_EXTRA = `
   .swagger-ui small > .version,
   .swagger-ui small > pre.version,
   .swagger-ui pre.version { color: #ccc !important; background: #333 !important; }
-`;
+`
 
 // ---------------------------------------------------------------------------
 // Left nav — reads tags from the rendered DOM and tracks active section
 // ---------------------------------------------------------------------------
 
 interface NavTag {
-  id: string;   // the CSS id Swagger UI assigns, e.g. "operations-tag-Providers"
-  label: string;
+  id: string // the CSS id Swagger UI assigns, e.g. "operations-tag-Providers"
+  label: string
 }
 
 interface OpenAPISpec {
-  paths?: Record<string, Record<string, { tags?: string[] }>>;
+  paths?: Record<string, Record<string, { tags?: string[] }>>
 }
 
 function buildNavTags(spec: OpenAPISpec): NavTag[] {
-  if (!spec?.paths) return [];
-  const seen = new Set<string>();
-  const tags: NavTag[] = [];
+  if (!spec?.paths) return []
+  const seen = new Set<string>()
+  const tags: NavTag[] = []
   for (const methods of Object.values(spec.paths)) {
     for (const op of Object.values(methods)) {
-      if (!op?.tags) continue;
+      if (!op?.tags) continue
       for (const tag of op.tags) {
         if (!seen.has(tag)) {
-          seen.add(tag);
+          seen.add(tag)
           // Swagger UI encodes spaces as underscores in tag section ids
-          tags.push({ id: `operations-tag-${tag.replace(/\s+/g, '_')}`, label: tag });
+          tags.push({ id: `operations-tag-${tag.replace(/\s+/g, '_')}`, label: tag })
         }
       }
     }
   }
-  tags.sort((a, b) => a.label.localeCompare(b.label));
-  return tags;
+  tags.sort((a, b) => a.label.localeCompare(b.label))
+  return tags
 }
 
-const NAV_WIDTH = 200;
+const NAV_WIDTH = 200
 
 const ApiDocumentation: React.FC = () => {
-  const theme = useTheme();
-  const isDark = theme.palette.mode === 'dark';
+  const theme = useTheme()
+  const isDark = theme.palette.mode === 'dark'
 
-  const [navTags, setNavTags] = useState<NavTag[]>([]);
-  const [activeTag, setActiveTag] = useState<string>('');
-  const specRef = useRef<OpenAPISpec | null>(null);
-  const observerRef = useRef<IntersectionObserver | null>(null);
-  const contentRef = useRef<HTMLDivElement>(null);
-  const mutationObserverRef = useRef<MutationObserver | null>(null);
+  const [navTags, setNavTags] = useState<NavTag[]>([])
+  const [activeTag, setActiveTag] = useState<string>('')
+  const specRef = useRef<OpenAPISpec | null>(null)
+  const observerRef = useRef<IntersectionObserver | null>(null)
+  const contentRef = useRef<HTMLDivElement>(null)
+  const mutationObserverRef = useRef<MutationObserver | null>(null)
 
   // Forward the user's bearer token so "Try it out" works on auth'd endpoints.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- swagger-ui-react's Request type lacks headers
   const requestInterceptor = useCallback((req: any) => {
-    const token = localStorage.getItem('auth_token');
-    if (token) req.headers['Authorization'] = `Bearer ${token}`;
-    return req;
-  }, []);
+    const token = localStorage.getItem('auth_token')
+    if (token) req.headers['Authorization'] = `Bearer ${token}`
+    return req
+  }, [])
 
   // onComplete fires when SwaggerUI finishes rendering.
   // We extract tags from the loaded spec at that point.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- swagger-ui-react system type is not exported
-  const onComplete = useCallback((system: any) => {
-    try {
-      const spec = system.getState().toJS().spec?.json;
-      if (spec) {
-        specRef.current = spec;
-        setNavTags(buildNavTags(spec));
+  const onComplete = useCallback(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- swagger-ui-react system type is not exported
+    (system: any) => {
+      try {
+        const spec = system.getState().toJS().spec?.json
+        if (spec) {
+          specRef.current = spec
+          setNavTags(buildNavTags(spec))
+        }
+      } catch {
+        // spec not available yet — harmless
       }
-    } catch {
-      // spec not available yet — harmless
-    }
 
-    // a11y fix: enforce WCAG-compliant styles after Swagger UI renders.
-    // Small delay to allow Swagger UI to finish its own DOM mutations.
-    setTimeout(() => enforceSwaggerA11yStyles(isDark), 300);
-  }, [isDark]);
+      // a11y fix: enforce WCAG-compliant styles after Swagger UI renders.
+      // Small delay to allow Swagger UI to finish its own DOM mutations.
+      setTimeout(() => enforceSwaggerA11yStyles(isDark), 300)
+    },
+    [isDark],
+  )
 
   // Set up an IntersectionObserver to track which tag section is visible.
   useEffect(() => {
-    if (!navTags.length) return;
+    if (!navTags.length) return
 
-    observerRef.current?.disconnect();
+    observerRef.current?.disconnect()
 
     const observer = new IntersectionObserver(
       (entries) => {
         // Find the topmost visible section
         const visible = entries
           .filter((e) => e.isIntersecting)
-          .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
+          .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top)
         if (visible.length > 0) {
-          setActiveTag(visible[0].target.id);
+          setActiveTag(visible[0].target.id)
         }
       },
-      { rootMargin: '-10% 0px -70% 0px', threshold: 0 }
-    );
+      { rootMargin: '-10% 0px -70% 0px', threshold: 0 },
+    )
 
     // Small delay to allow Swagger UI to finish rendering its DOM
     const timer = setTimeout(() => {
       navTags.forEach(({ id }) => {
-        const el = document.getElementById(id);
-        if (el) observer.observe(el);
-      });
-    }, 300);
+        const el = document.getElementById(id)
+        if (el) observer.observe(el)
+      })
+    }, 300)
 
-    observerRef.current = observer;
+    observerRef.current = observer
     return () => {
-      clearTimeout(timer);
-      observer.disconnect();
-    };
-  }, [navTags]);
+      clearTimeout(timer)
+      observer.disconnect()
+    }
+  }, [navTags])
 
   // MutationObserver: re-enforce a11y styles whenever Swagger UI mutates its DOM
   // (e.g. user expands/collapses an operation, switches tabs, etc.)
   useEffect(() => {
-    const container = contentRef.current;
-    if (!container) return;
+    const container = contentRef.current
+    if (!container) return
 
-    let debounceTimer: ReturnType<typeof setTimeout>;
+    let debounceTimer: ReturnType<typeof setTimeout>
     const mo = new MutationObserver(() => {
-      clearTimeout(debounceTimer);
-      debounceTimer = setTimeout(() => enforceSwaggerA11yStyles(isDark), 100);
-    });
+      clearTimeout(debounceTimer)
+      debounceTimer = setTimeout(() => enforceSwaggerA11yStyles(isDark), 100)
+    })
 
-    mo.observe(container, { childList: true, subtree: true });
-    mutationObserverRef.current = mo;
+    mo.observe(container, { childList: true, subtree: true })
+    mutationObserverRef.current = mo
 
     return () => {
-      clearTimeout(debounceTimer);
-      mo.disconnect();
-      mutationObserverRef.current = null;
-    };
-  }, [isDark]);
+      clearTimeout(debounceTimer)
+      mo.disconnect()
+      mutationObserverRef.current = null
+    }
+  }, [isDark])
 
   const scrollToTag = useCallback((id: string) => {
-    const el = document.getElementById(id);
-    if (!el) return;
+    const el = document.getElementById(id)
+    if (!el) return
     // Offset for the fixed AppBar (~64px) plus a little breathing room
-    const y = el.getBoundingClientRect().top + window.scrollY - 80;
-    window.scrollTo({ top: y, behavior: 'smooth' });
-    setActiveTag(id);
-  }, []);
+    const y = el.getBoundingClientRect().top + window.scrollY - 80
+    window.scrollTo({ top: y, behavior: 'smooth' })
+    setActiveTag(id)
+  }, [])
 
-  const primaryColor = theme.palette.primary.main;
-  const navBg = isDark ? '#1e1e1e' : '#fafafa';
-  const navBorder = isDark ? '#333' : '#e0e0e0';
-  const navText = isDark ? '#ccc' : '#555';
-  const activeText = primaryColor;
-  const activeBg = isDark ? `${primaryColor}26` : `${primaryColor}14`;
+  const primaryColor = theme.palette.primary.main
+  const navBg = isDark ? '#1e1e1e' : '#fafafa'
+  const navBorder = isDark ? '#333' : '#e0e0e0'
+  const navText = isDark ? '#ccc' : '#555'
+  const activeText = primaryColor
+  const activeBg = isDark ? `${primaryColor}26` : `${primaryColor}14`
 
   return (
     <Box>
@@ -517,7 +522,6 @@ const ApiDocumentation: React.FC = () => {
 
       {/* Layout: sticky left nav + Swagger UI content */}
       <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 0 }}>
-
         {/* ---- Left navigation panel ---- */}
         {navTags.length > 0 && (
           <Box
@@ -525,7 +529,7 @@ const ApiDocumentation: React.FC = () => {
               width: NAV_WIDTH,
               flexShrink: 0,
               position: 'sticky',
-              top: 80,           // below the fixed AppBar
+              top: 80, // below the fixed AppBar
               maxHeight: 'calc(100vh - 100px)',
               overflowY: 'auto',
               mr: 2,
@@ -558,7 +562,7 @@ const ApiDocumentation: React.FC = () => {
               </Typography>
               <List dense disablePadding>
                 {navTags.map(({ id, label }) => {
-                  const isActive = activeTag === id;
+                  const isActive = activeTag === id
                   return (
                     <ListItem key={id} disablePadding>
                       <ListItemButton
@@ -566,7 +570,9 @@ const ApiDocumentation: React.FC = () => {
                         sx={{
                           py: 0.5,
                           px: 2,
-                          borderLeft: isActive ? `3px solid ${primaryColor}` : '3px solid transparent',
+                          borderLeft: isActive
+                            ? `3px solid ${primaryColor}`
+                            : '3px solid transparent',
                           background: isActive ? activeBg : 'transparent',
                           borderRadius: 0,
                           '&:hover': {
@@ -587,7 +593,7 @@ const ApiDocumentation: React.FC = () => {
                         />
                       </ListItemButton>
                     </ListItem>
-                  );
+                  )
                 })}
               </List>
             </Paper>
@@ -611,7 +617,7 @@ const ApiDocumentation: React.FC = () => {
         </Box>
       </Box>
     </Box>
-  );
-};
+  )
+}
 
-export default ApiDocumentation;
+export default ApiDocumentation

--- a/frontend/src/pages/admin/ModuleUploadPage.tsx
+++ b/frontend/src/pages/admin/ModuleUploadPage.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import React, { useState } from 'react'
+import { useLocation, useNavigate } from 'react-router-dom'
 import {
   Container,
   Typography,
@@ -14,108 +14,122 @@ import {
   CardActionArea,
   CardContent,
   LinearProgress,
-} from '@mui/material';
-import CloudUpload from '@mui/icons-material/CloudUpload';
-import SCMIcon from '@mui/icons-material/AccountTree';
-import ArrowBack from '@mui/icons-material/ArrowBack';
-import api from '../../services/api';
-import { getErrorMessage } from '../../utils/errors';
-import PublishFromSCMWizard from '../../components/PublishFromSCMWizard';
-import FileDropZone from '../../components/FileDropZone';
+} from '@mui/material'
+import CloudUpload from '@mui/icons-material/CloudUpload'
+import SCMIcon from '@mui/icons-material/AccountTree'
+import ArrowBack from '@mui/icons-material/ArrowBack'
+import api from '../../services/api'
+import { getErrorMessage } from '../../utils/errors'
+import PublishFromSCMWizard from '../../components/PublishFromSCMWizard'
+import FileDropZone from '../../components/FileDropZone'
+import PolicyResultsPanel from '../../components/PolicyResultsPanel'
+import { PolicyResult } from '../../types'
 
-type ModuleMethod = 'choose' | 'upload' | 'scm';
+type ModuleMethod = 'choose' | 'upload' | 'scm'
 
 const ModuleUploadPage: React.FC = () => {
-  const location = useLocation();
-  const navigate = useNavigate();
+  const location = useLocation()
+  const navigate = useNavigate()
   const state = location.state as {
-    moduleData?: { namespace: string; name: string; provider: string };
-    method?: ModuleMethod;
-  };
-  const prefilledModule = state?.moduleData;
+    moduleData?: { namespace: string; name: string; provider: string }
+    method?: ModuleMethod
+  }
+  const prefilledModule = state?.moduleData
 
-  const [moduleMethod, setModuleMethod] = useState<ModuleMethod>(state?.method ?? 'choose');
+  const [moduleMethod, setModuleMethod] = useState<ModuleMethod>(state?.method ?? 'choose')
 
   // SCM new-module metadata (before wizard)
-  const [scmNamespace, setScmNamespace] = useState(prefilledModule?.namespace || '');
-  const [scmName, setScmName] = useState(prefilledModule?.name || '');
-  const [scmSystem, setScmSystem] = useState(prefilledModule?.provider || '');
-  const [scmDescription, setScmDescription] = useState('');
-  const [scmModuleId, setScmModuleId] = useState<string | null>(null);
-  const [scmCreating, setScmCreating] = useState(false);
-  const [scmError, setScmError] = useState<string | null>(null);
+  const [scmNamespace, setScmNamespace] = useState(prefilledModule?.namespace || '')
+  const [scmName, setScmName] = useState(prefilledModule?.name || '')
+  const [scmSystem, setScmSystem] = useState(prefilledModule?.provider || '')
+  const [scmDescription, setScmDescription] = useState('')
+  const [scmModuleId, setScmModuleId] = useState<string | null>(null)
+  const [scmCreating, setScmCreating] = useState(false)
+  const [scmError, setScmError] = useState<string | null>(null)
 
-  const [uploading, setUploading] = useState(false);
-  const [uploadPercent, setUploadPercent] = useState<number | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [success, setSuccess] = useState<string | null>(null);
+  const [uploading, setUploading] = useState(false)
+  const [uploadPercent, setUploadPercent] = useState<number | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState<string | null>(null)
+  const [policyResult, setPolicyResult] = useState<PolicyResult | null>(null)
 
   // Module upload state
-  const [moduleFile, setModuleFile] = useState<File | null>(null);
-  const [moduleNamespace, setModuleNamespace] = useState(prefilledModule?.namespace || '');
-  const [moduleName, setModuleName] = useState(prefilledModule?.name || '');
-  const [moduleProvider, setModuleProvider] = useState(prefilledModule?.provider || '');
-  const [moduleVersion, setModuleVersion] = useState('');
-  const [moduleDescription, setModuleDescription] = useState('');
+  const [moduleFile, setModuleFile] = useState<File | null>(null)
+  const [moduleNamespace, setModuleNamespace] = useState(prefilledModule?.namespace || '')
+  const [moduleName, setModuleName] = useState(prefilledModule?.name || '')
+  const [moduleProvider, setModuleProvider] = useState(prefilledModule?.provider || '')
+  const [moduleVersion, setModuleVersion] = useState('')
+  const [moduleDescription, setModuleDescription] = useState('')
 
   const handleModuleFileSelected = (file: File) => {
-    setModuleFile(file);
-    setError(null);
-  };
+    setModuleFile(file)
+    setError(null)
+  }
 
   const handleModuleUpload = async () => {
     if (!moduleFile || !moduleNamespace || !moduleName || !moduleProvider || !moduleVersion) {
-      setError('Please fill in all required fields');
-      return;
+      setError('Please fill in all required fields')
+      return
     }
 
     try {
-      setUploading(true);
-      setUploadPercent(0);
-      setError(null);
-      setSuccess(null);
+      setUploading(true)
+      setUploadPercent(0)
+      setError(null)
+      setSuccess(null)
+      setPolicyResult(null)
 
-      const formData = new FormData();
-      formData.append('namespace', moduleNamespace);
-      formData.append('name', moduleName);
-      formData.append('system', moduleProvider);
-      formData.append('version', moduleVersion);
-      if (moduleDescription) formData.append('description', moduleDescription);
-      formData.append('file', moduleFile);
+      const formData = new FormData()
+      formData.append('namespace', moduleNamespace)
+      formData.append('name', moduleName)
+      formData.append('system', moduleProvider)
+      formData.append('version', moduleVersion)
+      if (moduleDescription) formData.append('description', moduleDescription)
+      formData.append('file', moduleFile)
 
-      await api.uploadModule(formData, {
+      const result = await api.uploadModule(formData, {
         onUploadProgress: (percent) => setUploadPercent(percent),
-      });
+      })
 
-      navigate(`/modules/${moduleNamespace}/${moduleName}/${moduleProvider}`);
+      const pr: PolicyResult | undefined = result?.policy_result
+      if (pr) {
+        setPolicyResult(pr)
+        setUploading(false)
+        setUploadPercent(null)
+        if (pr.allowed) {
+          setSuccess('Module uploaded successfully.')
+        }
+      } else {
+        navigate(`/modules/${moduleNamespace}/${moduleName}/${moduleProvider}`)
+      }
     } catch (err: unknown) {
-      setError(getErrorMessage(err, 'Failed to upload module. Please try again.'));
-      setUploading(false);
-      setUploadPercent(null);
+      setError(getErrorMessage(err, 'Failed to upload module. Please try again.'))
+      setUploading(false)
+      setUploadPercent(null)
     }
-  };
+  }
 
   const handleScmProceed = async () => {
     if (!scmNamespace || !scmName || !scmSystem) {
-      setScmError('Namespace, name, and provider are required');
-      return;
+      setScmError('Namespace, name, and provider are required')
+      return
     }
     try {
-      setScmCreating(true);
-      setScmError(null);
+      setScmCreating(true)
+      setScmError(null)
       const module = await api.createModuleRecord({
         namespace: scmNamespace,
         name: scmName,
         system: scmSystem,
         description: scmDescription || undefined,
-      });
-      setScmModuleId(module.id);
+      })
+      setScmModuleId(module.id)
     } catch (err: unknown) {
-      setScmError(getErrorMessage(err, 'Failed to create module record'));
+      setScmError(getErrorMessage(err, 'Failed to create module record'))
     } finally {
-      setScmCreating(false);
+      setScmCreating(false)
     }
-  };
+  }
 
   const renderModuleMethodChooser = () => (
     <Box sx={{ p: 3 }}>
@@ -123,7 +137,8 @@ const ModuleUploadPage: React.FC = () => {
         How would you like to publish this module?
       </Typography>
       <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
-        Upload a packaged archive directly, or connect a git repository for automated publishing via webhooks.
+        Upload a packaged archive directly, or connect a git repository for automated publishing via
+        webhooks.
       </Typography>
       <Box sx={{ display: 'flex', gap: 3, flexDirection: { xs: 'column', sm: 'row' } }}>
         <Card
@@ -137,7 +152,8 @@ const ModuleUploadPage: React.FC = () => {
                 Upload from File
               </Typography>
               <Typography variant="body2" color="text.secondary">
-                Package your module as a <strong>.tar.gz</strong> archive and upload it directly. Best for one-off or manual releases.
+                Package your module as a <strong>.tar.gz</strong> archive and upload it directly.
+                Best for one-off or manual releases.
               </Typography>
             </CardContent>
           </CardActionArea>
@@ -154,20 +170,25 @@ const ModuleUploadPage: React.FC = () => {
                 Link from SCM Repository
               </Typography>
               <Typography variant="body2" color="text.secondary">
-                Connect a GitHub, Azure DevOps, GitLab, or Bitbucket repository. New versions publish automatically when tags are pushed.
+                Connect a GitHub, Azure DevOps, GitLab, or Bitbucket repository. New versions
+                publish automatically when tags are pushed.
               </Typography>
             </CardContent>
           </CardActionArea>
         </Card>
       </Box>
     </Box>
-  );
+  )
 
   const renderScmMetadataForm = () => (
     <Box sx={{ p: 3 }}>
       <Button
         startIcon={<ArrowBack />}
-        onClick={() => { setModuleMethod('choose'); setScmError(null); setScmModuleId(null); }}
+        onClick={() => {
+          setModuleMethod('choose')
+          setScmError(null)
+          setScmModuleId(null)
+        }}
         sx={{ mb: 2 }}
       >
         Back
@@ -181,17 +202,18 @@ const ModuleUploadPage: React.FC = () => {
           moduleId={scmModuleId}
           moduleSystem={scmSystem}
           onComplete={() => {
-            navigate(`/modules/${scmNamespace}/${scmName}/${scmSystem}`);
+            navigate(`/modules/${scmNamespace}/${scmName}/${scmSystem}`)
           }}
           onCancel={() => {
-            setModuleMethod('choose');
-            setScmModuleId(null);
+            setModuleMethod('choose')
+            setScmModuleId(null)
           }}
         />
       ) : (
         <>
           <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
-            First, define the module identity. Then you'll choose a repository and configure publishing settings.
+            First, define the module identity. Then you'll choose a repository and configure
+            publishing settings.
           </Typography>
           <Stack spacing={3} sx={{ maxWidth: 500 }}>
             <TextField
@@ -244,13 +266,17 @@ const ModuleUploadPage: React.FC = () => {
         </>
       )}
     </Box>
-  );
+  )
 
   const renderFileUploadForm = () => (
     <Box sx={{ p: 3 }}>
       <Button
         startIcon={<ArrowBack />}
-        onClick={() => { setModuleMethod('choose'); setError(null); setSuccess(null); }}
+        onClick={() => {
+          setModuleMethod('choose')
+          setError(null)
+          setSuccess(null)
+        }}
         sx={{ mb: 2 }}
       >
         Back
@@ -258,16 +284,24 @@ const ModuleUploadPage: React.FC = () => {
       <Typography variant="h6" gutterBottom>
         Upload Terraform Module
       </Typography>
-      <Box sx={{ mb: 3, p: 2, bgcolor: (theme) => theme.palette.mode === 'dark' ? 'grey.800' : 'grey.50', borderRadius: 1 }}>
+      <Box
+        sx={{
+          mb: 3,
+          p: 2,
+          bgcolor: (theme) => (theme.palette.mode === 'dark' ? 'grey.800' : 'grey.50'),
+          borderRadius: 1,
+        }}
+      >
         <Typography variant="body2" color="text.secondary" gutterBottom>
           <strong>Requirements:</strong>
         </Typography>
         <Typography variant="body2" color="text.secondary" component="div">
-          • Package your module as a <strong>.tar.gz</strong> or <strong>.tgz</strong> file<br />
-          • Include all <strong>.tf</strong> files (main.tf, variables.tf, outputs.tf)<br />
-          • Add a <strong>README.md</strong> with usage documentation<br />
-          • Use semantic versioning (1.0.0, 2.1.3, etc.)<br />
-          • Module address format: <strong>namespace/name/provider</strong>
+          • Package your module as a <strong>.tar.gz</strong> or <strong>.tgz</strong> file
+          <br />• Include all <strong>.tf</strong> files (main.tf, variables.tf, outputs.tf)
+          <br />• Add a <strong>README.md</strong> with usage documentation
+          <br />
+          • Use semantic versioning (1.0.0, 2.1.3, etc.)
+          <br />• Module address format: <strong>namespace/name/provider</strong>
         </Typography>
       </Box>
 
@@ -348,18 +382,31 @@ const ModuleUploadPage: React.FC = () => {
         {error && <Alert severity="error">{error}</Alert>}
         {success && <Alert severity="success">{success}</Alert>}
 
-        <Button
-          variant="contained"
-          onClick={handleModuleUpload}
-          disabled={uploading || !moduleFile}
-          startIcon={uploading ? <CircularProgress size={20} /> : <CloudUpload />}
-          size="large"
-        >
-          {uploading ? 'Uploading...' : 'Upload Module'}
-        </Button>
+        {policyResult && <PolicyResultsPanel policyResult={policyResult} />}
+
+        <Stack direction="row" spacing={2}>
+          <Button
+            variant="contained"
+            onClick={handleModuleUpload}
+            disabled={uploading || !moduleFile || (policyResult?.mode === 'block' && !policyResult?.allowed)}
+            startIcon={uploading ? <CircularProgress size={20} /> : <CloudUpload />}
+            size="large"
+          >
+            {uploading ? 'Uploading...' : 'Upload Module'}
+          </Button>
+          {policyResult?.allowed && (
+            <Button
+              variant="outlined"
+              size="large"
+              onClick={() => navigate(`/modules/${moduleNamespace}/${moduleName}/${moduleProvider}`)}
+            >
+              View Module
+            </Button>
+          )}
+        </Stack>
       </Stack>
     </Box>
-  );
+  )
 
   return (
     <Container maxWidth="md" sx={{ py: 4 }}>
@@ -376,7 +423,7 @@ const ModuleUploadPage: React.FC = () => {
         {moduleMethod === 'scm' && renderScmMetadataForm()}
       </Paper>
     </Container>
-  );
-};
+  )
+}
 
-export default ModuleUploadPage;
+export default ModuleUploadPage

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -499,6 +499,19 @@ export interface VersionInfo {
   }
 }
 
+// ---- Policy Engine ----
+
+export interface PolicyViolation {
+  rule: string
+  message: string
+}
+
+export interface PolicyResult {
+  allowed: boolean
+  mode: string
+  violations: PolicyViolation[]
+}
+
 // ---- Module Security Scan ----
 
 export type ModuleScanStatus = 'pending' | 'scanning' | 'clean' | 'findings' | 'error'


### PR DESCRIPTION
Implements Phase 4 item F-E4.2: display policy evaluation results in the module upload flow.

## Changes

- **`types/index.ts`** — adds `PolicyViolation` and `PolicyResult` types
- **`components/PolicyResultsPanel.tsx`** — new component following `SecurityScanPanel` pattern; shows PASS/WARN/BLOCK chip with mode label and expandable violation list
- **`pages/admin/ModuleUploadPage.tsx`** — captures upload response, renders `PolicyResultsPanel` when `policy_result` is present, adds "View Module" button on success, disables re-upload when `mode=block && !allowed`
- **`pages/ApiDocumentation.tsx`** — fix misplaced `eslint-disable-next-line` directive (Prettier wrap moved `any` one line down)

## Changelog

- feat: display policy evaluation results (PASS/WARN/BLOCK) in the module upload page

Closes #174