### PR TITLE
fix(ci): drop E2E workers to 2 to fix Firefox networkidle flake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,8 +202,13 @@ jobs:
 
       - name: Run Playwright tests
         working-directory: e2e
+        # workers=2 (not 4) — under heavier parallelism, Firefox occasionally
+        # hangs `waitForLoadState('networkidle')` on /modules and /providers,
+        # exhausting the single retry and tripping --max-failures=1. Same
+        # mitigation that PR #182 originally applied; see #233 post-merge run
+        # 25007086815 for the regression that prompted reverting to 2.
         run: >-
-          npx playwright test --workers=4 --max-failures=1 --retries=1
+          npx playwright test --workers=2 --max-failures=1 --retries=1
           --reporter=list --grep-invert="Visual regression"
 
       - name: Upload Playwright artifacts


### PR DESCRIPTION
## Summary

The post-#233 main CI run (25007086815) failed on the Playwright E2E job. Root cause is **not** anything in #233 — it's a pre-existing Firefox \`waitForLoadState('networkidle')\` flake on \`/modules\` and \`/providers\`, which has now ticked over from \"recovers on retry\" to \"both attempts time out at 60s.\"

PR #182 originally fixed this by capping workers at 2. A later commit (alongside the visual-regression \`grep-invert\`) bumped them back to 4. Under that level of parallelism Firefox networkidle hangs deterministically enough that the single retry isn't enough headroom; once one test exhausts its retry, \`--max-failures=1\` aborts the whole suite.

## Evidence

- Pre-#233 run 25003691661: \`firefox › Modules (/modules)\` failed first attempt (1.0m timeout), passed on retry (10.3s). Suite passed overall.
- Post-#233 run 25007086815: \`firefox › Providers (/providers)\` failed first attempt (1.0m timeout), failed retry (1.0m timeout). Suite aborted via \`--max-failures=1\`.
- Chromium passes both pages in 2–5s in both runs — purely a Firefox issue.

## Change

\`.github/workflows/ci.yml\`: \`--workers=4\` → \`--workers=2\`, plus a comment pointing at #182 and this regression so the next person to bump it knows why it was capped.

## Test plan

- [ ] CI on this PR's E2E run completes without networkidle timeouts.