### PR TITLE
fix: correct sort field names sent to backend for newest/recently-updated

### DIFF
--- a/frontend/src/pages/ModulesPage.tsx
+++ b/frontend/src/pages/ModulesPage.tsx
@@ -81,8 +81,8 @@ const ModulesPage: React.FC = () => {
       { value: 'name:asc', label: t('modules.sortNameAsc') },
       { value: 'name:desc', label: t('modules.sortNameDesc') },
       { value: 'downloads:desc', label: t('modules.sortDownloads') },
-      { value: 'created_at:desc', label: t('modules.sortNewest') },
-      { value: 'updated_at:desc', label: t('modules.sortRecentlyUpdated') },
+      { value: 'created:desc', label: t('modules.sortNewest') },
+      { value: 'updated:desc', label: t('modules.sortRecentlyUpdated') },
     ],
     [t],
   )

--- a/frontend/src/pages/ProvidersPage.tsx
+++ b/frontend/src/pages/ProvidersPage.tsx
@@ -55,7 +55,7 @@ const ProvidersPage: React.FC = () => {
       { value: 'relevance', label: t('providers.sortRelevance') },
       { value: 'name:asc', label: t('providers.sortNameAsc') },
       { value: 'name:desc', label: t('providers.sortNameDesc') },
-      { value: 'created_at:desc', label: t('providers.sortNewest') },
+      { value: 'created:desc', label: t('providers.sortNewest') },
     ],
     [t],
   )

--- a/frontend/src/pages/__tests__/ProvidersPage.test.tsx
+++ b/frontend/src/pages/__tests__/ProvidersPage.test.tsx
@@ -236,7 +236,7 @@ describe('ProvidersPage', () => {
     fireEvent.click(opt)
     await waitFor(() => {
       expect(searchProvidersMock).toHaveBeenCalledWith(
-        expect.objectContaining({ sort: 'created_at', order: 'desc' }),
+        expect.objectContaining({ sort: 'created', order: 'desc' }),
       )
     })
   })
@@ -288,10 +288,10 @@ describe('ProvidersPage', () => {
 
   it('reflects a sort URL param on initial render', async () => {
     searchProvidersMock.mockResolvedValue({ providers: fakeProviders, meta: { total: 2 } })
-    renderPage('/providers?sort=created_at&order=desc')
+    renderPage('/providers?sort=created&order=desc')
     await waitFor(() => {
       expect(searchProvidersMock).toHaveBeenCalledWith(
-        expect.objectContaining({ sort: 'created_at', order: 'desc' }),
+        expect.objectContaining({ sort: 'created', order: 'desc' }),
       )
     })
   })


### PR DESCRIPTION
The sort option values used `created_at` and `updated_at` as field names, but the backend only accepts `created` and `updated` in its allow-list. This caused a 400 response which the UI surfaced as a generic "Failed to load" error whenever either sort option was selected.

## Changes

- `ProvidersPage.tsx`: `created_at:desc` → `created:desc`
- `ModulesPage.tsx`: `created_at:desc` → `created:desc`, `updated_at:desc` → `updated:desc`

Closes #253
