### PR TITLE
fix(module-upload): validate namespace/name/provider against Terraform segment rules (#290)

### DIFF
--- a/frontend/src/pages/admin/ModuleUploadPage.tsx
+++ b/frontend/src/pages/admin/ModuleUploadPage.tsx
@@ -20,6 +20,10 @@ import SCMIcon from '@mui/icons-material/AccountTree'
 import ArrowBack from '@mui/icons-material/ArrowBack'
 import api from '../../services/api'
 import { getErrorMessage } from '../../utils/errors'
+import {
+  isValidRegistrySegment,
+  REGISTRY_SEGMENT_HELP,
+} from '../../utils/registrySegment'
 import PublishFromSCMWizard from '../../components/PublishFromSCMWizard'
 import FileDropZone from '../../components/FileDropZone'
 import PolicyResultsPanel from '../../components/PolicyResultsPanel'
@@ -71,6 +75,16 @@ const ModuleUploadPage: React.FC = () => {
       setError('Please fill in all required fields')
       return
     }
+    for (const [label, val] of [
+      ['Namespace', moduleNamespace],
+      ['Module Name', moduleName],
+      ['Provider', moduleProvider],
+    ] as const) {
+      if (!isValidRegistrySegment(val)) {
+        setError(`${label} is not a valid Terraform registry segment. ${REGISTRY_SEGMENT_HELP}`)
+        return
+      }
+    }
 
     try {
       setUploading(true)
@@ -113,6 +127,16 @@ const ModuleUploadPage: React.FC = () => {
     if (!scmNamespace || !scmName || !scmSystem) {
       setScmError('Namespace, name, and provider are required')
       return
+    }
+    for (const [label, val] of [
+      ['Namespace', scmNamespace],
+      ['Module Name', scmName],
+      ['Provider', scmSystem],
+    ] as const) {
+      if (!isValidRegistrySegment(val)) {
+        setScmError(`${label} is not a valid Terraform registry segment. ${REGISTRY_SEGMENT_HELP}`)
+        return
+      }
     }
     try {
       setScmCreating(true)
@@ -223,7 +247,12 @@ const ModuleUploadPage: React.FC = () => {
               placeholder="e.g., bconline"
               required
               fullWidth
-              helperText="Your organization identifier"
+              error={!!scmNamespace && !isValidRegistrySegment(scmNamespace)}
+              helperText={
+                scmNamespace && !isValidRegistrySegment(scmNamespace)
+                  ? REGISTRY_SEGMENT_HELP
+                  : 'Your organization identifier'
+              }
             />
             <TextField
               label="Module Name"
@@ -232,6 +261,10 @@ const ModuleUploadPage: React.FC = () => {
               placeholder="e.g., networking-vpc"
               required
               fullWidth
+              error={!!scmName && !isValidRegistrySegment(scmName)}
+              helperText={
+                scmName && !isValidRegistrySegment(scmName) ? REGISTRY_SEGMENT_HELP : undefined
+              }
             />
             <TextField
               label="Provider"
@@ -240,7 +273,12 @@ const ModuleUploadPage: React.FC = () => {
               placeholder="e.g., aws"
               required
               fullWidth
-              helperText="Cloud provider this module targets (aws, azure, google, etc.)"
+              error={!!scmSystem && !isValidRegistrySegment(scmSystem)}
+              helperText={
+                scmSystem && !isValidRegistrySegment(scmSystem)
+                  ? REGISTRY_SEGMENT_HELP
+                  : 'Cloud provider this module targets (aws, azure, google, etc.)'
+              }
             />
             <TextField
               label="Description (optional)"
@@ -256,7 +294,15 @@ const ModuleUploadPage: React.FC = () => {
             <Button
               variant="contained"
               onClick={handleScmProceed}
-              disabled={scmCreating || !scmNamespace || !scmName || !scmSystem}
+              disabled={
+                scmCreating ||
+                !scmNamespace ||
+                !scmName ||
+                !scmSystem ||
+                !isValidRegistrySegment(scmNamespace) ||
+                !isValidRegistrySegment(scmName) ||
+                !isValidRegistrySegment(scmSystem)
+              }
               startIcon={scmCreating ? <CircularProgress size={18} /> : <SCMIcon />}
               size="large"
             >
@@ -315,7 +361,12 @@ const ModuleUploadPage: React.FC = () => {
             required
             fullWidth
             disabled={uploading}
-            helperText="Your organization identifier"
+            error={!!moduleNamespace && !isValidRegistrySegment(moduleNamespace)}
+            helperText={
+              moduleNamespace && !isValidRegistrySegment(moduleNamespace)
+                ? REGISTRY_SEGMENT_HELP
+                : 'Your organization identifier'
+            }
           />
           <TextField
             label="Module Name"
@@ -325,7 +376,12 @@ const ModuleUploadPage: React.FC = () => {
             required
             fullWidth
             disabled={uploading}
-            helperText="Descriptive name for what the module does"
+            error={!!moduleName && !isValidRegistrySegment(moduleName)}
+            helperText={
+              moduleName && !isValidRegistrySegment(moduleName)
+                ? REGISTRY_SEGMENT_HELP
+                : 'Descriptive name for what the module does'
+            }
           />
           <TextField
             label="Provider"
@@ -335,7 +391,12 @@ const ModuleUploadPage: React.FC = () => {
             required
             fullWidth
             disabled={uploading}
-            helperText="Target cloud (aws, azure, google, etc.)"
+            error={!!moduleProvider && !isValidRegistrySegment(moduleProvider)}
+            helperText={
+              moduleProvider && !isValidRegistrySegment(moduleProvider)
+                ? REGISTRY_SEGMENT_HELP
+                : 'Target cloud (aws, azure, google, etc.)'
+            }
           />
         </Stack>
         <TextField
@@ -389,7 +450,12 @@ const ModuleUploadPage: React.FC = () => {
             variant="contained"
             onClick={handleModuleUpload}
             disabled={
-              uploading || !moduleFile || (policyResult?.mode === 'block' && !policyResult?.allowed)
+              uploading ||
+              !moduleFile ||
+              (policyResult?.mode === 'block' && !policyResult?.allowed) ||
+              !isValidRegistrySegment(moduleNamespace) ||
+              !isValidRegistrySegment(moduleName) ||
+              !isValidRegistrySegment(moduleProvider)
             }
             startIcon={uploading ? <CircularProgress size={20} /> : <CloudUpload />}
             size="large"

--- a/frontend/src/pages/admin/OrganizationsPage.tsx
+++ b/frontend/src/pages/admin/OrganizationsPage.tsx
@@ -31,8 +31,7 @@ import {
   Tooltip,
 } from '@mui/material'
 
-/** Regex matching Terraform registry identifier rules (namespace / org name). */
-const REGISTRY_SEGMENT_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/
+import { REGISTRY_SEGMENT_RE } from '../../utils/registrySegment'
 import EditIcon from '@mui/icons-material/Edit'
 import DeleteIcon from '@mui/icons-material/Delete'
 import AddIcon from '@mui/icons-material/Add'

--- a/frontend/src/pages/admin/__tests__/ModuleUploadPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/ModuleUploadPage.test.tsx
@@ -157,6 +157,34 @@ describe('ModuleUploadPage — upload form (roadmap 2.5)', () => {
     expect(screen.getByText('mod.tar.gz')).toBeInTheDocument()
   })
 
+  it('disables Upload Module when a registry segment is invalid', async () => {
+    const user = userEvent.setup()
+    await openUploadForm(user)
+    const byLabel = (t: RegExp) => screen.getByLabelText(t) as HTMLInputElement
+    await user.type(byLabel(/Namespace/), 'My Org') // space + uppercase
+    await user.type(byLabel(/Module Name/), 'vpc')
+    await user.type(byLabel(/^Provider/), 'aws')
+    await user.type(byLabel(/Version/), '1.0.0')
+    const dropInput = screen.getByTestId('module-upload-dropzone-input') as HTMLInputElement
+    await user.upload(dropInput, new File(['x'], 'm.tar.gz'))
+    expect(screen.getByRole('button', { name: /Upload Module/i })).toBeDisabled()
+    // Inline helper switches to the segment-format hint
+    expect(screen.getAllByText(/1.{0,4}64 chars/i).length).toBeGreaterThan(0)
+  })
+
+  it('disables SCM Continue when any segment is invalid', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    await user.click(screen.getByText('Link from SCM Repository'))
+    const byLabel = (t: RegExp) => screen.getByLabelText(t) as HTMLInputElement
+    await user.type(byLabel(/Namespace/), 'myns')
+    await user.type(byLabel(/Module Name/), 'BAD NAME')
+    await user.type(byLabel(/^Provider/), 'aws')
+    expect(
+      screen.getByRole('button', { name: /Continue to Repository Selection/i }),
+    ).toBeDisabled()
+  })
+
   it('shows upload progress bar and preserves field state after upload failure', async () => {
     const user = userEvent.setup()
     api.uploadModule.mockImplementationOnce(

--- a/frontend/src/utils/__tests__/registrySegment.test.ts
+++ b/frontend/src/utils/__tests__/registrySegment.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest'
+import { isValidRegistrySegment, REGISTRY_SEGMENT_RE } from '../registrySegment'
+
+describe('isValidRegistrySegment', () => {
+  it('accepts simple lowercase identifiers', () => {
+    expect(isValidRegistrySegment('myorg')).toBe(true)
+    expect(isValidRegistrySegment('my-org')).toBe(true)
+    expect(isValidRegistrySegment('my_org')).toBe(true)
+    expect(isValidRegistrySegment('a')).toBe(true)
+    expect(isValidRegistrySegment('1org')).toBe(true)
+    expect(isValidRegistrySegment('terraform-aws-123')).toBe(true)
+  })
+
+  it('accepts max-length (64-char) segments', () => {
+    expect(isValidRegistrySegment('a'.repeat(64))).toBe(true)
+  })
+
+  it('rejects empty, spaces, and uppercase', () => {
+    expect(isValidRegistrySegment('')).toBe(false)
+    expect(isValidRegistrySegment('My Org')).toBe(false)
+    expect(isValidRegistrySegment('MyOrg')).toBe(false)
+  })
+
+  it('rejects leading hyphen/underscore', () => {
+    expect(isValidRegistrySegment('-myorg')).toBe(false)
+    expect(isValidRegistrySegment('_myorg')).toBe(false)
+  })
+
+  it('rejects special characters and dots/slashes', () => {
+    expect(isValidRegistrySegment('my.org')).toBe(false)
+    expect(isValidRegistrySegment('my/org')).toBe(false)
+    expect(isValidRegistrySegment('my@org')).toBe(false)
+  })
+
+  it('rejects over-length (65-char) segments', () => {
+    expect(isValidRegistrySegment('a'.repeat(65))).toBe(false)
+  })
+
+  it('regex is sealed (anchored at both ends)', () => {
+    expect(REGISTRY_SEGMENT_RE.test('myorg\nbad')).toBe(false)
+    expect(REGISTRY_SEGMENT_RE.test(' myorg ')).toBe(false)
+  })
+})

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -1,3 +1,8 @@
 export { formatDate } from './formatting'
 export { getScopeInfo, getScopeColor } from './scopes'
 export { getErrorMessage, getErrorStatus } from './errors'
+export {
+  REGISTRY_SEGMENT_RE,
+  REGISTRY_SEGMENT_HELP,
+  isValidRegistrySegment,
+} from './registrySegment'

--- a/frontend/src/utils/registrySegment.ts
+++ b/frontend/src/utils/registrySegment.ts
@@ -1,0 +1,13 @@
+// Shared validation for Terraform registry identifier segments.
+// Terraform CLI parses module/provider source addresses as
+// <hostname>/<namespace>/<name>/<provider>, so each segment must be a valid
+// URL path component. The pattern below mirrors the backend's
+// internal/validation/segment.go regex so the UI and API agree.
+export const REGISTRY_SEGMENT_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/
+
+export const REGISTRY_SEGMENT_HELP =
+  '1–64 chars; must start with a lowercase letter or digit; only lowercase letters, digits, hyphens, and underscores.'
+
+export function isValidRegistrySegment(s: string): boolean {
+  return REGISTRY_SEGMENT_RE.test(s)
+}


### PR DESCRIPTION
Closes #290

## Summary
- Add shared util `utils/registrySegment.ts` exposing `REGISTRY_SEGMENT_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/` — exact mirror of the backend's `internal/validation/segment.go` regex.
- ModuleUploadPage (Upload + SCM flows) now validates `namespace`, `name`, and `provider` against the registry-segment rules:
  - Inline `error` + helper text on the six TextFields
  - Submit guard in `handleModuleUpload` / `handleScmProceed`
  - Disabled submit/continue while any segment is invalid
- Refactor OrganizationsPage to import the shared `REGISTRY_SEGMENT_RE` instead of redeclaring it locally.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `npm test -- src/utils/__tests__/registrySegment.test.ts src/pages/admin/__tests__/ModuleUploadPage.test.tsx src/pages/admin/__tests__/OrganizationsPage.test.tsx` — 48/48 pass
- [ ] After deploy: typing `"My Org"` in the Namespace field shows the inline format hint and disables the submit button.

## Notes
The backend already enforces this regex server-side (terraform-registry-backend [#372](https://github.com/sethbacon/terraform-registry-backend/pull/372), shipped in 1.1.10), so anything that slipped past the UI would have been rejected anyway. This PR moves the rejection upstream so users see a helpful inline error instead of a 400 toast.