### PR TITLE
feat: OCI distribution affordances in usage example (F-E4.5)

### DIFF
--- a/frontend/src/components/UsageExample.tsx
+++ b/frontend/src/components/UsageExample.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from 'react'
 import {
   Box,
   IconButton,
@@ -10,47 +10,49 @@ import {
   ToggleButtonGroup,
   Tooltip,
   Typography,
-} from '@mui/material';
-import ContentCopy from '@mui/icons-material/ContentCopy';
-import type { ModuleInputVar } from '../types';
+} from '@mui/material'
+import ContentCopy from '@mui/icons-material/ContentCopy'
+import type { ModuleInputVar } from '../types'
 import {
   buildRequiredInputsExample,
   buildSourceExample,
   hasRequiredInputs,
-} from '../utils/terraformExample';
+} from '../utils/terraformExample'
 
-export type UsageTool = 'terraform' | 'opentofu';
+export type UsageTool = 'terraform' | 'opentofu' | 'oci'
 
-const STORAGE_KEY = 'preferredTool';
+const STORAGE_KEY = 'preferredTool'
 
 function readPreferredTool(): UsageTool {
   try {
-    const v = localStorage.getItem(STORAGE_KEY);
-    if (v === 'opentofu' || v === 'terraform') return v;
+    const v = localStorage.getItem(STORAGE_KEY)
+    if (v === 'opentofu' || v === 'terraform') return v
   } catch {
     // ignore
   }
-  return 'terraform';
+  return 'terraform'
 }
 
 function writePreferredTool(tool: UsageTool): void {
   try {
-    localStorage.setItem(STORAGE_KEY, tool);
+    localStorage.setItem(STORAGE_KEY, tool)
   } catch {
     // ignore
   }
 }
 
 export interface UsageExampleProps {
-  registryHost: string;
-  namespace: string;
-  name: string;
-  system: string;
-  version: string;
-  inputs?: ModuleInputVar[] | null;
+  registryHost: string
+  namespace: string
+  name: string
+  system: string
+  version: string
+  inputs?: ModuleInputVar[] | null
+  /** Show the OCI distribution tab (requires backend OCI support). */
+  ociEnabled?: boolean
   /** Called after a successful clipboard write (used for aria-live announce / toast). */
-  onCopied?: () => void;
-  'data-testid'?: string;
+  onCopied?: () => void
+  'data-testid'?: string
 }
 
 const UsageExample: React.FC<UsageExampleProps> = ({
@@ -60,37 +62,46 @@ const UsageExample: React.FC<UsageExampleProps> = ({
   system,
   version,
   inputs,
+  ociEnabled = false,
   onCopied,
   'data-testid': testId = 'usage-example',
 }) => {
-  const [tool, setTool] = React.useState<UsageTool>(() => readPreferredTool());
-  const [tab, setTab] = React.useState(0);
-  const [copied, setCopied] = React.useState(false);
+  const [tool, setTool] = React.useState<UsageTool>(() => readPreferredTool())
+  const [tab, setTab] = React.useState(0)
+  const [copied, setCopied] = React.useState(false)
 
-  const showInputsTab = hasRequiredInputs(inputs);
-  const activeTab = showInputsTab ? tab : 0;
+  const isOci = tool === 'oci'
+  const showInputsTab = !isOci && hasRequiredInputs(inputs)
+  const activeTab = showInputsTab ? tab : 0
 
-  const opts = { registryHost, namespace, name, system, version, inputs, tool };
-  const sourceBlock = buildSourceExample(opts);
-  const inputsBlock = buildRequiredInputsExample(opts);
-  const visible = activeTab === 1 ? inputsBlock : sourceBlock;
+  // When switching to OCI, reset tab to avoid stale state
+  React.useEffect(() => {
+    if (isOci) setTab(0)
+  }, [isOci])
+
+  const opts = { registryHost, namespace, name, system, version, inputs, tool: isOci ? 'terraform' as const : tool }
+  const sourceBlock = buildSourceExample(opts)
+  const inputsBlock = buildRequiredInputsExample(opts)
+  const ociBlock = `oras pull ${registryHost}/modules/${namespace}/${name}/${system}:${version}`
+  const visible = isOci ? ociBlock : (activeTab === 1 ? inputsBlock : sourceBlock)
 
   const handleToolChange = (_: unknown, next: UsageTool | null) => {
-    if (!next) return;
-    setTool(next);
-    writePreferredTool(next);
-  };
+    if (!next) return
+    setTool(next)
+    // Only persist terraform/opentofu preference; OCI is ephemeral
+    if (next !== 'oci') writePreferredTool(next)
+  }
 
   const handleCopy = async () => {
     try {
-      await navigator.clipboard.writeText(visible);
-      setCopied(true);
-      onCopied?.();
-      window.setTimeout(() => setCopied(false), 2000);
+      await navigator.clipboard.writeText(visible)
+      setCopied(true)
+      onCopied?.()
+      window.setTimeout(() => setCopied(false), 2000)
     } catch {
       // clipboard may be unavailable (e.g. insecure context) — no-op
     }
-  };
+  }
 
   return (
     <Paper sx={{ p: 3, mb: 3 }} data-testid={testId}>
@@ -117,6 +128,11 @@ const UsageExample: React.FC<UsageExampleProps> = ({
             <ToggleButton value="opentofu" aria-label="OpenTofu">
               OpenTofu
             </ToggleButton>
+            {ociEnabled && (
+              <ToggleButton value="oci" aria-label="OCI">
+                OCI
+              </ToggleButton>
+            )}
           </ToggleButtonGroup>
           <Tooltip title={copied ? 'Copied!' : 'Copy example'}>
             <IconButton
@@ -149,8 +165,7 @@ const UsageExample: React.FC<UsageExampleProps> = ({
         sx={{
           p: 2,
           m: 0,
-          backgroundColor: (theme) =>
-            theme.palette.mode === 'dark' ? '#2d2d2d' : '#f5f5f5',
+          backgroundColor: (theme) => (theme.palette.mode === 'dark' ? '#2d2d2d' : '#f5f5f5'),
           color: (theme) => (theme.palette.mode === 'dark' ? '#e6e6e6' : '#1e1e1e'),
           borderRadius: 1,
           overflow: 'auto',
@@ -163,11 +178,20 @@ const UsageExample: React.FC<UsageExampleProps> = ({
       {showInputsTab && activeTab === 1 && (
         <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 1 }}>
           Placeholders are the zero-value for each type — fill them before running
-          <code style={{ marginLeft: 4 }}>{tool === 'opentofu' ? 'tofu apply' : 'terraform apply'}</code>.
+          <code style={{ marginLeft: 4 }}>
+            {tool === 'opentofu' ? 'tofu apply' : 'terraform apply'}
+          </code>
+          .
+        </Typography>
+      )}
+      {isOci && (
+        <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 1 }}>
+          Requires{' '}
+          <code>oras</code> CLI. Pull the module archive directly from the OCI registry.
         </Typography>
       )}
     </Paper>
-  );
-};
+  )
+}
 
-export default UsageExample;
+export default UsageExample

--- a/frontend/src/hooks/useModuleDetail.ts
+++ b/frontend/src/hooks/useModuleDetail.ts
@@ -1,13 +1,13 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import api from '../services/api';
-import { ModuleVersion, ModuleScan, ModuleDoc } from '../types';
-import type { ModuleSCMLink, SCMWebhookEvent } from '../types/scm';
-import { useAuth } from '../contexts/AuthContext';
-import { REGISTRY_HOST } from '../config';
-import { getErrorMessage, getErrorStatus } from '../utils/errors';
-import { queryKeys } from '../services/queryKeys';
+import { useState, useEffect, useCallback, useMemo } from 'react'
+import { useParams, useNavigate } from 'react-router-dom'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import api from '../services/api'
+import { ModuleVersion, ModuleScan, ModuleDoc } from '../types'
+import type { ModuleSCMLink, SCMWebhookEvent } from '../types/scm'
+import { useAuth } from '../contexts/AuthContext'
+import { REGISTRY_HOST } from '../config'
+import { getErrorMessage, getErrorStatus } from '../utils/errors'
+import { queryKeys } from '../services/queryKeys'
 
 // ---------------------------------------------------------------------------
 // Semver sort helper (shared by query & version selection)
@@ -15,53 +15,54 @@ import { queryKeys } from '../services/queryKeys';
 function sortVersionsDesc(raw: ModuleVersion[]): ModuleVersion[] {
   return [...raw].sort((a, b) => {
     const parseParts = (v: string): [number, number, number] => {
-      const clean = v.replace(/^v/, '').split('-')[0];
-      const [maj = 0, min = 0, pat = 0] = clean.split('.').map(Number);
-      return [maj, min, pat];
-    };
-    const [aMaj, aMin, aPat] = parseParts(a.version);
-    const [bMaj, bMin, bPat] = parseParts(b.version);
-    return bMaj !== aMaj ? bMaj - aMaj : bMin !== aMin ? bMin - aMin : bPat - aPat;
-  });
+      const clean = v.replace(/^v/, '').split('-')[0]
+      const [maj = 0, min = 0, pat = 0] = clean.split('.').map(Number)
+      return [maj, min, pat]
+    }
+    const [aMaj, aMin, aPat] = parseParts(a.version)
+    const [bMaj, bMin, bPat] = parseParts(b.version)
+    return bMaj !== aMaj ? bMaj - aMaj : bMin !== aMin ? bMin - aMin : bPat - aPat
+  })
 }
 
 export function useModuleDetail() {
   const { namespace, name, system } = useParams<{
-    namespace: string;
-    name: string;
-    system: string;
-  }>();
-  const navigate = useNavigate();
-  const queryClient = useQueryClient();
-  const { isAuthenticated, allowedScopes } = useAuth();
-  const canManage = isAuthenticated && (allowedScopes.includes('admin') || allowedScopes.includes('modules:write'));
+    namespace: string
+    name: string
+    system: string
+  }>()
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const { isAuthenticated, allowedScopes } = useAuth()
+  const canManage =
+    isAuthenticated && (allowedScopes.includes('admin') || allowedScopes.includes('modules:write'))
 
   // UI-only state (not server data)
-  const [selectedVersion, setSelectedVersion] = useState<ModuleVersion | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [copiedSource, setCopiedSource] = useState(false);
-  const [deleteModuleDialogOpen, setDeleteModuleDialogOpen] = useState(false);
-  const [deleteVersionDialogOpen, setDeleteVersionDialogOpen] = useState(false);
-  const [versionToDelete, setVersionToDelete] = useState<string | null>(null);
-  const [deprecateDialogOpen, setDeprecateDialogOpen] = useState(false);
-  const [deprecationMessage, setDeprecationMessage] = useState('');
-  const [deprecationReplacementSource, setDeprecationReplacementSource] = useState('');
+  const [selectedVersion, setSelectedVersion] = useState<ModuleVersion | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [copiedSource, setCopiedSource] = useState(false)
+  const [deleteModuleDialogOpen, setDeleteModuleDialogOpen] = useState(false)
+  const [deleteVersionDialogOpen, setDeleteVersionDialogOpen] = useState(false)
+  const [versionToDelete, setVersionToDelete] = useState<string | null>(null)
+  const [deprecateDialogOpen, setDeprecateDialogOpen] = useState(false)
+  const [deprecationMessage, setDeprecationMessage] = useState('')
+  const [deprecationReplacementSource, setDeprecationReplacementSource] = useState('')
 
   // Module-level deprecation UI state
-  const [deprecateModuleDialogOpen, setDeprecateModuleDialogOpen] = useState(false);
-  const [moduleDeprecationMessage, setModuleDeprecationMessage] = useState('');
-  const [successorModuleId, setSuccessorModuleId] = useState('');
-  const [undeprecateModuleDialogOpen, setUndeprecateModuleDialogOpen] = useState(false);
+  const [deprecateModuleDialogOpen, setDeprecateModuleDialogOpen] = useState(false)
+  const [moduleDeprecationMessage, setModuleDeprecationMessage] = useState('')
+  const [successorModuleId, setSuccessorModuleId] = useState('')
+  const [undeprecateModuleDialogOpen, setUndeprecateModuleDialogOpen] = useState(false)
   // SCM linking UI state
-  const [scmWizardOpen, setScmWizardOpen] = useState(false);
+  const [scmWizardOpen, setScmWizardOpen] = useState(false)
 
   // Webhook events UI state
-  const [webhookEventsExpanded, setWebhookEventsExpanded] = useState(false);
+  const [webhookEventsExpanded, setWebhookEventsExpanded] = useState(false)
 
   // =========================================================================
   // 1. Module + versions query (primary)
   // =========================================================================
-  const moduleQueryEnabled = !!(namespace && name && system);
+  const moduleQueryEnabled = !!(namespace && name && system)
 
   const {
     data: moduleData,
@@ -73,128 +74,130 @@ export function useModuleDetail() {
       const [mod, versionsData] = await Promise.all([
         api.getModule(namespace!, name!, system!),
         api.getModuleVersions(namespace!, name!, system!),
-      ]);
-      if (!mod) throw new Error('Module not found');
+      ])
+      if (!mod) throw new Error('Module not found')
 
       const protocolVersions = Array.isArray(versionsData?.modules?.[0]?.versions)
         ? versionsData.modules[0].versions
-        : [];
-      const moduleVersions = Array.isArray(mod?.versions) ? mod.versions : [];
+        : []
+      const moduleVersions = Array.isArray(mod?.versions) ? mod.versions : []
       const rawVersions: ModuleVersion[] =
-        protocolVersions.length > 0 ? protocolVersions : moduleVersions;
-      const mergedVersions = sortVersionsDesc(rawVersions);
+        protocolVersions.length > 0 ? protocolVersions : moduleVersions
+      const mergedVersions = sortVersionsDesc(rawVersions)
 
-      return { module: mod, versions: mergedVersions };
+      return { module: mod, versions: mergedVersions }
     },
     enabled: moduleQueryEnabled,
-  });
+  })
 
-  const module = moduleData?.module ?? null;
-  const versions = useMemo(() => moduleData?.versions ?? [], [moduleData?.versions]);
+  const module = moduleData?.module ?? null
+  const versions = useMemo(() => moduleData?.versions ?? [], [moduleData?.versions])
 
   // Derive error from query
   useEffect(() => {
     if (moduleQueryError) {
       if (getErrorStatus(moduleQueryError) === 404) {
-        setError('Module not found');
+        setError('Module not found')
       } else {
-        setError(getErrorMessage(moduleQueryError, 'Failed to load module details'));
+        setError(getErrorMessage(moduleQueryError, 'Failed to load module details'))
       }
     }
-  }, [moduleQueryError]);
+  }, [moduleQueryError])
 
   // Auto-select latest version (or preserve current selection on refetch)
   useEffect(() => {
-    if (versions.length === 0) return;
+    if (versions.length === 0) return
     setSelectedVersion((prev) => {
-      const current = prev?.version;
-      const match = current ? versions.find((v) => v.version === current) : null;
-      return match || versions[0];
-    });
-  }, [versions]);
+      const current = prev?.version
+      const match = current ? versions.find((v) => v.version === current) : null
+      return match || versions[0]
+    })
+  }, [versions])
 
   // =========================================================================
   // 2. SCM Link query (depends on module.id)
   // =========================================================================
-  const {
-    data: scmLink = null,
-    isSuccess: scmLinkLoaded,
-  } = useQuery<ModuleSCMLink | null>({
+  const { data: scmLink = null, isSuccess: scmLinkLoaded } = useQuery<ModuleSCMLink | null>({
     queryKey: queryKeys.modules.scm(module?.id ?? ''),
     queryFn: async () => {
       try {
-        return await api.getModuleSCMInfo(module!.id);
+        return await api.getModuleSCMInfo(module!.id)
       } catch {
-        return null; // 404 = not linked, which is fine
+        return null // 404 = not linked, which is fine
       }
     },
     enabled: !!module?.id && isAuthenticated,
-  });
+  })
 
   // =========================================================================
   // 3. Module scan query (depends on selectedVersion)
   // =========================================================================
-  const scanVersion = selectedVersion?.version ?? '';
+  const scanVersion = selectedVersion?.version ?? ''
 
-  const {
-    data: scanData,
-    isLoading: scanLoading,
-  } = useQuery({
+  const { data: scanData, isLoading: scanLoading } = useQuery({
     queryKey: queryKeys.modules.scan(namespace ?? '', name ?? '', system ?? '', scanVersion),
     queryFn: async () => {
       try {
-        const scan = await api.getModuleScan(namespace!, name!, system!, scanVersion);
-        return { scan, notFound: false };
+        const scan = await api.getModuleScan(namespace!, name!, system!, scanVersion)
+        return { scan, notFound: false }
       } catch (err: unknown) {
         if (getErrorStatus(err) === 404) {
-          return { scan: null, notFound: true };
+          return { scan: null, notFound: true }
         }
-        throw err;
+        throw err
       }
     },
     enabled: moduleQueryEnabled && !!scanVersion && canManage,
-  });
+  })
 
-  const moduleScan: ModuleScan | null = scanData?.scan ?? null;
-  const scanNotFound = scanData?.notFound ?? false;
+  const moduleScan: ModuleScan | null = scanData?.scan ?? null
+  const scanNotFound = scanData?.notFound ?? false
 
   // =========================================================================
   // 4. Module docs query (depends on selectedVersion)
   // =========================================================================
-  const {
-    data: moduleDocs = null,
-    isLoading: docsLoading,
-  } = useQuery<ModuleDoc | null>({
+  const { data: moduleDocs = null, isLoading: docsLoading } = useQuery<ModuleDoc | null>({
     queryKey: queryKeys.modules.docs(namespace ?? '', name ?? '', system ?? '', scanVersion),
     queryFn: async () => {
       try {
-        return await api.getModuleDocs(namespace!, name!, system!, scanVersion);
+        return await api.getModuleDocs(namespace!, name!, system!, scanVersion)
       } catch {
-        return null;
+        return null
       }
     },
     enabled: moduleQueryEnabled && !!scanVersion,
-  });
+  })
 
   // =========================================================================
-  // 5. Webhook events (on-demand via loadWebhookEvents)
+  // 5. Version info / capabilities (global, stale 5 min)
   // =========================================================================
-  const [webhookEventsLoaded, setWebhookEventsLoaded] = useState(false);
-  const [webhookEventsLoading, setWebhookEventsLoading] = useState(false);
-  const [webhookEvents, setWebhookEvents] = useState<SCMWebhookEvent[]>([]);
+  const { data: versionInfo } = useQuery({
+    queryKey: queryKeys.versionInfo.get(),
+    queryFn: () => api.getVersionInfo(),
+    staleTime: 5 * 60 * 1000,
+  })
+
+  const ociEnabled = versionInfo?.oci === true
+
+  // =========================================================================
+  // 6. Webhook events (on-demand via loadWebhookEvents)
+  // =========================================================================
+  const [webhookEventsLoaded, setWebhookEventsLoaded] = useState(false)
+  const [webhookEventsLoading, setWebhookEventsLoading] = useState(false)
+  const [webhookEvents, setWebhookEvents] = useState<SCMWebhookEvent[]>([])
 
   const loadWebhookEvents = async (moduleId: string) => {
     try {
-      setWebhookEventsLoading(true);
-      const events = await api.getWebhookEvents(moduleId);
-      setWebhookEvents(Array.isArray(events) ? events : []);
+      setWebhookEventsLoading(true)
+      const events = await api.getWebhookEvents(moduleId)
+      setWebhookEvents(Array.isArray(events) ? events : [])
     } catch {
-      setWebhookEvents([]);
+      setWebhookEvents([])
     } finally {
-      setWebhookEventsLoading(false);
-      setWebhookEventsLoaded(true);
+      setWebhookEventsLoading(false)
+      setWebhookEventsLoaded(true)
     }
-  };
+  }
 
   // =========================================================================
   // Mutations
@@ -203,49 +206,56 @@ export function useModuleDetail() {
   const deleteModuleMutation = useMutation({
     mutationFn: () => api.deleteModule(namespace!, name!, system!),
     onSuccess: () => {
-      navigate('/modules');
+      navigate('/modules')
     },
     onError: (err: unknown) => {
-      setError(getErrorMessage(err, 'Failed to delete module. Please try again.'));
+      setError(getErrorMessage(err, 'Failed to delete module. Please try again.'))
     },
     onSettled: () => {
-      setDeleteModuleDialogOpen(false);
+      setDeleteModuleDialogOpen(false)
     },
-  });
+  })
 
   const deleteVersionMutation = useMutation({
     mutationFn: (version: string) => api.deleteModuleVersion(namespace!, name!, system!, version),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: queryKeys.modules.detail(namespace ?? '', name ?? '', system ?? ''),
-      });
-      setVersionToDelete(null);
+      })
+      setVersionToDelete(null)
     },
     onError: (err: unknown) => {
-      setError(getErrorMessage(err, 'Failed to delete version. Please try again.'));
+      setError(getErrorMessage(err, 'Failed to delete version. Please try again.'))
     },
     onSettled: () => {
-      setDeleteVersionDialogOpen(false);
+      setDeleteVersionDialogOpen(false)
     },
-  });
+  })
 
   const deprecateVersionMutation = useMutation({
     mutationFn: (args: { version: string; message?: string; replacementSource?: string }) =>
-      api.deprecateModuleVersion(namespace!, name!, system!, args.version, args.message, args.replacementSource),
+      api.deprecateModuleVersion(
+        namespace!,
+        name!,
+        system!,
+        args.version,
+        args.message,
+        args.replacementSource,
+      ),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: queryKeys.modules.detail(namespace ?? '', name ?? '', system ?? ''),
-      });
-      setDeprecationMessage('');
-      setDeprecationReplacementSource('');
+      })
+      setDeprecationMessage('')
+      setDeprecationReplacementSource('')
     },
     onError: (err: unknown) => {
-      setError(getErrorMessage(err, 'Failed to deprecate version. Please try again.'));
+      setError(getErrorMessage(err, 'Failed to deprecate version. Please try again.'))
     },
     onSettled: () => {
-      setDeprecateDialogOpen(false);
+      setDeprecateDialogOpen(false)
     },
-  });
+  })
 
   const undeprecateVersionMutation = useMutation({
     mutationFn: (version: string) =>
@@ -253,12 +263,12 @@ export function useModuleDetail() {
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: queryKeys.modules.detail(namespace ?? '', name ?? '', system ?? ''),
-      });
+      })
     },
     onError: (err: unknown) => {
-      setError(getErrorMessage(err, 'Failed to remove deprecation. Please try again.'));
+      setError(getErrorMessage(err, 'Failed to remove deprecation. Please try again.'))
     },
-  });
+  })
 
   const deprecateModuleMutation = useMutation({
     mutationFn: (args: { message: string; successor_module_id?: string }) =>
@@ -266,59 +276,60 @@ export function useModuleDetail() {
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: queryKeys.modules.detail(namespace ?? '', name ?? '', system ?? ''),
-      });
-      setModuleDeprecationMessage('');
-      setSuccessorModuleId('');
+      })
+      setModuleDeprecationMessage('')
+      setSuccessorModuleId('')
     },
     onError: (err: unknown) => {
-      setError(getErrorMessage(err, 'Failed to deprecate module. Please try again.'));
+      setError(getErrorMessage(err, 'Failed to deprecate module. Please try again.'))
     },
     onSettled: () => {
-      setDeprecateModuleDialogOpen(false);
+      setDeprecateModuleDialogOpen(false)
     },
-  });
+  })
 
   const undeprecateModuleMutation = useMutation({
     mutationFn: () => api.undeprecateModule(namespace!, name!, system!),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: queryKeys.modules.detail(namespace ?? '', name ?? '', system ?? ''),
-      });
+      })
     },
     onError: (err: unknown) => {
-      setError(getErrorMessage(err, 'Failed to remove module deprecation. Please try again.'));
+      setError(getErrorMessage(err, 'Failed to remove module deprecation. Please try again.'))
     },
     onSettled: () => {
-      setUndeprecateModuleDialogOpen(false);
+      setUndeprecateModuleDialogOpen(false)
     },
-  });
+  })
 
   const updateDescriptionMutation = useMutation({
-    mutationFn: (newDescription: string) => api.updateModule(module!.id, { description: newDescription }),
+    mutationFn: (newDescription: string) =>
+      api.updateModule(module!.id, { description: newDescription }),
     onSuccess: (_data, newDescription) => {
       // Optimistically update the cached module
       queryClient.setQueryData(
         queryKeys.modules.detail(namespace ?? '', name ?? '', system ?? ''),
         (old: typeof moduleData) =>
           old ? { ...old, module: { ...old.module, description: newDescription } } : old,
-      );
+      )
     },
     onError: (err: unknown) => {
-      setError(getErrorMessage(err, 'Failed to update description'));
+      setError(getErrorMessage(err, 'Failed to update description'))
     },
-  });
+  })
 
   const scmUnlinkMutation = useMutation({
     mutationFn: () => api.unlinkModuleFromSCM(module!.id),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: queryKeys.modules.scm(module?.id ?? ''),
-      });
+      })
     },
     onError: (err: unknown) => {
-      setError(getErrorMessage(err, 'Failed to unlink repository'));
+      setError(getErrorMessage(err, 'Failed to unlink repository'))
     },
-  });
+  })
 
   const rescanMutation = useMutation({
     mutationFn: () =>
@@ -341,20 +352,20 @@ export function useModuleDetail() {
   const scmSyncMutation = useMutation({
     mutationFn: () => api.triggerManualSync(module!.id),
     onSuccess: () => {
-      setError(null);
+      setError(null)
       // Poll for updated versions after an async sync (202) at 2s, 5s, and 12s.
-      [2000, 5000, 12000].forEach((delay) => {
+      ;[2000, 5000, 12000].forEach((delay) => {
         setTimeout(() => {
           queryClient.invalidateQueries({
             queryKey: queryKeys.modules.detail(namespace ?? '', name ?? '', system ?? ''),
-          });
-        }, delay);
-      });
+          })
+        }, delay)
+      })
     },
     onError: (err: unknown) => {
-      setError(getErrorMessage(err, 'Failed to trigger sync'));
+      setError(getErrorMessage(err, 'Failed to trigger sync'))
     },
-  });
+  })
 
   // =========================================================================
   // Handler wrappers (preserve existing call signatures for the page)
@@ -364,20 +375,20 @@ export function useModuleDetail() {
     (_moduleId: string) => {
       // SCM link is now loaded via React Query; this is a no-op kept for
       // backward compatibility with the page component.
-      queryClient.invalidateQueries({ queryKey: queryKeys.modules.scm(_moduleId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.modules.scm(_moduleId) })
     },
     [queryClient],
-  );
+  )
 
   const pollForVersions = useCallback(() => {
-    [2000, 5000, 12000].forEach((delay) => {
+    ;[2000, 5000, 12000].forEach((delay) => {
       setTimeout(() => {
         queryClient.invalidateQueries({
           queryKey: queryKeys.modules.detail(namespace ?? '', name ?? '', system ?? ''),
-        });
-      }, delay);
-    });
-  }, [queryClient, namespace, name, system]);
+        })
+      }, delay)
+    })
+  }, [queryClient, namespace, name, system])
 
   const handleRescan = () => {
     if (!namespace || !name || !system || !selectedVersion) return;
@@ -386,24 +397,24 @@ export function useModuleDetail() {
 
   const handleSCMSync = () => {
     if (!module?.id) {
-      console.error('Cannot sync: module.id is not available');
-      return;
+      console.error('Cannot sync: module.id is not available')
+      return
     }
-    scmSyncMutation.mutate();
-  };
+    scmSyncMutation.mutate()
+  }
 
   const handleSCMUnlink = () => {
-    if (!module?.id) return;
-    scmUnlinkMutation.mutate();
-  };
+    if (!module?.id) return
+    scmUnlinkMutation.mutate()
+  }
 
   const handleCopySource = () => {
-    if (!module || !selectedVersion) return;
-    const source = `${namespace}/${name}/${system}`;
-    navigator.clipboard.writeText(source);
-    setCopiedSource(true);
-    setTimeout(() => setCopiedSource(false), 2000);
-  };
+    if (!module || !selectedVersion) return
+    const source = `${namespace}/${name}/${system}`
+    navigator.clipboard.writeText(source)
+    setCopiedSource(true)
+    setTimeout(() => setCopiedSource(false), 2000)
+  }
 
   const handlePublishNewVersion = () => {
     navigate('/admin/upload/module', {
@@ -414,67 +425,67 @@ export function useModuleDetail() {
           provider: system,
         },
       },
-    });
-  };
+    })
+  }
 
   const handleDeleteModule = () => {
-    if (!namespace || !name || !system) return;
-    deleteModuleMutation.mutate();
-  };
+    if (!namespace || !name || !system) return
+    deleteModuleMutation.mutate()
+  }
 
   const handleDeleteVersion = () => {
-    if (!namespace || !name || !system || !versionToDelete) return;
-    deleteVersionMutation.mutate(versionToDelete);
-  };
+    if (!namespace || !name || !system || !versionToDelete) return
+    deleteVersionMutation.mutate(versionToDelete)
+  }
 
   const openDeleteVersionDialog = (version: string) => {
-    setVersionToDelete(version);
-    setDeleteVersionDialogOpen(true);
-  };
+    setVersionToDelete(version)
+    setDeleteVersionDialogOpen(true)
+  }
 
   const handleDeprecateVersion = () => {
-    if (!namespace || !name || !system || !selectedVersion) return;
+    if (!namespace || !name || !system || !selectedVersion) return
     deprecateVersionMutation.mutate({
       version: selectedVersion.version,
       message: deprecationMessage || undefined,
       replacementSource: deprecationReplacementSource || undefined,
-    });
-  };
+    })
+  }
 
   const handleUndeprecateVersion = () => {
-    if (!namespace || !name || !system || !selectedVersion) return;
-    undeprecateVersionMutation.mutate(selectedVersion.version);
-  };
+    if (!namespace || !name || !system || !selectedVersion) return
+    undeprecateVersionMutation.mutate(selectedVersion.version)
+  }
 
   const handleUpdateDescription = (newDescription: string) => {
-    if (!module?.id) return;
-    updateDescriptionMutation.mutate(newDescription);
-  };
+    if (!module?.id) return
+    updateDescriptionMutation.mutate(newDescription)
+  }
 
   const handleDeprecateModule = () => {
-    if (!namespace || !name || !system) return;
+    if (!namespace || !name || !system) return
     deprecateModuleMutation.mutate({
       message: moduleDeprecationMessage,
       successor_module_id: successorModuleId || undefined,
-    });
-  };
+    })
+  }
 
   const handleUndeprecateModule = () => {
-    if (!namespace || !name || !system) return;
-    undeprecateModuleMutation.mutate();
-  };
+    if (!namespace || !name || !system) return
+    undeprecateModuleMutation.mutate()
+  }
 
   const getTerraformExample = () => {
-    if (!module || !selectedVersion) return '';
+    if (!module || !selectedVersion) return ''
 
-    const v = selectedVersion.version;
-    const majorMinor = v.split('.').slice(0, 2).join('.');
+    const v = selectedVersion.version
+    const majorMinor = v.split('.').slice(0, 2).join('.')
 
     return `module "${name}" {
   source  = "${REGISTRY_HOST}/${namespace}/${name}/${system}"
   version = ">=${majorMinor}"
-}`;
-  };
+}`
+  }
 
   return {
     // Route params
@@ -540,6 +551,8 @@ export function useModuleDetail() {
     // Module docs
     moduleDocs,
     docsLoading,
+    // OCI distribution
+    ociEnabled,
     // Handlers
     loadSCMLink,
     loadWebhookEvents,
@@ -557,5 +570,5 @@ export function useModuleDetail() {
     handleUndeprecateModule,
     handleUpdateDescription,
     getTerraformExample,
-  };
+  }
 }

--- a/frontend/src/pages/ModuleDetailPage.tsx
+++ b/frontend/src/pages/ModuleDetailPage.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
-import { useNavigate, Link as RouterLink } from 'react-router-dom';
-import MarkdownRenderer from '../components/MarkdownRenderer';
+import React from 'react'
+import { useNavigate, Link as RouterLink } from 'react-router-dom'
+import MarkdownRenderer from '../components/MarkdownRenderer'
 import {
   Container,
   Typography,
@@ -21,32 +21,32 @@ import {
   TextField,
   Tabs,
   Tab,
-} from '@mui/material';
-import ArrowBack from '@mui/icons-material/ArrowBack';
-import Add from '@mui/icons-material/Add';
-import Warning from '@mui/icons-material/Warning';
-import EditIcon from '@mui/icons-material/Edit';
-import Check from '@mui/icons-material/Check';
-import Close from '@mui/icons-material/Close';
-import PublishFromSCMWizard from '../components/PublishFromSCMWizard';
-import ModuleDocumentation from '../components/ModuleDocumentation';
-import SecurityScanPanel from '../components/SecurityScanPanel';
-import SCMRepositoryPanel from '../components/SCMRepositoryPanel';
-import WebhookEventsPanel from '../components/WebhookEventsPanel';
-import VersionDetailsPanel from '../components/VersionDetailsPanel';
-import ConfirmDialog from '../components/ConfirmDialog';
-import VersionSelector from '../components/VersionSelector';
-import ModuleActionsMenu from '../components/ModuleActionsMenu';
-import DetailPageSkeleton from '../components/skeletons/DetailPageSkeleton';
-import UsageExample from '../components/UsageExample';
-import { REGISTRY_HOST } from '../config';
-import { useModuleDetail } from '../hooks/useModuleDetail';
+} from '@mui/material'
+import ArrowBack from '@mui/icons-material/ArrowBack'
+import Add from '@mui/icons-material/Add'
+import Warning from '@mui/icons-material/Warning'
+import EditIcon from '@mui/icons-material/Edit'
+import Check from '@mui/icons-material/Check'
+import Close from '@mui/icons-material/Close'
+import PublishFromSCMWizard from '../components/PublishFromSCMWizard'
+import ModuleDocumentation from '../components/ModuleDocumentation'
+import SecurityScanPanel from '../components/SecurityScanPanel'
+import SCMRepositoryPanel from '../components/SCMRepositoryPanel'
+import WebhookEventsPanel from '../components/WebhookEventsPanel'
+import VersionDetailsPanel from '../components/VersionDetailsPanel'
+import ConfirmDialog from '../components/ConfirmDialog'
+import VersionSelector from '../components/VersionSelector'
+import ModuleActionsMenu from '../components/ModuleActionsMenu'
+import DetailPageSkeleton from '../components/skeletons/DetailPageSkeleton'
+import UsageExample from '../components/UsageExample'
+import { REGISTRY_HOST } from '../config'
+import { useModuleDetail } from '../hooks/useModuleDetail'
 
 const ModuleDetailPage: React.FC = () => {
-  const navigate = useNavigate();
-  const [editingDescription, setEditingDescription] = React.useState(false);
-  const [editDescription, setEditDescription] = React.useState('');
-  const [docTab, setDocTab] = React.useState(0);
+  const navigate = useNavigate()
+  const [editingDescription, setEditingDescription] = React.useState(false)
+  const [editDescription, setEditDescription] = React.useState('')
+  const [docTab, setDocTab] = React.useState(0)
   const {
     namespace,
     name,
@@ -114,7 +114,8 @@ const ModuleDetailPage: React.FC = () => {
     handleDeprecateModule,
     handleUndeprecateModule,
     handleUpdateDescription,
-  } = useModuleDetail();
+    ociEnabled,
+  } = useModuleDetail()
 
   return (
     <Box aria-busy={loading} aria-live="polite">
@@ -123,11 +124,7 @@ const ModuleDetailPage: React.FC = () => {
       ) : error || !module ? (
         <Container maxWidth="lg" sx={{ py: 4 }}>
           <Alert severity="error">{error || 'Module not found'}</Alert>
-          <Button
-            startIcon={<ArrowBack />}
-            onClick={() => navigate('/modules')}
-            sx={{ mt: 2 }}
-          >
+          <Button startIcon={<ArrowBack />} onClick={() => navigate('/modules')} sx={{ mt: 2 }}>
             Back to Modules
           </Button>
         </Container>
@@ -156,19 +153,30 @@ const ModuleDetailPage: React.FC = () => {
             <Alert severity="warning" sx={{ mb: 2 }}>
               This module is deprecated. {module.deprecation_message}
               {module.successor_module && (
-                <> Consider using <Link
-                  component={RouterLink}
-                  to={`/modules/${module.successor_module.namespace}/${module.successor_module.name}/${module.successor_module.system}`}
-                >
-                  {module.successor_module.namespace}/{module.successor_module.name}/{module.successor_module.system}
-                </Link> instead.</>
+                <>
+                  {' '}
+                  Consider using{' '}
+                  <Link
+                    component={RouterLink}
+                    to={`/modules/${module.successor_module.namespace}/${module.successor_module.name}/${module.successor_module.system}`}
+                  >
+                    {module.successor_module.namespace}/{module.successor_module.name}/
+                    {module.successor_module.system}
+                  </Link>{' '}
+                  instead.
+                </>
               )}
             </Alert>
           )}
 
           {/* Header */}
           <Box sx={{ mb: 4 }}>
-            <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 2 }}>
+            <Stack
+              direction="row"
+              alignItems="center"
+              justifyContent="space-between"
+              sx={{ mb: 2 }}
+            >
               <Stack direction="row" alignItems="center" spacing={2}>
                 <IconButton aria-label="Back to modules" onClick={() => navigate('/modules')}>
                   <ArrowBack />
@@ -178,11 +186,7 @@ const ModuleDetailPage: React.FC = () => {
                 </Typography>
               </Stack>
               {canManage && (
-                <Button
-                  variant="contained"
-                  startIcon={<Add />}
-                  onClick={handlePublishNewVersion}
-                >
+                <Button variant="contained" startIcon={<Add />} onClick={handlePublishNewVersion}>
                   Publish New Version
                 </Button>
               )}
@@ -199,10 +203,10 @@ const ModuleDetailPage: React.FC = () => {
                     autoFocus
                     onKeyDown={(e) => {
                       if (e.key === 'Enter') {
-                        handleUpdateDescription(editDescription);
-                        setEditingDescription(false);
+                        handleUpdateDescription(editDescription)
+                        setEditingDescription(false)
                       } else if (e.key === 'Escape') {
-                        setEditingDescription(false);
+                        setEditingDescription(false)
                       }
                     }}
                   />
@@ -210,8 +214,8 @@ const ModuleDetailPage: React.FC = () => {
                     size="small"
                     color="primary"
                     onClick={() => {
-                      handleUpdateDescription(editDescription);
-                      setEditingDescription(false);
+                      handleUpdateDescription(editDescription)
+                      setEditingDescription(false)
                     }}
                     aria-label="Save description"
                   >
@@ -235,8 +239,8 @@ const ModuleDetailPage: React.FC = () => {
                       <IconButton
                         size="small"
                         onClick={() => {
-                          setEditDescription(module.description || '');
-                          setEditingDescription(true);
+                          setEditDescription(module.description || '')
+                          setEditingDescription(true)
                         }}
                         aria-label="Edit description"
                       >
@@ -256,20 +260,15 @@ const ModuleDetailPage: React.FC = () => {
                 data-testid="module-version-selector"
               />
               {selectedVersion?.deprecated && (
-                <Chip
-                  label="Deprecated"
-                  color="warning"
-                  size="small"
-                  icon={<Warning />}
-                />
+                <Chip label="Deprecated" color="warning" size="small" icon={<Warning />} />
               )}
               <Chip label={`${module.download_count ?? 0} downloads`} />
               <ModuleActionsMenu
                 canManage={canManage}
                 deprecated={!!module.deprecated}
                 onEditDescription={() => {
-                  setEditDescription(module.description || '');
-                  setEditingDescription(true);
+                  setEditDescription(module.description || '')
+                  setEditingDescription(true)
                 }}
                 onDeprecateModule={() => setDeprecateModuleDialogOpen(true)}
                 onUndeprecateModule={() => setUndeprecateModuleDialogOpen(true)}
@@ -290,28 +289,24 @@ const ModuleDetailPage: React.FC = () => {
                 version={selectedVersion?.version || ''}
                 inputs={moduleDocs?.inputs ?? null}
                 onCopied={handleCopySource}
+                ociEnabled={ociEnabled}
               />
 
               {/* Documentation Tabs */}
               <Paper sx={{ p: 3 }}>
-                <Tabs
-                  value={docTab}
-                  onChange={(_, newValue) => setDocTab(newValue)}
-                  sx={{ mb: 2 }}
-                >
+                <Tabs value={docTab} onChange={(_, newValue) => setDocTab(newValue)} sx={{ mb: 2 }}>
                   <Tab label="README" />
                   <Tab label="Inputs / Outputs" />
                 </Tabs>
                 <Divider sx={{ mb: 2 }} />
-                {docTab === 0 && (
-                  selectedVersion && selectedVersion.readme ? (
+                {docTab === 0 &&
+                  (selectedVersion && selectedVersion.readme ? (
                     <MarkdownRenderer>{selectedVersion.readme}</MarkdownRenderer>
                   ) : (
                     <Typography variant="body2" color="text.secondary">
                       No README provided for this module version.
                     </Typography>
-                  )
-                )}
+                  ))}
                 {docTab === 1 && (
                   <ModuleDocumentation moduleDocs={moduleDocs} docsLoading={docsLoading} />
                 )}
@@ -337,7 +332,10 @@ const ModuleDetailPage: React.FC = () => {
                     <strong>Provider:</strong> {system}
                   </Typography>
                   <Typography variant="body2">
-                    <strong>Latest Version:</strong> {versions.length > 0 ? (versions.find(v => !v.deprecated) ?? versions[0]).version : 'N/A'}
+                    <strong>Latest Version:</strong>{' '}
+                    {versions.length > 0
+                      ? (versions.find((v) => !v.deprecated) ?? versions[0]).version
+                      : 'N/A'}
                   </Typography>
                   <Typography variant="body2">
                     <strong>Total Downloads:</strong> {module.download_count ?? 0}
@@ -405,9 +403,12 @@ const ModuleDetailPage: React.FC = () => {
             title="Delete Module"
             description={
               <>
-                Are you sure you want to delete the module <strong>{namespace}/{name}/{system}</strong>?
-                This will permanently delete all versions and associated files.
-                This action cannot be undone.
+                Are you sure you want to delete the module{' '}
+                <strong>
+                  {namespace}/{name}/{system}
+                </strong>
+                ? This will permanently delete all versions and associated files. This action cannot
+                be undone.
               </>
             }
             confirmLabel={deleting ? 'Deleting...' : 'Delete Module'}
@@ -426,9 +427,11 @@ const ModuleDetailPage: React.FC = () => {
             description={
               <>
                 Are you sure you want to delete version <strong>{versionToDelete}</strong> of{' '}
-                <strong>{namespace}/{name}/{system}</strong>?
-                This will permanently delete the version and its associated files.
-                This action cannot be undone.
+                <strong>
+                  {namespace}/{name}/{system}
+                </strong>
+                ? This will permanently delete the version and its associated files. This action
+                cannot be undone.
               </>
             }
             confirmLabel={deleting ? 'Deleting...' : 'Delete Version'}
@@ -452,11 +455,11 @@ const ModuleDetailPage: React.FC = () => {
                   moduleId={module.id}
                   moduleSystem={system}
                   onComplete={() => {
-                    setScmWizardOpen(false);
+                    setScmWizardOpen(false)
                     // Reload SCM link immediately, then poll for versions the
                     // background sync will create over the next several seconds.
-                    if (module?.id) loadSCMLink(module.id);
-                    pollForVersions();
+                    if (module?.id) loadSCMLink(module.id)
+                    pollForVersions()
                   }}
                   onCancel={() => setScmWizardOpen(false)}
                 />
@@ -468,23 +471,26 @@ const ModuleDetailPage: React.FC = () => {
           <ConfirmDialog
             open={deprecateDialogOpen}
             onClose={() => {
-              setDeprecateDialogOpen(false);
-              setDeprecationMessage('');
-              setDeprecationReplacementSource('');
+              setDeprecateDialogOpen(false)
+              setDeprecationMessage('')
+              setDeprecationReplacementSource('')
             }}
             onSubmit={async (values) => {
-              setDeprecationMessage(values.message ?? '');
-              setDeprecationReplacementSource(values.replacement_source ?? '');
+              setDeprecationMessage(values.message ?? '')
+              setDeprecationReplacementSource(values.replacement_source ?? '')
               // Defer one tick so the message state is applied before the handler reads it.
-              await Promise.resolve();
-              handleDeprecateVersion();
+              await Promise.resolve()
+              handleDeprecateVersion()
             }}
             title="Deprecate Version"
             description={
               <>
-                Are you sure you want to deprecate version <strong>{selectedVersion?.version}</strong> of{' '}
-                <strong>{namespace}/{name}/{system}</strong>?
-                This will mark the version as deprecated, warning users not to use it.
+                Are you sure you want to deprecate version{' '}
+                <strong>{selectedVersion?.version}</strong> of{' '}
+                <strong>
+                  {namespace}/{name}/{system}
+                </strong>
+                ? This will mark the version as deprecated, warning users not to use it.
               </>
             }
             severity="warning"
@@ -514,21 +520,24 @@ const ModuleDetailPage: React.FC = () => {
           <ConfirmDialog
             open={deprecateModuleDialogOpen}
             onClose={() => {
-              setDeprecateModuleDialogOpen(false);
-              setModuleDeprecationMessage('');
-              setSuccessorModuleId('');
+              setDeprecateModuleDialogOpen(false)
+              setModuleDeprecationMessage('')
+              setSuccessorModuleId('')
             }}
             onSubmit={async (values) => {
-              setModuleDeprecationMessage(values.message ?? '');
-              setSuccessorModuleId(values.successor ?? '');
-              await Promise.resolve();
-              handleDeprecateModule();
+              setModuleDeprecationMessage(values.message ?? '')
+              setSuccessorModuleId(values.successor ?? '')
+              await Promise.resolve()
+              handleDeprecateModule()
             }}
             title="Deprecate Module"
             description={
               <>
-                Are you sure you want to deprecate the module <strong>{namespace}/{name}/{system}</strong>?
-                This will mark the entire module as deprecated, warning users not to use it.
+                Are you sure you want to deprecate the module{' '}
+                <strong>
+                  {namespace}/{name}/{system}
+                </strong>
+                ? This will mark the entire module as deprecated, warning users not to use it.
               </>
             }
             severity="warning"
@@ -563,8 +572,11 @@ const ModuleDetailPage: React.FC = () => {
             title="Undeprecate Module"
             description={
               <>
-                Are you sure you want to remove the deprecation from <strong>{namespace}/{name}/{system}</strong>?
-                This will make the module available for normal use again.
+                Are you sure you want to remove the deprecation from{' '}
+                <strong>
+                  {namespace}/{name}/{system}
+                </strong>
+                ? This will make the module available for normal use again.
               </>
             }
             severity="info"
@@ -575,7 +587,7 @@ const ModuleDetailPage: React.FC = () => {
         </Container>
       )}
     </Box>
-  );
-};
+  )
+}
 
-export default ModuleDetailPage;
+export default ModuleDetailPage

--- a/frontend/src/services/queryKeys.ts
+++ b/frontend/src/services/queryKeys.ts
@@ -102,6 +102,10 @@ export const queryKeys = {
     _def: ['oidcConfig'] as const,
     get: () => [...queryKeys.oidcConfig._def, 'get'] as const,
   },
+  versionInfo: {
+    _def: ['versionInfo'] as const,
+    get: () => [...queryKeys.versionInfo._def, 'get'] as const,
+  },
   terraformMirrors: {
     _def: ['terraformMirrors'] as const,
     list: () => [...queryKeys.terraformMirrors._def, 'list'] as const,

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -497,6 +497,7 @@ export interface VersionInfo {
     providers: string
     mirror: string
   }
+  oci?: boolean
 }
 
 // ---- Module Security Scan ----


### PR DESCRIPTION
Implements Phase 4 item F-E4.5: OCI distribution affordances in the module detail usage example.

## Changes

- **`types/index.ts`** — adds `oci?: boolean` to `VersionInfo`
- **`queryKeys.ts`** — adds `versionInfo` query key family
- **`hooks/useModuleDetail.ts`** — fetches `GET /version`, derives `ociEnabled`, returns it from the hook
- **`pages/ModuleDetailPage.tsx`** — passes `ociEnabled` to `UsageExample`
- **`components/UsageExample.tsx`** — adds `ociEnabled` prop; when true, shows "OCI" in the tool toggle group; OCI mode shows `oras pull <host>/modules/<ns>/<name>/<system>:<version>`; OCI preference is not persisted to localStorage

## Changelog

- feat: show OCI `oras pull` command in usage example when backend advertises OCI support

Closes #176