### PR TITLE
fix(scanning): add format auto-detection for unknown scanner names

### DIFF
--- a/frontend/src/utils/__tests__/scanParsers.test.ts
+++ b/frontend/src/utils/__tests__/scanParsers.test.ts
@@ -188,4 +188,74 @@ describe('parseScanFindings', () => {
     const rows = parseScanFindings('trivy', raw)
     expect(rows.map((r) => r.severity)).toEqual(['CRITICAL', 'HIGH', 'MEDIUM', 'LOW'])
   })
+
+  describe('format auto-detection (unknown scanner name)', () => {
+    it('detects Trivy format by Results array', () => {
+      const raw = {
+        Results: [
+          {
+            Target: 'main.tf',
+            Misconfigurations: [
+              { ID: 'AVD-001', Title: 'Issue', Severity: 'HIGH', Resolution: 'Fix it' },
+            ],
+          },
+        ],
+      }
+      const rows = parseScanFindings('pending', raw)
+      expect(rows).toHaveLength(1)
+      expect(rows[0].ruleId).toBe('AVD-001')
+      expect(rows[0].severity).toBe('HIGH')
+    })
+
+    it('detects Checkov format by results.failed_checks', () => {
+      const raw = {
+        results: {
+          failed_checks: [
+            {
+              check: { id: 'CKV_AWS_18', name: 'S3 logging', severity: 'medium' },
+              resource: 'aws_s3_bucket.example',
+            },
+          ],
+        },
+      }
+      const rows = parseScanFindings('unknown', raw)
+      expect(rows).toHaveLength(1)
+      expect(rows[0].ruleId).toBe('CKV_AWS_18')
+    })
+
+    it('detects Terrascan format by results.violations', () => {
+      const raw = {
+        results: {
+          violations: [
+            { rule_id: 'AC_001', rule_name: 'test', severity: 'high', resource_name: 'r1' },
+          ],
+        },
+      }
+      const rows = parseScanFindings('pending', raw)
+      expect(rows).toHaveLength(1)
+      expect(rows[0].ruleId).toBe('AC_001')
+    })
+
+    it('detects Snyk format by vulnerabilities array', () => {
+      const raw = {
+        vulnerabilities: [{ id: 'SNYK-001', title: 'Issue', severity: 'critical' }],
+      }
+      const rows = parseScanFindings('pending', raw)
+      expect(rows).toHaveLength(1)
+      expect(rows[0].ruleId).toBe('SNYK-001')
+    })
+
+    it('detects SARIF format by runs array', () => {
+      const raw = {
+        runs: [
+          {
+            results: [{ ruleId: 'R1', level: 'error', message: { text: 'Desc' } }],
+          },
+        ],
+      }
+      const rows = parseScanFindings('pending', raw)
+      expect(rows).toHaveLength(1)
+      expect(rows[0].severity).toBe('HIGH')
+    })
+  })
 })

--- a/frontend/src/utils/scanParsers.ts
+++ b/frontend/src/utils/scanParsers.ts
@@ -177,6 +177,18 @@ export function parseScanFindings(
     rows = parseSnyk(rawResults)
   } else if (rawResults.runs) {
     rows = parseSarif(rawResults)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } else if (Array.isArray((rawResults as any)?.Results)) {
+    rows = parseTrivy(rawResults)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } else if (Array.isArray((rawResults as any)?.results?.failed_checks)) {
+    rows = parseCheckov(rawResults)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } else if (Array.isArray((rawResults as any)?.results?.violations)) {
+    rows = parseTerrascan(rawResults)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } else if (Array.isArray((rawResults as any)?.vulnerabilities)) {
+    rows = parseSnyk(rawResults)
   } else {
     rows = []
   }


### PR DESCRIPTION
## Summary

- Add structure-based format auto-detection fallback in `parseScanFindings` for when the scanner name is unknown/pending
- Detects Trivy (`Results[]`), Checkov (`results.failed_checks[]`), Terrascan (`results.violations[]`), Snyk (`vulnerabilities[]`) from JSON structure
- 5 new tests covering auto-detection for each format

Companion to sethbacon/terraform-registry-backend#299 which fixes the root cause (scanner column never updated from 'pending').

Closes #242