### PR TITLE
fix(ci): grant packages:read in weekly-security so the reused ci.yml can launch

### DIFF
--- a/.github/workflows/weekly-security.yml
+++ b/.github/workflows/weekly-security.yml
@@ -14,10 +14,17 @@ permissions:
 
 jobs:
   # ── Full CI ────────────────────────────────────────────
+  # Calls ci.yml, which requests `packages: read` to pull the ghcr.io
+  # backend image used by the Contract Check job. A reusable workflow can
+  # only request permissions the caller has already granted, so we elevate
+  # explicitly here.
   ci:
     name: CI
     uses: ./.github/workflows/ci.yml
     secrets: inherit
+    permissions:
+      contents: read
+      packages: read
 
   # ── Dependency Audit ──────────────────────────────────
   npm-audit:


### PR DESCRIPTION
## Summary
Every scheduled run of the **Weekly Security Scan** since 2026-04-25 has been `startup_failure`. Root cause: ci.yml (called via `workflow_call`) declares `permissions: packages: read` so its Contract Check job can pull the ghcr.io backend image. A reusable workflow inherits the caller permission set as its ceiling, and `weekly-security.yml` only granted `contents: read`. GitHub Actions rejected the launch with:

> Invalid workflow file: .github/workflows/weekly-security.yml#L17
> ...is requesting `packages: read`, but is only allowed `packages: none`.

Granted `contents: read` + `packages: read` explicitly on the called job. The other jobs (npm-audit, osv-scan, codeql, stale-dependabot, notify-on-failure) keep their existing per-job permissions.

## Test plan
- [x] `gh workflow run weekly-security.yml --ref main` previously errored with the message above.
- [ ] After merge: re-run via `gh workflow run weekly-security.yml`, confirm the CI job spawns and runs to completion.
- [ ] Next scheduled Monday run lands without `startup_failure`.