### PR TITLE
fix: enable org rename with cascade warning and name format validation

### DIFF
--- a/frontend/src/pages/admin/OrganizationsPage.tsx
+++ b/frontend/src/pages/admin/OrganizationsPage.tsx
@@ -30,6 +30,9 @@ import {
   Chip,
   Tooltip,
 } from '@mui/material'
+
+/** Regex matching Terraform registry identifier rules (namespace / org name). */
+const REGISTRY_SEGMENT_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/
 import EditIcon from '@mui/icons-material/Edit'
 import DeleteIcon from '@mui/icons-material/Delete'
 import AddIcon from '@mui/icons-material/Add'
@@ -121,6 +124,7 @@ const OrganizationsPage: React.FC = () => {
     mutationFn: async () => {
       if (editingOrg) {
         await api.updateOrganization(editingOrg.id, {
+          ...(formData.name !== editingOrg.name ? { name: formData.name } : {}),
           display_name: formData.display_name,
           idp_type: formData.idp_type || null,
           idp_name: formData.idp_name || null,
@@ -153,6 +157,13 @@ const OrganizationsPage: React.FC = () => {
 
   const handleSaveOrganization = () => {
     setError(null)
+    if (!REGISTRY_SEGMENT_RE.test(formData.name)) {
+      setError(
+        'Organization name must be 1–64 characters, start with a lowercase letter or digit, ' +
+          'and contain only lowercase letters, digits, hyphens, or underscores.',
+      )
+      return
+    }
     saveOrgMutation.mutate()
   }
 
@@ -382,8 +393,22 @@ const OrganizationsPage: React.FC = () => {
               onChange={(e) => setFormData({ ...formData, name: e.target.value })}
               required
               fullWidth
-              helperText="Organization name (e.g., myorg)"
+              error={!!formData.name && !REGISTRY_SEGMENT_RE.test(formData.name)}
+              helperText={
+                formData.name && !REGISTRY_SEGMENT_RE.test(formData.name)
+                  ? 'Must start with a lowercase letter or digit; only lowercase letters, digits, hyphens, and underscores allowed (max 64 chars)'
+                  : 'Organization name used in registry URLs (e.g., myorg)'
+              }
             />
+            {editingOrg && formData.name !== editingOrg.name && REGISTRY_SEGMENT_RE.test(formData.name) && (
+              <Alert severity="warning">
+                Renaming this organization will update all module and provider namespaces that
+                currently use <strong>{editingOrg.name}</strong> to{' '}
+                <strong>{formData.name}</strong>. User memberships are linked by ID and will not
+                be affected. Ensure any Terraform configurations referencing the old name are
+                updated.
+              </Alert>
+            )}
             <TextField
               label="Display Name"
               value={formData.display_name}

--- a/frontend/src/pages/admin/__tests__/OrganizationsPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/OrganizationsPage.test.tsx
@@ -379,4 +379,87 @@ describe('OrganizationsPage', () => {
     await waitFor(() => expect(screen.getByText('acme-corp')).toBeInTheDocument())
     expect(screen.getByText('LDAP')).toBeInTheDocument()
   })
+
+  // ── Rename tests ──────────────────────────────────────────────────────────
+
+  it('includes name in update payload when org name is changed', async () => {
+    listOrganizationsMock.mockResolvedValue(fakeOrgs)
+    updateOrganizationMock.mockResolvedValue({})
+    renderPage()
+    await waitFor(() => expect(screen.getByText('acme-corp')).toBeInTheDocument())
+    const editBtns = screen.getAllByRole('button', { name: /edit organization/i })
+    await userEvent.click(editBtns[0])
+    await waitFor(() => expect(screen.getByText('Edit Organization')).toBeInTheDocument())
+
+    const nameInput = screen.getByLabelText(/^Name/i)
+    await userEvent.clear(nameInput)
+    await userEvent.type(nameInput, 'acme-renamed')
+
+    const saveBtn = screen.getByRole('button', { name: /^save$/i })
+    await userEvent.click(saveBtn)
+
+    await waitFor(() =>
+      expect(updateOrganizationMock).toHaveBeenCalledWith(
+        'org-1',
+        expect.objectContaining({ name: 'acme-renamed' }),
+      ),
+    )
+  })
+
+  it('shows rename cascade warning when name is changed to a valid value', async () => {
+    listOrganizationsMock.mockResolvedValue(fakeOrgs)
+    renderPage()
+    await waitFor(() => expect(screen.getByText('acme-corp')).toBeInTheDocument())
+    const editBtns = screen.getAllByRole('button', { name: /edit organization/i })
+    await userEvent.click(editBtns[0])
+    await waitFor(() => expect(screen.getByText('Edit Organization')).toBeInTheDocument())
+
+    const nameInput = screen.getByLabelText(/^Name/i)
+    await userEvent.clear(nameInput)
+    await userEvent.type(nameInput, 'new-name')
+
+    await waitFor(() =>
+      expect(screen.getByText(/Renaming this organization will update all module/i)).toBeInTheDocument(),
+    )
+  })
+
+  it('does not include name in update payload when name is unchanged', async () => {
+    listOrganizationsMock.mockResolvedValue(fakeOrgs)
+    updateOrganizationMock.mockResolvedValue({})
+    renderPage()
+    await waitFor(() => expect(screen.getByText('acme-corp')).toBeInTheDocument())
+    const editBtns = screen.getAllByRole('button', { name: /edit organization/i })
+    await userEvent.click(editBtns[0])
+    await waitFor(() => expect(screen.getByText('Edit Organization')).toBeInTheDocument())
+
+    const saveBtn = screen.getByRole('button', { name: /^save$/i })
+    await userEvent.click(saveBtn)
+
+    await waitFor(() => expect(updateOrganizationMock).toHaveBeenCalled())
+    const callArg = updateOrganizationMock.mock.calls[0][1]
+    expect(callArg).not.toHaveProperty('name')
+  })
+
+  it('blocks save and shows field error when name format is invalid', async () => {
+    listOrganizationsMock.mockResolvedValue(fakeOrgs)
+    renderPage()
+    await waitFor(() => expect(screen.getByText('acme-corp')).toBeInTheDocument())
+
+    // Open Add dialog (create path) to test name validation
+    await userEvent.click(screen.getByRole('button', { name: /add organization/i }))
+    await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument())
+
+    const nameInput = screen.getByLabelText(/^Name/i)
+    await userEvent.type(nameInput, 'Bad Name!')
+    const dnInput = screen.getByLabelText(/Display Name/i)
+    await userEvent.type(dnInput, 'Something')
+    const saveBtn = screen.getByRole('button', { name: /^create$/i })
+    await userEvent.click(saveBtn)
+
+    await waitFor(() =>
+      expect(screen.getByText(/must start with a lowercase letter or digit/i)).toBeInTheDocument(),
+    )
+    expect(updateOrganizationMock).not.toHaveBeenCalled()
+    expect(createOrganizationMock).not.toHaveBeenCalled()
+  })
 })

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -591,7 +591,7 @@ class ApiClient {
 
   async updateOrganization(
     id: string,
-    data: { display_name: string; idp_type?: string | null; idp_name?: string | null },
+    data: { name?: string; display_name: string; idp_type?: string | null; idp_name?: string | null },
   ) {
     const response = await this.client.put(`/api/v1/organizations/${id}`, data)
     return this.transformOrganization(response.data.organization)


### PR DESCRIPTION
## Summary

Enables organization rename through the Admin UI with inline cascade warning and name format validation.

## Changes

### `frontend/src/services/api.ts`
Adds `name?: string` to the `updateOrganization` data parameter so callers can include a new name in the PUT payload.

### `frontend/src/pages/admin/OrganizationsPage.tsx`
- Adds `REGISTRY_SEGMENT_RE` constant (`^[a-z0-9][a-z0-9_-]{0,63}$`) matching Terraform registry naming rules
- `saveOrgMutation` now spreads `{ name: formData.name }` into the update payload when the name differs from the current org name
- `handleSaveOrganization` validates the name format before calling the mutation; shows an error and blocks submission if invalid
- The Name `TextField` shows a live field error (`error` + `helperText`) when the value fails the regex
- A `warning` Alert appears in the dialog when the name is changed to a valid new value, explaining the cascade impact on modules, providers, and noting that user memberships are unaffected

### `frontend/src/pages/admin/__tests__/OrganizationsPage.test.tsx`
Added 4 regression tests:
- `includes name in update payload when org name is changed`
- `shows rename cascade warning when name is changed to a valid value`
- `does not include name in update payload when name is unchanged`
- `blocks save and shows field error when name format is invalid`

Closes #289
