### PR TITLE
fix: replace free-text platform filter with structured os/arch multi-select

### DIFF
--- a/frontend/src/pages/admin/MirrorsPage.tsx
+++ b/frontend/src/pages/admin/MirrorsPage.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import {
+  Autocomplete,
   Box,
   Button,
   Card,
@@ -32,6 +33,22 @@ import {
   Collapse,
   Tooltip,
 } from '@mui/material'
+
+/** Known Terraform provider platform combinations (os/arch). */
+const KNOWN_PLATFORMS = [
+  'linux/amd64',
+  'linux/arm64',
+  'linux/386',
+  'linux/arm',
+  'darwin/amd64',
+  'darwin/arm64',
+  'windows/amd64',
+  'windows/386',
+  'windows/arm64',
+  'freebsd/amd64',
+  'freebsd/386',
+  'freebsd/arm',
+] as const
 import AddIcon from '@mui/icons-material/Add'
 import EditIcon from '@mui/icons-material/Edit'
 import DeleteIcon from '@mui/icons-material/Delete'
@@ -257,7 +274,7 @@ const MirrorsPage: React.FC = () => {
   const [namespaceFilterInput, setNamespaceFilterInput] = useState('')
   const [providerFilterInput, setProviderFilterInput] = useState('')
   const [versionFilterInput, setVersionFilterInput] = useState('')
-  const [platformFilterInput, setPlatformFilterInput] = useState('')
+  const [platformFilterInput, setPlatformFilterInput] = useState<string[]>([])
 
   const [searchParams] = useSearchParams()
 
@@ -341,10 +358,7 @@ const MirrorsPage: React.FC = () => {
         .map((s) => s.trim())
         .filter(Boolean),
       version_filter: versionFilterInput.trim() || undefined,
-      platform_filter: platformFilterInput
-        .split(',')
-        .map((s) => s.trim())
-        .filter(Boolean),
+      platform_filter: platformFilterInput.length > 0 ? platformFilterInput : undefined,
     }
     createMutation.mutate(data as CreateMirrorConfigRequest)
   }
@@ -365,10 +379,7 @@ const MirrorsPage: React.FC = () => {
         .map((s) => s.trim())
         .filter(Boolean),
       version_filter: versionFilterInput.trim() || undefined,
-      platform_filter: platformFilterInput
-        .split(',')
-        .map((s) => s.trim())
-        .filter(Boolean),
+      platform_filter: platformFilterInput.length > 0 ? platformFilterInput : undefined,
       enabled: formData.enabled,
       sync_interval_hours: formData.sync_interval_hours,
     }
@@ -434,7 +445,7 @@ const MirrorsPage: React.FC = () => {
     setNamespaceFilterInput('')
     setProviderFilterInput('')
     setVersionFilterInput('')
-    setPlatformFilterInput('')
+    setPlatformFilterInput([])
   }
 
   const openEditDialog = (mirror: MirrorConfiguration) => {
@@ -450,7 +461,7 @@ const MirrorsPage: React.FC = () => {
     setNamespaceFilterInput(parsed.namespaceFilters.join(', '))
     setProviderFilterInput(parsed.providerFilters.join(', '))
     setVersionFilterInput(mirror.version_filter || '')
-    setPlatformFilterInput(parsed.platformFilters.join(', '))
+    setPlatformFilterInput(parsed.platformFilters)
   }
 
   const getStatusChip = (mirror: MirrorConfiguration) => {
@@ -785,13 +796,29 @@ const MirrorsPage: React.FC = () => {
                   placeholder="e.g., 3. or latest:5 or >=3.0.0"
                 />
 
-                <TextField
-                  label="Platform Filter"
-                  fullWidth
+                <Autocomplete
+                  multiple
+                  options={KNOWN_PLATFORMS}
                   value={platformFilterInput}
-                  onChange={(e) => setPlatformFilterInput(e.target.value)}
-                  helperText="Comma-separated list of platforms to sync in 'os/arch' format. Leave empty for all platforms."
-                  placeholder="e.g., linux/amd64, windows/amd64, darwin/arm64"
+                  onChange={(_event, newValue) => setPlatformFilterInput(newValue)}
+                  renderInput={(params) => (
+                    <TextField
+                      {...params}
+                      label="Platform Filter"
+                      placeholder={platformFilterInput.length === 0 ? 'All platforms' : ''}
+                      helperText="Select platforms to sync. Leave empty to sync all platforms."
+                    />
+                  )}
+                  renderTags={(value, getTagProps) =>
+                    value.map((option, index) => (
+                      <Chip
+                        label={option}
+                        size="small"
+                        {...getTagProps({ index })}
+                        key={option}
+                      />
+                    ))
+                  }
                 />
 
                 <TextField

--- a/frontend/src/pages/admin/TerraformMirrorPage.tsx
+++ b/frontend/src/pages/admin/TerraformMirrorPage.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { queryKeys } from '../../services/queryKeys'
 import {
+  Autocomplete,
   Alert,
   Box,
   Button,
@@ -32,6 +33,22 @@ import {
   Tooltip,
   Typography,
 } from '@mui/material'
+
+/** Known Terraform binary platform combinations (os/arch). */
+const KNOWN_PLATFORMS = [
+  'linux/amd64',
+  'linux/arm64',
+  'linux/386',
+  'linux/arm',
+  'darwin/amd64',
+  'darwin/arm64',
+  'windows/amd64',
+  'windows/386',
+  'windows/arm64',
+  'freebsd/amd64',
+  'freebsd/386',
+  'freebsd/arm',
+] as const
 import AddIcon from '@mui/icons-material/Add'
 import CheckCircleIcon from '@mui/icons-material/CheckCircle'
 import DeleteIcon from '@mui/icons-material/Delete'
@@ -385,13 +402,13 @@ const TerraformMirrorPage: React.FC = () => {
   const [createOpen, setCreateOpen] = useState(false)
   const [createForm, setCreateForm] = useState<CreateTerraformMirrorConfigRequest>(emptyCreate())
   const [createVersionFilter, setCreateVersionFilter] = useState('')
-  const [createPlatformFilter, setCreatePlatformFilter] = useState('')
+  const [createPlatformFilter, setCreatePlatformFilter] = useState<string[]>([])
 
   // ---- edit dialog ----
   const [editConfig, setEditConfig] = useState<TerraformMirrorConfig | null>(null)
   const [editForm, setEditForm] = useState<UpdateTerraformMirrorConfigRequest>({})
   const [editVersionFilter, setEditVersionFilter] = useState('')
-  const [editPlatformFilter, setEditPlatformFilter] = useState('')
+  const [editPlatformFilter, setEditPlatformFilter] = useState<string[]>([])
 
   // ---- delete dialog ----
   const [deleteConfig, setDeleteConfig] = useState<TerraformMirrorConfig | null>(null)
@@ -450,13 +467,9 @@ const TerraformMirrorPage: React.FC = () => {
   // ---------------------------------------------------------------------------
   const createMutation = useMutation({
     mutationFn: async () => {
-      const platformFilter = createPlatformFilter
-        .split(',')
-        .map((s) => s.trim())
-        .filter(Boolean)
       await api.createTerraformMirrorConfig({
         ...createForm,
-        platform_filter: platformFilter.length > 0 ? platformFilter : undefined,
+        platform_filter: createPlatformFilter.length > 0 ? createPlatformFilter : undefined,
         version_filter: createVersionFilter.trim() || undefined,
       })
     },
@@ -465,7 +478,7 @@ const TerraformMirrorPage: React.FC = () => {
       setCreateOpen(false)
       setCreateForm(emptyCreate())
       setCreateVersionFilter('')
-      setCreatePlatformFilter('')
+      setCreatePlatformFilter([])
       queryClient.invalidateQueries({ queryKey: queryKeys.terraformMirrors._def })
     },
     onError: (err: unknown) => {
@@ -483,7 +496,7 @@ const TerraformMirrorPage: React.FC = () => {
   const openEdit = (config: TerraformMirrorConfig) => {
     setEditConfig(config)
     setEditVersionFilter(config.version_filter ?? '')
-    setEditPlatformFilter(parsePlatformFilter(config.platform_filter).join(', '))
+    setEditPlatformFilter(parsePlatformFilter(config.platform_filter))
     setEditForm({
       name: config.name,
       description: config.description ?? '',
@@ -499,13 +512,9 @@ const TerraformMirrorPage: React.FC = () => {
   const editMutation = useMutation({
     mutationFn: async () => {
       if (!editConfig) throw new Error('No config to edit')
-      const platformFilter = editPlatformFilter
-        .split(',')
-        .map((s) => s.trim())
-        .filter(Boolean)
       await api.updateTerraformMirrorConfig(editConfig.id, {
         ...editForm,
-        platform_filter: platformFilter.length > 0 ? platformFilter : [],
+        platform_filter: editPlatformFilter.length > 0 ? editPlatformFilter : [],
         version_filter: editVersionFilter.trim() || '',
       })
     },
@@ -842,12 +851,30 @@ const TerraformMirrorPage: React.FC = () => {
                   helperText='Limit versions to sync: "1.9." (prefix), "latest:5", ">=1.5.0" (semver), "1.5.0,1.6.0" (list). Leave blank for all.'
                   fullWidth
                 />
-                <TextField
-                  label="Platform Filter"
+                <Autocomplete
+                  multiple
+                  options={KNOWN_PLATFORMS}
                   value={createPlatformFilter}
-                  onChange={(e) => setCreatePlatformFilter(e.target.value)}
-                  helperText='Comma-separated os/arch pairs, e.g. "linux/amd64, darwin/arm64, windows/amd64". Leave blank for all platforms.'
-                  fullWidth
+                  onChange={(_event, newValue) => setCreatePlatformFilter(newValue)}
+                  renderInput={(params) => (
+                    <TextField
+                      {...params}
+                      label="Platform Filter"
+                      placeholder={createPlatformFilter.length === 0 ? 'All platforms' : ''}
+                      helperText="Select platforms to sync. Leave empty to sync all platforms."
+                      fullWidth
+                    />
+                  )}
+                  renderTags={(value, getTagProps) =>
+                    value.map((option, index) => (
+                      <Chip
+                        label={option}
+                        size="small"
+                        {...getTagProps({ index })}
+                        key={option}
+                      />
+                    ))
+                  }
                 />
               </Box>
             </DialogContent>
@@ -978,12 +1005,30 @@ const TerraformMirrorPage: React.FC = () => {
                   helperText='Limit versions to sync: "1.9." (prefix), "latest:5", ">=1.5.0" (semver), "1.5.0,1.6.0" (list). Leave blank for all.'
                   fullWidth
                 />
-                <TextField
-                  label="Platform Filter"
+                <Autocomplete
+                  multiple
+                  options={KNOWN_PLATFORMS}
                   value={editPlatformFilter}
-                  onChange={(e) => setEditPlatformFilter(e.target.value)}
-                  helperText='Comma-separated os/arch pairs, e.g. "linux/amd64, darwin/arm64, windows/amd64". Leave blank for all platforms.'
-                  fullWidth
+                  onChange={(_event, newValue) => setEditPlatformFilter(newValue)}
+                  renderInput={(params) => (
+                    <TextField
+                      {...params}
+                      label="Platform Filter"
+                      placeholder={editPlatformFilter.length === 0 ? 'All platforms' : ''}
+                      helperText="Select platforms to sync. Leave empty to sync all platforms."
+                      fullWidth
+                    />
+                  )}
+                  renderTags={(value, getTagProps) =>
+                    value.map((option, index) => (
+                      <Chip
+                        label={option}
+                        size="small"
+                        {...getTagProps({ index })}
+                        key={option}
+                      />
+                    ))
+                  }
                 />
               </Box>
             </DialogContent>

--- a/frontend/src/pages/admin/TerraformMirrorPage.tsx
+++ b/frontend/src/pages/admin/TerraformMirrorPage.tsx
@@ -673,7 +673,7 @@ const TerraformMirrorPage: React.FC = () => {
                 onClick={() => {
                   setCreateForm(emptyCreate())
                   setCreateVersionFilter('')
-                  setCreatePlatformFilter('')
+                  setCreatePlatformFilter([])
                   setCreateOpen(true)
                 }}
               >

--- a/frontend/src/pages/admin/__tests__/MirrorsPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/MirrorsPage.test.tsx
@@ -260,7 +260,9 @@ describe('MirrorsPage', () => {
     expect(screen.getByLabelText('Namespace Filter')).toHaveValue('hashicorp')
     expect(screen.getByLabelText('Provider Filter')).toHaveValue('aws, google')
     expect(screen.getByLabelText('Version Filter')).toHaveValue('>=3.0.0')
-    expect(screen.getByLabelText('Platform Filter')).toHaveValue('linux/amd64, darwin/arm64')
+    // Platform filter is now a multi-select — check chips are rendered
+    expect(screen.getByText('linux/amd64')).toBeInTheDocument()
+    expect(screen.getByText('darwin/arm64')).toBeInTheDocument()
     expect(screen.getByText('Update')).toBeInTheDocument()
   })
 


### PR DESCRIPTION
The `platform_filter` field in both the Provider Mirror and Terraform Binary Mirror config dialogs used a plain `TextField` that expected users to type comma-separated `os/arch` pairs. Typos and unknown values were silently accepted with no validation feedback.

## Changes

- `MirrorsPage.tsx`: Replaced `platformFilterInput` `TextField` with `Autocomplete multiple` backed by `KNOWN_PLATFORMS` constant; state changed from `string` to `string[]`; `handleCreate`/`handleUpdate` now pass the array directly
- `TerraformMirrorPage.tsx`: Same change for `createPlatformFilter` / `editPlatformFilter`; `openEdit` now sets the array from `parsePlatformFilter()` directly without `.join(', ')`
- `MirrorsPage.test.tsx`: Updated edit-dialog test to assert chip presence instead of the old `.toHaveValue('linux/amd64, darwin/arm64')` assertion

### Supported platforms

`linux/amd64`, `linux/arm64`, `linux/386`, `linux/arm`, `darwin/amd64`, `darwin/arm64`, `windows/amd64`, `windows/386`, `windows/arm64`, `freebsd/amd64`, `freebsd/386`, `freebsd/arm`

Closes #250
