### PR TITLE
fix(i18n): correct stale comment referencing nonexistent CONTRIBUTING.md section

### DIFF
--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -13,9 +13,9 @@ import nbTranslation from './locales/nb/translation.json';
 import zhTranslation from './locales/zh/translation.json';
 import itTranslation from './locales/it/translation.json';
 
-// Machine-translated locales are baseline placeholders flagged for human review.
-// All non-English strings carry a // MACHINE_TRANSLATED marker in the contributing
-// notes — see CONTRIBUTING.md §Translation workflow.
+// Non-English locales are machine-translated via DeepL. The translation
+// script (scripts/translate.mjs) tracks source hashes to detect stale
+// translations when English strings change.
 
 i18n
   .use(LanguageDetector)


### PR DESCRIPTION
The i18n.ts comment referenced a `MACHINE_TRANSLATED` marker and `CONTRIBUTING.md §Translation workflow` section that were never created. Replace with accurate description of the DeepL pipeline.

This change is inside `frontend/` so release-please will pick it up (previous PRs #225 and #226 only touched `scripts/` and `.github/`, which are outside the tracked package path).