### PR TITLE
fix: limit gated E2E to 2 workers to avoid Firefox networkidle timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,7 +220,7 @@ jobs:
       - name: Run Playwright tests
         working-directory: e2e
         run: >-
-          npx playwright test --max-failures=1 --retries=1 --reporter=list
+          npx playwright test --workers=2 --max-failures=1 --retries=1 --reporter=list
 
       - name: Upload Playwright artifacts
         # v7


### PR DESCRIPTION
Closes #181

Firefox's `networkidle` detection is sensitive to resource contention when 4 parallel Playwright workers compete for the CI runner. The PR E2E job hard-codes `--workers=1` and reliably passes; the gated job (used by `release.yml`) inherits `workers: 4` from `playwright.config.ts` and consistently fails on the Providers accessibility test.

Changing to `--workers=2` halves contention while preserving meaningful parallelism (compared to `--workers=1`).

## Changelog

- fix: limit gated E2E to 2 parallel workers to prevent Firefox networkidle timeout on Providers page