### PR TITLE
fix(ci): drop swagger-gap allowlist entries; bump pinned backend to v1.1.3

### DIFF
--- a/deployments/docker-compose.contract-check.yml
+++ b/deployments/docker-compose.contract-check.yml
@@ -20,7 +20,7 @@ services:
     # Pinned backend image. Bump this tag in lockstep with backend releases
     # whose API surface the frontend wants to depend on. The contract check
     # validates that every route api.ts calls exists on this exact backend.
-    image: ${BACKEND_IMAGE:-ghcr.io/sethbacon/terraform-registry-backend:1.1.2}
+    image: ${BACKEND_IMAGE:-ghcr.io/sethbacon/terraform-registry-backend:1.1.3}
     environment:
       - TFR_DATABASE_HOST=postgres
       - TFR_DATABASE_PORT=5432

--- a/frontend/scripts/contract-check.allowlist.json
+++ b/frontend/scripts/contract-check.allowlist.json
@@ -17,21 +17,6 @@
       "reason": "https://github.com/sethbacon/terraform-registry-frontend/issues/277 — frontend calls a backend route that does not exist; resolve by either implementing on the backend or removing the frontend caller."
     },
     {
-      "method": "POST",
-      "path": "/api/v1/modules",
-      "reason": "https://github.com/sethbacon/terraform-registry-backend/issues/343 — route exists on backend (router.go:780) but is missing its @Router swagger annotation. Remove this entry once the backend ships the annotation."
-    },
-    {
-      "method": "POST",
-      "path": "/api/v1/providers",
-      "reason": "https://github.com/sethbacon/terraform-registry-backend/issues/343 — route exists on backend (router.go:786) but is missing its @Router swagger annotation. Remove this entry once the backend ships the annotation."
-    },
-    {
-      "method": "GET",
-      "path": "/api/v1/modules/{}/{}/{}/versions/{}/docs",
-      "reason": "https://github.com/sethbacon/terraform-registry-backend/issues/343 — route exists on backend (router.go:749) but swagger documents it under the wrong path (without /versions/). Remove this entry once swagger is corrected."
-    },
-    {
       "method": "GET",
       "path": "/api/v1/dev/status",
       "reason": "Backend route is registered conditionally under DEV_MODE=true and is intentionally undocumented in production swagger. Permanent allowlist entry."


### PR DESCRIPTION
## Summary

Backend [v1.1.3](https://github.com/sethbacon/terraform-registry-backend/releases/tag/v1.1.3) shipped [terraform-registry-backend#348](https://github.com/sethbacon/terraform-registry-backend/pull/348) which fixed the four `@Router` annotations the contract check was working around. The corresponding allowlist entries are now obsolete.

## Changes

- `deployments/docker-compose.contract-check.yml`: bump pinned backend image from `1.1.2` to `1.1.3`.
- `frontend/scripts/contract-check.allowlist.json`: remove 3 entries that pointed at [terraform-registry-backend#343](https://github.com/sethbacon/terraform-registry-backend/issues/343):
  - `POST /api/v1/modules`
  - `POST /api/v1/providers`
  - `GET /api/v1/modules/{}/{}/{}/versions/{}/docs`

## Allowlist after this change: 7 entries

| Method | Path | Reason |
|---|---|---|
| `GET` | `/api/v1/admin/quotas` | [#276](https://github.com/sethbacon/terraform-registry-frontend/issues/276) — frontend calls a backend route that does not exist |
| `GET` | `/api/v1/ui/theme` | [#277](https://github.com/sethbacon/terraform-registry-frontend/issues/277) — frontend calls a backend route that does not exist |
| `PUT` | `/api/v1/admin/ui-theme` | [#277](https://github.com/sethbacon/terraform-registry-frontend/issues/277) — same |
| `GET` | `/api/v1/dev/status` | DEV_MODE-only, intentionally undocumented (permanent) |
| `POST` | `/api/v1/dev/login` | DEV_MODE-only (permanent) |
| `GET` | `/api/v1/dev/users` | DEV_MODE-only (permanent) |
| `POST` | `/api/v1/dev/impersonate/{}` | DEV_MODE-only (permanent) |

## Verified locally

```
$ docker compose -f deployments/docker-compose.contract-check.yml up -d
$ BACKEND_URL=http://localhost:8080 npx tsx scripts/contract-check.ts
==> Extracting frontend API calls from frontend\src\services\api.ts
    Found 162 call sites
==> Fetching swagger from http://localhost:8080/swagger.json
    Backend has 196 (method, path) tuples
    Allowlist has 7 entries (see contract-check.allowlist.json)
  Skipped (allowlist): 7
    [...]
OK: every frontend route exists on backend (or is on the allowlist).
```

## Test plan

- [x] Contract check passes locally against `ghcr.io/sethbacon/terraform-registry-backend:1.1.3` with the trimmed allowlist.
- [ ] CI green.
