### PR TITLE
fix: re-scan button gives no feedback when scanner not configured; scan status never polls

### DIFF
--- a/frontend/src/components/SecurityScanPanel.tsx
+++ b/frontend/src/components/SecurityScanPanel.tsx
@@ -20,6 +20,7 @@ interface SecurityScanPanelProps {
   moduleScan: ModuleScan | null
   scanLoading: boolean
   scanNotFound: boolean
+  scanNotConfigured?: boolean
   onRescan?: () => void
   rescanPending?: boolean
 }
@@ -30,6 +31,7 @@ const SecurityScanPanel: React.FC<SecurityScanPanelProps> = ({
   moduleScan,
   scanLoading,
   scanNotFound,
+  scanNotConfigured = false,
   onRescan,
   rescanPending = false,
 }) => {
@@ -62,6 +64,11 @@ const SecurityScanPanel: React.FC<SecurityScanPanelProps> = ({
         <Box display="flex" justifyContent="center" py={2}>
           <CircularProgress size={24} />
         </Box>
+      ) : scanNotConfigured ? (
+        <Alert severity="warning" sx={{ mt: 1 }}>
+          Security scanning is not configured on this registry. Set up a scanner binary path in the
+          backend configuration to enable scanning.
+        </Alert>
       ) : scanNotFound ? (
         <Typography variant="body2" color="text.secondary">
           No scan available for this version.

--- a/frontend/src/hooks/useModuleDetail.ts
+++ b/frontend/src/hooks/useModuleDetail.ts
@@ -53,6 +53,7 @@ export function useModuleDetail() {
   const [moduleDeprecationMessage, setModuleDeprecationMessage] = useState('')
   const [successorModuleId, setSuccessorModuleId] = useState('')
   const [undeprecateModuleDialogOpen, setUndeprecateModuleDialogOpen] = useState(false)
+  const [scanNotConfigured, setScanNotConfigured] = useState(false)
   // SCM linking UI state
   const [scmWizardOpen, setScmWizardOpen] = useState(false)
 
@@ -148,6 +149,10 @@ export function useModuleDetail() {
       }
     },
     enabled: moduleQueryEnabled && !!scanVersion && canManage,
+    refetchInterval: (query) => {
+      const status = query.state.data?.scan?.status
+      return status === 'pending' || status === 'scanning' ? 3000 : false
+    },
   })
 
   const moduleScan: ModuleScan | null = scanData?.scan ?? null
@@ -332,9 +337,14 @@ export function useModuleDetail() {
   })
 
   const rescanMutation = useMutation({
-    mutationFn: () =>
-      api.reanalyzeModuleVersion(namespace!, name!, system!, selectedVersion!.version),
-    onSuccess: () => {
+    mutationFn: () => {
+      setScanNotConfigured(false)
+      return api.reanalyzeModuleVersion(namespace!, name!, system!, selectedVersion!.version)
+    },
+    onSuccess: (data: { scan?: string }) => {
+      if (data?.scan === 'not_configured') {
+        setScanNotConfigured(true)
+      }
       queryClient.invalidateQueries({
         queryKey: queryKeys.modules.scan(
           namespace ?? '',
@@ -546,6 +556,7 @@ export function useModuleDetail() {
     moduleScan,
     scanLoading,
     scanNotFound,
+    scanNotConfigured,
     rescanPending: rescanMutation.isPending,
     handleRescan,
     // Module docs

--- a/frontend/src/pages/ModuleDetailPage.tsx
+++ b/frontend/src/pages/ModuleDetailPage.tsx
@@ -95,6 +95,7 @@ const ModuleDetailPage: React.FC = () => {
     moduleScan,
     scanLoading,
     scanNotFound,
+    scanNotConfigured,
     rescanPending,
     handleRescan,
     moduleDocs,
@@ -389,6 +390,7 @@ const ModuleDetailPage: React.FC = () => {
                 moduleScan={moduleScan}
                 scanLoading={scanLoading}
                 scanNotFound={scanNotFound}
+                scanNotConfigured={scanNotConfigured}
                 onRescan={handleRescan}
                 rescanPending={rescanPending}
               />


### PR DESCRIPTION
Closes #185

## Changes

**`useModuleDetail.ts`**
- Added `refetchInterval: 3000` on the scan query when status is `pending` or `scanning` — the panel now automatically updates every 3 s until the scan completes, no manual refresh needed
- Track `scanNotConfigured` state: the `reanalyze` response body now includes `"scan":"not_configured"` when the backend has no scanner binary configured; this state is exposed from the hook

**`SecurityScanPanel.tsx`**
- Added `scanNotConfigured?: boolean` prop
- When true, renders a `warning` Alert explaining that scanning is not set up, instead of silently looking like nothing happened

**`ModuleDetailPage.tsx`**
- Destructures and passes `scanNotConfigured` to `SecurityScanPanel`

## Changelog
- fix: re-scan button now shows a warning when scanning is not configured on the registry; scan status updates automatically every 3 s while pending/scanning