### PR TITLE
fix(auth): validate returnUrl before redirect in CallbackPage

### DIFF
--- a/frontend/src/pages/CallbackPage.tsx
+++ b/frontend/src/pages/CallbackPage.tsx
@@ -36,9 +36,11 @@ const CallbackPage: React.FC = () => {
       // New flow: The backend set an HttpOnly cookie during the OIDC callback
       // redirect. AuthContext will detect the session via /auth/me on mount.
       // Navigate to the return URL; AuthContext handles the rest.
-      const returnUrl = sessionStorage.getItem('returnUrl') || '/'
+      const raw = sessionStorage.getItem('returnUrl') || '/'
       sessionStorage.removeItem('returnUrl')
-      window.location.replace(returnUrl)
+      // Reject absolute URLs and protocol-relative paths to prevent open redirect.
+      const safeReturnUrl = /^\/(?!\/)/.test(raw) ? raw : '/'
+      window.location.replace(safeReturnUrl)
     }
 
     handleCallback()

--- a/frontend/src/pages/CallbackPage.tsx
+++ b/frontend/src/pages/CallbackPage.tsx
@@ -38,8 +38,17 @@ const CallbackPage: React.FC = () => {
       // Navigate to the return URL; AuthContext handles the rest.
       const raw = sessionStorage.getItem('returnUrl') || '/'
       sessionStorage.removeItem('returnUrl')
-      // Reject absolute URLs and protocol-relative paths to prevent open redirect.
-      const safeReturnUrl = /^\/(?!\/)/.test(raw) ? raw : '/'
+      // Reject absolute and protocol-relative URLs to prevent open redirect.
+      // Use URL parsing to catch backslash normalisation bypasses (/\\ → //).
+      let safeReturnUrl = '/'
+      try {
+        const resolved = new URL(raw, window.location.origin)
+        if (resolved.origin === window.location.origin) {
+          safeReturnUrl = resolved.pathname + resolved.search + resolved.hash
+        }
+      } catch {
+        // malformed URL — fall back to '/'
+      }
       window.location.replace(safeReturnUrl)
     }
 


### PR DESCRIPTION
## Summary

- Validates `returnUrl` from `sessionStorage` before passing it to `window.location.replace()`, blocking open redirect attacks.

## Problem

`CallbackPage.tsx` read `sessionStorage.returnUrl` and passed it directly to `window.location.replace()`. Any absolute URL (e.g. `https://attacker.example.com`) was accepted, enabling an open redirect if an attacker could write to `sessionStorage` on the same origin.

## Fix

Reject any value that is not a relative path starting with `/` (and not a protocol-relative `//` path):

```typescript
const safeReturnUrl = /^\/(?!\/)/.test(raw) ? raw : '/'
window.location.replace(safeReturnUrl)
```

## Test plan

- [ ] Log in via OIDC — confirm normal redirect to `/` still works
- [ ] Set `sessionStorage.setItem('returnUrl', 'https://example.com')` before callback — confirm redirect goes to `/` instead
- [ ] Set `returnUrl` to `//example.com` — confirm redirect goes to `/`
- [ ] Set `returnUrl` to `/dashboard` — confirm redirect goes to `/dashboard`

Closes #298