### PR TITLE
feat: add scan status filtering with pagination and namespace editing

### DIFF
--- a/frontend/src/hooks/useModuleDetail.ts
+++ b/frontend/src/hooks/useModuleDetail.ts
@@ -472,6 +472,23 @@ export function useModuleDetail() {
     updateDescriptionMutation.mutate(newDescription)
   }
 
+  const updateNamespaceMutation = useMutation({
+    mutationFn: (newNamespace: string) => api.updateModule(module!.id, { namespace: newNamespace }),
+    onSuccess: (_data, newNamespace) => {
+      // Navigate to the new namespace URL since it has changed
+      navigate(`/modules/${newNamespace}/${name}/${system}`)
+      queryClient.invalidateQueries({ queryKey: queryKeys.modules.detail(newNamespace, name ?? '', system ?? '') })
+    },
+    onError: (err: unknown) => {
+      setError(getErrorMessage(err, 'Failed to update namespace'))
+    },
+  })
+
+  const handleUpdateNamespace = (newNamespace: string) => {
+    if (!module?.id) return
+    updateNamespaceMutation.mutate(newNamespace)
+  }
+
   const handleDeprecateModule = () => {
     if (!namespace || !name || !system) return
     deprecateModuleMutation.mutate({
@@ -580,6 +597,7 @@ export function useModuleDetail() {
     handleDeprecateModule,
     handleUndeprecateModule,
     handleUpdateDescription,
+    handleUpdateNamespace,
     getTerraformExample,
   }
 }

--- a/frontend/src/pages/ModuleDetailPage.tsx
+++ b/frontend/src/pages/ModuleDetailPage.tsx
@@ -115,8 +115,12 @@ const ModuleDetailPage: React.FC = () => {
     handleDeprecateModule,
     handleUndeprecateModule,
     handleUpdateDescription,
+    handleUpdateNamespace,
     ociEnabled,
   } = useModuleDetail()
+
+  const [editingNamespace, setEditingNamespace] = React.useState(false)
+  const [editNamespace, setEditNamespace] = React.useState('')
 
   return (
     <Box aria-busy={loading} aria-live="polite">
@@ -323,9 +327,69 @@ const ModuleDetailPage: React.FC = () => {
                 </Typography>
                 <Divider sx={{ mb: 2 }} />
                 <Box sx={{ '& > *': { mb: 1 } }}>
-                  <Typography variant="body2">
-                    <strong>Namespace:</strong> {namespace}
-                  </Typography>
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                    <Typography variant="body2">
+                      <strong>Namespace:</strong>
+                    </Typography>
+                    {editingNamespace ? (
+                      <>
+                        <TextField
+                          size="small"
+                          value={editNamespace}
+                          onChange={(e) => setEditNamespace(e.target.value)}
+                          placeholder="Namespace"
+                          autoFocus
+                          sx={{ ml: 0.5, flex: 1 }}
+                          onKeyDown={(e) => {
+                            if (e.key === 'Enter' && editNamespace.trim()) {
+                              handleUpdateNamespace(editNamespace.trim())
+                              setEditingNamespace(false)
+                            } else if (e.key === 'Escape') {
+                              setEditingNamespace(false)
+                            }
+                          }}
+                        />
+                        <IconButton
+                          size="small"
+                          color="primary"
+                          onClick={() => {
+                            if (editNamespace.trim()) {
+                              handleUpdateNamespace(editNamespace.trim())
+                              setEditingNamespace(false)
+                            }
+                          }}
+                          aria-label="Save namespace"
+                        >
+                          <Check fontSize="small" />
+                        </IconButton>
+                        <IconButton
+                          size="small"
+                          onClick={() => setEditingNamespace(false)}
+                          aria-label="Cancel editing namespace"
+                        >
+                          <Close fontSize="small" />
+                        </IconButton>
+                      </>
+                    ) : (
+                      <>
+                        <Typography variant="body2">{namespace}</Typography>
+                        {canManage && (
+                          <Tooltip title="Edit namespace">
+                            <IconButton
+                              size="small"
+                              onClick={() => {
+                                setEditNamespace(namespace || '')
+                                setEditingNamespace(true)
+                              }}
+                              aria-label="Edit namespace"
+                            >
+                              <EditIcon fontSize="small" />
+                            </IconButton>
+                          </Tooltip>
+                        )}
+                      </>
+                    )}
+                  </Box>
                   <Typography variant="body2">
                     <strong>Name:</strong> {name}
                   </Typography>

--- a/frontend/src/pages/admin/SecurityScanningPage.tsx
+++ b/frontend/src/pages/admin/SecurityScanningPage.tsx
@@ -19,6 +19,7 @@ import {
   Grid,
   IconButton,
   Collapse,
+  TablePagination,
 } from '@mui/material'
 import CheckCircle from '@mui/icons-material/CheckCircle'
 import Error from '@mui/icons-material/Error'
@@ -98,13 +99,22 @@ const SecurityScanningPage: React.FC = () => {
     queryFn: () => api.getScanningConfig(),
   })
 
+  const [statusFilter, setStatusFilter] = useState<string | undefined>(undefined)
+  const [page, setPage] = useState(0)
+  const [rowsPerPage, setRowsPerPage] = useState(20)
+
   const {
     data: stats,
     isLoading: statsLoading,
     error: statsError,
   } = useQuery({
-    queryKey: ['scanning', 'stats'],
-    queryFn: () => api.getScanningStats(),
+    queryKey: ['scanning', 'stats', statusFilter, page, rowsPerPage],
+    queryFn: () =>
+      api.getScanningStats({
+        status: statusFilter,
+        limit: rowsPerPage,
+        offset: page * rowsPerPage,
+      }),
   })
 
   const [expandedScanId, setExpandedScanId] = useState<string | null>(null)
@@ -277,17 +287,46 @@ const SecurityScanningPage: React.FC = () => {
                   label: 'Total Scans',
                   value: stats.total,
                   icon: <CheckCircle fontSize="small" />,
+                  filterValue: undefined as string | undefined,
                 },
                 {
                   label: 'Pending',
                   value: stats.pending,
                   icon: <HourglassEmpty fontSize="small" />,
+                  filterValue: 'pending',
                 },
-                { label: 'Clean', value: stats.clean, color: 'success.main' },
-                { label: 'Findings', value: stats.findings, color: 'warning.main' },
-                { label: 'Errors', value: stats.error, color: 'error.main' },
+                { label: 'Clean', value: stats.clean, color: 'success.main', filterValue: 'clean' },
+                {
+                  label: 'Findings',
+                  value: stats.findings,
+                  color: 'warning.main',
+                  filterValue: 'findings',
+                },
+                { label: 'Errors', value: stats.error, color: 'error.main', filterValue: 'error' },
               ].map((item) => (
-                <Paper key={item.label} sx={{ px: 2, py: 1.5, flex: 1, minWidth: 120 }}>
+                <Paper
+                  key={item.label}
+                  sx={{
+                    px: 2,
+                    py: 1.5,
+                    flex: 1,
+                    minWidth: 120,
+                    cursor: 'pointer',
+                    outline:
+                      statusFilter === item.filterValue
+                        ? '2px solid'
+                        : statusFilter === undefined && item.filterValue === undefined
+                          ? '2px solid'
+                          : 'none',
+                    outlineColor: 'primary.main',
+                    '&:hover': { bgcolor: 'action.hover' },
+                  }}
+                  onClick={() => {
+                    setStatusFilter(item.filterValue)
+                    setPage(0)
+                  }}
+                  data-testid={`stat-card-${item.label.toLowerCase().replace(/\s/g, '-')}`}
+                >
                   <Typography variant="caption" color="text.secondary">
                     {item.label}
                   </Typography>
@@ -374,7 +413,8 @@ const SecurityScanningPage: React.FC = () => {
                 No scans recorded yet.
               </Typography>
             ) : (
-              <TableContainer>
+              <>
+                <TableContainer>
                 <Table size="small">
                   <TableHead>
                     <TableRow>
@@ -465,6 +505,19 @@ const SecurityScanningPage: React.FC = () => {
                   </TableBody>
                 </Table>
               </TableContainer>
+              <TablePagination
+                component="div"
+                count={stats.total_filtered}
+                page={page}
+                onPageChange={(_, newPage) => setPage(newPage)}
+                rowsPerPage={rowsPerPage}
+                onRowsPerPageChange={(e) => {
+                  setRowsPerPage(parseInt(e.target.value, 10))
+                  setPage(0)
+                }}
+                rowsPerPageOptions={[10, 20, 50, 100]}
+              />
+              </>
             )}
           </Paper>
         </>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -824,7 +824,7 @@ class ApiClient {
     return response.data
   }
 
-  async updateModule(id: string, data: { description?: string; source?: string }) {
+  async updateModule(id: string, data: { description?: string; source?: string; namespace?: string }) {
     const response = await this.client.put(`/api/v1/admin/modules/${id}`, data)
     return response.data
   }
@@ -846,8 +846,12 @@ class ApiClient {
     return response.data
   }
 
-  async getScanningStats(): Promise<import('../types').ScanningStats> {
-    const response = await this.client.get('/api/v1/admin/scanning/stats')
+  async getScanningStats(params?: {
+    status?: string
+    limit?: number
+    offset?: number
+  }): Promise<import('../types').ScanningStats> {
+    const response = await this.client.get('/api/v1/admin/scanning/stats', { params })
     return response.data
   }
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -607,6 +607,7 @@ export interface ScanningStats {
   findings: number
   error: number
   recent_scans: RecentScanEntry[]
+  total_filtered: number
 }
 
 // ---- Scan findings (parsed from raw_results) ----


### PR DESCRIPTION
## Summary

Two feature additions addressing issues #269 and #270:

### Security Scanning Page (#269)
- Clickable stat cards - clicking Findings, Errors, Pending, etc. filters the Recent Scans table by that status
- Pagination - the table now shows 20 results by default with page controls (10/20/50/100 rows per page)
- Visual filter indicator - the active stat card is highlighted with an outline
- API service updated to pass status, limit, offset query params to the backend

### Module Detail Page (#270)
- Editable namespace - admins can click the edit icon next to the namespace field in the Module Information sidebar
- Inline edit control with save/cancel (Enter/Escape keyboard shortcuts)
- After saving, navigates to the new module URL at the updated namespace
- API service updated to include namespace in the update payload

## Backend Dependencies

Requires backend v1.1.1 with:
- sethbacon/terraform-registry-backend#340 (scan filtering)
- sethbacon/terraform-registry-backend#341 (namespace update)

Closes #269
Closes #270