### PR TITLE
fix: add CSV export to scanning findings modal

### DIFF
--- a/frontend/src/components/ScanFindingsModal.tsx
+++ b/frontend/src/components/ScanFindingsModal.tsx
@@ -17,13 +17,43 @@ import {
   Stack,
   Button,
   Collapse,
+  Tooltip,
 } from '@mui/material'
 import CloseIcon from '@mui/icons-material/Close'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import ExpandLessIcon from '@mui/icons-material/ExpandLess'
-import type { ModuleScan } from '../types'
+import DownloadIcon from '@mui/icons-material/Download'
+import type { FindingRow, ModuleScan } from '../types'
 import { parseScanFindings } from '../utils/scanParsers'
 import ScanDiagnostics from './ScanDiagnostics'
+
+/** Escape a single CSV field value (RFC 4180). */
+function csvEscape(value: string): string {
+  if (value.includes('"') || value.includes(',') || value.includes('\n')) {
+    return `"${value.replace(/"/g, '""')}"`
+  }
+  return value
+}
+
+/** Convert an array of FindingRow records to a CSV string. */
+function findingsToCsv(findings: FindingRow[]): string {
+  const header = ['Severity', 'Rule ID', 'Title', 'Resource', 'File', 'Resolution']
+  const rows = findings.map((f) =>
+    [f.severity, f.ruleId, f.title, f.resource, f.file, f.resolution].map(csvEscape).join(','),
+  )
+  return [header.join(','), ...rows].join('\r\n')
+}
+
+/** Trigger a CSV download in the browser. */
+function downloadCsv(csv: string, filename: string): void {
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  link.href = url
+  link.download = filename
+  link.click()
+  URL.revokeObjectURL(url)
+}
 
 interface ScanFindingsModalProps {
   open: boolean
@@ -58,6 +88,15 @@ const ScanFindingsModal: React.FC<ScanFindingsModalProps> = ({
   const [rawOpen, setRawOpen] = useState(false)
 
   const findings = scan ? parseScanFindings(scan.scanner, scan.raw_results) : []
+
+  const handleDownloadCsv = () => {
+    if (findings.length === 0) return
+    const date = new Date().toISOString().slice(0, 10)
+    const slug = moduleLabel
+      ? moduleLabel.replace(/[^a-z0-9]+/gi, '-').toLowerCase()
+      : 'scan'
+    downloadCsv(findingsToCsv(findings), `scan-findings-${slug}-${date}.csv`)
+  }
 
   return (
     <Dialog open={open} onClose={onClose} maxWidth="lg" fullWidth>
@@ -110,6 +149,19 @@ const ScanFindingsModal: React.FC<ScanFindingsModalProps> = ({
               )}
               {scan.low_count > 0 && (
                 <Chip label={`Low: ${scan.low_count}`} size="small" color="info" />
+              )}
+              {findings.length > 0 && (
+                <Tooltip title="Download findings as CSV">
+                  <Button
+                    size="small"
+                    variant="outlined"
+                    startIcon={<DownloadIcon />}
+                    onClick={handleDownloadCsv}
+                    data-testid="findings-csv-download"
+                  >
+                    Export CSV
+                  </Button>
+                </Tooltip>
               )}
             </Stack>
 

--- a/frontend/src/components/__tests__/ScanFindingsModal.test.tsx
+++ b/frontend/src/components/__tests__/ScanFindingsModal.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import ScanFindingsModal from '../ScanFindingsModal'
@@ -99,5 +99,66 @@ describe('ScanFindingsModal', () => {
     expect(
       screen.getByText('Could not parse individual findings from scanner output.'),
     ).toBeInTheDocument()
+  })
+
+  describe('CSV export', () => {
+    let mockLink: { href: string; download: string; click: ReturnType<typeof vi.fn> }
+
+    beforeEach(() => {
+      mockLink = { href: '', download: '', click: vi.fn() }
+      vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+        if (tag === 'a') return mockLink as unknown as HTMLElement
+        return document.createElement(tag)
+      })
+      vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:mock')
+      vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
+    })
+
+    it('shows Export CSV button when findings are present', () => {
+      render(<ScanFindingsModal open={true} onClose={() => { }} scan={baseScan} />)
+      expect(screen.getByTestId('findings-csv-download')).toBeInTheDocument()
+    })
+
+    it('does not show Export CSV button when findings cannot be parsed', () => {
+      const scan = { ...baseScan, raw_results: { unknown_format: true } }
+      render(<ScanFindingsModal open={true} onClose={() => { }} scan={scan} />)
+      expect(screen.queryByTestId('findings-csv-download')).not.toBeInTheDocument()
+    })
+
+    it('triggers CSV download with correct filename when Export CSV is clicked', async () => {
+      const user = userEvent.setup()
+      render(
+        <ScanFindingsModal
+          open={true}
+          onClose={() => { }}
+          scan={baseScan}
+          moduleLabel="hashicorp/vpc/aws v1.0.0"
+        />,
+      )
+      await user.click(screen.getByTestId('findings-csv-download'))
+      expect(mockLink.click).toHaveBeenCalledOnce()
+      expect(mockLink.download).toMatch(/^scan-findings-hashicorp-vpc-aws-v1-0-0-\d{4}-\d{2}-\d{2}\.csv$/)
+      expect(URL.createObjectURL).toHaveBeenCalledOnce()
+      expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock')
+    })
+
+    it('CSV content contains header and finding rows', async () => {
+      const user = userEvent.setup()
+      let capturedCsv = ''
+      vi.spyOn(URL, 'createObjectURL').mockImplementation((blob: Blob | MediaSource) => {
+        if (blob instanceof Blob) blob.text().then((text) => { capturedCsv = text })
+        return 'blob:mock'
+      })
+
+      render(<ScanFindingsModal open={true} onClose={() => { }} scan={baseScan} />)
+      await user.click(screen.getByTestId('findings-csv-download'))
+
+      // Allow the blob.text() promise to resolve
+      await new Promise((r) => setTimeout(r, 0))
+      expect(capturedCsv).toContain('Severity,Rule ID,Title,Resource,File,Resolution')
+      expect(capturedCsv).toContain('CRITICAL')
+      expect(capturedCsv).toContain('AVD-AWS-0001')
+      expect(capturedCsv).toContain('S3 bucket unencrypted')
+    })
   })
 })

--- a/frontend/src/components/__tests__/ScanFindingsModal.test.tsx
+++ b/frontend/src/components/__tests__/ScanFindingsModal.test.tsx
@@ -106,7 +106,7 @@ describe('ScanFindingsModal', () => {
 
     beforeEach(() => {
       mockLink = { href: '', download: '', click: vi.fn() }
-      const originalCreateElement = document.createElement.bind(document)
+      const originalCreateElement = Document.prototype.createElement.bind(document)
       vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
         if (tag === 'a') return mockLink as unknown as HTMLElement
         return originalCreateElement(tag)

--- a/frontend/src/components/__tests__/ScanFindingsModal.test.tsx
+++ b/frontend/src/components/__tests__/ScanFindingsModal.test.tsx
@@ -106,9 +106,10 @@ describe('ScanFindingsModal', () => {
 
     beforeEach(() => {
       mockLink = { href: '', download: '', click: vi.fn() }
+      const originalCreateElement = document.createElement.bind(document)
       vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
         if (tag === 'a') return mockLink as unknown as HTMLElement
-        return document.createElement(tag)
+        return originalCreateElement(tag)
       })
       vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:mock')
       vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})


### PR DESCRIPTION
Add an **Export CSV** button to the `ScanFindingsModal` that downloads all currently displayed findings as a well-formed CSV file (RFC 4180).

## Changes

- `ScanFindingsModal.tsx`: Added `findingsToCsv`, `csvEscape`, and `downloadCsv` helpers; added Export CSV button to the summary chips row; button is only visible when `findings.length > 0`
- `ScanFindingsModal.test.tsx`: Added `describe('CSV export')` block with four new test cases covering button visibility, download trigger, filename format, and CSV content

### CSV columns

```
Severity,Rule ID,Title,Resource,File,Resolution
```

### Filename format

`scan-findings-<slugified-module-label>-<YYYY-MM-DD>.csv`

Closes #251
