### PR TITLE
fix(users): use inline memberships from list response to eliminate N+1 requests

### DIFF
--- a/frontend/src/pages/admin/UsersPage.tsx
+++ b/frontend/src/pages/admin/UsersPage.tsx
@@ -123,18 +123,30 @@ const UsersPage: React.FC = () => {
   useEffect(() => {
     for (const user of rawUsers) {
       if (userMemberships[user.id] === undefined) {
-        setUserMemberships((prev) => ({ ...prev, [user.id]: { loading: true } }))
-        api
-          .getUserMemberships(user.id)
-          .then((memberships) => {
-            setUserMemberships((prev) => ({ ...prev, [user.id]: { memberships, loading: false } }))
-          })
-          .catch(() => {
-            setUserMemberships((prev) => ({
-              ...prev,
-              [user.id]: { memberships: [], loading: false },
-            }))
-          })
+        // If the list response already includes memberships inline, use them directly
+        // to avoid N+1 individual GET /api/v1/users/{id}/memberships requests.
+        if (user.memberships !== undefined) {
+          setUserMemberships((prev) => ({
+            ...prev,
+            [user.id]: { memberships: user.memberships, loading: false },
+          }))
+        } else {
+          setUserMemberships((prev) => ({ ...prev, [user.id]: { loading: true } }))
+          api
+            .getUserMemberships(user.id)
+            .then((memberships) => {
+              setUserMemberships((prev) => ({
+                ...prev,
+                [user.id]: { memberships, loading: false },
+              }))
+            })
+            .catch(() => {
+              setUserMemberships((prev) => ({
+                ...prev,
+                [user.id]: { memberships: [], loading: false },
+              }))
+            })
+        }
       }
     }
   }, [rawUsers]) // eslint-disable-line react-hooks/exhaustive-deps

--- a/frontend/src/pages/admin/__tests__/UsersPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/UsersPage.test.tsx
@@ -348,4 +348,26 @@ describe('UsersPage', () => {
       expect(listUsersMock).toHaveBeenCalledWith(1, 25)
     })
   })
+
+  it('uses inline memberships and skips individual getUserMemberships calls', async () => {
+    // When the list response already includes memberships on each user,
+    // the page must NOT fire individual GET /users/{id}/memberships requests.
+    const responseWithInlineMemberships = {
+      ...fakeUsersResponse,
+      users: fakeUsersResponse.users.map((u) => ({
+        ...u,
+        memberships: [fakeMembership],
+      })),
+    }
+    listUsersMock.mockResolvedValue(responseWithInlineMemberships)
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getAllByText(/Acme/).length).toBeGreaterThan(0)
+    })
+
+    // The individual membership fetches must not have been called
+    expect(getUserMembershipsMock).not.toHaveBeenCalled()
+  })
 })

--- a/frontend/src/services/__tests__/api.test.ts
+++ b/frontend/src/services/__tests__/api.test.ts
@@ -833,6 +833,35 @@ describe('ApiClient', () => {
       expect(result.email).toBe('a@b.com')
       expect(result.role_template_id).toBe('r1')
     })
+
+    it('listUsers passes through inline memberships on each user', async () => {
+      const client = await getApiClient()
+      const inlineMembership = {
+        organization_id: 'org-1',
+        organization_name: 'Acme',
+        role_template_name: 'admin',
+        created_at: '2025-01-01',
+      }
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: {
+            users: [
+              {
+                id: 'u1',
+                email: 'a@b.com',
+                name: 'A',
+                created_at: '2025-01-01',
+                updated_at: '2025-01-01',
+                memberships: [inlineMembership],
+              },
+            ],
+            pagination: { total: 1, page: 1, per_page: 20 },
+          },
+        })
+      const result = await client.listUsers(1, 20)
+      expect(result.users).toHaveLength(1)
+      expect(result.users[0].memberships).toHaveLength(1)
+      expect(result.users[0].memberships![0].organization_name).toBe('Acme')
+    })
   })
 
   // ─── Organizations ────────────────────────────────────────────────────────

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -465,6 +465,9 @@ class ApiClient {
         user.role_template_display_name) as string | undefined,
       created_at: (user.CreatedAt || user.created_at) as string,
       updated_at: (user.UpdatedAt || user.updated_at) as string,
+      memberships: (user.memberships || user.Memberships) as
+        | import('../types').UserMembership[]
+        | undefined,
     }
   }
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -8,6 +8,7 @@ export interface User {
   oidc_sub?: string
   created_at: string
   updated_at: string
+  memberships?: UserMembership[] // Included inline when fetched via list/search endpoints
 }
 
 export type { RoleTemplate } from './rbac'


### PR DESCRIPTION
## Summary

Eliminates the N+1 API request pattern on the admin Users page that caused 429 rate-limit errors and inconsistent org/role display.

Companion backend PR: sethbacon/terraform-registry-backend#325

## Problem

The admin Users page rendered users correctly but had to call `GET /api/v1/users/{id}/memberships` individually for each user after the list loaded. With 8-20 users per page, all requests fired simultaneously, exhausting the rate-limiter burst (10 tokens) and returning 429 for users lower in the list. Those users would display "No organisations" until the page was refreshed.

## What changed

### `src/types/index.ts`
- Added `memberships?: UserMembership[]` to the `User` interface.

### `src/services/api.ts`
- Updated `transformUser` to include `memberships`/`Memberships` from the server response.

### `src/pages/admin/UsersPage.tsx`
- Updated the `useEffect` that loads per-user memberships: when a user already has an inline `memberships` array (served by the updated backend), it is used directly without an extra API call. Falls back to `getUserMemberships()` when the field is absent for backward compatibility.

### Tests
- Added regression test in `UsersPage.test.tsx`: page renders org chips and does **not** call `getUserMemberships` when inline memberships are present (21 tests total, all pass).
- Added test in `api.test.ts`: `listUsers` passes through inline memberships on each user (184 tests total, all pass).

## How tested

`npx vitest run src/pages/admin/__tests__/UsersPage.test.tsx src/services/__tests__/api.test.ts` -- all pass
`npx tsc --noEmit` -- clean

## Related

Closes #259
Backend: sethbacon/terraform-registry-backend#325