### PR TITLE
feat(security-scanning): show binary path and detected version in config section

### DIFF
--- a/frontend/src/pages/admin/SecurityScanningPage.tsx
+++ b/frontend/src/pages/admin/SecurityScanningPage.tsx
@@ -21,6 +21,7 @@ import {
 import CheckCircle from '@mui/icons-material/CheckCircle';
 import Error from '@mui/icons-material/Error';
 import HourglassEmpty from '@mui/icons-material/HourglassEmpty';
+import WarningAmber from '@mui/icons-material/WarningAmber';
 import api from '../../services/api';
 
 function statusChip(status: string) {
@@ -112,6 +113,35 @@ const SecurityScanningPage: React.FC = () => {
                 <Typography variant="body1" fontFamily="monospace">
                   {config?.worker_count ?? '—'} workers, every {config?.scan_interval_mins ?? '—'}m
                 </Typography>
+              </Grid>
+              <Grid size={{ xs: 12, sm: 6, md: 4 }}>
+                <Typography variant="caption" color="text.secondary">Binary Path</Typography>
+                {config?.binary_path ? (
+                  <Typography variant="body1" fontFamily="monospace" sx={{ wordBreak: 'break-all' }}>
+                    {config.binary_path}
+                  </Typography>
+                ) : (
+                  <Typography variant="body2" color="text.disabled">
+                    Not reported by backend
+                  </Typography>
+                )}
+              </Grid>
+              <Grid size={{ xs: 12, sm: 6, md: 4 }}>
+                <Typography variant="caption" color="text.secondary">Detected Version</Typography>
+                {config?.detected_version ? (
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mt: 0.5 }}>
+                    <Typography variant="body1" fontFamily="monospace">{config.detected_version}</Typography>
+                    {config.expected_version && config.detected_version !== config.expected_version && (
+                      <Tooltip title={`Expected ${config.expected_version}`}>
+                        <WarningAmber fontSize="small" color="warning" />
+                      </Tooltip>
+                    )}
+                  </Box>
+                ) : (
+                  <Typography variant="body2" color="text.disabled">
+                    Not reported by backend
+                  </Typography>
+                )}
               </Grid>
             </Grid>
           </Paper>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -570,6 +570,9 @@ export interface ScanningConfig {
   timeout: string
   worker_count: number
   scan_interval_mins: number
+  // Added in backend #263 — optional until backend is updated
+  binary_path?: string
+  detected_version?: string
 }
 
 export interface RecentScanEntry {


### PR DESCRIPTION
Surfaces scanner binary details in the Security Scanning admin page, providing visibility into which binary the backend is actually using and whether its version matches the expected pinned version.

- Adds **Binary Path** field (shows reported path or "Not reported by backend")
- Adds **Detected Version** field with a warning icon when it mismatches `expected_version`
- Extends `ScanningConfig` type with optional `binary_path` and `detected_version` fields (graceful fallback until backend ships sethbacon/terraform-registry-backend#263)

Closes #198