### PR TITLE
fix: widen module detail page to match provider detail width

### DIFF
--- a/frontend/src/components/skeletons/DetailPageSkeleton.tsx
+++ b/frontend/src/components/skeletons/DetailPageSkeleton.tsx
@@ -9,7 +9,7 @@ export default function DetailPageSkeleton({
   'data-testid': testId = 'detail-page-skeleton',
 }: DetailPageSkeletonProps) {
   return (
-    <Container maxWidth="lg" sx={{ py: 4 }} data-testid={testId}>
+    <Container maxWidth="xl" sx={{ py: 4 }} data-testid={testId}>
       <Skeleton variant="text" width={220} height={20} sx={{ mb: 2 }} />
       <Stack direction="row" alignItems="center" spacing={2} sx={{ mb: 2 }}>
         <Skeleton variant="circular" width={40} height={40} />

--- a/frontend/src/pages/ModuleDetailPage.tsx
+++ b/frontend/src/pages/ModuleDetailPage.tsx
@@ -123,14 +123,14 @@ const ModuleDetailPage: React.FC = () => {
       {loading ? (
         <DetailPageSkeleton />
       ) : error || !module ? (
-        <Container maxWidth="lg" sx={{ py: 4 }}>
+        <Container maxWidth="xl" sx={{ py: 4 }}>
           <Alert severity="error">{error || 'Module not found'}</Alert>
           <Button startIcon={<ArrowBack />} onClick={() => navigate('/modules')} sx={{ mt: 2 }}>
             Back to Modules
           </Button>
         </Container>
       ) : (
-        <Container maxWidth="lg" sx={{ py: 4 }}>
+        <Container maxWidth="xl" sx={{ py: 4 }}>
           {/* Breadcrumbs */}
           <Breadcrumbs sx={{ mb: 3 }}>
             <Link


### PR DESCRIPTION
Module detail page used `maxWidth="lg"` while Provider detail page uses `maxWidth="xl"`, making the module detail page unnecessarily narrow on wide screens. Updated both the page container and the shared `DetailPageSkeleton` to use `maxWidth="xl"` for consistent layout across both resource types.

## Changes

- `frontend/src/pages/ModuleDetailPage.tsx`: `maxWidth="lg"` → `maxWidth="xl"`
- `frontend/src/components/skeletons/DetailPageSkeleton.tsx`: `maxWidth="lg"` → `maxWidth="xl"`

Closes #252
