### PR TITLE
feat(scanning): surface security scanner logs and diagnostics

### DIFF
--- a/frontend/src/components/ScanDiagnostics.tsx
+++ b/frontend/src/components/ScanDiagnostics.tsx
@@ -1,0 +1,89 @@
+import React from 'react'
+import { Box, Typography, Stack } from '@mui/material'
+
+interface ScanDiagnosticsProps {
+  errorMessage?: string | null
+  executionLog?: string | null
+  rawResults?: Record<string, unknown> | null
+  /** Optional max height for the scrollable log/raw blocks. */
+  maxBlockHeight?: number
+}
+
+/**
+ * Renders the diagnostic fields a scan can carry: the brief error_message,
+ * the captured stderr/stdout (execution_log), and the raw scanner JSON
+ * payload. Returns null when none are populated so callers can drop it in
+ * unconditionally.
+ */
+const ScanDiagnostics: React.FC<ScanDiagnosticsProps> = ({
+  errorMessage,
+  executionLog,
+  rawResults,
+  maxBlockHeight = 240,
+}) => {
+  const hasErrorMessage = Boolean(errorMessage)
+  const hasLog = Boolean(executionLog)
+  const hasRaw = rawResults != null && Object.keys(rawResults).length > 0
+
+  if (!hasErrorMessage && !hasLog && !hasRaw) return null
+
+  return (
+    <Stack spacing={2} data-testid="scan-diagnostics">
+      {hasErrorMessage && (
+        <Section title="Error message" testId="scan-diagnostics-error">
+          <Typography variant="body2" color="error.main" sx={{ whiteSpace: 'pre-wrap' }}>
+            {errorMessage}
+          </Typography>
+        </Section>
+      )}
+      {hasLog && (
+        <Section title="Scanner output (stderr / stdout)" testId="scan-diagnostics-log">
+          <LogBlock content={executionLog as string} maxHeight={maxBlockHeight} />
+        </Section>
+      )}
+      {hasRaw && (
+        <Section title="Raw scanner JSON" testId="scan-diagnostics-raw">
+          <LogBlock
+            content={JSON.stringify(rawResults, null, 2)}
+            maxHeight={maxBlockHeight}
+          />
+        </Section>
+      )}
+    </Stack>
+  )
+}
+
+const Section: React.FC<{
+  title: string
+  testId?: string
+  children: React.ReactNode
+}> = ({ title, testId, children }) => (
+  <Box data-testid={testId}>
+    <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.5 }}>
+      {title}
+    </Typography>
+    {children}
+  </Box>
+)
+
+const LogBlock: React.FC<{ content: string; maxHeight: number }> = ({ content, maxHeight }) => (
+  <Box
+    component="pre"
+    sx={{
+      m: 0,
+      p: 1.5,
+      maxHeight,
+      overflow: 'auto',
+      backgroundColor: 'action.hover',
+      borderRadius: 1,
+      fontSize: '0.75rem',
+      fontFamily: 'monospace',
+      whiteSpace: 'pre-wrap',
+      wordBreak: 'break-word',
+    }}
+  >
+    {content}
+  </Box>
+)
+
+export default ScanDiagnostics

--- a/frontend/src/components/SecurityScanPanel.tsx
+++ b/frontend/src/components/SecurityScanPanel.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import {
   Box,
   Paper,
@@ -9,9 +9,13 @@ import {
   Alert,
   Stack,
   Button,
+  Collapse,
 } from '@mui/material'
 import SecurityIcon from '@mui/icons-material/Security'
 import RefreshIcon from '@mui/icons-material/Refresh'
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
+import ExpandLessIcon from '@mui/icons-material/ExpandLess'
+import ScanDiagnostics from './ScanDiagnostics'
 import { ModuleVersion, ModuleScan } from '../types'
 
 interface SecurityScanPanelProps {
@@ -35,10 +39,17 @@ const SecurityScanPanel: React.FC<SecurityScanPanelProps> = ({
   onRescan,
   rescanPending = false,
 }) => {
+  const [diagnosticsOpen, setDiagnosticsOpen] = useState(false)
+
   if (!canManage || !selectedVersion) return null
 
   const scanInProgress =
     moduleScan?.status === 'pending' || moduleScan?.status === 'scanning' || rescanPending
+
+  const hasDiagnostics = Boolean(
+    moduleScan?.execution_log ||
+      (moduleScan?.raw_results && Object.keys(moduleScan.raw_results).length > 0),
+  )
 
   return (
     <Paper sx={{ p: 3, mb: 3 }}>
@@ -91,7 +102,7 @@ const SecurityScanPanel: React.FC<SecurityScanPanelProps> = ({
             />
           </Box>
           {moduleScan.status === 'error' && moduleScan.error_message && (
-            <Alert severity="error" sx={{ mb: 1.5 }}>
+            <Alert severity="error" sx={{ mb: 1.5 }} data-testid="scan-error-alert">
               {moduleScan.error_message}
             </Alert>
           )}
@@ -127,6 +138,27 @@ const SecurityScanPanel: React.FC<SecurityScanPanelProps> = ({
             <Typography variant="caption" color="text.secondary" display="block">
               Scanned: {new Date(moduleScan.scanned_at).toLocaleString()}
             </Typography>
+          )}
+          {hasDiagnostics && (
+            <Box sx={{ mt: 1.5 }}>
+              <Button
+                size="small"
+                variant="text"
+                onClick={() => setDiagnosticsOpen((prev) => !prev)}
+                startIcon={diagnosticsOpen ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+                data-testid="scan-diagnostics-toggle"
+                sx={{ textTransform: 'none', mb: 1 }}
+              >
+                {diagnosticsOpen ? 'Hide' : 'Show'} scanner output
+              </Button>
+              <Collapse in={diagnosticsOpen} unmountOnExit>
+                <ScanDiagnostics
+                  errorMessage={null}
+                  executionLog={moduleScan.execution_log}
+                  rawResults={moduleScan.raw_results}
+                />
+              </Collapse>
+            </Box>
           )}
         </Box>
       ) : null}

--- a/frontend/src/components/__tests__/ScanDiagnostics.test.tsx
+++ b/frontend/src/components/__tests__/ScanDiagnostics.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import ScanDiagnostics from '../ScanDiagnostics'
+
+describe('ScanDiagnostics', () => {
+  it('renders nothing when all fields are empty', () => {
+    const { container } = render(
+      <ScanDiagnostics errorMessage={null} executionLog={null} rawResults={null} />,
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders nothing when rawResults is an empty object', () => {
+    const { container } = render(<ScanDiagnostics rawResults={{}} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders the error message section when provided', () => {
+    render(<ScanDiagnostics errorMessage="exec format error" />)
+    expect(screen.getByTestId('scan-diagnostics-error')).toBeInTheDocument()
+    expect(screen.getByText('exec format error')).toBeInTheDocument()
+  })
+
+  it('renders the scanner output section when execution_log is provided', () => {
+    render(<ScanDiagnostics executionLog="line 1\nline 2" />)
+    expect(screen.getByTestId('scan-diagnostics-log')).toBeInTheDocument()
+    expect(screen.getByText(/line 1/)).toBeInTheDocument()
+  })
+
+  it('renders raw scanner JSON when rawResults has keys', () => {
+    render(<ScanDiagnostics rawResults={{ vulns: 3 }} />)
+    expect(screen.getByTestId('scan-diagnostics-raw')).toBeInTheDocument()
+    expect(screen.getByText(/"vulns": 3/)).toBeInTheDocument()
+  })
+
+  it('renders all three sections together', () => {
+    render(
+      <ScanDiagnostics
+        errorMessage="boom"
+        executionLog="stderr output"
+        rawResults={{ a: 1 }}
+      />,
+    )
+    expect(screen.getByTestId('scan-diagnostics-error')).toBeInTheDocument()
+    expect(screen.getByTestId('scan-diagnostics-log')).toBeInTheDocument()
+    expect(screen.getByTestId('scan-diagnostics-raw')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/__tests__/SecurityScanPanel.test.tsx
+++ b/frontend/src/components/__tests__/SecurityScanPanel.test.tsx
@@ -190,4 +190,68 @@ describe('SecurityScanPanel', () => {
     )
     expect(screen.queryByTestId('rescan-button')).not.toBeInTheDocument()
   })
+
+  // Diagnostics — added in #199
+  describe('scanner output diagnostics', () => {
+    it('does not show the toggle when no execution_log or raw_results are present', () => {
+      render(
+        <SecurityScanPanel
+          canManage={true}
+          selectedVersion={fakeVersion}
+          moduleScan={{ ...baseScan, status: 'clean' }}
+          scanLoading={false}
+          scanNotFound={false}
+        />,
+      )
+      expect(screen.queryByTestId('scan-diagnostics-toggle')).not.toBeInTheDocument()
+    })
+
+    it('shows the toggle and reveals scanner output on click when execution_log is present', async () => {
+      const user = userEvent.setup()
+      render(
+        <SecurityScanPanel
+          canManage={true}
+          selectedVersion={fakeVersion}
+          moduleScan={{
+            ...baseScan,
+            status: 'error',
+            error_message: 'exit 1',
+            execution_log: 'fatal: cannot read tfconfig',
+          }}
+          scanLoading={false}
+          scanNotFound={false}
+        />,
+      )
+
+      // Error alert is always shown immediately for an error status
+      expect(screen.getByTestId('scan-error-alert')).toBeInTheDocument()
+
+      // Diagnostics start collapsed
+      expect(screen.queryByText('fatal: cannot read tfconfig')).not.toBeInTheDocument()
+
+      // Expand
+      await user.click(screen.getByTestId('scan-diagnostics-toggle'))
+      expect(screen.getByTestId('scan-diagnostics-log')).toBeInTheDocument()
+      expect(screen.getByText('fatal: cannot read tfconfig')).toBeInTheDocument()
+    })
+
+    it('reveals raw scanner JSON when raw_results has content', async () => {
+      const user = userEvent.setup()
+      render(
+        <SecurityScanPanel
+          canManage={true}
+          selectedVersion={fakeVersion}
+          moduleScan={{
+            ...baseScan,
+            status: 'findings',
+            raw_results: { Results: [{ id: 'CVE-2026-0001' }] },
+          }}
+          scanLoading={false}
+          scanNotFound={false}
+        />,
+      )
+      await user.click(screen.getByTestId('scan-diagnostics-toggle'))
+      expect(screen.getByText(/CVE-2026-0001/)).toBeInTheDocument()
+    })
+  })
 })

--- a/frontend/src/pages/admin/SecurityScanningPage.tsx
+++ b/frontend/src/pages/admin/SecurityScanningPage.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useMemo, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import {
   Container,
@@ -17,12 +17,18 @@ import {
   TableRow,
   Tooltip,
   Grid,
+  IconButton,
+  Collapse,
 } from '@mui/material'
 import CheckCircle from '@mui/icons-material/CheckCircle'
 import Error from '@mui/icons-material/Error'
 import HourglassEmpty from '@mui/icons-material/HourglassEmpty'
 import WarningAmber from '@mui/icons-material/WarningAmber'
+import KeyboardArrowDown from '@mui/icons-material/KeyboardArrowDown'
+import KeyboardArrowRight from '@mui/icons-material/KeyboardArrowRight'
+import ScanDiagnostics from '../../components/ScanDiagnostics'
 import api from '../../services/api'
+import type { RecentScanEntry } from '../../types'
 
 function statusChip(status: string) {
   switch (status) {
@@ -51,6 +57,33 @@ function timeAgo(iso: string): string {
   return `${Math.floor(hrs / 24)}d ago`
 }
 
+interface ScannerHealth {
+  lastSuccess: RecentScanEntry | null
+  lastError: RecentScanEntry | null
+  errorRatePct: number
+  windowSize: number
+}
+
+function computeScannerHealth(scans: RecentScanEntry[]): ScannerHealth {
+  // Health is computed from the last 20 scans the API returns. Pending and
+  // in-progress scans are excluded from the error-rate denominator since
+  // they have no terminal outcome yet.
+  const window = scans.slice(0, 20)
+  const terminal = window.filter(
+    (s) => s.status === 'clean' || s.status === 'findings' || s.status === 'error',
+  )
+  const errors = terminal.filter((s) => s.status === 'error').length
+  const lastSuccess =
+    window.find((s) => (s.status === 'clean' || s.status === 'findings') && s.scanned_at) ?? null
+  const lastError = window.find((s) => s.status === 'error') ?? null
+  return {
+    lastSuccess,
+    lastError,
+    errorRatePct: terminal.length === 0 ? 0 : Math.round((errors / terminal.length) * 100),
+    windowSize: terminal.length,
+  }
+}
+
 const SecurityScanningPage: React.FC = () => {
   const {
     data: config,
@@ -69,6 +102,13 @@ const SecurityScanningPage: React.FC = () => {
     queryKey: ['scanning', 'stats'],
     queryFn: () => api.getScanningStats(),
   })
+
+  const [expandedScanId, setExpandedScanId] = useState<string | null>(null)
+
+  const health = useMemo(
+    () => computeScannerHealth(stats?.recent_scans ?? []),
+    [stats?.recent_scans],
+  )
 
   const loading = configLoading || statsLoading
   const error = configError || statsError
@@ -223,6 +263,70 @@ const SecurityScanningPage: React.FC = () => {
             </Box>
           )}
 
+          {/* Scanner Health */}
+          {stats && stats.recent_scans.length > 0 && (
+            <Paper sx={{ p: 3, mb: 3 }} data-testid="scanner-health">
+              <Typography variant="h6" gutterBottom>
+                Scanner Health
+              </Typography>
+              <Divider sx={{ mb: 2 }} />
+              <Grid container spacing={2}>
+                <Grid size={{ xs: 12, sm: 4 }}>
+                  <Typography variant="caption" color="text.secondary">
+                    Last successful scan
+                  </Typography>
+                  {health.lastSuccess?.scanned_at ? (
+                    <Tooltip title={new Date(health.lastSuccess.scanned_at).toLocaleString()}>
+                      <Typography variant="body1">
+                        {timeAgo(health.lastSuccess.scanned_at)}
+                      </Typography>
+                    </Tooltip>
+                  ) : (
+                    <Typography variant="body2" color="text.disabled">
+                      No successful scans in window
+                    </Typography>
+                  )}
+                </Grid>
+                <Grid size={{ xs: 12, sm: 4 }}>
+                  <Typography variant="caption" color="text.secondary">
+                    Error rate (last {health.windowSize || 0} scans)
+                  </Typography>
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, mt: 0.5 }}>
+                    <Typography
+                      variant="h6"
+                      sx={{ color: health.errorRatePct > 0 ? 'error.main' : 'success.main' }}
+                    >
+                      {health.errorRatePct}%
+                    </Typography>
+                    {health.errorRatePct > 0 && <WarningAmber fontSize="small" color="warning" />}
+                  </Box>
+                </Grid>
+                <Grid size={{ xs: 12, sm: 4 }}>
+                  <Typography variant="caption" color="text.secondary">
+                    Last error
+                  </Typography>
+                  {health.lastError ? (
+                    <Box>
+                      <Typography variant="body2" fontFamily="monospace" noWrap>
+                        {health.lastError.namespace}/{health.lastError.module_name}/
+                        {health.lastError.system}
+                      </Typography>
+                      <Typography variant="caption" color="text.secondary">
+                        {health.lastError.scanned_at
+                          ? timeAgo(health.lastError.scanned_at)
+                          : timeAgo(health.lastError.created_at)}
+                      </Typography>
+                    </Box>
+                  ) : (
+                    <Typography variant="body2" color="success.main">
+                      No errors in window
+                    </Typography>
+                  )}
+                </Grid>
+              </Grid>
+            </Paper>
+          )}
+
           {/* Recent Scans */}
           <Paper sx={{ p: 3 }}>
             <Typography variant="h6" gutterBottom>
@@ -238,6 +342,7 @@ const SecurityScanningPage: React.FC = () => {
                 <Table size="small">
                   <TableHead>
                     <TableRow>
+                      <TableCell sx={{ width: 40 }} />
                       <TableCell>Module</TableCell>
                       <TableCell>Version</TableCell>
                       <TableCell>Scanner</TableCell>
@@ -250,35 +355,70 @@ const SecurityScanningPage: React.FC = () => {
                     </TableRow>
                   </TableHead>
                   <TableBody>
-                    {stats.recent_scans.map((scan) => (
-                      <TableRow key={scan.id} hover>
-                        <TableCell>
-                          <Typography variant="body2" fontFamily="monospace" noWrap>
-                            {scan.namespace}/{scan.module_name}/{scan.system}
-                          </Typography>
-                        </TableCell>
-                        <TableCell>{scan.module_version}</TableCell>
-                        <TableCell>{scan.scanner}</TableCell>
-                        <TableCell>{statusChip(scan.status)}</TableCell>
-                        <TableCell align="right">{scan.critical_count}</TableCell>
-                        <TableCell align="right">{scan.high_count}</TableCell>
-                        <TableCell align="right">{scan.medium_count}</TableCell>
-                        <TableCell align="right">{scan.low_count}</TableCell>
-                        <TableCell align="right">
-                          <Tooltip
-                            title={
-                              scan.scanned_at
-                                ? new Date(scan.scanned_at).toLocaleString()
-                                : 'Not scanned yet'
-                            }
-                          >
-                            <Typography variant="caption" color="text.secondary">
-                              {scan.scanned_at ? timeAgo(scan.scanned_at) : '—'}
-                            </Typography>
-                          </Tooltip>
-                        </TableCell>
-                      </TableRow>
-                    ))}
+                    {stats.recent_scans.map((scan) => {
+                      const hasDiagnostics =
+                        Boolean(scan.error_message) || Boolean(scan.execution_log)
+                      const isExpanded = expandedScanId === scan.id
+                      return (
+                        <React.Fragment key={scan.id}>
+                          <TableRow hover>
+                            <TableCell sx={{ p: 0.5 }}>
+                              {hasDiagnostics && (
+                                <IconButton
+                                  size="small"
+                                  aria-label={
+                                    isExpanded ? 'Hide scan details' : 'Show scan details'
+                                  }
+                                  onClick={() => setExpandedScanId(isExpanded ? null : scan.id)}
+                                  data-testid={`scan-row-toggle-${scan.id}`}
+                                >
+                                  {isExpanded ? <KeyboardArrowDown /> : <KeyboardArrowRight />}
+                                </IconButton>
+                              )}
+                            </TableCell>
+                            <TableCell>
+                              <Typography variant="body2" fontFamily="monospace" noWrap>
+                                {scan.namespace}/{scan.module_name}/{scan.system}
+                              </Typography>
+                            </TableCell>
+                            <TableCell>{scan.module_version}</TableCell>
+                            <TableCell>{scan.scanner}</TableCell>
+                            <TableCell>{statusChip(scan.status)}</TableCell>
+                            <TableCell align="right">{scan.critical_count}</TableCell>
+                            <TableCell align="right">{scan.high_count}</TableCell>
+                            <TableCell align="right">{scan.medium_count}</TableCell>
+                            <TableCell align="right">{scan.low_count}</TableCell>
+                            <TableCell align="right">
+                              <Tooltip
+                                title={
+                                  scan.scanned_at
+                                    ? new Date(scan.scanned_at).toLocaleString()
+                                    : 'Not scanned yet'
+                                }
+                              >
+                                <Typography variant="caption" color="text.secondary">
+                                  {scan.scanned_at ? timeAgo(scan.scanned_at) : '—'}
+                                </Typography>
+                              </Tooltip>
+                            </TableCell>
+                          </TableRow>
+                          {hasDiagnostics && (
+                            <TableRow>
+                              <TableCell colSpan={10} sx={{ py: 0, border: 0 }}>
+                                <Collapse in={isExpanded} unmountOnExit>
+                                  <Box sx={{ py: 2, px: 1 }}>
+                                    <ScanDiagnostics
+                                      errorMessage={scan.error_message}
+                                      executionLog={scan.execution_log}
+                                    />
+                                  </Box>
+                                </Collapse>
+                              </TableCell>
+                            </TableRow>
+                          )}
+                        </React.Fragment>
+                      )
+                    })}
                   </TableBody>
                 </Table>
               </TableContainer>

--- a/frontend/src/pages/admin/__tests__/SecurityScanningPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/SecurityScanningPage.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
@@ -133,6 +134,89 @@ describe('SecurityScanningPage', () => {
     renderPage()
     await waitFor(() => {
       expect(screen.getByText('No scans recorded yet.')).toBeInTheDocument()
+    })
+  })
+
+  // Scanner Health + diagnostics — added in #199
+  describe('scanner health and diagnostics', () => {
+    const failedScan = {
+      id: 's-err',
+      namespace: 'acme',
+      module_name: 'vpc',
+      system: 'aws',
+      module_version: '2.0.0',
+      scanner: 'trivy',
+      status: 'error',
+      critical_count: 0,
+      high_count: 0,
+      medium_count: 0,
+      low_count: 0,
+      scanned_at: new Date(Date.now() - 5 * 60_000).toISOString(),
+      created_at: new Date(Date.now() - 5 * 60_000).toISOString(),
+      error_message: 'scanner exited 1',
+      execution_log: 'panic: runtime error: invalid memory address',
+    }
+
+    it('renders Scanner Health card when scans are present', async () => {
+      getScanningConfigMock.mockResolvedValue(fakeConfig)
+      getScanningStatsMock.mockResolvedValue(fakeStats)
+      renderPage()
+      await waitFor(() => {
+        expect(screen.getByTestId('scanner-health')).toBeInTheDocument()
+      })
+      expect(screen.getByText('Scanner Health')).toBeInTheDocument()
+      expect(screen.getByText('Last successful scan')).toBeInTheDocument()
+    })
+
+    it('hides Scanner Health card when there are no scans', async () => {
+      getScanningConfigMock.mockResolvedValue(fakeConfig)
+      getScanningStatsMock.mockResolvedValue({ ...fakeStats, recent_scans: [] })
+      renderPage()
+      await waitFor(() => {
+        expect(screen.getByText('No scans recorded yet.')).toBeInTheDocument()
+      })
+      expect(screen.queryByTestId('scanner-health')).not.toBeInTheDocument()
+    })
+
+    it('reports a non-zero error rate when window contains errors', async () => {
+      getScanningConfigMock.mockResolvedValue(fakeConfig)
+      getScanningStatsMock.mockResolvedValue({
+        ...fakeStats,
+        recent_scans: [failedScan, fakeStats.recent_scans[0]],
+      })
+      renderPage()
+      const health = await screen.findByTestId('scanner-health')
+      // 1 error out of 2 terminal scans = 50%
+      expect(within(health).getByText('50%')).toBeInTheDocument()
+    })
+
+    it('does not render an expand toggle for scans with no diagnostics', async () => {
+      getScanningConfigMock.mockResolvedValue(fakeConfig)
+      getScanningStatsMock.mockResolvedValue(fakeStats)
+      renderPage()
+      await waitFor(() => {
+        expect(screen.getByText('hashicorp/consul/aws')).toBeInTheDocument()
+      })
+      expect(screen.queryByTestId('scan-row-toggle-s-1')).not.toBeInTheDocument()
+    })
+
+    it('expands a failed scan row to show execution_log on toggle click', async () => {
+      const user = userEvent.setup()
+      getScanningConfigMock.mockResolvedValue(fakeConfig)
+      getScanningStatsMock.mockResolvedValue({
+        ...fakeStats,
+        recent_scans: [failedScan],
+      })
+      renderPage()
+
+      const toggle = await screen.findByTestId('scan-row-toggle-s-err')
+
+      // Collapsed initially
+      expect(screen.queryByText(/panic: runtime error/)).not.toBeInTheDocument()
+
+      await user.click(toggle)
+      expect(await screen.findByText(/panic: runtime error/)).toBeInTheDocument()
+      expect(screen.getByText('scanner exited 1')).toBeInTheDocument()
     })
   })
 })

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -554,6 +554,9 @@ export interface ModuleScan {
   low_count: number
   raw_results: Record<string, unknown> | null
   error_message: string | null
+  // Scanner stderr/stdout captured during execution. Added in backend #264;
+  // optional because older scans predate the column.
+  execution_log?: string | null
   created_at: string
   updated_at: string
 }
@@ -589,6 +592,10 @@ export interface RecentScanEntry {
   low_count: number
   scanned_at: string | null
   created_at: string
+  // Diagnostic fields — optional; only populated by recent backends (>= #264).
+  // Surfaced in the admin Recent Scans table for troubleshooting failed scans.
+  error_message?: string | null
+  execution_log?: string | null
 }
 
 export interface ScanningStats {


### PR DESCRIPTION
## Summary

Surfaces the scanner stderr/stdout (`execution_log`) the backend now captures (sethbacon/terraform-registry-backend#264) so admins can diagnose failed scans without shelling onto the host.

Three places get diagnostics:

- **Admin → Security Scanning → Scanner Health card** — last successful scan time, rolling error rate over the last 20 terminal scans, and the most recent failure.
- **Admin → Security Scanning → Recent Scans table** — each row that has diagnostics gets an inline expand toggle that shows the error message and scanner output.
- **Module/Provider detail → SecurityScanPanel** — a \"Show scanner output\" toggle below the existing summary reveals `execution_log` and the raw scanner JSON when present.

A shared `ScanDiagnostics` component renders the three blobs (error_message, execution_log, raw_results) and returns null when nothing's there, so callers drop it in unconditionally.

## Type changes

- `ModuleScan` gains optional `execution_log?: string | null`.
- `RecentScanEntry` gains optional `error_message?: string | null` and `execution_log?: string | null`.

Both are optional because they post-date older scans / older backends.

## Test plan

- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean
- [x] `npm test` — 1444/1444 passing (1430 + 14 new)
- [ ] Manual: with a backend on the post-#264 build, force a scan failure (e.g. point the binary path at /bin/false) and confirm the row in the Recent Scans table expands to show stderr; confirm the Scanner Health card flips error rate above 0%.
- [ ] Manual: on a successful scan with non-empty raw_results, expand the SecurityScanPanel toggle and confirm the JSON renders.

Closes #199