### PR TITLE
feat(cve): add advisory banner for active CVE advisories

### DIFF
--- a/frontend/src/components/AdvisoryBanner.tsx
+++ b/frontend/src/components/AdvisoryBanner.tsx
@@ -1,0 +1,155 @@
+import { useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { Link as RouterLink } from 'react-router-dom'
+import {
+  Alert,
+  AlertTitle,
+  Box,
+  Collapse,
+  IconButton,
+  Tooltip,
+  Typography,
+} from '@mui/material'
+import CloseIcon from '@mui/icons-material/Close'
+import apiClient from '../services/api'
+import { queryKeys } from '../services/queryKeys'
+import type { CVEAdvisory, CVESeverity } from '../types'
+
+// One banner per severity level so colours are consistent and legible.
+const SEVERITY_ORDER: CVESeverity[] = ['critical', 'high', 'medium', 'low', 'unknown']
+
+const SEVERITY_LABEL: Record<CVESeverity, string> = {
+  critical: 'Critical',
+  high: 'High',
+  medium: 'Medium',
+  low: 'Low',
+  unknown: 'Unknown',
+}
+
+// MUI Alert severity mapping — 'error' gives the red/critical look.
+const MUI_SEVERITY: Record<CVESeverity, 'error' | 'warning' | 'info'> = {
+  critical: 'error',
+  high: 'error',
+  medium: 'warning',
+  low: 'info',
+  unknown: 'info',
+}
+
+// Refetch every 5 minutes (matches the backend Cache-Control max-age).
+const REFETCH_INTERVAL_MS = 5 * 60 * 1000
+
+// sessionStorage key prefix for per-severity dismissals.
+const DISMISS_KEY = 'cve_banner_dismissed_'
+
+function isDismissed(severity: CVESeverity): boolean {
+  try {
+    return sessionStorage.getItem(DISMISS_KEY + severity) === '1'
+  } catch {
+    return false
+  }
+}
+
+function setDismissed(severity: CVESeverity): void {
+  try {
+    sessionStorage.setItem(DISMISS_KEY + severity, '1')
+  } catch {
+    // sessionStorage not available (e.g., private browsing with restrictions) — ignore
+  }
+}
+
+/**
+ * AdvisoryBanner polls the public /api/v1/advisories/active endpoint every
+ * 5 minutes and renders a stacked set of MUI Alerts — one per severity level —
+ * when active CVE advisories are present. Each band is dismissible for the
+ * current browser session.
+ *
+ * Mount this component once inside Layout, just below <Toolbar />.
+ */
+export default function AdvisoryBanner() {
+  const { data: advisories } = useQuery({
+    queryKey: queryKeys.advisories.active(),
+    queryFn: () => apiClient.getActiveAdvisories(),
+    refetchInterval: REFETCH_INTERVAL_MS,
+    // Don't show a loading skeleton — the banner is an enhancement; absence is fine.
+    placeholderData: [],
+  })
+
+  // Track per-severity dismissal state locally so closing one band doesn't re-render others.
+  const [dismissed, setDismissedState] = useState<Partial<Record<CVESeverity, boolean>>>(() => {
+    const initial: Partial<Record<CVESeverity, boolean>> = {}
+    for (const s of SEVERITY_ORDER) {
+      if (isDismissed(s)) initial[s] = true
+    }
+    return initial
+  })
+
+  if (!advisories || advisories.length === 0) return null
+
+  // Group advisories by severity.
+  const bySeverity = new Map<CVESeverity, CVEAdvisory[]>()
+  for (const adv of advisories) {
+    const bucket = bySeverity.get(adv.severity) ?? []
+    bucket.push(adv)
+    bySeverity.set(adv.severity, bucket)
+  }
+
+  const visibleSeverities = SEVERITY_ORDER.filter(
+    (s) => bySeverity.has(s) && !dismissed[s],
+  )
+
+  if (visibleSeverities.length === 0) return null
+
+  const handleDismiss = (severity: CVESeverity) => {
+    setDismissed(severity)
+    setDismissedState((prev) => ({ ...prev, [severity]: true }))
+  }
+
+  return (
+    <Box sx={{ mb: 1 }} role="region" aria-label="Security advisories">
+      {visibleSeverities.map((severity) => {
+        const group = bySeverity.get(severity)!
+        const count = group.length
+        const muiSeverity = MUI_SEVERITY[severity]
+
+        // Collect all target kinds present in this severity group.
+        const kinds = Array.from(new Set(group.map((a) => a.target_kind))).join(', ')
+
+        return (
+          <Collapse key={severity} in unmountOnExit>
+            <Alert
+              severity={muiSeverity}
+              sx={{ borderRadius: 0, mb: 0.5 }}
+              action={
+                <Tooltip title="Dismiss for this session">
+                  <IconButton
+                    size="small"
+                    color="inherit"
+                    aria-label={`Dismiss ${severity} advisory banner`}
+                    onClick={() => handleDismiss(severity)}
+                  >
+                    <CloseIcon fontSize="inherit" />
+                  </IconButton>
+                </Tooltip>
+              }
+            >
+              <AlertTitle>
+                {SEVERITY_LABEL[severity]} severity CVE{count > 1 ? 's' : ''} detected ({kinds})
+              </AlertTitle>
+              <Typography variant="body2" component="span">
+                {count === 1
+                  ? `${group[0].source_id}: ${group[0].summary}`
+                  : `${count} advisories affect your registry's ${kinds}.`}{' '}
+                <RouterLink
+                  to="/admin/security-scanning"
+                  style={{ color: 'inherit', fontWeight: 600 }}
+                >
+                  Review in Security Scanning →
+                </RouterLink>
+              </Typography>
+            </Alert>
+          </Collapse>
+        )
+      })}
+    </Box>
+  )
+}

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -65,6 +65,7 @@ import AdminBreadcrumbs from './AdminBreadcrumbs'
 import CommandPalette from './CommandPalette'
 import { useHotkey } from '../hooks/useHotkey'
 import SessionExpiryWarning from './SessionExpiryWarning'
+import AdvisoryBanner from './AdvisoryBanner'
 
 const drawerWidth = 240
 
@@ -408,11 +409,11 @@ const Layout = () => {
     () =>
       isAuthenticated
         ? adminNavGroups
-            .map((group) => ({
-              ...group,
-              items: group.items.filter((item) => item.scope === null || hasScope(item.scope)),
-            }))
-            .filter((group) => group.items.length > 0)
+          .map((group) => ({
+            ...group,
+            items: group.items.filter((item) => item.scope === null || hasScope(item.scope)),
+          }))
+          .filter((group) => group.items.length > 0)
         : [],
     [isAuthenticated, adminNavGroups, hasScope],
   )
@@ -838,6 +839,7 @@ const Layout = () => {
         }}
       >
         <Toolbar />
+        <AdvisoryBanner />
         <AdminBreadcrumbs />
         <Outlet />
       </Box>

--- a/frontend/src/components/__tests__/AdvisoryBanner.test.tsx
+++ b/frontend/src/components/__tests__/AdvisoryBanner.test.tsx
@@ -1,0 +1,210 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter } from 'react-router-dom'
+
+// ── Mock api client ────────────────────────────────────────────────────────
+
+const mockGetActiveAdvisories = vi.fn()
+
+vi.mock('../../services/api', () => ({
+  default: {
+    getActiveAdvisories: (...args: unknown[]) => mockGetActiveAdvisories(...args),
+  },
+}))
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+import AdvisoryBanner from '../AdvisoryBanner'
+import type { CVEAdvisory } from '../../types'
+
+function makeAdvisory(overrides: Partial<CVEAdvisory> = {}): CVEAdvisory {
+  return {
+    id: 'adv-1',
+    source_id: 'CVE-2024-1234',
+    severity: 'high',
+    summary: 'Remote code execution in terraform binary',
+    references: ['https://example.com/cve-1234'],
+    target_kind: 'binary',
+    targets: [],
+    ...overrides,
+  }
+}
+
+function renderBanner() {
+  // Use a fresh QueryClient per test so cached query data doesn't bleed between tests.
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  })
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <AdvisoryBanner />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+// ── Setup ──────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  // Clear any banner dismissal flags persisted from a previous test.
+  for (const key of Object.keys(sessionStorage)) {
+    if (key.startsWith('cve_banner_dismissed_')) sessionStorage.removeItem(key)
+  }
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('AdvisoryBanner', () => {
+  // 1. Nothing rendered when there are no active advisories
+  it('renders nothing when getActiveAdvisories returns an empty array', async () => {
+    mockGetActiveAdvisories.mockResolvedValue([])
+
+    const { container } = renderBanner()
+
+    await waitFor(() => expect(mockGetActiveAdvisories).toHaveBeenCalledOnce())
+    expect(container.firstChild).toBeNull()
+  })
+
+  // 2. Nothing rendered while the query is loading (placeholderData=[])
+  it('renders nothing while the query has no data yet', () => {
+    // Never resolves — simulates loading state.
+    mockGetActiveAdvisories.mockReturnValue(new Promise(() => { }))
+
+    const { container } = renderBanner()
+    expect(container.firstChild).toBeNull()
+  })
+
+  // 3. Single advisory shows correct severity band
+  it('renders a banner with the advisory severity and source ID', async () => {
+    mockGetActiveAdvisories.mockResolvedValue([makeAdvisory()])
+
+    renderBanner()
+
+    await waitFor(() =>
+      expect(screen.getByText(/high severity cve detected/i)).toBeInTheDocument(),
+    )
+    expect(screen.getByText(/CVE-2024-1234/)).toBeInTheDocument()
+    expect(screen.getByText(/Remote code execution in terraform binary/)).toBeInTheDocument()
+  })
+
+  // 4. Multiple advisories of same severity show count
+  it('shows advisory count when multiple advisories share a severity', async () => {
+    mockGetActiveAdvisories.mockResolvedValue([
+      makeAdvisory({ id: 'a1', source_id: 'CVE-2024-1' }),
+      makeAdvisory({ id: 'a2', source_id: 'CVE-2024-2', target_kind: 'provider' }),
+    ])
+
+    renderBanner()
+
+    await waitFor(() =>
+      expect(screen.getByText(/2 advisories affect/i)).toBeInTheDocument(),
+    )
+  })
+
+  // 5. Multiple severities render separate bands
+  it('renders one band per severity level', async () => {
+    mockGetActiveAdvisories.mockResolvedValue([
+      makeAdvisory({ id: 'a1', severity: 'critical' }),
+      makeAdvisory({ id: 'a2', severity: 'medium' }),
+    ])
+
+    renderBanner()
+
+    await waitFor(() =>
+      expect(screen.getByText(/critical severity cve detected/i)).toBeInTheDocument(),
+    )
+    expect(screen.getByText(/medium severity cve detected/i)).toBeInTheDocument()
+  })
+
+  // 6. "Review in Security Scanning" link points to correct route
+  it('contains a link to /admin/security-scanning', async () => {
+    mockGetActiveAdvisories.mockResolvedValue([makeAdvisory()])
+
+    renderBanner()
+
+    await waitFor(() => expect(screen.getByText(/Review in Security Scanning/i)).toBeInTheDocument())
+
+    const link = screen.getByRole('link', { name: /Review in Security Scanning/i })
+    expect(link).toHaveAttribute('href', '/admin/security-scanning')
+  })
+
+  // 7. Dismiss button hides the band for the session
+  it('dismisses a severity band when the close button is clicked', async () => {
+    mockGetActiveAdvisories.mockResolvedValue([makeAdvisory()])
+
+    renderBanner()
+
+    await waitFor(() =>
+      expect(screen.getByText(/high severity cve detected/i)).toBeInTheDocument(),
+    )
+
+    const dismissBtn = screen.getByRole('button', { name: /dismiss high advisory banner/i })
+    fireEvent.click(dismissBtn)
+
+    await waitFor(() =>
+      expect(screen.queryByText(/high severity cve detected/i)).not.toBeInTheDocument(),
+    )
+  })
+
+  // 8. Dismissal is written to sessionStorage
+  it('persists dismissal to sessionStorage when close is clicked', async () => {
+    mockGetActiveAdvisories.mockResolvedValue([makeAdvisory()])
+
+    renderBanner()
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /dismiss high advisory banner/i })).toBeInTheDocument(),
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /dismiss high advisory banner/i }))
+
+    expect(sessionStorage.getItem('cve_banner_dismissed_high')).toBe('1')
+  })
+
+  // 9. Previously dismissed severity is not shown on mount
+  it('does not render a band that was dismissed in the current session', async () => {
+    sessionStorage.setItem('cve_banner_dismissed_high', '1')
+
+    mockGetActiveAdvisories.mockResolvedValue([makeAdvisory()])
+
+    const { container } = renderBanner()
+
+    await waitFor(() => expect(mockGetActiveAdvisories).toHaveBeenCalledOnce())
+    expect(container.firstChild).toBeNull()
+  })
+
+  // 10. The region landmark is accessible
+  it('renders with the correct aria-label region', async () => {
+    mockGetActiveAdvisories.mockResolvedValue([makeAdvisory()])
+
+    renderBanner()
+
+    await waitFor(() =>
+      expect(screen.getByRole('region', { name: /security advisories/i })).toBeInTheDocument(),
+    )
+  })
+
+  // 11. Undismissed severities still show when only one of two is dismissed
+  it('keeps undismissed bands visible when another severity is dismissed', async () => {
+    sessionStorage.setItem('cve_banner_dismissed_high', '1')
+
+    mockGetActiveAdvisories.mockResolvedValue([
+      makeAdvisory({ id: 'a1', severity: 'high' }),
+      makeAdvisory({ id: 'a2', severity: 'critical' }),
+    ])
+
+    renderBanner()
+
+    await waitFor(() =>
+      expect(screen.getByText(/critical severity cve detected/i)).toBeInTheDocument(),
+    )
+    expect(screen.queryByText(/high severity cve detected/i)).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/__tests__/Layout.test.tsx
+++ b/frontend/src/components/__tests__/Layout.test.tsx
@@ -41,6 +41,12 @@ vi.mock('../AboutModal', () => ({
     ) : null,
 }))
 
+// AdvisoryBanner fetches data via useQuery; stub it out so Layout tests
+// don't need a QueryClientProvider and don't hit the network.
+vi.mock('../AdvisoryBanner', () => ({
+  default: () => null,
+}))
+
 import Layout from '../Layout'
 import i18n from '../../i18n'
 

--- a/frontend/src/services/__tests__/api.test.ts
+++ b/frontend/src/services/__tests__/api.test.ts
@@ -211,7 +211,7 @@ describe('ApiClient', () => {
       const client = await getApiClient()
 
       const mockResponse = { data: { valid: true } }
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce(mockResponse)
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce(mockResponse)
 
       await client.validateSetupToken('my-setup-token')
 
@@ -232,7 +232,7 @@ describe('ApiClient', () => {
       const client = await getApiClient()
 
       const mockResponse = { data: { modules: [], meta: { total: 0 } } }
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce(mockResponse)
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce(mockResponse)
 
       const result = await client.searchModules({ query: 'vpc', limit: 10, offset: 0 })
 
@@ -248,7 +248,7 @@ describe('ApiClient', () => {
       const client = await getApiClient()
 
       const mockResponse = { data: { providers: [], meta: { total: 0 } } }
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce(mockResponse)
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce(mockResponse)
 
       const result = await client.searchProviders({ query: 'aws', limit: 5, offset: 0 })
 
@@ -269,7 +269,7 @@ describe('ApiClient', () => {
           pagination: { page: 1, per_page: 20, total: 1 },
         },
       }
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce(mockResponse)
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce(mockResponse)
 
       const result = await client.listUsers(1, 20)
 
@@ -286,7 +286,7 @@ describe('ApiClient', () => {
       const client = await getApiClient()
 
       const mockResponse = { data: { id: 's1', backend_type: 'local', is_active: true } }
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce(mockResponse)
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce(mockResponse)
 
       const result = await client.getActiveStorageConfig()
 
@@ -311,6 +311,83 @@ describe('ApiClient', () => {
       expect(typeof client.searchProviders).toBe('function')
       expect(typeof client.validateSetupToken).toBe('function')
       expect(typeof client.getVersionInfo).toBe('function')
+      expect(typeof client.getActiveAdvisories).toBe('function')
+      expect(typeof client.listAdminAdvisories).toBe('function')
+      expect(typeof client.triggerAdvisoryPoll).toBe('function')
+    })
+  })
+
+  // ─── CVE Advisories ───────────────────────────────────────────────────────
+  describe('CVE advisories', () => {
+    describe('getActiveAdvisories', () => {
+      it('calls GET /api/v1/advisories/active and returns array', async () => {
+        const client = await getApiClient()
+
+        const advisories = [
+          { id: 'a1', source_id: 'CVE-2024-1234', severity: 'high', summary: 'A vuln', references: [], target_kind: 'binary', targets: [] },
+        ]
+          ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: advisories })
+
+        const result = await client.getActiveAdvisories()
+
+        expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/advisories/active')
+        expect(result).toHaveLength(1)
+        expect(result[0].source_id).toBe('CVE-2024-1234')
+      })
+
+      it('returns empty array when response is not an array', async () => {
+        const client = await getApiClient()
+
+          ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: null })
+
+        const result = await client.getActiveAdvisories()
+
+        expect(result).toEqual([])
+      })
+    })
+
+    describe('listAdminAdvisories', () => {
+      it('calls GET /api/v1/admin/advisories without params when kind is omitted', async () => {
+        const client = await getApiClient()
+
+        const mockResponse = { data: { advisories: [], total: 0 } }
+          ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce(mockResponse)
+
+        const result = await client.listAdminAdvisories()
+
+        expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/advisories', {
+          params: undefined,
+        })
+        expect(result.total).toBe(0)
+      })
+
+      it('passes kind as query param when provided', async () => {
+        const client = await getApiClient()
+
+        const mockResponse = { data: { advisories: [], total: 0 } }
+          ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce(mockResponse)
+
+        await client.listAdminAdvisories('binary')
+
+        expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/advisories', {
+          params: { kind: 'binary' },
+        })
+      })
+    })
+
+    describe('triggerAdvisoryPoll', () => {
+      it('calls POST /api/v1/admin/advisories/poll and returns message', async () => {
+        const client = await getApiClient()
+
+          ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+            data: { message: 'poll queued' },
+          })
+
+        const result = await client.triggerAdvisoryPoll()
+
+        expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/admin/advisories/poll')
+        expect(result.message).toBe('poll queued')
+      })
     })
   })
 
@@ -318,9 +395,9 @@ describe('ApiClient', () => {
   describe('auth methods', () => {
     it('refreshToken calls POST /api/v1/auth/refresh', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { token: 'new' },
-      })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { token: 'new' },
+        })
       const result = await client.refreshToken()
       expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/auth/refresh')
       expect(result.token).toBe('new')
@@ -328,9 +405,9 @@ describe('ApiClient', () => {
 
     it('getCurrentUser calls GET /api/v1/auth/me', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { user: { id: 'u1', email: 'a@b.com' } },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { user: { id: 'u1', email: 'a@b.com' } },
+        })
       const result = await client.getCurrentUser()
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/auth/me')
       expect(result.id).toBe('u1')
@@ -338,9 +415,9 @@ describe('ApiClient', () => {
 
     it('getCurrentUserWithRole returns user, role_template, allowed_scopes', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { user: { id: 'u1' }, role_template: { id: 'r1' }, allowed_scopes: ['admin'] },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { user: { id: 'u1' }, role_template: { id: 'r1' }, allowed_scopes: ['admin'] },
+        })
       const result = await client.getCurrentUserWithRole()
       expect(result.user.id).toBe('u1')
       expect(result.role_template?.id).toBe('r1')
@@ -349,9 +426,9 @@ describe('ApiClient', () => {
 
     it('getCurrentUserWithRole defaults missing fields', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { user: { id: 'u1' } },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { user: { id: 'u1' } },
+        })
       const result = await client.getCurrentUserWithRole()
       expect(result.role_template).toBeNull()
       expect(result.allowed_scopes).toEqual([])
@@ -359,9 +436,9 @@ describe('ApiClient', () => {
 
     it('devLogin calls POST /api/v1/dev/login', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { token: 'dev-tok' },
-      })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { token: 'dev-tok' },
+        })
       const result = await client.devLogin()
       expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/dev/login')
       expect(result.token).toBe('dev-tok')
@@ -369,9 +446,9 @@ describe('ApiClient', () => {
 
     it('getDevStatus calls GET /api/v1/dev/status', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { dev_mode: true },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { dev_mode: true },
+        })
       const result = await client.getDevStatus()
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/dev/status')
       expect(result.dev_mode).toBe(true)
@@ -379,9 +456,9 @@ describe('ApiClient', () => {
 
     it('listUsersForImpersonation calls GET /api/v1/dev/users', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { users: [], dev_mode: true },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { users: [], dev_mode: true },
+        })
       const result = await client.listUsersForImpersonation()
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/dev/users')
       expect(result.dev_mode).toBe(true)
@@ -389,9 +466,9 @@ describe('ApiClient', () => {
 
     it('impersonateUser calls POST /api/v1/dev/impersonate/:id', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { token: 'imp-tok', message: 'ok' },
-      })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { token: 'imp-tok', message: 'ok' },
+        })
       const result = await client.impersonateUser('u1')
       expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/dev/impersonate/u1')
       expect(result.token).toBe('imp-tok')
@@ -402,9 +479,9 @@ describe('ApiClient', () => {
   describe('module methods', () => {
     it('getModuleVersions', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { versions: [] },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { versions: [] },
+        })
       await client.getModuleVersions('hashicorp', 'consul', 'aws')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith(
         '/v1/modules/hashicorp/consul/aws/versions',
@@ -413,9 +490,9 @@ describe('ApiClient', () => {
 
     it('createModuleRecord', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { id: 'm1' },
-      })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { id: 'm1' },
+        })
       const result = await client.createModuleRecord({
         namespace: 'ns',
         name: 'mod',
@@ -432,9 +509,9 @@ describe('ApiClient', () => {
     it('uploadModule sends FormData', async () => {
       const client = await getApiClient()
       const fd = new FormData()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { ok: true },
-      })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { ok: true },
+        })
       await client.uploadModule(fd)
       expect(mockAxiosInstance.post).toHaveBeenCalledWith(
         '/api/v1/modules',
@@ -445,23 +522,23 @@ describe('ApiClient', () => {
 
     it('getModule', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { id: 'm1' },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { id: 'm1' },
+        })
       await client.getModule('ns', 'mod', 'aws')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/modules/ns/mod/aws')
     })
 
     it('deleteModule', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.deleteModule('ns', 'mod', 'aws')
       expect(mockAxiosInstance.delete).toHaveBeenCalledWith('/api/v1/modules/ns/mod/aws')
     })
 
     it('deleteModuleVersion', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.deleteModuleVersion('ns', 'mod', 'aws', '1.0.0')
       expect(mockAxiosInstance.delete).toHaveBeenCalledWith(
         '/api/v1/modules/ns/mod/aws/versions/1.0.0',
@@ -470,7 +547,7 @@ describe('ApiClient', () => {
 
     it('deprecateModuleVersion with message', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.deprecateModuleVersion('ns', 'mod', 'aws', '1.0.0', 'old')
       expect(mockAxiosInstance.post).toHaveBeenCalledWith(
         '/api/v1/modules/ns/mod/aws/versions/1.0.0/deprecate',
@@ -480,7 +557,7 @@ describe('ApiClient', () => {
 
     it('deprecateModuleVersion without message', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.deprecateModuleVersion('ns', 'mod', 'aws', '1.0.0')
       expect(mockAxiosInstance.post).toHaveBeenCalledWith(
         '/api/v1/modules/ns/mod/aws/versions/1.0.0/deprecate',
@@ -490,7 +567,7 @@ describe('ApiClient', () => {
 
     it('undeprecateModuleVersion', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.undeprecateModuleVersion('ns', 'mod', 'aws', '1.0.0')
       expect(mockAxiosInstance.delete).toHaveBeenCalledWith(
         '/api/v1/modules/ns/mod/aws/versions/1.0.0/deprecate',
@@ -499,7 +576,7 @@ describe('ApiClient', () => {
 
     it('deprecateModule', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.deprecateModule('ns', 'mod', 'aws', { message: 'eol' })
       expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/modules/ns/mod/aws/deprecate', {
         message: 'eol',
@@ -508,14 +585,14 @@ describe('ApiClient', () => {
 
     it('undeprecateModule', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.undeprecateModule('ns', 'mod', 'aws')
       expect(mockAxiosInstance.delete).toHaveBeenCalledWith('/api/v1/modules/ns/mod/aws/deprecate')
     })
 
     it('updateModule', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.updateModule('m1', { description: 'new desc' })
       expect(mockAxiosInstance.put).toHaveBeenCalledWith('/api/v1/admin/modules/m1', {
         description: 'new desc',
@@ -524,9 +601,9 @@ describe('ApiClient', () => {
 
     it('getModuleScan', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { status: 'clean' },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { status: 'clean' },
+        })
       await client.getModuleScan('ns', 'mod', 'aws', '1.0.0')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith(
         '/api/v1/modules/ns/mod/aws/versions/1.0.0/scan',
@@ -535,9 +612,9 @@ describe('ApiClient', () => {
 
     it('getModuleDocs', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { content: '' },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { content: '' },
+        })
       await client.getModuleDocs('ns', 'mod', 'aws', '1.0.0')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith(
         '/api/v1/modules/ns/mod/aws/versions/1.0.0/docs',
@@ -549,9 +626,9 @@ describe('ApiClient', () => {
   describe('provider methods', () => {
     it('getProviderVersions', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { versions: [] },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { versions: [] },
+        })
       await client.getProviderVersions('hashicorp', 'aws')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/v1/providers/hashicorp/aws/versions')
     })
@@ -559,7 +636,7 @@ describe('ApiClient', () => {
     it('uploadProvider sends FormData', async () => {
       const client = await getApiClient()
       const fd = new FormData()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.uploadProvider(fd)
       expect(mockAxiosInstance.post).toHaveBeenCalledWith(
         '/api/v1/providers',
@@ -570,23 +647,23 @@ describe('ApiClient', () => {
 
     it('getProvider', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { id: 'p1' },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { id: 'p1' },
+        })
       await client.getProvider('hashicorp', 'aws')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/providers/hashicorp/aws')
     })
 
     it('deleteProvider', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.deleteProvider('hashicorp', 'aws')
       expect(mockAxiosInstance.delete).toHaveBeenCalledWith('/api/v1/providers/hashicorp/aws')
     })
 
     it('deleteProviderVersion', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.deleteProviderVersion('hashicorp', 'aws', '5.0.0')
       expect(mockAxiosInstance.delete).toHaveBeenCalledWith(
         '/api/v1/providers/hashicorp/aws/versions/5.0.0',
@@ -595,7 +672,7 @@ describe('ApiClient', () => {
 
     it('deprecateProviderVersion with message', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.deprecateProviderVersion('hashicorp', 'aws', '5.0.0', 'old')
       expect(mockAxiosInstance.post).toHaveBeenCalledWith(
         '/api/v1/providers/hashicorp/aws/versions/5.0.0/deprecate',
@@ -605,7 +682,7 @@ describe('ApiClient', () => {
 
     it('deprecateProviderVersion without message', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.deprecateProviderVersion('hashicorp', 'aws', '5.0.0')
       expect(mockAxiosInstance.post).toHaveBeenCalledWith(
         '/api/v1/providers/hashicorp/aws/versions/5.0.0/deprecate',
@@ -615,7 +692,7 @@ describe('ApiClient', () => {
 
     it('undeprecateProviderVersion', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.undeprecateProviderVersion('hashicorp', 'aws', '5.0.0')
       expect(mockAxiosInstance.delete).toHaveBeenCalledWith(
         '/api/v1/providers/hashicorp/aws/versions/5.0.0/deprecate',
@@ -624,9 +701,9 @@ describe('ApiClient', () => {
 
     it('getProviderDocs with all params', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { docs: [] },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { docs: [] },
+        })
       await client.getProviderDocs('hashicorp', 'aws', '5.0.0', 'resources', 'en', 10, 0)
       expect(mockAxiosInstance.get).toHaveBeenCalledWith(
         '/api/v1/providers/hashicorp/aws/versions/5.0.0/docs',
@@ -636,9 +713,9 @@ describe('ApiClient', () => {
 
     it('getProviderDocs without optional params', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { docs: [] },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { docs: [] },
+        })
       await client.getProviderDocs('hashicorp', 'aws', '5.0.0')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith(
         '/api/v1/providers/hashicorp/aws/versions/5.0.0/docs',
@@ -648,9 +725,9 @@ describe('ApiClient', () => {
 
     it('getProviderDocContent', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { content: '# Doc' },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { content: '# Doc' },
+        })
       await client.getProviderDocContent('hashicorp', 'aws', '5.0.0', 'resources', 'aws_instance')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith(
         '/api/v1/providers/hashicorp/aws/versions/5.0.0/docs/resources/aws_instance',
@@ -662,12 +739,12 @@ describe('ApiClient', () => {
   describe('user methods', () => {
     it('searchUsers', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: {
-          users: [{ id: 'u1', email: 'a@b.com', name: 'A', created_at: '', updated_at: '' }],
-          pagination: {},
-        },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: {
+            users: [{ id: 'u1', email: 'a@b.com', name: 'A', created_at: '', updated_at: '' }],
+            pagination: {},
+          },
+        })
       const result = await client.searchUsers('test', 1, 10)
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/users/search', {
         params: { q: 'test', page: 1, per_page: 10 },
@@ -677,18 +754,18 @@ describe('ApiClient', () => {
 
     it('getUser', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { user: { id: 'u1', email: 'a@b.com', name: 'A', created_at: '', updated_at: '' } },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { user: { id: 'u1', email: 'a@b.com', name: 'A', created_at: '', updated_at: '' } },
+        })
       const result = await client.getUser('u1')
       expect(result.id).toBe('u1')
     })
 
     it('createUser', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { user: { id: 'u2', email: 'b@b.com', name: 'B', created_at: '', updated_at: '' } },
-      })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { user: { id: 'u2', email: 'b@b.com', name: 'B', created_at: '', updated_at: '' } },
+        })
       const result = await client.createUser({ email: 'b@b.com', name: 'B' })
       expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/users', {
         email: 'b@b.com',
@@ -699,11 +776,11 @@ describe('ApiClient', () => {
 
     it('updateUser', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: {
-          user: { id: 'u1', email: 'a@b.com', name: 'Updated', created_at: '', updated_at: '' },
-        },
-      })
+        ; (mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: {
+            user: { id: 'u1', email: 'a@b.com', name: 'Updated', created_at: '', updated_at: '' },
+          },
+        })
       const result = await client.updateUser('u1', { name: 'Updated' })
       expect(mockAxiosInstance.put).toHaveBeenCalledWith('/api/v1/users/u1', { name: 'Updated' })
       expect(result.name).toBe('Updated')
@@ -711,18 +788,18 @@ describe('ApiClient', () => {
 
     it('deleteUser', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { ok: true },
-      })
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { ok: true },
+        })
       await client.deleteUser('u1')
       expect(mockAxiosInstance.delete).toHaveBeenCalledWith('/api/v1/users/u1')
     })
 
     it('getUserMemberships', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { memberships: [{ org_id: 'o1' }] },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { memberships: [{ org_id: 'o1' }] },
+        })
       const result = await client.getUserMemberships('u1')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/users/u1/memberships')
       expect(result).toHaveLength(1)
@@ -730,27 +807,27 @@ describe('ApiClient', () => {
 
     it('getCurrentUserMemberships', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { memberships: [] },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { memberships: [] },
+        })
       await client.getCurrentUserMemberships()
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/users/me/memberships')
     })
 
     it('transformUser handles PascalCase fields', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: {
-          user: {
-            ID: 'u1',
-            Email: 'a@b.com',
-            Name: 'A',
-            CreatedAt: '2025-01-01',
-            UpdatedAt: '2025-01-01',
-            RoleTemplateID: 'r1',
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: {
+            user: {
+              ID: 'u1',
+              Email: 'a@b.com',
+              Name: 'A',
+              CreatedAt: '2025-01-01',
+              UpdatedAt: '2025-01-01',
+              RoleTemplateID: 'r1',
+            },
           },
-        },
-      })
+        })
       const result = await client.getUser('u1')
       expect(result.id).toBe('u1')
       expect(result.email).toBe('a@b.com')
@@ -762,13 +839,13 @@ describe('ApiClient', () => {
   describe('organization methods', () => {
     it('listOrganizations', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: {
-          organizations: [
-            { id: 'o1', name: 'org1', display_name: 'Org 1', created_at: '', updated_at: '' },
-          ],
-        },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: {
+            organizations: [
+              { id: 'o1', name: 'org1', display_name: 'Org 1', created_at: '', updated_at: '' },
+            ],
+          },
+        })
       const result = await client.listOrganizations(1, 20)
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/organizations', {
         params: { page: 1, per_page: 20 },
@@ -778,13 +855,13 @@ describe('ApiClient', () => {
 
     it('searchOrganizations', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: {
-          organizations: [
-            { id: 'o1', name: 'org1', display_name: 'Org 1', created_at: '', updated_at: '' },
-          ],
-        },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: {
+            organizations: [
+              { id: 'o1', name: 'org1', display_name: 'Org 1', created_at: '', updated_at: '' },
+            ],
+          },
+        })
       const result = await client.searchOrganizations('org', 1, 10)
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/organizations/search', {
         params: { q: 'org', page: 1, per_page: 10 },
@@ -794,66 +871,66 @@ describe('ApiClient', () => {
 
     it('getOrganization', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: {
-          organization: {
-            id: 'o1',
-            name: 'org1',
-            display_name: 'Org 1',
-            created_at: '',
-            updated_at: '',
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: {
+            organization: {
+              id: 'o1',
+              name: 'org1',
+              display_name: 'Org 1',
+              created_at: '',
+              updated_at: '',
+            },
           },
-        },
-      })
+        })
       const result = await client.getOrganization('o1')
       expect(result.id).toBe('o1')
     })
 
     it('createOrganization', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        status: 201,
-        data: {
-          organization: {
-            id: 'o2',
-            name: 'new',
-            display_name: 'New',
-            created_at: '',
-            updated_at: '',
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          status: 201,
+          data: {
+            organization: {
+              id: 'o2',
+              name: 'new',
+              display_name: 'New',
+              created_at: '',
+              updated_at: '',
+            },
           },
-        },
-      })
+        })
       const result = await client.createOrganization({ name: 'new', display_name: 'New' })
       expect(result.id).toBe('o2')
     })
 
     it('updateOrganization', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: {
-          organization: {
-            id: 'o1',
-            name: 'org1',
-            display_name: 'Updated',
-            created_at: '',
-            updated_at: '',
+        ; (mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: {
+            organization: {
+              id: 'o1',
+              name: 'org1',
+              display_name: 'Updated',
+              created_at: '',
+              updated_at: '',
+            },
           },
-        },
-      })
+        })
       const result = await client.updateOrganization('o1', { display_name: 'Updated' })
       expect(result.display_name).toBe('Updated')
     })
 
     it('deleteOrganization', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.deleteOrganization('o1')
       expect(mockAxiosInstance.delete).toHaveBeenCalledWith('/api/v1/organizations/o1')
     })
 
     it('addOrganizationMember', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.addOrganizationMember('o1', { user_id: 'u1' })
       expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/organizations/o1/members', {
         user_id: 'u1',
@@ -862,7 +939,7 @@ describe('ApiClient', () => {
 
     it('updateOrganizationMember', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.updateOrganizationMember('o1', 'u1', { role_template_id: 'r1' })
       expect(mockAxiosInstance.put).toHaveBeenCalledWith('/api/v1/organizations/o1/members/u1', {
         role_template_id: 'r1',
@@ -871,16 +948,16 @@ describe('ApiClient', () => {
 
     it('removeOrganizationMember', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.removeOrganizationMember('o1', 'u1')
       expect(mockAxiosInstance.delete).toHaveBeenCalledWith('/api/v1/organizations/o1/members/u1')
     })
 
     it('listOrganizationMembers', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { members: [{ user_id: 'u1' }] },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { members: [{ user_id: 'u1' }] },
+        })
       const result = await client.listOrganizationMembers('o1')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/organizations/o1/members')
       expect(result).toHaveLength(1)
@@ -888,9 +965,9 @@ describe('ApiClient', () => {
 
     it('transformOrganization throws for undefined org', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { organization: undefined },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { organization: undefined },
+        })
       await expect(client.getOrganization('bad')).rejects.toThrow(
         'Cannot transform undefined organization',
       )
@@ -901,9 +978,9 @@ describe('ApiClient', () => {
   describe('API key methods', () => {
     it('listAPIKeys without org filter', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { keys: [{ id: 'k1', name: 'key1', scopes: [], created_at: '' }] },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { keys: [{ id: 'k1', name: 'key1', scopes: [], created_at: '' }] },
+        })
       const result = await client.listAPIKeys()
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/apikeys', { params: {} })
       expect(result).toHaveLength(1)
@@ -911,9 +988,9 @@ describe('ApiClient', () => {
 
     it('listAPIKeys with org filter', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { keys: [] },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { keys: [] },
+        })
       await client.listAPIKeys('org-1')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/apikeys', {
         params: { organization_id: 'org-1' },
@@ -922,9 +999,9 @@ describe('ApiClient', () => {
 
     it('listAPIKeys normalizes PascalCase keys', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { keys: [{ ID: 'k1', Name: 'mykey', Scopes: ['read'], CreatedAt: '2025-01-01' }] },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { keys: [{ ID: 'k1', Name: 'mykey', Scopes: ['read'], CreatedAt: '2025-01-01' }] },
+        })
       const result = await client.listAPIKeys()
       expect(result[0].id).toBe('k1')
       expect(result[0].name).toBe('mykey')
@@ -933,9 +1010,9 @@ describe('ApiClient', () => {
 
     it('createAPIKey', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { key: 'secret', id: 'k1' },
-      })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { key: 'secret', id: 'k1' },
+        })
       const data = { name: 'key1', organization_id: 'o1', scopes: ['read'] }
       await client.createAPIKey(data)
       expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/apikeys', data)
@@ -943,32 +1020,32 @@ describe('ApiClient', () => {
 
     it('getAPIKey', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { id: 'k1' },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { id: 'k1' },
+        })
       await client.getAPIKey('k1')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/apikeys/k1')
     })
 
     it('updateAPIKey', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.updateAPIKey('k1', { name: 'updated' })
       expect(mockAxiosInstance.put).toHaveBeenCalledWith('/api/v1/apikeys/k1', { name: 'updated' })
     })
 
     it('deleteAPIKey', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.deleteAPIKey('k1')
       expect(mockAxiosInstance.delete).toHaveBeenCalledWith('/api/v1/apikeys/k1')
     })
 
     it('rotateAPIKey', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { new_key: 'secret2' },
-      })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { new_key: 'secret2' },
+        })
       await client.rotateAPIKey('k1', 24)
       expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/apikeys/k1/rotate', {
         grace_period_hours: 24,
@@ -980,14 +1057,14 @@ describe('ApiClient', () => {
   describe('SCM provider methods', () => {
     it('listSCMProviders', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: [] })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: [] })
       await client.listSCMProviders()
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/scm-providers', { params: {} })
     })
 
     it('listSCMProviders with org', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: [] })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: [] })
       await client.listSCMProviders('org-1')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/scm-providers', {
         params: { organization_id: 'org-1' },
@@ -996,9 +1073,9 @@ describe('ApiClient', () => {
 
     it('createSCMProvider', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { id: 'scm-1' },
-      })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { id: 'scm-1' },
+        })
       await client.createSCMProvider({ organization_id: 'o1', provider_type: 'github', name: 'GH' })
       expect(mockAxiosInstance.post).toHaveBeenCalledWith(
         '/api/v1/scm-providers',
@@ -1008,16 +1085,16 @@ describe('ApiClient', () => {
 
     it('getSCMProvider', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { id: 'scm-1' },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { id: 'scm-1' },
+        })
       await client.getSCMProvider('scm-1')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/scm-providers/scm-1')
     })
 
     it('updateSCMProvider', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.updateSCMProvider('scm-1', { name: 'Updated' })
       expect(mockAxiosInstance.put).toHaveBeenCalledWith('/api/v1/scm-providers/scm-1', {
         name: 'Updated',
@@ -1026,16 +1103,16 @@ describe('ApiClient', () => {
 
     it('deleteSCMProvider', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.deleteSCMProvider('scm-1')
       expect(mockAxiosInstance.delete).toHaveBeenCalledWith('/api/v1/scm-providers/scm-1')
     })
 
     it('initiateSCMOAuth', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { redirect_url: 'https://github.com/oauth' },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { redirect_url: 'https://github.com/oauth' },
+        })
       await client.initiateSCMOAuth('scm-1')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith(
         '/api/v1/scm-providers/scm-1/oauth/authorize',
@@ -1044,7 +1121,7 @@ describe('ApiClient', () => {
 
     it('refreshSCMToken', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.refreshSCMToken('scm-1')
       expect(mockAxiosInstance.post).toHaveBeenCalledWith(
         '/api/v1/scm-providers/scm-1/oauth/refresh',
@@ -1053,18 +1130,18 @@ describe('ApiClient', () => {
 
     it('getSCMTokenStatus', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { connected: true },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { connected: true },
+        })
       const result = await client.getSCMTokenStatus('scm-1')
       expect(result.connected).toBe(true)
     })
 
     it('listSCMRepositories', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { repositories: [] },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { repositories: [] },
+        })
       await client.listSCMRepositories('scm-1', 'search')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith(
         '/api/v1/scm-providers/scm-1/repositories',
@@ -1074,9 +1151,9 @@ describe('ApiClient', () => {
 
     it('listSCMRepositoryTags', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { tags: [] },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { tags: [] },
+        })
       await client.listSCMRepositoryTags('scm-1', 'owner', 'repo')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith(
         '/api/v1/scm-providers/scm-1/repositories/owner/repo/tags',
@@ -1085,9 +1162,9 @@ describe('ApiClient', () => {
 
     it('listSCMRepositoryBranches', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { branches: [] },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { branches: [] },
+        })
       await client.listSCMRepositoryBranches('scm-1', 'owner', 'repo')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith(
         '/api/v1/scm-providers/scm-1/repositories/owner/repo/branches',
@@ -1096,7 +1173,7 @@ describe('ApiClient', () => {
 
     it('revokeSCMToken', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.revokeSCMToken('scm-1')
       expect(mockAxiosInstance.delete).toHaveBeenCalledWith(
         '/api/v1/scm-providers/scm-1/oauth/token',
@@ -1105,7 +1182,7 @@ describe('ApiClient', () => {
 
     it('saveSCMToken', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.saveSCMToken('scm-1', 'token123')
       expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/scm-providers/scm-1/token', {
         access_token: 'token123',
@@ -1117,7 +1194,7 @@ describe('ApiClient', () => {
   describe('module SCM linking', () => {
     it('linkModuleToSCM', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.linkModuleToSCM('m1', {
         provider_id: 'scm-1',
         repository_owner: 'org',
@@ -1131,16 +1208,16 @@ describe('ApiClient', () => {
 
     it('getModuleSCMInfo', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { linked: true },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { linked: true },
+        })
       await client.getModuleSCMInfo('m1')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/modules/m1/scm')
     })
 
     it('updateModuleSCMLink', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.updateModuleSCMLink('m1', { auto_publish_enabled: true })
       expect(mockAxiosInstance.put).toHaveBeenCalledWith('/api/v1/admin/modules/m1/scm', {
         auto_publish_enabled: true,
@@ -1149,14 +1226,14 @@ describe('ApiClient', () => {
 
     it('unlinkModuleFromSCM', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.unlinkModuleFromSCM('m1')
       expect(mockAxiosInstance.delete).toHaveBeenCalledWith('/api/v1/admin/modules/m1/scm')
     })
 
     it('triggerManualSync', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.triggerManualSync('m1', { tag_name: 'v1.0.0' })
       expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/admin/modules/m1/scm/sync', {
         tag_name: 'v1.0.0',
@@ -1165,16 +1242,16 @@ describe('ApiClient', () => {
 
     it('triggerManualSync without data', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.triggerManualSync('m1')
       expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/admin/modules/m1/scm/sync', {})
     })
 
     it('getWebhookEvents', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { events: [] },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { events: [] },
+        })
       await client.getWebhookEvents('m1')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/modules/m1/scm/events')
     })
@@ -1184,18 +1261,18 @@ describe('ApiClient', () => {
   describe('scanning methods', () => {
     it('getScanningConfig', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { enabled: true },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { enabled: true },
+        })
       await client.getScanningConfig()
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/scanning/config')
     })
 
     it('getScanningStats', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { total: 10 },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { total: 10 },
+        })
       await client.getScanningStats()
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/scanning/stats')
     })
@@ -1205,9 +1282,9 @@ describe('ApiClient', () => {
   describe('dashboard methods', () => {
     it('getDashboardStats', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { modules: {} },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { modules: {} },
+        })
       await client.getDashboardStats()
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/stats/dashboard')
     })
@@ -1217,9 +1294,9 @@ describe('ApiClient', () => {
   describe('mirror methods', () => {
     it('listMirrors', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { mirrors: [{ id: 'mir-1' }] },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { mirrors: [{ id: 'mir-1' }] },
+        })
       const result = await client.listMirrors()
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/mirrors', { params: {} })
       expect(result).toHaveLength(1)
@@ -1227,9 +1304,9 @@ describe('ApiClient', () => {
 
     it('listMirrors enabledOnly', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { mirrors: [] },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { mirrors: [] },
+        })
       await client.listMirrors(true)
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/mirrors', {
         params: { enabled: 'true' },
@@ -1238,18 +1315,18 @@ describe('ApiClient', () => {
 
     it('getMirror', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { id: 'mir-1' },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { id: 'mir-1' },
+        })
       await client.getMirror('mir-1')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/mirrors/mir-1')
     })
 
     it('createMirror', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { id: 'mir-2' },
-      })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { id: 'mir-2' },
+        })
       await client.createMirror({
         name: 'test',
         upstream_registry_url: 'https://registry.terraform.io',
@@ -1262,7 +1339,7 @@ describe('ApiClient', () => {
 
     it('updateMirror', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.updateMirror('mir-1', { name: 'updated' })
       expect(mockAxiosInstance.put).toHaveBeenCalledWith('/api/v1/admin/mirrors/mir-1', {
         name: 'updated',
@@ -1271,14 +1348,14 @@ describe('ApiClient', () => {
 
     it('deleteMirror', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.deleteMirror('mir-1')
       expect(mockAxiosInstance.delete).toHaveBeenCalledWith('/api/v1/admin/mirrors/mir-1')
     })
 
     it('triggerMirrorSync', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.triggerMirrorSync('mir-1', { namespace: 'hashicorp' })
       expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/admin/mirrors/mir-1/sync', {
         namespace: 'hashicorp',
@@ -1287,18 +1364,18 @@ describe('ApiClient', () => {
 
     it('getMirrorStatus', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { status: 'idle' },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { status: 'idle' },
+        })
       await client.getMirrorStatus('mir-1')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/mirrors/mir-1/status')
     })
 
     it('getMirrorProviders', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { providers: ['hashicorp/aws'] },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { providers: ['hashicorp/aws'] },
+        })
       const result = await client.getMirrorProviders('mir-1')
       expect(result).toEqual(['hashicorp/aws'])
     })
@@ -1308,9 +1385,9 @@ describe('ApiClient', () => {
   describe('role template methods', () => {
     it('listRoleTemplates', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: [{ id: 'r1' }],
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: [{ id: 'r1' }],
+        })
       const result = await client.listRoleTemplates()
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/role-templates')
       expect(result).toHaveLength(1)
@@ -1318,18 +1395,18 @@ describe('ApiClient', () => {
 
     it('getRoleTemplate', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { id: 'r1' },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { id: 'r1' },
+        })
       await client.getRoleTemplate('r1')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/role-templates/r1')
     })
 
     it('createRoleTemplate', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { id: 'r2' },
-      })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { id: 'r2' },
+        })
       await client.createRoleTemplate({ name: 'editor', display_name: 'Editor', scopes: ['write'] })
       expect(mockAxiosInstance.post).toHaveBeenCalledWith(
         '/api/v1/admin/role-templates',
@@ -1339,7 +1416,7 @@ describe('ApiClient', () => {
 
     it('updateRoleTemplate', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.updateRoleTemplate('r1', { display_name: 'Updated' })
       expect(mockAxiosInstance.put).toHaveBeenCalledWith('/api/v1/admin/role-templates/r1', {
         display_name: 'Updated',
@@ -1348,7 +1425,7 @@ describe('ApiClient', () => {
 
     it('deleteRoleTemplate', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.deleteRoleTemplate('r1')
       expect(mockAxiosInstance.delete).toHaveBeenCalledWith('/api/v1/admin/role-templates/r1')
     })
@@ -1358,9 +1435,9 @@ describe('ApiClient', () => {
   describe('approval methods', () => {
     it('listApprovalRequests', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: [{ id: 'a1' }],
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: [{ id: 'a1' }],
+        })
       const result = await client.listApprovalRequests({ status: 'pending' })
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/approvals', {
         params: { status: 'pending' },
@@ -1370,25 +1447,25 @@ describe('ApiClient', () => {
 
     it('listApprovalRequests without filters', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: [] })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: [] })
       await client.listApprovalRequests()
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/approvals', { params: {} })
     })
 
     it('getApprovalRequest', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { id: 'a1' },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { id: 'a1' },
+        })
       await client.getApprovalRequest('a1')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/approvals/a1')
     })
 
     it('createApprovalRequest', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { id: 'a2' },
-      })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { id: 'a2' },
+        })
       await client.createApprovalRequest({
         mirror_config_id: 'mir-1',
         provider_namespace: 'hashicorp',
@@ -1401,7 +1478,7 @@ describe('ApiClient', () => {
 
     it('reviewApproval', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.reviewApproval('a1', { status: 'approved', notes: 'lgtm' })
       expect(mockAxiosInstance.put).toHaveBeenCalledWith('/api/v1/admin/approvals/a1/review', {
         status: 'approved',
@@ -1414,16 +1491,16 @@ describe('ApiClient', () => {
   describe('mirror policy methods', () => {
     it('listMirrorPolicies', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: [{ id: 'p1' }],
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: [{ id: 'p1' }],
+        })
       await client.listMirrorPolicies()
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/policies', { params: {} })
     })
 
     it('listMirrorPolicies with org', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: [] })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: [] })
       await client.listMirrorPolicies('org-1')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/policies', {
         params: { organization_id: 'org-1' },
@@ -1432,18 +1509,18 @@ describe('ApiClient', () => {
 
     it('getMirrorPolicy', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { id: 'p1' },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { id: 'p1' },
+        })
       await client.getMirrorPolicy('p1')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/policies/p1')
     })
 
     it('createMirrorPolicy', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { id: 'p2' },
-      })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { id: 'p2' },
+        })
       await client.createMirrorPolicy({ name: 'allow-all', policy_type: 'allow' })
       expect(mockAxiosInstance.post).toHaveBeenCalledWith(
         '/api/v1/admin/policies',
@@ -1453,7 +1530,7 @@ describe('ApiClient', () => {
 
     it('updateMirrorPolicy', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.updateMirrorPolicy('p1', { name: 'updated' })
       expect(mockAxiosInstance.put).toHaveBeenCalledWith('/api/v1/admin/policies/p1', {
         name: 'updated',
@@ -1462,16 +1539,16 @@ describe('ApiClient', () => {
 
     it('deleteMirrorPolicy', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.deleteMirrorPolicy('p1')
       expect(mockAxiosInstance.delete).toHaveBeenCalledWith('/api/v1/admin/policies/p1')
     })
 
     it('evaluateMirrorPolicy', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { allowed: true },
-      })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { allowed: true },
+        })
       await client.evaluateMirrorPolicy(
         { registry: 'https://registry.terraform.io', namespace: 'hashicorp', provider: 'aws' },
         'org-1',
@@ -1488,36 +1565,36 @@ describe('ApiClient', () => {
   describe('storage methods', () => {
     it('getSetupStatus', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { setup_required: false },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { setup_required: false },
+        })
       await client.getSetupStatus()
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/setup/status')
     })
 
     it('listStorageConfigs', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: [{ id: 's1' }],
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: [{ id: 's1' }],
+        })
       await client.listStorageConfigs()
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/storage/configs')
     })
 
     it('getStorageConfig', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { id: 's1' },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { id: 's1' },
+        })
       await client.getStorageConfig('s1')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/storage/configs/s1')
     })
 
     it('createStorageConfig', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { id: 's2' },
-      })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { id: 's2' },
+        })
       await client.createStorageConfig({ backend_type: 's3' } as never)
       expect(mockAxiosInstance.post).toHaveBeenCalledWith(
         '/api/v1/storage/configs',
@@ -1527,7 +1604,7 @@ describe('ApiClient', () => {
 
     it('updateStorageConfig', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.updateStorageConfig('s1', { backend_type: 's3' } as never)
       expect(mockAxiosInstance.put).toHaveBeenCalledWith(
         '/api/v1/storage/configs/s1',
@@ -1537,25 +1614,25 @@ describe('ApiClient', () => {
 
     it('deleteStorageConfig', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.deleteStorageConfig('s1')
       expect(mockAxiosInstance.delete).toHaveBeenCalledWith('/api/v1/storage/configs/s1')
     })
 
     it('activateStorageConfig', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { message: 'activated' },
-      })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { message: 'activated' },
+        })
       await client.activateStorageConfig('s1')
       expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/storage/configs/s1/activate')
     })
 
     it('testStorageConfig', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { success: true, message: 'ok' },
-      })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { success: true, message: 'ok' },
+        })
       await client.testStorageConfig({ backend_type: 'local' } as never)
       expect(mockAxiosInstance.post).toHaveBeenCalledWith(
         '/api/v1/storage/configs/test',
@@ -1565,9 +1642,9 @@ describe('ApiClient', () => {
 
     it('planStorageMigration', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { items: 10 },
-      })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { items: 10 },
+        })
       await client.planStorageMigration('s1', 's2')
       expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/admin/storage/migrations/plan', {
         source_config_id: 's1',
@@ -1577,9 +1654,9 @@ describe('ApiClient', () => {
 
     it('startStorageMigration', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { id: 'mig-1' },
-      })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { id: 'mig-1' },
+        })
       await client.startStorageMigration('s1', 's2')
       expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/admin/storage/migrations', {
         source_config_id: 's1',
@@ -1589,18 +1666,18 @@ describe('ApiClient', () => {
 
     it('getStorageMigration', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { id: 'mig-1' },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { id: 'mig-1' },
+        })
       await client.getStorageMigration('mig-1')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/storage/migrations/mig-1')
     })
 
     it('cancelStorageMigration', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { id: 'mig-1', status: 'cancelled' },
-      })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { id: 'mig-1', status: 'cancelled' },
+        })
       await client.cancelStorageMigration('mig-1')
       expect(mockAxiosInstance.post).toHaveBeenCalledWith(
         '/api/v1/admin/storage/migrations/mig-1/cancel',
@@ -1609,9 +1686,9 @@ describe('ApiClient', () => {
 
     it('listStorageMigrations', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: [{ id: 'mig-1' }],
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: [{ id: 'mig-1' }],
+        })
       await client.listStorageMigrations()
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/storage/migrations')
     })
@@ -1621,9 +1698,9 @@ describe('ApiClient', () => {
   describe('setup wizard methods', () => {
     it('testOIDCConfig', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { success: true },
-      })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { success: true },
+        })
       await client.testOIDCConfig('tok', {
         issuer_url: 'https://auth.example.com',
         client_id: 'id',
@@ -1638,7 +1715,7 @@ describe('ApiClient', () => {
 
     it('saveOIDCConfig', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.saveOIDCConfig('tok', { issuer_url: 'https://auth.example.com' } as never)
       expect(mockAxiosInstance.post).toHaveBeenCalledWith(
         '/api/v1/setup/oidc',
@@ -1649,16 +1726,16 @@ describe('ApiClient', () => {
 
     it('getAdminOIDCConfig', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { issuer_url: 'https://auth.example.com' },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { issuer_url: 'https://auth.example.com' },
+        })
       await client.getAdminOIDCConfig()
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/oidc/config')
     })
 
     it('updateOIDCGroupMapping', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.updateOIDCGroupMapping({ group_claim_name: 'groups' } as never)
       expect(mockAxiosInstance.put).toHaveBeenCalledWith(
         '/api/v1/admin/oidc/group-mapping',
@@ -1668,9 +1745,9 @@ describe('ApiClient', () => {
 
     it('testSetupStorageConfig', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { success: true },
-      })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { success: true },
+        })
       await client.testSetupStorageConfig('tok', { backend_type: 'local' } as never)
       expect(mockAxiosInstance.post).toHaveBeenCalledWith(
         '/api/v1/setup/storage/test',
@@ -1681,9 +1758,9 @@ describe('ApiClient', () => {
 
     it('saveSetupStorageConfig', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { message: 'saved' },
-      })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { message: 'saved' },
+        })
       await client.saveSetupStorageConfig('tok', { backend_type: 'local' } as never)
       expect(mockAxiosInstance.post).toHaveBeenCalledWith(
         '/api/v1/setup/storage',
@@ -1694,9 +1771,9 @@ describe('ApiClient', () => {
 
     it('testScanningConfig', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { success: true },
-      })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { success: true },
+        })
       await client.testScanningConfig('tok', { enabled: true } as never)
       expect(mockAxiosInstance.post).toHaveBeenCalledWith(
         '/api/v1/setup/scanning/test',
@@ -1707,9 +1784,9 @@ describe('ApiClient', () => {
 
     it('saveScanningConfig', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { message: 'saved' },
-      })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { message: 'saved' },
+        })
       await client.saveScanningConfig('tok', { enabled: true } as never)
       expect(mockAxiosInstance.post).toHaveBeenCalledWith(
         '/api/v1/setup/scanning',
@@ -1720,7 +1797,7 @@ describe('ApiClient', () => {
 
     it('configureAdmin', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.configureAdmin('tok', { admin_email: 'admin@example.com' } as never)
       expect(mockAxiosInstance.post).toHaveBeenCalledWith(
         '/api/v1/setup/admin',
@@ -1731,9 +1808,9 @@ describe('ApiClient', () => {
 
     it('completeSetup', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { success: true },
-      })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { success: true },
+        })
       await client.completeSetup('tok')
       expect(mockAxiosInstance.post).toHaveBeenCalledWith(
         '/api/v1/setup/complete',
@@ -1747,9 +1824,9 @@ describe('ApiClient', () => {
   describe('terraform mirror admin methods', () => {
     it('listPublicTerraformMirrorConfigs', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: [{ name: 'tf' }],
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: [{ name: 'tf' }],
+        })
       const result = await client.listPublicTerraformMirrorConfigs()
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/terraform/binaries')
       expect(result).toHaveLength(1)
@@ -1757,25 +1834,25 @@ describe('ApiClient', () => {
 
     it('listPublicTerraformMirrorConfigs handles non-array', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: null })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: null })
       const result = await client.listPublicTerraformMirrorConfigs()
       expect(result).toEqual([])
     })
 
     it('listTerraformMirrorConfigs', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { configs: [] },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { configs: [] },
+        })
       await client.listTerraformMirrorConfigs()
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/terraform-mirrors')
     })
 
     it('createTerraformMirrorConfig', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { id: 'tc-1' },
-      })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { id: 'tc-1' },
+        })
       await client.createTerraformMirrorConfig({ name: 'test', tool: 'terraform' } as never)
       expect(mockAxiosInstance.post).toHaveBeenCalledWith(
         '/api/v1/admin/terraform-mirrors',
@@ -1785,18 +1862,18 @@ describe('ApiClient', () => {
 
     it('getTerraformMirrorConfig', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { id: 'tc-1' },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { id: 'tc-1' },
+        })
       await client.getTerraformMirrorConfig('tc-1')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/terraform-mirrors/tc-1')
     })
 
     it('getTerraformMirrorStatus', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { status: 'idle' },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { status: 'idle' },
+        })
       await client.getTerraformMirrorStatus('tc-1')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith(
         '/api/v1/admin/terraform-mirrors/tc-1/status',
@@ -1805,7 +1882,7 @@ describe('ApiClient', () => {
 
     it('updateTerraformMirrorConfig', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.updateTerraformMirrorConfig('tc-1', { name: 'updated' } as never)
       expect(mockAxiosInstance.put).toHaveBeenCalledWith(
         '/api/v1/admin/terraform-mirrors/tc-1',
@@ -1815,16 +1892,16 @@ describe('ApiClient', () => {
 
     it('deleteTerraformMirrorConfig', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.deleteTerraformMirrorConfig('tc-1')
       expect(mockAxiosInstance.delete).toHaveBeenCalledWith('/api/v1/admin/terraform-mirrors/tc-1')
     })
 
     it('triggerTerraformMirrorSync', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { message: 'started' },
-      })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { message: 'started' },
+        })
       await client.triggerTerraformMirrorSync('tc-1')
       expect(mockAxiosInstance.post).toHaveBeenCalledWith(
         '/api/v1/admin/terraform-mirrors/tc-1/sync',
@@ -1834,9 +1911,9 @@ describe('ApiClient', () => {
 
     it('listTerraformVersions', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { versions: [] },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { versions: [] },
+        })
       await client.listTerraformVersions('tc-1', { synced: true })
       expect(mockAxiosInstance.get).toHaveBeenCalledWith(
         '/api/v1/admin/terraform-mirrors/tc-1/versions',
@@ -1846,9 +1923,9 @@ describe('ApiClient', () => {
 
     it('listTerraformVersions without filter', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { versions: [] },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { versions: [] },
+        })
       await client.listTerraformVersions('tc-1')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith(
         '/api/v1/admin/terraform-mirrors/tc-1/versions',
@@ -1858,9 +1935,9 @@ describe('ApiClient', () => {
 
     it('getTerraformVersion', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { version: '1.5.0' },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { version: '1.5.0' },
+        })
       await client.getTerraformVersion('tc-1', '1.5.0')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith(
         '/api/v1/admin/terraform-mirrors/tc-1/versions/1.5.0',
@@ -1869,7 +1946,7 @@ describe('ApiClient', () => {
 
     it('deleteTerraformVersion', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.deleteTerraformVersion('tc-1', '1.5.0')
       expect(mockAxiosInstance.delete).toHaveBeenCalledWith(
         '/api/v1/admin/terraform-mirrors/tc-1/versions/1.5.0',
@@ -1878,7 +1955,7 @@ describe('ApiClient', () => {
 
     it('deprecateTerraformVersion', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.deprecateTerraformVersion('tc-1', '1.5.0')
       expect(mockAxiosInstance.post).toHaveBeenCalledWith(
         '/api/v1/admin/terraform-mirrors/tc-1/versions/1.5.0/deprecate',
@@ -1888,7 +1965,7 @@ describe('ApiClient', () => {
 
     it('undeprecateTerraformVersion', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.undeprecateTerraformVersion('tc-1', '1.5.0')
       expect(mockAxiosInstance.delete).toHaveBeenCalledWith(
         '/api/v1/admin/terraform-mirrors/tc-1/versions/1.5.0/deprecate',
@@ -1897,27 +1974,27 @@ describe('ApiClient', () => {
 
     it('listTerraformVersionPlatforms returns array from data', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: [{ os: 'linux', arch: 'amd64' }],
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: [{ os: 'linux', arch: 'amd64' }],
+        })
       const result = await client.listTerraformVersionPlatforms('tc-1', '1.5.0')
       expect(result).toHaveLength(1)
     })
 
     it('listTerraformVersionPlatforms returns platforms from nested', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { platforms: [{ os: 'linux' }] },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { platforms: [{ os: 'linux' }] },
+        })
       const result = await client.listTerraformVersionPlatforms('tc-1', '1.5.0')
       expect(result).toHaveLength(1)
     })
 
     it('getTerraformMirrorHistory', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { history: [] },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { history: [] },
+        })
       await client.getTerraformMirrorHistory('tc-1', 10)
       expect(mockAxiosInstance.get).toHaveBeenCalledWith(
         '/api/v1/admin/terraform-mirrors/tc-1/history',
@@ -1930,18 +2007,18 @@ describe('ApiClient', () => {
   describe('terraform mirror public methods', () => {
     it('listPublicTerraformVersions', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { versions: [] },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { versions: [] },
+        })
       await client.listPublicTerraformVersions('terraform')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/terraform/binaries/terraform/versions')
     })
 
     it('getPublicLatestTerraformVersion', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { version: '1.9.0' },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { version: '1.9.0' },
+        })
       await client.getPublicLatestTerraformVersion('terraform')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith(
         '/terraform/binaries/terraform/versions/latest',
@@ -1950,9 +2027,9 @@ describe('ApiClient', () => {
 
     it('getPublicTerraformVersion', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { version: '1.5.0' },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { version: '1.5.0' },
+        })
       await client.getPublicTerraformVersion('terraform', '1.5.0')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith(
         '/terraform/binaries/terraform/versions/1.5.0',
@@ -1961,9 +2038,9 @@ describe('ApiClient', () => {
 
     it('getTerraformBinaryDownload', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { download_url: 'https://...' },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { download_url: 'https://...' },
+        })
       await client.getTerraformBinaryDownload('terraform', '1.5.0', 'linux', 'amd64')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith(
         '/terraform/binaries/terraform/versions/1.5.0/linux/amd64',
@@ -1975,9 +2052,9 @@ describe('ApiClient', () => {
   describe('audit log methods', () => {
     it('listAuditLogs with filters', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { logs: [], pagination: {} },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { logs: [], pagination: {} },
+        })
       await client.listAuditLogs({ page: 1, per_page: 25, resource_type: 'module' })
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/audit-logs', {
         params: { page: 1, per_page: 25, resource_type: 'module' },
@@ -1986,9 +2063,9 @@ describe('ApiClient', () => {
 
     it('getAuditLog', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { id: 'log-1' },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { id: 'log-1' },
+        })
       await client.getAuditLog('log-1')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/audit-logs/log-1')
     })
@@ -1996,7 +2073,7 @@ describe('ApiClient', () => {
     it('exportAuditLogsCSV creates download', async () => {
       const client = await getApiClient()
       const createElementSpy = vi.spyOn(document, 'createElement')
-      const revokeURLSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
+      const revokeURLSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => { })
       const createURLSpy = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:url')
       const clickSpy = vi.fn()
       createElementSpy.mockReturnValue({
@@ -2021,7 +2098,7 @@ describe('ApiClient', () => {
     it('exportAuditLogsJSON creates download', async () => {
       const client = await getApiClient()
       const createElementSpy = vi.spyOn(document, 'createElement')
-      const revokeURLSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
+      const revokeURLSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => { })
       const createURLSpy = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:url')
       const clickSpy = vi.fn()
       createElementSpy.mockReturnValue({
@@ -2045,14 +2122,14 @@ describe('ApiClient', () => {
   describe('enterprise identity methods', () => {
     it('getAuthProviders calls GET /api/v1/auth/providers', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: {
-          providers: [
-            { type: 'oidc', name: 'Corporate' },
-            { type: 'saml', name: 'Okta', id: 's1' },
-          ],
-        },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: {
+            providers: [
+              { type: 'oidc', name: 'Corporate' },
+              { type: 'saml', name: 'Okta', id: 's1' },
+            ],
+          },
+        })
       const result = await client.getAuthProviders()
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/auth/providers')
       expect(result.providers).toHaveLength(2)
@@ -2061,9 +2138,9 @@ describe('ApiClient', () => {
 
     it('ldapLogin calls POST /api/v1/auth/ldap/login with credentials', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { token: 'ldap-jwt-token' },
-      })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { token: 'ldap-jwt-token' },
+        })
       const result = await client.ldapLogin('admin', 'secret')
       expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/auth/ldap/login', {
         username: 'admin',
@@ -2074,9 +2151,9 @@ describe('ApiClient', () => {
 
     it('getIdentityGroupMappings calls GET /api/v1/admin/identity/group-mappings', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { saml: { group_mappings: [] }, ldap: { group_mappings: [] } },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { saml: { group_mappings: [] }, ldap: { group_mappings: [] } },
+        })
       const result = await client.getIdentityGroupMappings()
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/identity/group-mappings')
       expect(result).toHaveProperty('saml')
@@ -2085,9 +2162,9 @@ describe('ApiClient', () => {
 
     it('getMTLSConfig calls GET /api/v1/admin/mtls/config', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { enabled: true, client_ca_file: '/ca.pem', mappings: [] },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { enabled: true, client_ca_file: '/ca.pem', mappings: [] },
+        })
       const result = await client.getMTLSConfig()
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/mtls/config')
       expect(result.enabled).toBe(true)
@@ -2098,9 +2175,9 @@ describe('ApiClient', () => {
   describe('version info', () => {
     it('getVersionInfo', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { version: '1.0.0' },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { version: '1.0.0' },
+        })
       const result = await client.getVersionInfo()
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/version')
       expect(result.version).toBe('1.0.0')

--- a/frontend/src/services/__tests__/queryKeys.test.ts
+++ b/frontend/src/services/__tests__/queryKeys.test.ts
@@ -290,6 +290,34 @@ describe('queryKeys', () => {
     })
   })
 
+  describe('advisories', () => {
+    it('has a stable _def key', () => {
+      expect(queryKeys.advisories._def).toEqual(['advisories'])
+    })
+
+    it('active key is stable', () => {
+      expect(queryKeys.advisories.active()).toEqual(['advisories', 'active'])
+    })
+
+    it('adminList key without kind', () => {
+      expect(queryKeys.advisories.adminList()).toEqual(['advisories', 'admin', undefined])
+    })
+
+    it('adminList key includes kind when provided', () => {
+      expect(queryKeys.advisories.adminList('binary')).toEqual([
+        'advisories',
+        'admin',
+        'binary',
+      ])
+    })
+
+    it('adminList produces different keys for different kinds', () => {
+      const a = queryKeys.advisories.adminList('binary')
+      const b = queryKeys.advisories.adminList('provider')
+      expect(a).not.toEqual(b)
+    })
+  })
+
   describe('key uniqueness across all domains', () => {
     it('all top-level _def keys are unique', () => {
       const allDefs = [
@@ -309,6 +337,7 @@ describe('queryKeys', () => {
         queryKeys.policies._def,
         queryKeys.oidcConfig._def,
         queryKeys.terraformMirrors._def,
+        queryKeys.advisories._def,
       ]
       const prefixes = allDefs.map((d) => d[0])
       expect(new Set(prefixes).size).toBe(prefixes.length)

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -55,7 +55,7 @@ class ApiClient {
         }
 
         // Stamp the request start time for breadcrumb duration tracking
-        ;(config as InternalAxiosRequestConfig & { _startTime?: number })._startTime = Date.now()
+        ; (config as InternalAxiosRequestConfig & { _startTime?: number })._startTime = Date.now()
         return config
       },
       (error) => Promise.reject(error),
@@ -253,11 +253,11 @@ class ApiClient {
       },
       onUploadProgress: options?.onUploadProgress
         ? (event) => {
-            if (event.total && event.total > 0) {
-              const percent = Math.round((event.loaded / event.total) * 100)
-              options.onUploadProgress?.(percent)
-            }
+          if (event.total && event.total > 0) {
+            const percent = Math.round((event.loaded / event.total) * 100)
+            options.onUploadProgress?.(percent)
           }
+        }
         : undefined,
     })
     return response.data
@@ -371,11 +371,11 @@ class ApiClient {
       },
       onUploadProgress: options?.onUploadProgress
         ? (event) => {
-            if (event.total && event.total > 0) {
-              const percent = Math.round((event.loaded / event.total) * 100)
-              options.onUploadProgress?.(percent)
-            }
+          if (event.total && event.total > 0) {
+            const percent = Math.round((event.loaded / event.total) * 100)
+            options.onUploadProgress?.(percent)
           }
+        }
         : undefined,
     })
     return response.data
@@ -1667,6 +1667,32 @@ class ApiClient {
   ): Promise<import('../types').UIThemeConfig> {
     const response = await this.client.put('/api/v1/admin/ui-theme', config)
     return response.data as import('../types').UIThemeConfig
+  }
+
+  // ============================================================================
+  // CVE Advisories
+  // ============================================================================
+
+  /** Public endpoint — returns active advisories; cached 5 min by the backend. */
+  async getActiveAdvisories(): Promise<import('../types').CVEAdvisory[]> {
+    const response = await this.client.get('/api/v1/advisories/active')
+    return Array.isArray(response.data) ? response.data : []
+  }
+
+  /** Admin endpoint — returns all advisories (including withdrawn), with optional kind filter. */
+  async listAdminAdvisories(
+    kind?: 'binary' | 'provider' | 'scanner',
+  ): Promise<{ advisories: import('../types').CVEAdvisoryAdmin[]; total: number }> {
+    const response = await this.client.get('/api/v1/admin/advisories', {
+      params: kind ? { kind } : undefined,
+    })
+    return response.data
+  }
+
+  /** Admin endpoint — queues an immediate CVE poll outside the normal schedule. */
+  async triggerAdvisoryPoll(): Promise<{ message: string }> {
+    const response = await this.client.post('/api/v1/admin/advisories/poll')
+    return response.data
   }
 }
 

--- a/frontend/src/services/queryKeys.ts
+++ b/frontend/src/services/queryKeys.ts
@@ -121,4 +121,9 @@ export const queryKeys = {
     history: (configId: string) =>
       [...queryKeys.terraformMirrors._def, 'history', configId] as const,
   },
+  advisories: {
+    _def: ['advisories'] as const,
+    active: () => [...queryKeys.advisories._def, 'active'] as const,
+    adminList: (kind?: string) => [...queryKeys.advisories._def, 'admin', kind] as const,
+  },
 } as const

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -691,3 +691,46 @@ export interface StorageMigration {
   completed_at?: string
   created_at: string
 }
+
+// ---- CVE Advisories ----
+
+export type CVESeverity = 'critical' | 'high' | 'medium' | 'low' | 'unknown'
+export type CVETargetKind = 'binary' | 'provider' | 'scanner'
+
+export interface CVEAdvisory {
+  id: string
+  source_id: string
+  severity: CVESeverity
+  summary: string
+  references: string[]
+  target_kind: CVETargetKind
+  targets: CVEAffectedTarget[]
+}
+
+export interface CVEAffectedTarget {
+  id: string
+  advisory_id: string
+  target_kind: CVETargetKind
+  target_ref: {
+    tool?: string
+    version?: string
+    namespace?: string
+    type?: string
+    mirror_config_id?: string
+    provider_id?: string
+  }
+  terraform_version_id?: string
+  provider_version_id?: string
+  created_at: string
+}
+
+// Admin-only full advisory list entry
+export interface CVEAdvisoryAdmin {
+  id: string
+  source_id: string
+  severity: CVESeverity
+  summary: string
+  references: string[]
+  withdrawn: boolean
+  target_count: number
+}


### PR DESCRIPTION
## Summary

Displays a persistent warning banner in the main layout when the backend reports active CVE advisories. Polls \GET /api/v1/advisories/active\ every 5 minutes and renders one MUI Alert band per severity level.

## New files

- \rontend/src/components/AdvisoryBanner.tsx\
  Groups advisories by severity (critical/high/medium/low/unknown) and renders one coloured Alert band per level. Each band is independently dismissible for the current browser session via \sessionStorage\. Includes a 'Review in Security Scanning' link.
- \rontend/src/components/__tests__/AdvisoryBanner.test.tsx\ — 11 unit tests

## Modified files

| File | Change |
|------|--------|
| \rontend/src/types/index.ts\ | \CVEAdvisory\, \CVEAffectedTarget\, \CVEAdvisoryAdmin\ types |
| \rontend/src/services/queryKeys.ts\ | \dvisories.active()\ and \dvisories.adminList(kind?)\ |
| \rontend/src/services/api.ts\ | \getActiveAdvisories\, \listAdminAdvisories\, \	riggerAdvisoryPoll\ |
| \rontend/src/components/Layout.tsx\ | Mount \<AdvisoryBanner />\ below Toolbar |
| \rontend/src/components/__tests__/Layout.test.tsx\ | Mock \AdvisoryBanner\ so Layout tests don't need QueryClient |
| \rontend/src/services/__tests__/api.test.ts\ | 3 CVE API method tests |
| \rontend/src/services/__tests__/queryKeys.test.ts\ | 5 advisories query key tests |

## Cross-repo dependency

**Requires** backend PR #308 (\eat/cve-polling\ in \	erraform-registry-backend\). The \GET /api/v1/advisories/active\ endpoint must be deployed before this banner shows any content. The banner renders nothing when the endpoint returns an empty array (or before the backend is upgraded).