### PR TITLE
fix(setup): BrandingStep persists via /setup/ui-theme; remove backend-now-ships allowlist (#277, #276)

### DIFF
--- a/deployments/docker-compose.contract-check.yml
+++ b/deployments/docker-compose.contract-check.yml
@@ -20,7 +20,7 @@ services:
     # Pinned backend image. Bump this tag in lockstep with backend releases
     # whose API surface the frontend wants to depend on. The contract check
     # validates that every route api.ts calls exists on this exact backend.
-    image: ${BACKEND_IMAGE:-ghcr.io/sethbacon/terraform-registry-backend:1.1.3}
+    image: ${BACKEND_IMAGE:-ghcr.io/sethbacon/terraform-registry-backend:1.2.1}
     environment:
       - TFR_DATABASE_HOST=postgres
       - TFR_DATABASE_PORT=5432

--- a/frontend/scripts/contract-check.allowlist.json
+++ b/frontend/scripts/contract-check.allowlist.json
@@ -3,21 +3,6 @@
   "entries": [
     {
       "method": "GET",
-      "path": "/api/v1/admin/quotas",
-      "reason": "https://github.com/sethbacon/terraform-registry-frontend/issues/276 — frontend calls a backend route that does not exist; resolve by either implementing on the backend or removing the frontend caller."
-    },
-    {
-      "method": "GET",
-      "path": "/api/v1/ui/theme",
-      "reason": "https://github.com/sethbacon/terraform-registry-frontend/issues/277 — frontend calls a backend route that does not exist; resolve by either implementing on the backend or removing the frontend caller."
-    },
-    {
-      "method": "PUT",
-      "path": "/api/v1/admin/ui-theme",
-      "reason": "https://github.com/sethbacon/terraform-registry-frontend/issues/277 — frontend calls a backend route that does not exist; resolve by either implementing on the backend or removing the frontend caller."
-    },
-    {
-      "method": "GET",
       "path": "/api/v1/dev/status",
       "reason": "Backend route is registered conditionally under DEV_MODE=true and is intentionally undocumented in production swagger. Permanent allowlist entry."
     },

--- a/frontend/src/pages/setup/steps/BrandingStep.tsx
+++ b/frontend/src/pages/setup/steps/BrandingStep.tsx
@@ -15,7 +15,7 @@ import api from '../../../services/api'
 import { getErrorMessage } from '../../../utils/errors'
 
 const BrandingStep: React.FC = () => {
-  const { goToStep, setError, setSuccess } = useSetupWizard()
+  const { goToStep, setError, setSuccess, setupToken } = useSetupWizard()
 
   const [saving, setSaving] = useState(false)
   const [form, setForm] = useState({
@@ -35,7 +35,7 @@ const BrandingStep: React.FC = () => {
       setSaving(true)
       setError(null)
       const payload = Object.fromEntries(Object.entries(form).filter(([, v]) => v.trim() !== ''))
-      await api.updateAdminUITheme(payload)
+      await api.saveSetupUITheme(setupToken, payload)
       setSuccess('Branding saved successfully')
       goToStep(5)
     } catch (err: unknown) {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1703,6 +1703,23 @@ class ApiClient {
     return response.data as import('../types').UIThemeConfig
   }
 
+  /**
+   * Setup-wizard write path. Authenticated by the one-time setup token (not
+   * admin scope), so BrandingStep can persist branding before any user is
+   * configured. Backed by PUT /api/v1/setup/ui-theme on the backend.
+   */
+  async saveSetupUITheme(
+    setupToken: string,
+    config: import('../types').UIThemeConfig,
+  ): Promise<import('../types').UIThemeConfig> {
+    const response = await this.client.put(
+      '/api/v1/setup/ui-theme',
+      config,
+      this.setupRequest(setupToken),
+    )
+    return response.data as import('../types').UIThemeConfig
+  }
+
   // ============================================================================
   // CVE Advisories
   // ============================================================================


### PR DESCRIPTION
Closes #277, #276

## Summary
The setup wizard runs with a setup token (not admin scope), so `BrandingStep` calling `PUT /api/v1/admin/ui-theme` 401d and the "Branding saved successfully" toast lied. The backend now exposes `PUT /api/v1/setup/ui-theme` (same handler, setup-token middleware) for exactly this case (terraform-registry-backend 1.2.0).

- `api.saveSetupUITheme(setupToken, payload)` PUTs `/api/v1/setup/ui-theme` via the existing `setupRequest()` helper.
- `BrandingStep` reads `setupToken` from the wizard context and calls `saveSetupUITheme`.
- Remove three allowlist entries (`GET /admin/quotas`, `GET /ui/theme`, `PUT /admin/ui-theme`) now that all three exist on the backend.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `npm test -- src/pages/setup src/services` — 381/381 pass
- [x] Local docker stack + `npm run contract:check` — **OK: every frontend route exists on backend (or is on the allowlist)**
- [ ] After deploy: complete the setup wizard with branding fields filled in; verify the saved theme is returned by `GET /api/v1/ui/theme` post-setup.

## Coordination
Depends on terraform-registry-backend [#378](https://github.com/sethbacon/terraform-registry-backend/pull/378) to document `PUT /api/v1/setup/ui-theme` in the swagger spec (the handler already exists in 1.2.0; the annotation was missing). Frontend `contract:check` CI job will pass once #378 lands.