### PR TITLE
fix: replace duplicate sidebar icons and add missing context help

### DIFF
--- a/frontend/src/components/HelpPanel.tsx
+++ b/frontend/src/components/HelpPanel.tsx
@@ -276,6 +276,39 @@ const AUDIT_LOGS_HELP: HelpContent = {
   ],
 };
 
+const SECURITY_SCANNING_HELP: HelpContent = {
+  title: 'Security Scanning',
+  overview:
+    'Displays the current configuration and results of the module vulnerability scanner. The scanner analyses uploaded module archives for known security issues using an external scanning tool configured by the server administrator.',
+  actions: [
+    { heading: 'View Configuration', text: 'The top section shows whether scanning is enabled, the scanner tool and version, severity threshold, timeout, and worker/interval settings.' },
+    { heading: 'Summary Statistics', text: 'Aggregate counts show total scans, pending, clean, findings, and errors at a glance.' },
+    { heading: 'Review Scan Results', text: 'The recent scans table lists each module with its scan status and vulnerability counts broken down by severity (critical, high, medium, low).' },
+  ],
+};
+
+const MTLS_HELP: HelpContent = {
+  title: 'mTLS Certificates',
+  overview:
+    'Shows the current mutual TLS (mTLS) configuration, including whether client certificate authentication is enabled and which certificate subjects are mapped to authorization scopes. All mTLS settings are read-only in the UI — configuration is managed through the server config file.',
+  actions: [
+    { heading: 'View Status', text: 'The status indicator shows whether mTLS is enabled or disabled, along with the CA certificate file path used to verify client certificates.' },
+    { heading: 'Certificate Mappings', text: 'The mappings table lists each certificate subject and the scopes it is authorized to use. Clients presenting a matching certificate receive these scopes automatically.' },
+    { heading: 'Configuration Source', text: 'All mTLS settings are sourced from the server configuration file. To modify mappings, update the config file and restart the backend.' },
+  ],
+};
+
+const SCIM_HELP: HelpContent = {
+  title: 'SCIM Provisioning',
+  overview:
+    'SCIM 2.0 enables automatic user and group provisioning from your identity provider (e.g. Azure AD, Okta). This page shows the SCIM endpoint URLs and authentication requirements needed to configure your IdP.',
+  actions: [
+    { heading: 'Endpoint URLs', text: 'Copy the SCIM base URL, Users endpoint, and Groups endpoint into your identity provider\'s SCIM configuration.' },
+    { heading: 'Authentication', text: 'SCIM requests require a Bearer token with the scim:provision scope. Create one on the API Keys page and paste it into your IdP\'s SCIM token field.' },
+    { heading: 'Supported Operations', text: 'Users support full CRUD and soft-delete. Groups are read-only and map to registry organizations. Filtering and pagination are supported.' },
+  ],
+};
+
 const DEFAULT_HELP: HelpContent = {
   title: 'Help',
   overview: 'Navigate to a page using the sidebar to see context-sensitive help for that section.',
@@ -311,6 +344,9 @@ function getHelpContent(pathname: string): HelpContent {
     case '/admin/terraform-mirror': return TERRAFORM_MIRROR_HELP;
     case '/admin/approvals': return APPROVALS_HELP;
     case '/admin/policies': return MIRROR_POLICIES_HELP;
+    case '/admin/security-scanning': return SECURITY_SCANNING_HELP;
+    case '/admin/mtls': return MTLS_HELP;
+    case '/admin/scim': return SCIM_HELP;
     default: return DEFAULT_HELP;
   }
 }

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -40,7 +40,8 @@ import Brightness7 from '@mui/icons-material/Brightness7';
 import HelpOutline from '@mui/icons-material/HelpOutline';
 import InfoOutlined from '@mui/icons-material/InfoOutlined';
 import SearchIcon from '@mui/icons-material/Search';
-import Shield from '@mui/icons-material/Shield';
+import AdminPanelSettings from '@mui/icons-material/AdminPanelSettings';
+import VerifiedUser from '@mui/icons-material/VerifiedUser';
 import Security from '@mui/icons-material/Security';
 import Storage from '@mui/icons-material/Storage';
 import HourglassEmpty from '@mui/icons-material/HourglassEmpty';
@@ -138,11 +139,11 @@ const Layout = () => {
       label: t('nav.admin.identity'),
       items: [
         { text: t('nav.admin.organizations'), icon: <Business />, path: '/admin/organizations', tooltip: t('nav.admin.organizationsTooltip'), scope: 'organizations:read' },
-        { text: t('nav.admin.roles'), icon: <Shield />, path: '/admin/roles', tooltip: t('nav.admin.rolesTooltip'), scope: 'users:read' },
+        { text: t('nav.admin.roles'), icon: <AdminPanelSettings />, path: '/admin/roles', tooltip: t('nav.admin.rolesTooltip'), scope: 'users:read' },
         { text: t('nav.admin.users'), icon: <People />, path: '/admin/users', tooltip: t('nav.admin.usersTooltip'), scope: 'users:read' },
         { text: t('nav.admin.oidcGroups'), icon: <ManageAccounts />, path: '/admin/oidc', tooltip: t('nav.admin.oidcGroupsTooltip'), scope: 'admin' },
         { text: t('nav.admin.scim'), icon: <SyncAlt />, path: '/admin/scim', tooltip: t('nav.admin.scimTooltip'), scope: 'admin' },
-        { text: t('nav.admin.mtlsCerts'), icon: <Shield />, path: '/admin/mtls', tooltip: t('nav.admin.mtlsCertsTooltip'), scope: 'admin' },
+        { text: t('nav.admin.mtlsCerts'), icon: <VerifiedUser />, path: '/admin/mtls', tooltip: t('nav.admin.mtlsCertsTooltip'), scope: 'admin' },
         { text: t('nav.admin.apiKeys'), icon: <Key />, path: '/admin/apikeys', tooltip: t('nav.admin.apiKeysTooltip'), scope: null },
       ],
     },


### PR DESCRIPTION
Closes #195, Closes #197

## Summary
- Replace duplicate Shield icons in admin sidebar — Roles now uses AdminPanelSettings, mTLS Certs uses VerifiedUser
- Add context help panels for Security Scanning, mTLS Certificates, and SCIM Provisioning pages

## Changelog
- fix: replace duplicate Shield icons for Roles and mTLS Certs with distinct icons (#197)
- fix: add missing context help for Security Scanning, mTLS, and SCIM pages (#195)

## Test plan
- [ ] Verify sidebar icons for Roles and mTLS Certs are visually distinct
- [ ] Navigate to /admin/security-scanning, /admin/mtls, /admin/scim and open the help panel — each should show page-specific content instead of the generic default
- [ ] Lint, typecheck, and build all pass