### PR TITLE
fix: remove unnecessary rebase from prepare-release.yml

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -110,10 +110,6 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add -A
           git commit -m "chore: release v${VERSION}"
-          # Rebase onto latest main to avoid merge conflicts from concurrent
-          # feature merges landing between branch creation and PR merge.
-          git fetch origin main
-          git rebase origin/main
           git push origin "$BRANCH"
 
       - name: Open release PR


### PR DESCRIPTION
Closes #207

Removes the `git fetch origin main` + `git rebase origin/main` lines from the
`Create release branch, commit, and push` step.

Release PRs always use **merge commits**, not squash — so rebasing the release
branch onto `main` serves no purpose and actively causes failures when
`development` has diverged commits that conflict on replay.

## Changelog
- fix: prepare-release.yml no longer fails when development is ahead of main