### PR TITLE
fix: fix workflow_call boolean type causing release.yml startup_failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,11 @@ name: CI
       run-security-deep:
         description: >-
           Run extended security scans (npm audit, OSV-Scanner, CodeQL).
+          Pass "true" to enable; omit or pass "false" to skip.
           Enabled by weekly-security.yml; skipped on every PR/push.
-        type: boolean
+        type: string
         required: false
-        default: false
+        default: "false"
 
 concurrency:
   group: ci-${{ github.event_name }}-${{ github.head_ref || github.ref }}
@@ -241,7 +242,7 @@ jobs:
   npm-audit:
     name: Dependency Audit
     runs-on: ubuntu-latest
-    if: inputs.run-security-deep
+    if: inputs.run-security-deep == 'true'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup-frontend
@@ -260,7 +261,7 @@ jobs:
   osv-scan:
     name: OSV Scan
     runs-on: ubuntu-latest
-    if: inputs.run-security-deep
+    if: inputs.run-security-deep == 'true'
     permissions:
       security-events: write
     steps:
@@ -278,7 +279,7 @@ jobs:
   codeql:
     name: CodeQL (JavaScript/TypeScript)
     runs-on: ubuntu-latest
-    if: inputs.run-security-deep
+    if: inputs.run-security-deep == 'true'
     permissions:
       security-events: write
       actions: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,6 +87,15 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      - name: Resolve release tag
+        id: tag
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "value=${{ github.event.inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
         with:
@@ -100,10 +109,10 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{version}},value=${{ steps.tag.outputs.value }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ steps.tag.outputs.value }}
+            type=semver,pattern={{major}},value=${{ steps.tag.outputs.value }}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
@@ -144,7 +153,12 @@ jobs:
     steps:
       - name: Extract version from tag
         id: version
-        run: echo "version=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "version=${{ github.event.inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
@@ -172,7 +186,12 @@ jobs:
     steps:
       - name: Extract version from tag
         id: version
-        run: echo "version=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "version=${{ github.event.inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Clone wiki
         run: |

--- a/.github/workflows/weekly-security.yml
+++ b/.github/workflows/weekly-security.yml
@@ -19,12 +19,7 @@ jobs:
     uses: ./.github/workflows/ci.yml
     secrets: inherit
     with:
-      run-security-deep: true
-    permissions:
-      contents: read
-      packages: read
-      security-events: write
-      actions: read
+      run-security-deep: "true"
 
   # ── Flag stale Dependabot PRs ──────────────────────────
   stale-dependabot:


### PR DESCRIPTION
## Problem

`release.yml` has been failing with `startup_failure` (zero jobs, no log) since the trunk-based workflow cutover. Every run at the v0.13.0 tag fails instantly, so the Docker image for v0.13.0 was never built or pushed.

**Root cause 1 — `ci.yml` `workflow_call` boolean input**: GitHub Actions fails with `startup_failure` when a reusable workflow defines a `workflow_call` input with `type: boolean` and the caller does not explicitly pass it via `with:`. `release.yml`'s `ci` job calls `ci.yml` without a `with:` block, triggering this validation failure.

**Root cause 2 — `weekly-security.yml` invalid `permissions:` on reusable call**: GitHub Actions does not allow the `permissions:` key on a job that calls a reusable workflow (`uses:`). The `ci` job in `weekly-security.yml` had this invalid combination, which would have caused `startup_failure` for the weekly security scan on the next Monday run.

**Root cause 3 — `release.yml` workflow_dispatch version**: When `release.yml` is triggered via `workflow_dispatch` (used to backfill the v0.13.0 Docker image after this fix lands), `GITHUB_REF_NAME` resolves to the branch name rather than the release tag. The docker/metadata-action also won't generate semver tags from a branch ref. The `release` and `update-wiki` jobs would write `main` as the release name.

## Changes

### Commit 1 — `ci.yml` + `weekly-security.yml`

- **`ci.yml`**: Change `run-security-deep` input from `type: boolean` / `default: false` to `type: string` / `default: "false"`. Update all three `if: inputs.run-security-deep` conditions to `if: inputs.run-security-deep == 'true'`.
- **`weekly-security.yml`**: Remove the invalid `permissions:` block from the `ci` job (permissions on reusable workflow call jobs are not supported; jobs within `ci.yml` manage their own permissions). Update `run-security-deep: true` → `run-security-deep: "true"` to match the new string type.

### Commit 2 — `release.yml` workflow_dispatch path

- **`docker` job**: Add a "Resolve release tag" step that sets `steps.tag.outputs.value` to either `inputs.tag` (workflow_dispatch) or `GITHUB_REF_NAME` (tag push). Pass `value=` to each `type=semver` pattern so correct Docker image tags are generated regardless of triggering ref. Fix `type=raw,value=latest` enable condition to also fire on workflow_dispatch.
- **`release` job**: Use `inputs.tag` when `workflow_dispatch` for version extraction.
- **`update-wiki` job**: Use `inputs.tag` when `workflow_dispatch` for version extraction.

## Test plan

- [ ] Merge this PR — CI will validate the workflow changes on main
- [ ] Manually dispatch `release.yml` with `tag=v0.13.0` to backfill the missing Docker image and update the GitHub Release
- [ ] Confirm `ghcr.io/sethbacon/terraform-registry-frontend:0.13.0` appears in the package registry
- [ ] Confirm the v0.13.0 GitHub Release body contains the `docker pull` instructions