### PR TITLE
fix(ui): cancel SCM sync timers on unmount; stabilise SetupWizard callbacks

### DIFF
--- a/frontend/src/hooks/useModuleDetail.ts
+++ b/frontend/src/hooks/useModuleDetail.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from 'react'
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import api from '../services/api'
@@ -359,18 +359,22 @@ export function useModuleDetail() {
     },
   })
 
+  const syncTimersRef = useRef<ReturnType<typeof setTimeout>[]>([])
+
   const scmSyncMutation = useMutation({
     mutationFn: () => api.triggerManualSync(module!.id),
     onSuccess: () => {
       setError(null)
       // Poll for updated versions after an async sync (202) at 2s, 5s, and 12s.
-      ;[2000, 5000, 12000].forEach((delay) => {
+      // Timers are tracked so they can be cancelled on unmount or re-sync.
+      syncTimersRef.current.forEach(clearTimeout)
+      syncTimersRef.current = [2000, 5000, 12000].map((delay) =>
         setTimeout(() => {
           queryClient.invalidateQueries({
             queryKey: queryKeys.modules.detail(namespace ?? '', name ?? '', system ?? ''),
           })
-        }, delay)
-      })
+        }, delay),
+      )
     },
     onError: (err: unknown) => {
       setError(getErrorMessage(err, 'Failed to trigger sync'))
@@ -391,13 +395,14 @@ export function useModuleDetail() {
   )
 
   const pollForVersions = useCallback(() => {
-    ;[2000, 5000, 12000].forEach((delay) => {
+    syncTimersRef.current.forEach(clearTimeout)
+    syncTimersRef.current = [2000, 5000, 12000].map((delay) =>
       setTimeout(() => {
         queryClient.invalidateQueries({
           queryKey: queryKeys.modules.detail(namespace ?? '', name ?? '', system ?? ''),
         })
-      }, delay)
-    })
+      }, delay),
+    )
   }, [queryClient, namespace, name, system])
 
   const handleRescan = () => {
@@ -412,6 +417,12 @@ export function useModuleDetail() {
     }
     scmSyncMutation.mutate()
   }
+
+  useEffect(() => {
+    return () => {
+      syncTimersRef.current.forEach(clearTimeout)
+    }
+  }, [])
 
   const handleSCMUnlink = () => {
     if (!module?.id) return

--- a/frontend/src/hooks/useModuleDetail.ts
+++ b/frontend/src/hooks/useModuleDetail.ts
@@ -25,6 +25,8 @@ function sortVersionsDesc(raw: ModuleVersion[]): ModuleVersion[] {
   })
 }
 
+const POLL_DELAYS = [2000, 5000, 12000] as const
+
 export function useModuleDetail() {
   const { namespace, name, system } = useParams<{
     namespace: string
@@ -361,20 +363,22 @@ export function useModuleDetail() {
 
   const syncTimersRef = useRef<ReturnType<typeof setTimeout>[]>([])
 
+  const pollForVersions = useCallback(() => {
+    syncTimersRef.current.forEach(clearTimeout)
+    syncTimersRef.current = POLL_DELAYS.map((delay) =>
+      setTimeout(() => {
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.modules.detail(namespace ?? '', name ?? '', system ?? ''),
+        })
+      }, delay),
+    )
+  }, [queryClient, namespace, name, system])
+
   const scmSyncMutation = useMutation({
     mutationFn: () => api.triggerManualSync(module!.id),
     onSuccess: () => {
       setError(null)
-      // Poll for updated versions after an async sync (202) at 2s, 5s, and 12s.
-      // Timers are tracked so they can be cancelled on unmount or re-sync.
-      syncTimersRef.current.forEach(clearTimeout)
-      syncTimersRef.current = [2000, 5000, 12000].map((delay) =>
-        setTimeout(() => {
-          queryClient.invalidateQueries({
-            queryKey: queryKeys.modules.detail(namespace ?? '', name ?? '', system ?? ''),
-          })
-        }, delay),
-      )
+      pollForVersions()
     },
     onError: (err: unknown) => {
       setError(getErrorMessage(err, 'Failed to trigger sync'))
@@ -393,17 +397,6 @@ export function useModuleDetail() {
     },
     [queryClient],
   )
-
-  const pollForVersions = useCallback(() => {
-    syncTimersRef.current.forEach(clearTimeout)
-    syncTimersRef.current = [2000, 5000, 12000].map((delay) =>
-      setTimeout(() => {
-        queryClient.invalidateQueries({
-          queryKey: queryKeys.modules.detail(namespace ?? '', name ?? '', system ?? ''),
-        })
-      }, delay),
-    )
-  }, [queryClient, namespace, name, system])
 
   const handleRescan = () => {
     if (!namespace || !name || !system || !selectedVersion) return

--- a/frontend/src/pages/SetupWizardPage.tsx
+++ b/frontend/src/pages/SetupWizardPage.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useCallback } from 'react'
 import {
   Box,
   Container,
@@ -132,10 +132,18 @@ const SetupWizardShell: React.FC = () => {
 
 const SetupWizardPage: React.FC = () => {
   const navigate = useNavigate()
+  const handleSetupCompleted = useCallback(
+    () => navigate('/', { replace: true }),
+    [navigate],
+  )
+  const handleSetupFinalized = useCallback(
+    () => navigate('/login', { replace: true }),
+    [navigate],
+  )
   return (
     <SetupWizardProvider
-      onSetupCompleted={() => navigate('/', { replace: true })}
-      onSetupFinalized={() => navigate('/login', { replace: true })}
+      onSetupCompleted={handleSetupCompleted}
+      onSetupFinalized={handleSetupFinalized}
     >
       <SetupWizardShell />
     </SetupWizardProvider>


### PR DESCRIPTION
## Summary

- Fixes uncancelled `setTimeout` calls in `useModuleDetail` that fired after component unmount (#301)
- Stabilises `onSetupCompleted`/`onSetupFinalized` props in `SetupWizardPage` to stop redundant `/setup/status` polls (#300)

## Problem

### #301 — Leaked timers in useModuleDetail

`scmSyncMutation.onSuccess` and `pollForVersions` in `useModuleDetail.ts` created three `setTimeout` calls each (at 2s/5s/12s) without storing the IDs. If the user navigated away within 12 seconds of triggering a sync, all six callbacks still fired, calling `queryClient.invalidateQueries` for a page no longer mounted.

### #300 — Unnecessary /setup/status polls

`SetupWizardPage` passed inline arrow functions as `onSetupCompleted`/`onSetupFinalized`. `SetupWizardContext.reloadStatus` has these props in its `useCallback` dependency array, so every re-render of `SetupWizardPage` recreated `reloadStatus`, which triggered its `useEffect` and an extra `GET /api/v1/setup/status` call.

## Fix

**#301:** Store timer IDs in a `useRef` and cancel them in a `useEffect` cleanup:
```typescript
const syncTimersRef = useRef<ReturnType<typeof setTimeout>[]>([])
// on sync success:
syncTimersRef.current.forEach(clearTimeout)
syncTimersRef.current = [2000, 5000, 12000].map((delay) => setTimeout(..., delay))
// cleanup:
useEffect(() => () => { syncTimersRef.current.forEach(clearTimeout) }, [])
```

**#300:** Wrap callbacks in `useCallback` in `SetupWizardPage` to stabilise their references.

## Test plan

- [ ] Trigger SCM sync on module detail page, navigate away within 5s — confirm no extra network requests for the previous module
- [ ] Visit setup wizard — confirm a single `GET /setup/status` call on mount, not repeated calls

Closes #301
Closes #300