### PR TITLE
feat(scanning): add clickable findings modal with parsed results table

### DIFF
--- a/frontend/src/components/ScanFindingsModal.tsx
+++ b/frontend/src/components/ScanFindingsModal.tsx
@@ -1,0 +1,186 @@
+import React, { useState } from 'react'
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  Box,
+  Typography,
+  Chip,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  CircularProgress,
+  IconButton,
+  Stack,
+  Button,
+  Collapse,
+} from '@mui/material'
+import CloseIcon from '@mui/icons-material/Close'
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
+import ExpandLessIcon from '@mui/icons-material/ExpandLess'
+import type { ModuleScan } from '../types'
+import { parseScanFindings } from '../utils/scanParsers'
+import ScanDiagnostics from './ScanDiagnostics'
+
+interface ScanFindingsModalProps {
+  open: boolean
+  onClose: () => void
+  scan: ModuleScan | null
+  loading?: boolean
+  moduleLabel?: string
+}
+
+function severityColor(severity: string): 'error' | 'warning' | 'default' | 'info' {
+  switch (severity) {
+    case 'CRITICAL':
+      return 'error'
+    case 'HIGH':
+      return 'warning'
+    case 'MEDIUM':
+      return 'default'
+    case 'LOW':
+      return 'info'
+    default:
+      return 'default'
+  }
+}
+
+const ScanFindingsModal: React.FC<ScanFindingsModalProps> = ({
+  open,
+  onClose,
+  scan,
+  loading = false,
+  moduleLabel,
+}) => {
+  const [rawOpen, setRawOpen] = useState(false)
+
+  const findings = scan ? parseScanFindings(scan.scanner, scan.raw_results) : []
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="lg" fullWidth>
+      <DialogTitle sx={{ display: 'flex', alignItems: 'center', gap: 1, pr: 6 }}>
+        <Typography variant="h6" component="span">
+          Scan Findings
+        </Typography>
+        {moduleLabel && (
+          <Typography variant="body2" color="text.secondary" component="span" sx={{ ml: 1 }}>
+            {moduleLabel}
+          </Typography>
+        )}
+        <IconButton
+          onClick={onClose}
+          sx={{ position: 'absolute', right: 8, top: 8 }}
+          aria-label="close"
+          data-testid="findings-modal-close"
+        >
+          <CloseIcon />
+        </IconButton>
+      </DialogTitle>
+      <DialogContent dividers>
+        {loading ? (
+          <Box display="flex" justifyContent="center" py={4}>
+            <CircularProgress data-testid="findings-loading" />
+          </Box>
+        ) : !scan ? (
+          <Typography color="text.secondary">No scan data available.</Typography>
+        ) : (
+          <>
+            <Stack direction="row" spacing={1} sx={{ mb: 2 }} alignItems="center" flexWrap="wrap">
+              <Typography variant="body2" color="text.secondary">
+                {scan.scanner}
+                {scan.scanner_version ? ` ${scan.scanner_version}` : ''}
+              </Typography>
+              {scan.scanned_at && (
+                <Typography variant="body2" color="text.secondary">
+                  {new Date(scan.scanned_at).toLocaleString()}
+                </Typography>
+              )}
+              <Box sx={{ flexGrow: 1 }} />
+              {scan.critical_count > 0 && (
+                <Chip label={`Critical: ${scan.critical_count}`} size="small" color="error" />
+              )}
+              {scan.high_count > 0 && (
+                <Chip label={`High: ${scan.high_count}`} size="small" color="warning" />
+              )}
+              {scan.medium_count > 0 && (
+                <Chip label={`Medium: ${scan.medium_count}`} size="small" />
+              )}
+              {scan.low_count > 0 && (
+                <Chip label={`Low: ${scan.low_count}`} size="small" color="info" />
+              )}
+            </Stack>
+
+            {findings.length > 0 ? (
+              <TableContainer sx={{ maxHeight: 400 }}>
+                <Table stickyHeader size="small">
+                  <TableHead>
+                    <TableRow>
+                      <TableCell sx={{ fontWeight: 'bold', width: 100 }}>Severity</TableCell>
+                      <TableCell sx={{ fontWeight: 'bold', width: 160 }}>Rule ID</TableCell>
+                      <TableCell sx={{ fontWeight: 'bold' }}>Title</TableCell>
+                      <TableCell sx={{ fontWeight: 'bold', width: 180 }}>Resource</TableCell>
+                      <TableCell sx={{ fontWeight: 'bold', width: 120 }}>File</TableCell>
+                      <TableCell sx={{ fontWeight: 'bold', width: 180 }}>Resolution</TableCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {findings.map((row, idx) => (
+                      <TableRow key={idx}>
+                        <TableCell>
+                          <Chip
+                            label={row.severity}
+                            size="small"
+                            color={severityColor(row.severity)}
+                            variant="outlined"
+                          />
+                        </TableCell>
+                        <TableCell sx={{ fontFamily: 'monospace', fontSize: '0.8rem' }}>
+                          {row.ruleId}
+                        </TableCell>
+                        <TableCell>{row.title}</TableCell>
+                        <TableCell sx={{ fontFamily: 'monospace', fontSize: '0.8rem' }}>
+                          {row.resource}
+                        </TableCell>
+                        <TableCell sx={{ fontFamily: 'monospace', fontSize: '0.8rem' }}>
+                          {row.file}
+                        </TableCell>
+                        <TableCell>{row.resolution}</TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </TableContainer>
+            ) : (
+              <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+                Could not parse individual findings from scanner output.
+              </Typography>
+            )}
+
+            {scan.raw_results && Object.keys(scan.raw_results).length > 0 && (
+              <Box sx={{ mt: 2 }}>
+                <Button
+                  size="small"
+                  variant="text"
+                  onClick={() => setRawOpen((prev) => !prev)}
+                  startIcon={rawOpen ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+                  sx={{ textTransform: 'none' }}
+                  data-testid="findings-raw-toggle"
+                >
+                  {rawOpen ? 'Hide' : 'Show'} raw JSON
+                </Button>
+                <Collapse in={rawOpen} unmountOnExit>
+                  <ScanDiagnostics rawResults={scan.raw_results} maxBlockHeight={300} />
+                </Collapse>
+              </Box>
+            )}
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default ScanFindingsModal

--- a/frontend/src/components/SecurityScanPanel.tsx
+++ b/frontend/src/components/SecurityScanPanel.tsx
@@ -16,6 +16,7 @@ import RefreshIcon from '@mui/icons-material/Refresh'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import ExpandLessIcon from '@mui/icons-material/ExpandLess'
 import ScanDiagnostics from './ScanDiagnostics'
+import ScanFindingsModal from './ScanFindingsModal'
 import { ModuleVersion, ModuleScan } from '../types'
 
 interface SecurityScanPanelProps {
@@ -40,6 +41,7 @@ const SecurityScanPanel: React.FC<SecurityScanPanelProps> = ({
   rescanPending = false,
 }) => {
   const [diagnosticsOpen, setDiagnosticsOpen] = useState(false)
+  const [findingsOpen, setFindingsOpen] = useState(false)
 
   if (!canManage || !selectedVersion) return null
 
@@ -48,7 +50,7 @@ const SecurityScanPanel: React.FC<SecurityScanPanelProps> = ({
 
   const hasDiagnostics = Boolean(
     moduleScan?.execution_log ||
-      (moduleScan?.raw_results && Object.keys(moduleScan.raw_results).length > 0),
+    (moduleScan?.raw_results && Object.keys(moduleScan.raw_results).length > 0),
   )
 
   return (
@@ -99,6 +101,9 @@ const SecurityScanPanel: React.FC<SecurityScanPanelProps> = ({
                       ? 'error'
                       : 'info'
               }
+              onClick={moduleScan.status === 'findings' ? () => setFindingsOpen(true) : undefined}
+              sx={moduleScan.status === 'findings' ? { cursor: 'pointer' } : {}}
+              data-testid="scan-status-chip"
             />
           </Box>
           {moduleScan.status === 'error' && moduleScan.error_message && (
@@ -162,6 +167,11 @@ const SecurityScanPanel: React.FC<SecurityScanPanelProps> = ({
           )}
         </Box>
       ) : null}
+      <ScanFindingsModal
+        open={findingsOpen}
+        onClose={() => setFindingsOpen(false)}
+        scan={moduleScan}
+      />
     </Paper>
   )
 }

--- a/frontend/src/components/__tests__/ScanFindingsModal.test.tsx
+++ b/frontend/src/components/__tests__/ScanFindingsModal.test.tsx
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import ScanFindingsModal from '../ScanFindingsModal'
+import type { ModuleScan } from '../../types'
+
+const baseScan: ModuleScan = {
+  id: 'scan-1',
+  module_version_id: 'ver-1',
+  scanner: 'trivy',
+  scanner_version: '0.50.0',
+  expected_version: null,
+  status: 'findings',
+  scanned_at: '2026-04-26T23:51:41Z',
+  critical_count: 1,
+  high_count: 0,
+  medium_count: 1,
+  low_count: 0,
+  raw_results: {
+    Results: [
+      {
+        Target: 'main.tf',
+        Misconfigurations: [
+          {
+            ID: 'AVD-AWS-0001',
+            Title: 'S3 bucket unencrypted',
+            Severity: 'CRITICAL',
+            Resolution: 'Enable encryption',
+            CauseMetadata: { Resource: 'aws_s3_bucket.example' },
+          },
+          {
+            ID: 'AVD-AWS-0002',
+            Title: 'Public access',
+            Severity: 'MEDIUM',
+          },
+        ],
+      },
+    ],
+  },
+  error_message: null,
+  created_at: '2026-04-26T23:51:00Z',
+  updated_at: '2026-04-26T23:51:41Z',
+}
+
+describe('ScanFindingsModal', () => {
+  it('does not render content when closed', () => {
+    render(<ScanFindingsModal open={false} onClose={() => { }} scan={baseScan} />)
+    expect(screen.queryByText('Scan Findings')).not.toBeInTheDocument()
+  })
+
+  it('renders findings table when open', () => {
+    render(<ScanFindingsModal open={true} onClose={() => { }} scan={baseScan} />)
+    expect(screen.getByText('Scan Findings')).toBeInTheDocument()
+    expect(screen.getByText('AVD-AWS-0001')).toBeInTheDocument()
+    expect(screen.getByText('S3 bucket unencrypted')).toBeInTheDocument()
+    expect(screen.getByText('AVD-AWS-0002')).toBeInTheDocument()
+  })
+
+  it('shows loading state', () => {
+    render(<ScanFindingsModal open={true} onClose={() => { }} scan={null} loading={true} />)
+    expect(screen.getByTestId('findings-loading')).toBeInTheDocument()
+  })
+
+  it('shows no data message when scan is null', () => {
+    render(<ScanFindingsModal open={true} onClose={() => { }} scan={null} />)
+    expect(screen.getByText('No scan data available.')).toBeInTheDocument()
+  })
+
+  it('shows module label', () => {
+    render(
+      <ScanFindingsModal
+        open={true}
+        onClose={() => { }}
+        scan={baseScan}
+        moduleLabel="hashicorp/vpc/aws v1.0.0"
+      />,
+    )
+    expect(screen.getByText('hashicorp/vpc/aws v1.0.0')).toBeInTheDocument()
+  })
+
+  it('toggles raw JSON section', async () => {
+    const user = userEvent.setup()
+    render(<ScanFindingsModal open={true} onClose={() => { }} scan={baseScan} />)
+    const toggle = screen.getByTestId('findings-raw-toggle')
+    expect(toggle).toHaveTextContent('Show raw JSON')
+    await user.click(toggle)
+    expect(toggle).toHaveTextContent('Hide raw JSON')
+  })
+
+  it('renders severity chips in header', () => {
+    render(<ScanFindingsModal open={true} onClose={() => { }} scan={baseScan} />)
+    expect(screen.getByText('Critical: 1')).toBeInTheDocument()
+    expect(screen.getByText('Medium: 1')).toBeInTheDocument()
+  })
+
+  it('shows fallback message when findings cannot be parsed', () => {
+    const scan = { ...baseScan, raw_results: { unknown_format: true } }
+    render(<ScanFindingsModal open={true} onClose={() => { }} scan={scan} />)
+    expect(
+      screen.getByText('Could not parse individual findings from scanner output.'),
+    ).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/__tests__/SecurityScanPanel.test.tsx
+++ b/frontend/src/components/__tests__/SecurityScanPanel.test.tsx
@@ -254,4 +254,51 @@ describe('SecurityScanPanel', () => {
       expect(screen.getByText(/CVE-2026-0001/)).toBeInTheDocument()
     })
   })
+
+  describe('findings modal', () => {
+    it('opens findings modal when clicking findings status chip', async () => {
+      const user = userEvent.setup()
+      render(
+        <SecurityScanPanel
+          canManage={true}
+          selectedVersion={fakeVersion}
+          moduleScan={{
+            ...baseScan,
+            status: 'findings',
+            critical_count: 1,
+            raw_results: {
+              Results: [
+                {
+                  Target: 'main.tf',
+                  Misconfigurations: [
+                    { ID: 'AVD-001', Title: 'Test finding', Severity: 'CRITICAL' },
+                  ],
+                },
+              ],
+            },
+          }}
+          scanLoading={false}
+          scanNotFound={false}
+        />,
+      )
+      await user.click(screen.getByTestId('scan-status-chip'))
+      expect(screen.getByText('Scan Findings')).toBeInTheDocument()
+      expect(screen.getByText('AVD-001')).toBeInTheDocument()
+    })
+
+    it('does not open modal when clicking clean status chip', async () => {
+      const user = userEvent.setup()
+      render(
+        <SecurityScanPanel
+          canManage={true}
+          selectedVersion={fakeVersion}
+          moduleScan={{ ...baseScan, status: 'clean' }}
+          scanLoading={false}
+          scanNotFound={false}
+        />,
+      )
+      await user.click(screen.getByTestId('scan-status-chip'))
+      expect(screen.queryByText('Scan Findings')).not.toBeInTheDocument()
+    })
+  })
 })

--- a/frontend/src/pages/admin/DashboardPage.tsx
+++ b/frontend/src/pages/admin/DashboardPage.tsx
@@ -531,40 +531,40 @@ const DashboardPage: React.FC = () => {
   // Normalise: backend may not yet have mirror fields on older builds.
   const data: DashboardData | null = raw
     ? {
-        modules: raw.modules ?? { total: 0, versions: 0, downloads: 0, by_system: [] },
-        providers: raw.providers ?? {
-          total: 0,
-          manual: 0,
-          mirrored: 0,
-          total_versions: 0,
-          manual_versions: 0,
-          mirrored_versions: 0,
-          downloads: 0,
-        },
-        users: raw.users ?? 0,
-        organizations: raw.organizations ?? 0,
-        downloads: raw.downloads ?? 0,
-        scm_providers: raw.scm_providers ?? 0,
-        binary_mirrors: raw.binary_mirrors ?? {
-          total: 0,
-          healthy: 0,
-          failed: 0,
-          syncing: 0,
-          platforms: 0,
-          downloads: 0,
-          by_tool: [],
-        },
-        provider_mirrors: raw.provider_mirrors ?? { total: 0, healthy: 0, failed: 0 },
-        scanning: raw.scanning ?? {
-          enabled: false,
-          total: 0,
-          pending: 0,
-          clean: 0,
-          findings: 0,
-          error: 0,
-        },
-        recent_syncs: raw.recent_syncs ?? [],
-      }
+      modules: raw.modules ?? { total: 0, versions: 0, downloads: 0, by_system: [] },
+      providers: raw.providers ?? {
+        total: 0,
+        manual: 0,
+        mirrored: 0,
+        total_versions: 0,
+        manual_versions: 0,
+        mirrored_versions: 0,
+        downloads: 0,
+      },
+      users: raw.users ?? 0,
+      organizations: raw.organizations ?? 0,
+      downloads: raw.downloads ?? 0,
+      scm_providers: raw.scm_providers ?? 0,
+      binary_mirrors: raw.binary_mirrors ?? {
+        total: 0,
+        healthy: 0,
+        failed: 0,
+        syncing: 0,
+        platforms: 0,
+        downloads: 0,
+        by_tool: [],
+      },
+      provider_mirrors: raw.provider_mirrors ?? { total: 0, healthy: 0, failed: 0 },
+      scanning: raw.scanning ?? {
+        enabled: false,
+        total: 0,
+        pending: 0,
+        clean: 0,
+        findings: 0,
+        error: 0,
+      },
+      recent_syncs: raw.recent_syncs ?? [],
+    }
     : null
 
   const hasScope = (scope: string) =>
@@ -579,77 +579,77 @@ const DashboardPage: React.FC = () => {
   const statCards: (StatCardProps & { scope: string | null; gridMd: number })[] = !data
     ? []
     : [
-        // Row 1 — content cards (each md=6)
-        {
-          title: 'Modules',
-          value: data.modules.total,
-          sub: `${data.modules.versions} versions`,
-          icon: <ViewModule sx={{ fontSize: 36 }} />,
-          accentColor: '#5C4EE5',
-          route: '/modules',
-          scope: 'modules:read',
-          gridMd: 6,
-          aside:
-            data.modules.by_system?.length > 0 ? (
-              <SystemBreakdown
-                items={data.modules.by_system}
-                total={data.modules.total}
-                color="#5C4EE5"
-              />
-            ) : undefined,
-        },
-        {
-          title: 'Providers',
-          value: data.providers.total,
-          sub: `${data.providers.total_versions} versions`,
-          icon: <Extension sx={{ fontSize: 36 }} />,
-          accentColor: '#00D9C0',
-          route: '/providers',
-          scope: 'providers:read',
-          gridMd: 6,
-          aside:
-            data.providers.total > 0 ? (
-              <ProviderBreakdown
-                manual={data.providers.manual}
-                mirrored={data.providers.mirrored}
-                manualVersions={data.providers.manual_versions}
-                mirroredVersions={data.providers.mirrored_versions}
-                color="#00D9C0"
-              />
-            ) : undefined,
-        },
-        // Row 2 — mirror/download summary (each md=6)
-        {
-          title: 'Terraform Binaries',
-          value: data.binary_mirrors.platforms,
-          sub: `across ${data.binary_mirrors.total} mirror${data.binary_mirrors.total !== 1 ? 's' : ''}`,
-          icon: <GetApp sx={{ fontSize: 36 }} />,
-          accentColor: '#FF7043',
-          route: '/admin/terraform-mirror',
-          scope: 'mirrors:read',
-          gridMd: 6,
-          aside:
-            data.binary_mirrors.by_tool?.length > 0 ? (
-              <BinaryToolBreakdown items={data.binary_mirrors.by_tool} color="#FF7043" />
-            ) : undefined,
-        },
-        {
-          title: 'Total Downloads',
-          value: data.downloads,
-          icon: <Download sx={{ fontSize: 36 }} />,
-          accentColor: '#FFB74D',
-          route: '/modules',
-          scope: null,
-          gridMd: 6,
-          aside: (
-            <DownloadBreakdown
-              moduleDownloads={data.modules.downloads}
-              providerDownloads={data.providers.downloads}
-              binaryDownloads={data.binary_mirrors.downloads}
+      // Row 1 — content cards (each md=6)
+      {
+        title: 'Modules',
+        value: data.modules.total,
+        sub: `${data.modules.versions} versions`,
+        icon: <ViewModule sx={{ fontSize: 36 }} />,
+        accentColor: '#5C4EE5',
+        route: '/modules',
+        scope: 'modules:read',
+        gridMd: 6,
+        aside:
+          data.modules.by_system?.length > 0 ? (
+            <SystemBreakdown
+              items={data.modules.by_system}
+              total={data.modules.total}
+              color="#5C4EE5"
             />
-          ),
-        },
-      ].filter((c) => c.scope === null || hasScope(c.scope))
+          ) : undefined,
+      },
+      {
+        title: 'Providers',
+        value: data.providers.total,
+        sub: `${data.providers.total_versions} versions`,
+        icon: <Extension sx={{ fontSize: 36 }} />,
+        accentColor: '#00D9C0',
+        route: '/providers',
+        scope: 'providers:read',
+        gridMd: 6,
+        aside:
+          data.providers.total > 0 ? (
+            <ProviderBreakdown
+              manual={data.providers.manual}
+              mirrored={data.providers.mirrored}
+              manualVersions={data.providers.manual_versions}
+              mirroredVersions={data.providers.mirrored_versions}
+              color="#00D9C0"
+            />
+          ) : undefined,
+      },
+      // Row 2 — mirror/download summary (each md=6)
+      {
+        title: 'Terraform Binaries',
+        value: data.binary_mirrors.platforms,
+        sub: `across ${data.binary_mirrors.total} mirror${data.binary_mirrors.total !== 1 ? 's' : ''}`,
+        icon: <GetApp sx={{ fontSize: 36 }} />,
+        accentColor: '#FF7043',
+        route: '/admin/terraform-mirror',
+        scope: 'mirrors:read',
+        gridMd: 6,
+        aside:
+          data.binary_mirrors.by_tool?.length > 0 ? (
+            <BinaryToolBreakdown items={data.binary_mirrors.by_tool} color="#FF7043" />
+          ) : undefined,
+      },
+      {
+        title: 'Total Downloads',
+        value: data.downloads,
+        icon: <Download sx={{ fontSize: 36 }} />,
+        accentColor: '#FFB74D',
+        route: '/modules',
+        scope: null,
+        gridMd: 6,
+        aside: (
+          <DownloadBreakdown
+            moduleDownloads={data.modules.downloads}
+            providerDownloads={data.providers.downloads}
+            binaryDownloads={data.binary_mirrors.downloads}
+          />
+        ),
+      },
+    ].filter((c) => c.scope === null || hasScope(c.scope))
 
   // ---- Zone 3 left: recent syncs -------------------------------------------
   const recentSyncs = data ? data.recent_syncs.slice(0, 8) : []
@@ -836,7 +836,16 @@ const DashboardPage: React.FC = () => {
                             size="small"
                             color="warning"
                             variant="outlined"
-                            sx={{ height: 20, fontSize: '0.7rem' }}
+                            onClick={(e) => {
+                              e.stopPropagation()
+                              navigate('/admin/security-scanning')
+                            }}
+                            sx={{
+                              height: 20,
+                              fontSize: '0.7rem',
+                              cursor: 'pointer',
+                              '&:hover': { textDecoration: 'underline' },
+                            }}
                           />
                         )}
                         {data.scanning.pending > 0 && (

--- a/frontend/src/pages/admin/SecurityScanningPage.tsx
+++ b/frontend/src/pages/admin/SecurityScanningPage.tsx
@@ -27,15 +27,19 @@ import WarningAmber from '@mui/icons-material/WarningAmber'
 import KeyboardArrowDown from '@mui/icons-material/KeyboardArrowDown'
 import KeyboardArrowRight from '@mui/icons-material/KeyboardArrowRight'
 import ScanDiagnostics from '../../components/ScanDiagnostics'
+import ScanFindingsModal from '../../components/ScanFindingsModal'
 import api from '../../services/api'
-import type { RecentScanEntry } from '../../types'
+import type { ModuleScan, RecentScanEntry } from '../../types'
 
-function statusChip(status: string) {
+function statusChip(status: string, onClick?: () => void) {
+  const clickProps = onClick ? { onClick, sx: { cursor: 'pointer' } } : {}
   switch (status) {
     case 'clean':
       return <Chip label="Clean" size="small" color="success" variant="outlined" />
     case 'findings':
-      return <Chip label="Findings" size="small" color="warning" variant="outlined" />
+      return (
+        <Chip label="Findings" size="small" color="warning" variant="outlined" {...clickProps} />
+      )
     case 'error':
       return <Chip label="Error" size="small" color="error" variant="outlined" />
     case 'pending':
@@ -104,6 +108,38 @@ const SecurityScanningPage: React.FC = () => {
   })
 
   const [expandedScanId, setExpandedScanId] = useState<string | null>(null)
+  const [findingsModalOpen, setFindingsModalOpen] = useState(false)
+  const [findingsModalScan, setFindingsModalScan] = useState<ModuleScan | null>(null)
+  const [findingsModalLoading, setFindingsModalLoading] = useState(false)
+  const [findingsModalLabel, setFindingsModalLabel] = useState('')
+
+  const handleFindingsClick = async (scan: RecentScanEntry) => {
+    setFindingsModalLabel(
+      `${scan.namespace}/${scan.module_name}/${scan.system} v${scan.module_version}`,
+    )
+    setFindingsModalScan(null)
+    setFindingsModalLoading(true)
+    setFindingsModalOpen(true)
+    try {
+      const full = await api.getScanByID(scan.id)
+      setFindingsModalScan(full)
+    } catch {
+      // Fallback: try the module version endpoint
+      try {
+        const full = await api.getModuleScan(
+          scan.namespace,
+          scan.module_name,
+          scan.system,
+          scan.module_version,
+        )
+        setFindingsModalScan(full)
+      } catch {
+        // Leave scan null — modal will show "no data" message
+      }
+    } finally {
+      setFindingsModalLoading(false)
+    }
+  }
 
   const health = useMemo(
     () => computeScannerHealth(stats?.recent_scans ?? []),
@@ -383,7 +419,14 @@ const SecurityScanningPage: React.FC = () => {
                             </TableCell>
                             <TableCell>{scan.module_version}</TableCell>
                             <TableCell>{scan.scanner}</TableCell>
-                            <TableCell>{statusChip(scan.status)}</TableCell>
+                            <TableCell>
+                              {statusChip(
+                                scan.status,
+                                scan.status === 'findings'
+                                  ? () => handleFindingsClick(scan)
+                                  : undefined,
+                              )}
+                            </TableCell>
                             <TableCell align="right">{scan.critical_count}</TableCell>
                             <TableCell align="right">{scan.high_count}</TableCell>
                             <TableCell align="right">{scan.medium_count}</TableCell>
@@ -426,6 +469,13 @@ const SecurityScanningPage: React.FC = () => {
           </Paper>
         </>
       )}
+      <ScanFindingsModal
+        open={findingsModalOpen}
+        onClose={() => setFindingsModalOpen(false)}
+        scan={findingsModalScan}
+        loading={findingsModalLoading}
+        moduleLabel={findingsModalLabel}
+      />
     </Container>
   )
 }

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -848,6 +848,11 @@ class ApiClient {
     return response.data
   }
 
+  async getScanByID(scanID: string): Promise<import('../types').ModuleScan> {
+    const response = await this.client.get(`/api/v1/admin/scanning/scans/${scanID}`)
+    return response.data
+  }
+
   async getModuleDocs(
     namespace: string,
     name: string,

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -608,6 +608,17 @@ export interface ScanningStats {
   recent_scans: RecentScanEntry[]
 }
 
+// ---- Scan findings (parsed from raw_results) ----
+
+export interface FindingRow {
+  severity: 'CRITICAL' | 'HIGH' | 'MEDIUM' | 'LOW'
+  ruleId: string
+  title: string
+  resource: string
+  file: string
+  resolution: string
+}
+
 // ---- Module terraform-docs ----
 
 export interface ModuleInputVar {

--- a/frontend/src/utils/__tests__/scanParsers.test.ts
+++ b/frontend/src/utils/__tests__/scanParsers.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from 'vitest'
+import { parseScanFindings } from '../scanParsers'
+
+describe('parseScanFindings', () => {
+  it('returns empty array for null raw_results', () => {
+    expect(parseScanFindings('trivy', null)).toEqual([])
+  })
+
+  it('returns empty array for unknown scanner with no SARIF runs', () => {
+    expect(parseScanFindings('unknown', { foo: 'bar' })).toEqual([])
+  })
+
+  describe('trivy', () => {
+    it('parses vulnerabilities and misconfigurations', () => {
+      const raw = {
+        Results: [
+          {
+            Target: 'main.tf',
+            Vulnerabilities: [
+              {
+                VulnerabilityID: 'CVE-2023-1234',
+                PkgName: 'some-pkg',
+                Title: 'Vuln title',
+                Severity: 'CRITICAL',
+                FixedVersion: '2.0.0',
+              },
+            ],
+            Misconfigurations: [
+              {
+                ID: 'AVD-AWS-0001',
+                Title: 'S3 bucket unencrypted',
+                Severity: 'HIGH',
+                Resolution: 'Enable encryption',
+                CauseMetadata: { Resource: 'aws_s3_bucket.example' },
+              },
+            ],
+          },
+        ],
+      }
+      const rows = parseScanFindings('trivy', raw)
+      expect(rows).toHaveLength(2)
+      expect(rows[0].severity).toBe('CRITICAL')
+      expect(rows[0].ruleId).toBe('CVE-2023-1234')
+      expect(rows[0].resolution).toBe('Upgrade to 2.0.0')
+      expect(rows[1].severity).toBe('HIGH')
+      expect(rows[1].ruleId).toBe('AVD-AWS-0001')
+      expect(rows[1].resource).toBe('aws_s3_bucket.example')
+    })
+
+    it('handles empty Results array', () => {
+      expect(parseScanFindings('trivy', { Results: [] })).toEqual([])
+    })
+  })
+
+  describe('checkov', () => {
+    it('parses single object output', () => {
+      const raw = {
+        results: {
+          failed_checks: [
+            {
+              check: { id: 'CKV_AWS_18', name: 'S3 logging', severity: 'medium' },
+              resource: 'aws_s3_bucket.example',
+              file_path: '/main.tf',
+              guideline: 'https://docs.example.com',
+            },
+          ],
+        },
+      }
+      const rows = parseScanFindings('checkov', raw)
+      expect(rows).toHaveLength(1)
+      expect(rows[0].severity).toBe('MEDIUM')
+      expect(rows[0].ruleId).toBe('CKV_AWS_18')
+      expect(rows[0].file).toBe('/main.tf')
+    })
+
+    it('parses array output (multiple frameworks)', () => {
+      const raw = [
+        {
+          results: {
+            failed_checks: [
+              { check: { id: 'CKV_1', name: 'Check 1', severity: 'high' }, resource: 'r1' },
+            ],
+          },
+        },
+        {
+          results: {
+            failed_checks: [
+              { check: { id: 'CKV_2', name: 'Check 2', severity: 'low' }, resource: 'r2' },
+            ],
+          },
+        },
+      ]
+      const rows = parseScanFindings('checkov', raw as unknown as Record<string, unknown>)
+      expect(rows).toHaveLength(2)
+      expect(rows[0].severity).toBe('HIGH')
+      expect(rows[1].severity).toBe('LOW')
+    })
+  })
+
+  describe('terrascan', () => {
+    it('parses violations', () => {
+      const raw = {
+        results: {
+          violations: [
+            {
+              rule_id: 'AC_AWS_0001',
+              rule_name: 's3BucketEncryption',
+              severity: 'high',
+              resource_name: 'aws_s3_bucket.example',
+              file: 'main.tf',
+            },
+          ],
+        },
+      }
+      const rows = parseScanFindings('terrascan', raw)
+      expect(rows).toHaveLength(1)
+      expect(rows[0].ruleId).toBe('AC_AWS_0001')
+      expect(rows[0].severity).toBe('HIGH')
+    })
+  })
+
+  describe('snyk', () => {
+    it('parses single object output', () => {
+      const raw = {
+        vulnerabilities: [{ id: 'SNYK-001', title: 'Issue', severity: 'critical' }],
+      }
+      const rows = parseScanFindings('snyk', raw)
+      expect(rows).toHaveLength(1)
+      expect(rows[0].severity).toBe('CRITICAL')
+      expect(rows[0].ruleId).toBe('SNYK-001')
+    })
+
+    it('parses array output (multiple files)', () => {
+      const raw = [
+        { vulnerabilities: [{ id: 'S1', title: 'A', severity: 'low' }] },
+        { vulnerabilities: [{ id: 'S2', title: 'B', severity: 'high' }] },
+      ]
+      const rows = parseScanFindings('snyk', raw as unknown as Record<string, unknown>)
+      expect(rows).toHaveLength(2)
+      expect(rows[0].severity).toBe('HIGH')
+      expect(rows[1].severity).toBe('LOW')
+    })
+  })
+
+  describe('SARIF / custom', () => {
+    it('parses SARIF runs', () => {
+      const raw = {
+        runs: [
+          {
+            results: [
+              {
+                ruleId: 'RULE-001',
+                level: 'error',
+                message: { text: 'Finding desc' },
+                locations: [{ physicalLocation: { artifactLocation: { uri: 'main.tf' } } }],
+              },
+              {
+                ruleId: 'RULE-002',
+                level: 'warning',
+                message: { text: 'Warning desc' },
+              },
+            ],
+          },
+        ],
+      }
+      const rows = parseScanFindings('custom', raw)
+      expect(rows).toHaveLength(2)
+      expect(rows[0].severity).toBe('HIGH')
+      expect(rows[0].file).toBe('main.tf')
+      expect(rows[1].severity).toBe('MEDIUM')
+    })
+  })
+
+  it('sorts by severity (critical first)', () => {
+    const raw = {
+      Results: [
+        {
+          Target: 'test.tf',
+          Misconfigurations: [
+            { ID: 'L1', Title: 'Low', Severity: 'LOW' },
+            { ID: 'C1', Title: 'Critical', Severity: 'CRITICAL' },
+            { ID: 'M1', Title: 'Medium', Severity: 'MEDIUM' },
+            { ID: 'H1', Title: 'High', Severity: 'HIGH' },
+          ],
+        },
+      ],
+    }
+    const rows = parseScanFindings('trivy', raw)
+    expect(rows.map((r) => r.severity)).toEqual(['CRITICAL', 'HIGH', 'MEDIUM', 'LOW'])
+  })
+})

--- a/frontend/src/utils/scanParsers.ts
+++ b/frontend/src/utils/scanParsers.ts
@@ -1,0 +1,186 @@
+import type { FindingRow } from '../types'
+
+type Severity = FindingRow['severity']
+
+const SEVERITY_ORDER: Record<Severity, number> = {
+  CRITICAL: 0,
+  HIGH: 1,
+  MEDIUM: 2,
+  LOW: 3,
+}
+
+function normalizeSeverity(raw: string): Severity | null {
+  const upper = String(raw).toUpperCase()
+  if (upper === 'CRITICAL' || upper === 'HIGH' || upper === 'MEDIUM' || upper === 'LOW') {
+    return upper as Severity
+  }
+  return null
+}
+
+function sarifLevelToSeverity(level: string): Severity | null {
+  switch (String(level).toLowerCase()) {
+    case 'error':
+      return 'HIGH'
+    case 'warning':
+      return 'MEDIUM'
+    case 'note':
+      return 'LOW'
+    default:
+      return null
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function parseTrivy(raw: any): FindingRow[] {
+  const rows: FindingRow[] = []
+  const results = Array.isArray(raw?.Results) ? raw.Results : []
+  for (const result of results) {
+    const target = String(result?.Target ?? '')
+    for (const v of Array.isArray(result?.Vulnerabilities) ? result.Vulnerabilities : []) {
+      const sev = normalizeSeverity(v?.Severity ?? '')
+      if (!sev) continue
+      rows.push({
+        severity: sev,
+        ruleId: String(v?.VulnerabilityID ?? v?.AVDID ?? ''),
+        title: String(v?.Title ?? ''),
+        resource: String(v?.PkgName ?? ''),
+        file: target,
+        resolution: String(v?.FixedVersion ? `Upgrade to ${v.FixedVersion}` : ''),
+      })
+    }
+    for (const m of Array.isArray(result?.Misconfigurations) ? result.Misconfigurations : []) {
+      const sev = normalizeSeverity(m?.Severity ?? '')
+      if (!sev) continue
+      rows.push({
+        severity: sev,
+        ruleId: String(m?.ID ?? m?.AVDID ?? ''),
+        title: String(m?.Title ?? ''),
+        resource: String(m?.CauseMetadata?.Resource ?? ''),
+        file: target,
+        resolution: String(m?.Resolution ?? ''),
+      })
+    }
+  }
+  return rows
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function parseCheckovSingle(obj: any): FindingRow[] {
+  const rows: FindingRow[] = []
+  const checks = Array.isArray(obj?.results?.failed_checks) ? obj.results.failed_checks : []
+  for (const fc of checks) {
+    const sev = normalizeSeverity(fc?.check?.severity ?? '')
+    if (!sev) continue
+    rows.push({
+      severity: sev,
+      ruleId: String(fc?.check?.id ?? ''),
+      title: String(fc?.check?.name ?? ''),
+      resource: String(fc?.resource ?? ''),
+      file: String(fc?.file_path ?? ''),
+      resolution: String(fc?.guideline ?? ''),
+    })
+  }
+  return rows
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function parseCheckov(raw: any): FindingRow[] {
+  if (Array.isArray(raw)) {
+    return raw.flatMap(parseCheckovSingle)
+  }
+  return parseCheckovSingle(raw)
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function parseTerrascan(raw: any): FindingRow[] {
+  const rows: FindingRow[] = []
+  const violations = Array.isArray(raw?.results?.violations) ? raw.results.violations : []
+  for (const v of violations) {
+    const sev = normalizeSeverity(v?.severity ?? '')
+    if (!sev) continue
+    rows.push({
+      severity: sev,
+      ruleId: String(v?.rule_id ?? ''),
+      title: String(v?.rule_name ?? v?.description ?? ''),
+      resource: String(v?.resource_name ?? ''),
+      file: String(v?.file ?? ''),
+      resolution: '',
+    })
+  }
+  return rows
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function parseSnykSingle(obj: any): FindingRow[] {
+  const rows: FindingRow[] = []
+  const vulns = Array.isArray(obj?.vulnerabilities) ? obj.vulnerabilities : []
+  for (const v of vulns) {
+    const sev = normalizeSeverity(v?.severity ?? '')
+    if (!sev) continue
+    rows.push({
+      severity: sev,
+      ruleId: String(v?.id ?? ''),
+      title: String(v?.title ?? ''),
+      resource: '',
+      file: '',
+      resolution: String(v?.remediation?.advice ?? ''),
+    })
+  }
+  return rows
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function parseSnyk(raw: any): FindingRow[] {
+  if (Array.isArray(raw)) {
+    return raw.flatMap(parseSnykSingle)
+  }
+  return parseSnykSingle(raw)
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function parseSarif(raw: any): FindingRow[] {
+  const rows: FindingRow[] = []
+  const runs = Array.isArray(raw?.runs) ? raw.runs : []
+  for (const run of runs) {
+    for (const r of Array.isArray(run?.results) ? run.results : []) {
+      const sev = sarifLevelToSeverity(r?.level ?? '')
+      if (!sev) continue
+      const loc = r?.locations?.[0]?.physicalLocation
+      rows.push({
+        severity: sev,
+        ruleId: String(r?.ruleId ?? ''),
+        title: String(r?.message?.text ?? ''),
+        resource: '',
+        file: String(loc?.artifactLocation?.uri ?? ''),
+        resolution: '',
+      })
+    }
+  }
+  return rows
+}
+
+export function parseScanFindings(
+  scanner: string,
+  rawResults: Record<string, unknown> | null,
+): FindingRow[] {
+  if (!rawResults) return []
+
+  let rows: FindingRow[]
+  const s = scanner.toLowerCase()
+  if (s === 'trivy') {
+    rows = parseTrivy(rawResults)
+  } else if (s === 'checkov') {
+    rows = parseCheckov(rawResults)
+  } else if (s === 'terrascan') {
+    rows = parseTerrascan(rawResults)
+  } else if (s === 'snyk') {
+    rows = parseSnyk(rawResults)
+  } else if (rawResults.runs) {
+    rows = parseSarif(rawResults)
+  } else {
+    rows = []
+  }
+
+  rows.sort((a, b) => (SEVERITY_ORDER[a.severity] ?? 9) - (SEVERITY_ORDER[b.severity] ?? 9))
+  return rows
+}


### PR DESCRIPTION
## Summary

- Make "Findings" chips clickable to open a modal displaying parsed scan results in a human-readable table
- New `ScanFindingsModal` component with MUI Dialog, severity-sorted table, and raw JSON toggle
- New `scanParsers.ts` with parser functions for Trivy, Checkov, Terrascan, Snyk, and SARIF output formats
- Module Detail: click findings chip → opens modal (scan data already loaded)
- Security Scanning: click Findings in table → fetches scan via `getScanByID` and opens modal
- Dashboard: findings chip navigates to Security Scanning page with hover indicator

## Test plan

- [x] 11 parser unit tests covering all 5 scanner formats + edge cases
- [x] 8 ScanFindingsModal tests (open/close, loading, table, raw JSON toggle, fallback)
- [x] 2 new SecurityScanPanel tests (findings chip click opens modal, clean chip does not)
- [x] ESLint passes with zero warnings
- [x] Prettier formatting clean on all changed files

Closes #239