### PR TITLE
feat: add Re-scan button to SecurityScanPanel

### DIFF
--- a/frontend/src/components/SecurityScanPanel.tsx
+++ b/frontend/src/components/SecurityScanPanel.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from 'react'
 import {
   Box,
   Paper,
@@ -8,16 +8,20 @@ import {
   CircularProgress,
   Alert,
   Stack,
-} from '@mui/material';
-import SecurityIcon from '@mui/icons-material/Security';
-import { ModuleVersion, ModuleScan } from '../types';
+  Button,
+} from '@mui/material'
+import SecurityIcon from '@mui/icons-material/Security'
+import RefreshIcon from '@mui/icons-material/Refresh'
+import { ModuleVersion, ModuleScan } from '../types'
 
 interface SecurityScanPanelProps {
-  canManage: boolean;
-  selectedVersion: ModuleVersion | null;
-  moduleScan: ModuleScan | null;
-  scanLoading: boolean;
-  scanNotFound: boolean;
+  canManage: boolean
+  selectedVersion: ModuleVersion | null
+  moduleScan: ModuleScan | null
+  scanLoading: boolean
+  scanNotFound: boolean
+  onRescan?: () => void
+  rescanPending?: boolean
 }
 
 const SecurityScanPanel: React.FC<SecurityScanPanelProps> = ({
@@ -26,16 +30,31 @@ const SecurityScanPanel: React.FC<SecurityScanPanelProps> = ({
   moduleScan,
   scanLoading,
   scanNotFound,
+  onRescan,
+  rescanPending = false,
 }) => {
-  if (!canManage || !selectedVersion) return null;
+  if (!canManage || !selectedVersion) return null
+
+  const scanInProgress =
+    moduleScan?.status === 'pending' || moduleScan?.status === 'scanning' || rescanPending
 
   return (
     <Paper sx={{ p: 3, mb: 3 }}>
       <Box display="flex" alignItems="center" gap={1} mb={1}>
         <SecurityIcon fontSize="small" color="action" />
         <Typography variant="h6">Security Scan</Typography>
-        {(moduleScan?.status === 'pending' || moduleScan?.status === 'scanning') && (
-          <CircularProgress size={16} sx={{ ml: 'auto' }} />
+        {scanInProgress && <CircularProgress size={16} sx={{ ml: 'auto' }} />}
+        {onRescan && !scanInProgress && (
+          <Button
+            size="small"
+            variant="outlined"
+            startIcon={<RefreshIcon />}
+            onClick={onRescan}
+            sx={{ ml: 'auto' }}
+            data-testid="rescan-button"
+          >
+            Re-scan
+          </Button>
         )}
       </Box>
       <Divider sx={{ mb: 2 }} />
@@ -54,9 +73,13 @@ const SecurityScanPanel: React.FC<SecurityScanPanelProps> = ({
               label={moduleScan.status}
               size="small"
               color={
-                moduleScan.status === 'clean' ? 'success' :
-                  moduleScan.status === 'findings' ? 'warning' :
-                    moduleScan.status === 'error' ? 'error' : 'info'
+                moduleScan.status === 'clean'
+                  ? 'success'
+                  : moduleScan.status === 'findings'
+                    ? 'warning'
+                    : moduleScan.status === 'error'
+                      ? 'error'
+                      : 'info'
               }
             />
           </Box>
@@ -79,14 +102,19 @@ const SecurityScanPanel: React.FC<SecurityScanPanelProps> = ({
               {moduleScan.low_count > 0 && (
                 <Chip label={`Low: ${moduleScan.low_count}`} size="small" />
               )}
-              {moduleScan.critical_count === 0 && moduleScan.high_count === 0 &&
-                moduleScan.medium_count === 0 && moduleScan.low_count === 0 && (
-                  <Typography variant="body2" color="success.main">No findings</Typography>
+              {moduleScan.critical_count === 0 &&
+                moduleScan.high_count === 0 &&
+                moduleScan.medium_count === 0 &&
+                moduleScan.low_count === 0 && (
+                  <Typography variant="body2" color="success.main">
+                    No findings
+                  </Typography>
                 )}
             </Stack>
           )}
           <Typography variant="caption" color="text.secondary" display="block">
-            Scanner: {moduleScan.scanner}{moduleScan.scanner_version ? ` ${moduleScan.scanner_version}` : ''}
+            Scanner: {moduleScan.scanner}
+            {moduleScan.scanner_version ? ` ${moduleScan.scanner_version}` : ''}
           </Typography>
           {moduleScan.scanned_at && (
             <Typography variant="caption" color="text.secondary" display="block">
@@ -96,7 +124,7 @@ const SecurityScanPanel: React.FC<SecurityScanPanelProps> = ({
         </Box>
       ) : null}
     </Paper>
-  );
-};
+  )
+}
 
-export default SecurityScanPanel;
+export default SecurityScanPanel

--- a/frontend/src/components/__tests__/SecurityScanPanel.test.tsx
+++ b/frontend/src/components/__tests__/SecurityScanPanel.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react'
-import { describe, it, expect } from 'vitest'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi } from 'vitest'
 import type { ModuleVersion, ModuleScan } from '../../types'
 import SecurityScanPanel from '../SecurityScanPanel'
 
@@ -99,7 +100,14 @@ describe('SecurityScanPanel', () => {
       <SecurityScanPanel
         canManage={true}
         selectedVersion={fakeVersion}
-        moduleScan={{ ...baseScan, status: 'findings', critical_count: 1, high_count: 2, medium_count: 3, low_count: 4 }}
+        moduleScan={{
+          ...baseScan,
+          status: 'findings',
+          critical_count: 1,
+          high_count: 2,
+          medium_count: 3,
+          low_count: 4,
+        }}
         scanLoading={false}
         scanNotFound={false}
       />,
@@ -118,5 +126,68 @@ describe('SecurityScanPanel', () => {
       />,
     )
     expect(screen.getByText('error')).toBeInTheDocument()
+  })
+
+  it('shows Re-scan button when onRescan is provided and scan is not in progress', () => {
+    const onRescan = vi.fn()
+    render(
+      <SecurityScanPanel
+        canManage={true}
+        selectedVersion={fakeVersion}
+        moduleScan={{ ...baseScan, status: 'clean' }}
+        scanLoading={false}
+        scanNotFound={false}
+        onRescan={onRescan}
+        rescanPending={false}
+      />,
+    )
+    expect(screen.getByTestId('rescan-button')).toBeInTheDocument()
+  })
+
+  it('calls onRescan when Re-scan button is clicked', async () => {
+    const onRescan = vi.fn()
+    render(
+      <SecurityScanPanel
+        canManage={true}
+        selectedVersion={fakeVersion}
+        moduleScan={{ ...baseScan, status: 'clean' }}
+        scanLoading={false}
+        scanNotFound={false}
+        onRescan={onRescan}
+        rescanPending={false}
+      />,
+    )
+    await userEvent.click(screen.getByTestId('rescan-button'))
+    expect(onRescan).toHaveBeenCalledOnce()
+  })
+
+  it('hides Re-scan button while scan is in progress', () => {
+    render(
+      <SecurityScanPanel
+        canManage={true}
+        selectedVersion={fakeVersion}
+        moduleScan={{ ...baseScan, status: 'scanning' }}
+        scanLoading={false}
+        scanNotFound={false}
+        onRescan={vi.fn()}
+        rescanPending={false}
+      />,
+    )
+    expect(screen.queryByTestId('rescan-button')).not.toBeInTheDocument()
+  })
+
+  it('hides Re-scan button while rescanPending is true', () => {
+    render(
+      <SecurityScanPanel
+        canManage={true}
+        selectedVersion={fakeVersion}
+        moduleScan={{ ...baseScan, status: 'clean' }}
+        scanLoading={false}
+        scanNotFound={false}
+        onRescan={vi.fn()}
+        rescanPending={true}
+      />,
+    )
+    expect(screen.queryByTestId('rescan-button')).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/hooks/useModuleDetail.ts
+++ b/frontend/src/hooks/useModuleDetail.ts
@@ -320,6 +320,24 @@ export function useModuleDetail() {
     },
   });
 
+  const rescanMutation = useMutation({
+    mutationFn: () =>
+      api.reanalyzeModuleVersion(namespace!, name!, system!, selectedVersion!.version),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.modules.scan(
+          namespace ?? '',
+          name ?? '',
+          system ?? '',
+          selectedVersion?.version ?? '',
+        ),
+      });
+    },
+    onError: (err: unknown) => {
+      setError(getErrorMessage(err, 'Failed to queue re-scan. Please try again.'));
+    },
+  });
+
   const scmSyncMutation = useMutation({
     mutationFn: () => api.triggerManualSync(module!.id),
     onSuccess: () => {
@@ -360,6 +378,11 @@ export function useModuleDetail() {
       }, delay);
     });
   }, [queryClient, namespace, name, system]);
+
+  const handleRescan = () => {
+    if (!namespace || !name || !system || !selectedVersion) return;
+    rescanMutation.mutate();
+  };
 
   const handleSCMSync = () => {
     if (!module?.id) {
@@ -512,6 +535,8 @@ export function useModuleDetail() {
     moduleScan,
     scanLoading,
     scanNotFound,
+    rescanPending: rescanMutation.isPending,
+    handleRescan,
     // Module docs
     moduleDocs,
     docsLoading,

--- a/frontend/src/pages/ModuleDetailPage.tsx
+++ b/frontend/src/pages/ModuleDetailPage.tsx
@@ -95,6 +95,8 @@ const ModuleDetailPage: React.FC = () => {
     moduleScan,
     scanLoading,
     scanNotFound,
+    rescanPending,
+    handleRescan,
     moduleDocs,
     docsLoading,
     loadSCMLink,
@@ -389,6 +391,8 @@ const ModuleDetailPage: React.FC = () => {
                 moduleScan={moduleScan}
                 scanLoading={scanLoading}
                 scanNotFound={scanNotFound}
+                onRescan={handleRescan}
+                rescanPending={rescanPending}
               />
             </Box>
           </Box>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -280,6 +280,18 @@ class ApiClient {
     return response.data
   }
 
+  async reanalyzeModuleVersion(
+    namespace: string,
+    name: string,
+    system: string,
+    version: string,
+  ) {
+    const response = await this.client.post(
+      `/api/v1/modules/${namespace}/${name}/${system}/versions/${version}/reanalyze`,
+    )
+    return response.data
+  }
+
   async deprecateModuleVersion(
     namespace: string,
     name: string,


### PR DESCRIPTION
Closes #178

Adds a Re-scan button to the `SecurityScanPanel` so admins can trigger a fresh security scan for a module version directly from the UI.

## Changes

- `services/api.ts` — added `reanalyzeModuleVersion()` method calling `POST /api/v1/modules/{ns}/{name}/{system}/versions/{version}/reanalyze`
- `hooks/useModuleDetail.ts` — added `rescanMutation` (React Query `useMutation`), `handleRescan` handler, and exposes `rescanPending` from hook return
- `components/SecurityScanPanel.tsx` — added optional `onRescan` and `rescanPending` props; renders Re-scan button in panel header when `onRescan` is provided and no scan is currently in progress (pending/scanning/rescanPending); progress spinner now shares the same `scanInProgress` derived boolean
- `components/__tests__/SecurityScanPanel.test.tsx` — 4 new test cases covering button visibility and click handler
- `pages/ModuleDetailPage.tsx` — wires `handleRescan` and `rescanPending` into `SecurityScanPanel`

## Changelog

- feat: add Re-scan button to SecurityScanPanel so admins can trigger a security rescan from the module detail page