### PR TITLE
fix(admin): add tooltips to edit and delete user buttons

### DIFF
--- a/frontend/src/components/PolicyResultsPanel.tsx
+++ b/frontend/src/components/PolicyResultsPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { Box, Paper, Typography, Divider, Chip, Stack, Collapse, IconButton } from '@mui/material'
+import { Box, Paper, Typography, Divider, Chip, Stack, Collapse, IconButton, Tooltip } from '@mui/material'
 import PolicyIcon from '@mui/icons-material/Policy'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import ExpandLessIcon from '@mui/icons-material/ExpandLess'
@@ -46,9 +46,11 @@ const PolicyResultsPanel: React.FC<PolicyResultsPanelProps> = ({ policyResult })
               {policyResult.violations.length} violation
               {policyResult.violations.length !== 1 ? 's' : ''}
             </Typography>
-            <IconButton size="small" sx={{ ml: 'auto' }}>
-              {expanded ? <ExpandLessIcon fontSize="small" /> : <ExpandMoreIcon fontSize="small" />}
-            </IconButton>
+            <Tooltip title={expanded ? 'Collapse' : 'Expand'}>
+              <IconButton size="small" aria-label={expanded ? 'Collapse' : 'Expand'} sx={{ ml: 'auto' }}>
+                {expanded ? <ExpandLessIcon fontSize="small" /> : <ExpandMoreIcon fontSize="small" />}
+              </IconButton>
+            </Tooltip>
           </Box>
           <Collapse in={expanded}>
             <Stack spacing={1} sx={{ mt: 1 }}>

--- a/frontend/src/pages/ModuleDetailPage.tsx
+++ b/frontend/src/pages/ModuleDetailPage.tsx
@@ -215,24 +215,28 @@ const ModuleDetailPage: React.FC = () => {
                       }
                     }}
                   />
-                  <IconButton
-                    size="small"
-                    color="primary"
-                    onClick={() => {
-                      handleUpdateDescription(editDescription)
-                      setEditingDescription(false)
-                    }}
-                    aria-label="Save description"
-                  >
-                    <Check fontSize="small" />
-                  </IconButton>
-                  <IconButton
-                    size="small"
-                    onClick={() => setEditingDescription(false)}
-                    aria-label="Cancel editing"
-                  >
-                    <Close fontSize="small" />
-                  </IconButton>
+                  <Tooltip title="Save description">
+                    <IconButton
+                      size="small"
+                      color="primary"
+                      onClick={() => {
+                        handleUpdateDescription(editDescription)
+                        setEditingDescription(false)
+                      }}
+                      aria-label="Save description"
+                    >
+                      <Check fontSize="small" />
+                    </IconButton>
+                  </Tooltip>
+                  <Tooltip title="Cancel editing">
+                    <IconButton
+                      size="small"
+                      onClick={() => setEditingDescription(false)}
+                      aria-label="Cancel editing"
+                    >
+                      <Close fontSize="small" />
+                    </IconButton>
+                  </Tooltip>
                 </>
               ) : (
                 <>
@@ -349,26 +353,30 @@ const ModuleDetailPage: React.FC = () => {
                             }
                           }}
                         />
-                        <IconButton
-                          size="small"
-                          color="primary"
-                          onClick={() => {
-                            if (editNamespace.trim()) {
-                              handleUpdateNamespace(editNamespace.trim())
-                              setEditingNamespace(false)
-                            }
-                          }}
-                          aria-label="Save namespace"
-                        >
-                          <Check fontSize="small" />
-                        </IconButton>
-                        <IconButton
-                          size="small"
-                          onClick={() => setEditingNamespace(false)}
-                          aria-label="Cancel editing namespace"
-                        >
-                          <Close fontSize="small" />
-                        </IconButton>
+                        <Tooltip title="Save namespace">
+                          <IconButton
+                            size="small"
+                            color="primary"
+                            onClick={() => {
+                              if (editNamespace.trim()) {
+                                handleUpdateNamespace(editNamespace.trim())
+                                setEditingNamespace(false)
+                              }
+                            }}
+                            aria-label="Save namespace"
+                          >
+                            <Check fontSize="small" />
+                          </IconButton>
+                        </Tooltip>
+                        <Tooltip title="Cancel editing namespace">
+                          <IconButton
+                            size="small"
+                            onClick={() => setEditingNamespace(false)}
+                            aria-label="Cancel editing namespace"
+                          >
+                            <Close fontSize="small" />
+                          </IconButton>
+                        </Tooltip>
                       </>
                     ) : (
                       <>

--- a/frontend/src/pages/admin/APIKeysPage.tsx
+++ b/frontend/src/pages/admin/APIKeysPage.tsx
@@ -606,12 +606,14 @@ const APIKeysPage: React.FC = () => {
                   readOnly: true,
                   endAdornment: (
                     <InputAdornment position="end">
-                      <IconButton
-                        aria-label="Copy API key"
-                        onClick={() => handleCopyKey(newKeyValue)}
-                      >
-                        <CopyIcon />
-                      </IconButton>
+                      <Tooltip title="Copy API key">
+                        <IconButton
+                          aria-label="Copy API key"
+                          onClick={() => handleCopyKey(newKeyValue)}
+                        >
+                          <CopyIcon />
+                        </IconButton>
+                      </Tooltip>
                     </InputAdornment>
                   ),
                   sx: { fontFamily: 'monospace' },
@@ -783,12 +785,14 @@ const APIKeysPage: React.FC = () => {
                   readOnly: true,
                   endAdornment: (
                     <InputAdornment position="end">
-                      <IconButton
-                        aria-label="Copy rotated key"
-                        onClick={() => handleCopyKey(rotatedKeyValue)}
-                      >
-                        <CopyIcon />
-                      </IconButton>
+                      <Tooltip title="Copy API key">
+                        <IconButton
+                          aria-label="Copy rotated key"
+                          onClick={() => handleCopyKey(rotatedKeyValue)}
+                        >
+                          <CopyIcon />
+                        </IconButton>
+                      </Tooltip>
                     </InputAdornment>
                   ),
                   sx: { fontFamily: 'monospace' },

--- a/frontend/src/pages/admin/OIDCSettingsPage.tsx
+++ b/frontend/src/pages/admin/OIDCSettingsPage.tsx
@@ -29,6 +29,7 @@ import {
   Chip,
   Divider,
   SelectChangeEvent,
+  Tooltip,
 } from '@mui/material'
 import AddIcon from '@mui/icons-material/Add'
 import EditIcon from '@mui/icons-material/Edit'
@@ -343,21 +344,25 @@ const OIDCSettingsPage: React.FC = () => {
                               />
                             </TableCell>
                             <TableCell align="right">
-                              <IconButton
-                                size="small"
-                                aria-label="Edit claim mapping"
-                                onClick={() => openEditDialog(i)}
-                              >
-                                <EditIcon fontSize="small" />
-                              </IconButton>
-                              <IconButton
-                                size="small"
-                                aria-label="Delete claim mapping"
-                                color="error"
-                                onClick={() => setDeleteIndex(i)}
-                              >
-                                <DeleteIcon fontSize="small" />
-                              </IconButton>
+                              <Tooltip title="Edit claim mapping">
+                                <IconButton
+                                  size="small"
+                                  aria-label="Edit claim mapping"
+                                  onClick={() => openEditDialog(i)}
+                                >
+                                  <EditIcon fontSize="small" />
+                                </IconButton>
+                              </Tooltip>
+                              <Tooltip title="Delete claim mapping">
+                                <IconButton
+                                  size="small"
+                                  aria-label="Delete claim mapping"
+                                  color="error"
+                                  onClick={() => setDeleteIndex(i)}
+                                >
+                                  <DeleteIcon fontSize="small" />
+                                </IconButton>
+                              </Tooltip>
                             </TableCell>
                           </TableRow>
                         ))}

--- a/frontend/src/pages/admin/OrganizationsPage.tsx
+++ b/frontend/src/pages/admin/OrganizationsPage.tsx
@@ -28,6 +28,7 @@ import {
   Autocomplete,
   SelectChangeEvent,
   Chip,
+  Tooltip,
 } from '@mui/material'
 import EditIcon from '@mui/icons-material/Edit'
 import DeleteIcon from '@mui/icons-material/Delete'

--- a/frontend/src/pages/admin/OrganizationsPage.tsx
+++ b/frontend/src/pages/admin/OrganizationsPage.tsx
@@ -341,22 +341,26 @@ const OrganizationsPage: React.FC = () => {
                     </TableCell>
                     <TableCell>{new Date(org.created_at).toLocaleDateString()}</TableCell>
                     <TableCell align="right">
-                      <IconButton
-                        size="small"
-                        aria-label="Edit organization"
-                        onClick={() => handleOpenDialog(org)}
-                        color="primary"
-                      >
-                        <EditIcon />
-                      </IconButton>
-                      <IconButton
-                        size="small"
-                        aria-label="Delete organization"
-                        onClick={() => handleDeleteClick(org)}
-                        color="error"
-                      >
-                        <DeleteIcon />
-                      </IconButton>
+                      <Tooltip title="Edit organization">
+                        <IconButton
+                          size="small"
+                          aria-label="Edit organization"
+                          onClick={() => handleOpenDialog(org)}
+                          color="primary"
+                        >
+                          <EditIcon />
+                        </IconButton>
+                      </Tooltip>
+                      <Tooltip title="Delete organization">
+                        <IconButton
+                          size="small"
+                          aria-label="Delete organization"
+                          onClick={() => handleDeleteClick(org)}
+                          color="error"
+                        >
+                          <DeleteIcon />
+                        </IconButton>
+                      </Tooltip>
                     </TableCell>
                   </TableRow>
                 ))}
@@ -541,15 +545,16 @@ const OrganizationsPage: React.FC = () => {
                       </TableCell>
                       {canManage && (
                         <TableCell align="right">
-                          <IconButton
-                            size="small"
-                            aria-label="Remove member"
-                            onClick={() => handleRemoveMember(member.user_id)}
-                            color="error"
-                            title="Remove member"
-                          >
-                            <DeleteIcon />
-                          </IconButton>
+                          <Tooltip title="Remove member">
+                            <IconButton
+                              size="small"
+                              aria-label="Remove member"
+                              onClick={() => handleRemoveMember(member.user_id)}
+                              color="error"
+                            >
+                              <DeleteIcon />
+                            </IconButton>
+                          </Tooltip>
                         </TableCell>
                       )}
                     </TableRow>

--- a/frontend/src/pages/admin/UsersPage.tsx
+++ b/frontend/src/pages/admin/UsersPage.tsx
@@ -536,14 +536,16 @@ const UsersPage: React.FC = () => {
                     </TableCell>
                     <TableCell>{new Date(user.created_at).toLocaleDateString()}</TableCell>
                     <TableCell align="right">
-                      <IconButton
-                        size="small"
-                        aria-label="Edit user"
-                        onClick={() => handleOpenDialog(user)}
-                        color="primary"
-                      >
-                        <EditIcon />
-                      </IconButton>
+                      <Tooltip title="Edit user">
+                        <IconButton
+                          size="small"
+                          aria-label="Edit user"
+                          onClick={() => handleOpenDialog(user)}
+                          color="primary"
+                        >
+                          <EditIcon />
+                        </IconButton>
+                      </Tooltip>
                       {isAdmin && (
                         <>
                           <Tooltip title="Export user data (GDPR Article 15/20)">
@@ -574,14 +576,16 @@ const UsersPage: React.FC = () => {
                           </Tooltip>
                         </>
                       )}
-                      <IconButton
-                        size="small"
-                        aria-label="Delete user"
-                        onClick={() => handleDeleteClick(user)}
-                        color="error"
-                      >
-                        <DeleteIcon />
-                      </IconButton>
+                      <Tooltip title="Delete user">
+                        <IconButton
+                          size="small"
+                          aria-label="Delete user"
+                          onClick={() => handleDeleteClick(user)}
+                          color="error"
+                        >
+                          <DeleteIcon />
+                        </IconButton>
+                      </Tooltip>
                     </TableCell>
                   </TableRow>
                 ))


### PR DESCRIPTION
Wraps the Edit and Delete `IconButton`s in the Users table with MUI `Tooltip` components, matching the existing pattern used by the Export and Erase buttons.

- Edit user → "Edit user"
- Delete user → "Delete user"