### PR TITLE
feat(admin): UI for GDPR user data export and erasure

### DIFF
--- a/e2e/tests/admin.spec.ts
+++ b/e2e/tests/admin.spec.ts
@@ -43,6 +43,69 @@ test.describe('Admin: Users', () => {
     const actionBtns = page.locator('[class*="MuiButton"], [class*="MuiIconButton"]');
     expect(await actionBtns.count()).toBeGreaterThan(0);
   });
+
+  test('admin sees GDPR export and erase action buttons per user', async ({
+    loggedInPage: page,
+  }) => {
+    await page.goto('/admin/users');
+    await page.waitForSelector('table, h6:has-text("No users")', { timeout: 10_000 });
+
+    // If empty state, skip the assertion — there's nothing to act on.
+    const hasUsers = await page.locator('table tbody tr').count();
+    if (hasUsers === 0) {
+      test.skip(true, 'No users present to test GDPR action buttons');
+      return;
+    }
+
+    // Each row should expose Export and Erase buttons in addition to Edit/Delete.
+    await expect(page.getByLabel('Export user data').first()).toBeVisible();
+    await expect(page.getByLabel('Erase user data').first()).toBeVisible();
+  });
+
+  test('clicking Export user data triggers a JSON file download', async ({
+    loggedInPage: page,
+  }) => {
+    await page.goto('/admin/users');
+    await page.waitForSelector('table, h6:has-text("No users")', { timeout: 10_000 });
+
+    const hasUsers = await page.locator('table tbody tr').count();
+    if (hasUsers === 0) {
+      test.skip(true, 'No users present to export');
+      return;
+    }
+
+    // Listen for the download event before clicking.
+    const downloadPromise = page.waitForEvent('download', { timeout: 15_000 });
+    await page.getByLabel('Export user data').first().click();
+    const download = await downloadPromise;
+
+    // Filename pattern: user-data-{uuid}.json (set by backend Content-Disposition).
+    expect(download.suggestedFilename()).toMatch(/user-data-.+\.json$/);
+  });
+
+  test('Erase confirmation requires typing the user email', async ({ loggedInPage: page }) => {
+    await page.goto('/admin/users');
+    await page.waitForSelector('table, h6:has-text("No users")', { timeout: 10_000 });
+
+    const hasUsers = await page.locator('table tbody tr').count();
+    if (hasUsers === 0) {
+      test.skip(true, 'No users present to test erase dialog');
+      return;
+    }
+
+    await page.getByLabel('Erase user data').first().click();
+
+    // Dialog opens with the GDPR Article 17 heading.
+    await expect(page.getByText(/Erase user data \(GDPR Article 17\)/i)).toBeVisible();
+
+    // Erase button should start disabled.
+    const eraseBtn = page.getByRole('button', { name: /^Erase$/ });
+    await expect(eraseBtn).toBeDisabled();
+
+    // Cancel without erasing.
+    await page.getByRole('button', { name: 'Cancel' }).click();
+    await expect(page.getByText(/Erase user data \(GDPR Article 17\)/i)).toBeHidden();
+  });
 });
 
 test.describe('Admin: Organizations', () => {

--- a/frontend/src/pages/admin/UsersPage.tsx
+++ b/frontend/src/pages/admin/UsersPage.tsx
@@ -38,8 +38,11 @@ import AddIcon from '@mui/icons-material/Add'
 import SearchIcon from '@mui/icons-material/Search'
 import BusinessIcon from '@mui/icons-material/Business'
 import PersonIcon from '@mui/icons-material/Person'
+import DownloadIcon from '@mui/icons-material/Download'
+import PrivacyTipIcon from '@mui/icons-material/PrivacyTip'
 import EmptyState from '../../components/EmptyState'
 import api from '../../services/api'
+import { useAuth } from '../../contexts/AuthContext'
 import { User, UserMembership, Organization } from '../../types'
 import { RoleTemplate } from '../../types/rbac'
 import { getErrorMessage } from '../../utils/errors'
@@ -52,10 +55,19 @@ interface UserWithMemberships extends User {
 
 const UsersPage: React.FC = () => {
   const queryClient = useQueryClient()
+  const { allowedScopes } = useAuth()
+  const isAdmin = allowedScopes.includes('admin')
   const [error, setError] = useState<string | null>(null)
+  const [info, setInfo] = useState<string | null>(null)
   const [searchQuery, setSearchQuery] = useState('')
   const [page, setPage] = useState(0)
   const [rowsPerPage, setRowsPerPage] = useState(10)
+
+  // GDPR action state
+  const [exportingUserId, setExportingUserId] = useState<string | null>(null)
+  const [eraseDialogOpen, setEraseDialogOpen] = useState(false)
+  const [userToErase, setUserToErase] = useState<User | null>(null)
+  const [eraseConfirmText, setEraseConfirmText] = useState('')
 
   // Local memberships state (per-user enrichment)
   const [userMemberships, setUserMemberships] = useState<
@@ -254,6 +266,59 @@ const UsersPage: React.FC = () => {
     },
   })
 
+  // GDPR Article 17 — anonymize user PII while preserving the audit trail.
+  const eraseUserMutation = useMutation({
+    mutationFn: (id: string) => api.eraseUser(id),
+    onSuccess: (data) => {
+      setEraseDialogOpen(false)
+      setUserToErase(null)
+      setEraseConfirmText('')
+      setError(null)
+      setInfo(data.message || 'User data erased.')
+      setUserMemberships({})
+      queryClient.invalidateQueries({ queryKey: queryKeys.users._def })
+    },
+    onError: (err: unknown) => {
+      setError(getErrorMessage(err, 'Failed to erase user data. Please try again.'))
+    },
+  })
+
+  // GDPR Articles 15/20 — full data export. Triggers a browser download
+  // by creating a temporary blob URL; cleaned up after the click is dispatched.
+  const handleExportClick = async (user: User) => {
+    setError(null)
+    setInfo(null)
+    setExportingUserId(user.id)
+    try {
+      const { blob, filename } = await api.exportUserData(user.id)
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = filename
+      document.body.appendChild(a)
+      a.click()
+      document.body.removeChild(a)
+      URL.revokeObjectURL(url)
+      setInfo(`Exported user data for ${user.email}.`)
+    } catch (err) {
+      setError(getErrorMessage(err, 'Failed to export user data.'))
+    } finally {
+      setExportingUserId(null)
+    }
+  }
+
+  const handleEraseClick = (user: User) => {
+    setUserToErase(user)
+    setEraseConfirmText('')
+    setEraseDialogOpen(true)
+  }
+
+  const handleEraseConfirm = () => {
+    if (!userToErase) return
+    if (eraseConfirmText !== userToErase.email) return
+    eraseUserMutation.mutate(userToErase.id)
+  }
+
   const handleSaveUser = () => {
     setError(null)
     saveUserMutation.mutate()
@@ -381,6 +446,12 @@ const UsersPage: React.FC = () => {
         </Alert>
       )}
 
+      {info && (
+        <Alert severity="success" sx={{ mb: 3 }} onClose={() => setInfo(null)}>
+          {info}
+        </Alert>
+      )}
+
       {/* Search Bar */}
       <TextField
         fullWidth
@@ -473,6 +544,36 @@ const UsersPage: React.FC = () => {
                       >
                         <EditIcon />
                       </IconButton>
+                      {isAdmin && (
+                        <>
+                          <Tooltip title="Export user data (GDPR Article 15/20)">
+                            <span>
+                              <IconButton
+                                size="small"
+                                aria-label="Export user data"
+                                onClick={() => handleExportClick(user)}
+                                disabled={exportingUserId === user.id}
+                              >
+                                {exportingUserId === user.id ? (
+                                  <CircularProgress size={20} />
+                                ) : (
+                                  <DownloadIcon />
+                                )}
+                              </IconButton>
+                            </span>
+                          </Tooltip>
+                          <Tooltip title="Erase user data (GDPR Article 17)">
+                            <IconButton
+                              size="small"
+                              aria-label="Erase user data"
+                              onClick={() => handleEraseClick(user)}
+                              color="warning"
+                            >
+                              <PrivacyTipIcon />
+                            </IconButton>
+                          </Tooltip>
+                        </>
+                      )}
                       <IconButton
                         size="small"
                         aria-label="Delete user"
@@ -670,6 +771,66 @@ const UsersPage: React.FC = () => {
           <Button onClick={() => setDeleteDialogOpen(false)}>Cancel</Button>
           <Button onClick={handleDeleteConfirm} color="error" variant="contained">
             Delete
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* GDPR Erase Confirmation Dialog */}
+      <Dialog
+        open={eraseDialogOpen}
+        onClose={() => {
+          if (!eraseUserMutation.isPending) {
+            setEraseDialogOpen(false)
+            setEraseConfirmText('')
+          }
+        }}
+        maxWidth="sm"
+        fullWidth
+      >
+        <DialogTitle>Erase user data (GDPR Article 17)</DialogTitle>
+        <DialogContent>
+          <Stack spacing={2} sx={{ mt: 1 }}>
+            <Alert severity="warning">
+              This permanently anonymizes <strong>{userToErase?.email}</strong>'s personal data.
+              The user record is tombstoned, API keys and organization memberships are deleted,
+              and all sessions are revoked. Audit log entries are preserved with anonymized
+              identifiers. <strong>This action cannot be undone.</strong>
+            </Alert>
+            <Typography variant="body2">
+              To confirm, type the user's email address (
+              <code>{userToErase?.email}</code>) below.
+            </Typography>
+            <TextField
+              autoFocus
+              fullWidth
+              size="small"
+              value={eraseConfirmText}
+              onChange={(e) => setEraseConfirmText(e.target.value)}
+              placeholder={userToErase?.email}
+              disabled={eraseUserMutation.isPending}
+              inputProps={{ 'aria-label': 'Confirm erasure by typing the user email' }}
+            />
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            onClick={() => {
+              setEraseDialogOpen(false)
+              setEraseConfirmText('')
+            }}
+            disabled={eraseUserMutation.isPending}
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={handleEraseConfirm}
+            color="error"
+            variant="contained"
+            disabled={
+              eraseUserMutation.isPending || eraseConfirmText !== (userToErase?.email ?? '')
+            }
+          >
+            {eraseUserMutation.isPending ? <CircularProgress size={20} /> : 'Erase'}
           </Button>
         </DialogActions>
       </Dialog>

--- a/frontend/src/pages/admin/__tests__/UsersPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/UsersPage.test.tsx
@@ -17,6 +17,8 @@ const deleteUserMock = vi.fn()
 const addOrganizationMemberMock = vi.fn()
 const updateOrganizationMemberMock = vi.fn()
 const removeOrganizationMemberMock = vi.fn()
+const exportUserDataMock = vi.fn()
+const eraseUserMock = vi.fn()
 
 vi.mock('../../../services/api', () => ({
   default: {
@@ -31,7 +33,20 @@ vi.mock('../../../services/api', () => ({
     addOrganizationMember: (...args: unknown[]) => addOrganizationMemberMock(...args),
     updateOrganizationMember: (...args: unknown[]) => updateOrganizationMemberMock(...args),
     removeOrganizationMember: (...args: unknown[]) => removeOrganizationMemberMock(...args),
+    exportUserData: (...args: unknown[]) => exportUserDataMock(...args),
+    eraseUser: (...args: unknown[]) => eraseUserMock(...args),
   },
+}))
+
+// Default to admin scope so existing tests pass; individual tests can override.
+const useAuthMock = vi.fn(() => ({
+  allowedScopes: ['admin'],
+  roleTemplate: { display_name: 'Administrator' },
+  user: { id: 'user-1' },
+}))
+
+vi.mock('../../../contexts/AuthContext', () => ({
+  useAuth: () => useAuthMock(),
 }))
 
 import UsersPage from '../../admin/UsersPage'
@@ -369,5 +384,165 @@ describe('UsersPage', () => {
 
     // The individual membership fetches must not have been called
     expect(getUserMembershipsMock).not.toHaveBeenCalled()
+  })
+
+  // ---- GDPR actions (admin-scoped) ----
+
+  describe('GDPR actions', () => {
+    beforeEach(() => {
+      // Reset to admin for this group; individual tests can override.
+      useAuthMock.mockReturnValue({
+        allowedScopes: ['admin'],
+        roleTemplate: { display_name: 'Administrator' },
+        user: { id: 'user-1' },
+      })
+      listUsersMock.mockResolvedValue(fakeUsersResponse)
+      getUserMembershipsMock.mockResolvedValue([])
+    })
+
+    it('shows export and erase buttons for admin users', async () => {
+      renderPage()
+      await waitFor(() => screen.getByText('alice@example.com'))
+
+      // Two users x two GDPR buttons each = 4 admin-only icon buttons.
+      expect(screen.getAllByLabelText('Export user data')).toHaveLength(2)
+      expect(screen.getAllByLabelText('Erase user data')).toHaveLength(2)
+    })
+
+    it('hides GDPR buttons for non-admin users', async () => {
+      useAuthMock.mockReturnValue({
+        allowedScopes: ['users:read', 'users:write'],
+        roleTemplate: { display_name: 'User Manager' },
+        user: { id: 'user-1' },
+      })
+      renderPage()
+      await waitFor(() => screen.getByText('alice@example.com'))
+
+      expect(screen.queryByLabelText('Export user data')).not.toBeInTheDocument()
+      expect(screen.queryByLabelText('Erase user data')).not.toBeInTheDocument()
+      // Edit is still available to non-admins (it's the existing behavior).
+      expect(screen.getAllByLabelText('Edit user').length).toBeGreaterThan(0)
+    })
+
+    it('triggers a browser download when export succeeds', async () => {
+      const blob = new Blob(['{"user":"data"}'], { type: 'application/json' })
+      exportUserDataMock.mockResolvedValue({ blob, filename: 'user-data-u1.json' })
+
+      // Stub URL APIs that JSDOM doesn't implement.
+      const createURL = vi.fn(() => 'blob:mock-url')
+      const revokeURL = vi.fn()
+      const origCreate = (URL as unknown as { createObjectURL?: typeof createURL }).createObjectURL
+      const origRevoke = (URL as unknown as { revokeObjectURL?: typeof revokeURL }).revokeObjectURL
+      ;(URL as unknown as { createObjectURL: typeof createURL }).createObjectURL = createURL
+      ;(URL as unknown as { revokeObjectURL: typeof revokeURL }).revokeObjectURL = revokeURL
+
+      try {
+        renderPage()
+        await waitFor(() => screen.getByText('alice@example.com'))
+
+        const exportButtons = screen.getAllByLabelText('Export user data')
+        fireEvent.click(exportButtons[0])
+
+        await waitFor(() => expect(exportUserDataMock).toHaveBeenCalledWith('u1'))
+        expect(createURL).toHaveBeenCalledWith(blob)
+        expect(revokeURL).toHaveBeenCalledWith('blob:mock-url')
+        await waitFor(() =>
+          expect(screen.getByText(/Exported user data for alice@example\.com/)).toBeInTheDocument(),
+        )
+      } finally {
+        if (origCreate) {
+          ;(URL as unknown as { createObjectURL: typeof origCreate }).createObjectURL = origCreate
+        }
+        if (origRevoke) {
+          ;(URL as unknown as { revokeObjectURL: typeof origRevoke }).revokeObjectURL = origRevoke
+        }
+      }
+    })
+
+    it('shows an error alert when export fails', async () => {
+      exportUserDataMock.mockRejectedValue(new Error('export blew up'))
+
+      renderPage()
+      await waitFor(() => screen.getByText('alice@example.com'))
+
+      const exportButtons = screen.getAllByLabelText('Export user data')
+      fireEvent.click(exportButtons[0])
+
+      await waitFor(() =>
+        expect(screen.getByText(/export blew up/)).toBeInTheDocument(),
+      )
+    })
+
+    it('opens the erase confirmation dialog and requires email match', async () => {
+      const user = userEvent.setup()
+      renderPage()
+      await waitFor(() => screen.getByText('alice@example.com'))
+
+      const eraseButtons = screen.getAllByLabelText('Erase user data')
+      fireEvent.click(eraseButtons[0])
+
+      // Dialog should be open with destructive copy referencing the email.
+      await waitFor(() =>
+        expect(screen.getByText(/permanently anonymizes/i)).toBeInTheDocument(),
+      )
+
+      // Erase button starts disabled because confirm text is empty.
+      const confirm = screen.getByRole('button', { name: /^Erase$/ })
+      expect(confirm).toBeDisabled()
+
+      // Wrong email keeps it disabled.
+      const input = screen.getByLabelText('Confirm erasure by typing the user email')
+      await user.type(input, 'wrong@example.com')
+      expect(confirm).toBeDisabled()
+
+      // Correct email enables it.
+      await user.clear(input)
+      await user.type(input, 'alice@example.com')
+      expect(confirm).not.toBeDisabled()
+    })
+
+    it('calls eraseUser and shows success when confirmed', async () => {
+      const user = userEvent.setup()
+      eraseUserMock.mockResolvedValue({
+        message: 'User data has been erased.',
+        user_id: 'u1',
+      })
+
+      renderPage()
+      await waitFor(() => screen.getByText('alice@example.com'))
+
+      const eraseButtons = screen.getAllByLabelText('Erase user data')
+      fireEvent.click(eraseButtons[0])
+
+      const input = await screen.findByLabelText('Confirm erasure by typing the user email')
+      await user.type(input, 'alice@example.com')
+
+      fireEvent.click(screen.getByRole('button', { name: /^Erase$/ }))
+
+      await waitFor(() => expect(eraseUserMock).toHaveBeenCalledWith('u1'))
+      await waitFor(() =>
+        expect(screen.getByText(/User data has been erased/)).toBeInTheDocument(),
+      )
+    })
+
+    it('surfaces backend error when erase fails', async () => {
+      const user = userEvent.setup()
+      eraseUserMock.mockRejectedValue(new Error('erase blew up'))
+
+      renderPage()
+      await waitFor(() => screen.getByText('alice@example.com'))
+
+      const eraseButtons = screen.getAllByLabelText('Erase user data')
+      fireEvent.click(eraseButtons[0])
+
+      const input = await screen.findByLabelText('Confirm erasure by typing the user email')
+      await user.type(input, 'alice@example.com')
+
+      fireEvent.click(screen.getByRole('button', { name: /^Erase$/ }))
+
+      await waitFor(() =>
+        expect(screen.getByText(/erase blew up/)).toBeInTheDocument(),
+      )
+    })
   })
 })

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -514,6 +514,33 @@ class ApiClient {
     return response.data
   }
 
+  // GDPR Article 15/20 — full data export.
+  // Returns the response Blob directly so the caller can let the browser
+  // download it via Content-Disposition. Do not parse as JSON: the backend
+  // sets `Content-Disposition: attachment; filename=user-data-{id}.json`
+  // and we want that filename hint to flow to the browser.
+  async exportUserData(id: string): Promise<{ blob: Blob; filename: string }> {
+    const response = await this.client.get(`/api/v1/admin/users/${id}/export`, {
+      responseType: 'blob',
+    })
+    // Default to user-data-{id}.json; override if the server provided a Content-Disposition.
+    let filename = `user-data-${id}.json`
+    const disposition = response.headers['content-disposition']
+    if (disposition) {
+      const match = /filename\s*=\s*"?([^";]+)"?/i.exec(disposition)
+      if (match && match[1]) {
+        filename = match[1].trim()
+      }
+    }
+    return { blob: response.data as Blob, filename }
+  }
+
+  // GDPR Article 17 — anonymize user PII while preserving audit trail.
+  async eraseUser(id: string): Promise<{ message: string; user_id: string }> {
+    const response = await this.client.post(`/api/v1/admin/users/${id}/erase`)
+    return response.data as { message: string; user_id: string }
+  }
+
   // Helper to transform organization from API format to frontend format
   private transformOrganization(org: Record<string, unknown>) {
     if (!org) {


### PR DESCRIPTION
Closes #284.

## Summary

Surfaces the backend GDPR endpoints (shipped in [terraform-registry-backend#350](https://github.com/sethbacon/terraform-registry-backend/pull/350) → v1.1.4) on the admin **Users** page. Until now, admins could only invoke export/erase via curl.

## UI

Two per-row icon buttons, **only visible to users with `admin` scope**:

| Button | Icon | Behavior |
|---|---|---|
| **Export user data** | `Download` | `GET /api/v1/admin/users/{id}/export` → triggers a browser download via temporary blob URL. Filename respects the backend's `Content-Disposition`. Read-only, no confirmation. |
| **Erase user data** | `PrivacyTip` (warning color) | Opens a confirmation dialog with destructive-action copy. The Erase button stays disabled until the admin types the target user's email exactly (GitHub repo-delete style). On success: success alert + users query invalidation. |

Non-admins (`users:write` only, etc.) see the existing Edit / Delete buttons only — no GDPR actions.

## Erase dialog

Confirmation copy:

> This permanently anonymizes **{user.email}**'s personal data. The user record is tombstoned, API keys and organization memberships are deleted, and all sessions are revoked. Audit log entries are preserved with anonymized identifiers. **This action cannot be undone.**

To confirm, the admin must type the user's email address exactly. Submit button is disabled otherwise.

## API additions in `api.ts`

```typescript
exportUserData(id): Promise<{ blob: Blob; filename: string }>
eraseUser(id): Promise<{ message: string; user_id: string }>
```

`exportUserData` uses `responseType: 'blob'` and parses `Content-Disposition` to extract the filename. The blob is returned so the caller controls download semantics (we call `URL.createObjectURL` + a synthetic `<a download>` click + `URL.revokeObjectURL`).

## Tests

**Unit (Vitest)** — 7 new tests in `UsersPage.test.tsx`:
- Admin sees both action buttons.
- Non-admin sees neither.
- Export succeeds → triggers download (stubs `URL.createObjectURL` / `revokeObjectURL`).
- Export fails → error alert.
- Erase dialog requires email match (button stays disabled with empty / wrong text).
- Erase success → calls API + shows success message.
- Erase failure → surfaces error.

`useAuth` is now mocked in this test file; the existing 21 tests pass with the mock in place. **Total: 28/28 passing.**

**E2E (Playwright)** — 4 new tests in `e2e/tests/admin.spec.ts`:
- Admin sees both buttons on each row.
- Clicking Export triggers a real `download` event with the expected filename pattern.
- Clicking Erase opens the dialog with the GDPR Article 17 heading and a disabled confirm button.
- Cancel closes the dialog.

E2E tests skip cleanly when the users table is empty.

## Test plan

- [x] `npx tsc --noEmit` clean.
- [x] `npm run lint` clean.
- [x] `npm test` — 96 files / 1505 tests pass (was 1497 → +8).
- [x] `npm run build` clean.
- [ ] CI green (including E2E and Contract Check).

## Out of scope

- User-initiated export ("download my data") — backend has no non-admin variant; would need a new route.
- Bulk export.
- Surfaces beyond the Users page (e.g. exposing the same buttons elsewhere).

These were called out as out-of-scope in the issue; left for future work.

## Related

- Backend implementation: [terraform-registry-backend#350](https://github.com/sethbacon/terraform-registry-backend/pull/350)
- Backend tracking issue: [terraform-registry-backend#347](https://github.com/sethbacon/terraform-registry-backend/issues/347) (closed)
