### PR TITLE
fix(auth): schedule session expiry warning for cookie-based OIDC sessions

### DIFF
--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -50,7 +50,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   const [sessionExpiresSoon, setSessionExpiresSoon] = useState(false)
   const warningTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   // Ref to break the circular dependency between scheduleSessionWarning and refreshToken.
-  const silentRefreshRef = useRef<() => Promise<void>>(async () => {})
+  const silentRefreshRef = useRef<() => Promise<void>>(async () => { })
 
   const clearWarningTimer = useCallback(() => {
     if (warningTimerRef.current !== null) {
@@ -60,10 +60,10 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   }, [])
 
   const scheduleSessionWarning = useCallback(
-    (token: string | null | undefined) => {
+    (token: string | null | undefined, expiresAt?: Date) => {
       clearWarningTimer()
       setSessionExpiresSoon(false)
-      const exp = parseTokenExpiry(token)
+      const exp = expiresAt ?? parseTokenExpiry(token)
       setSessionExpiresAt(exp)
       if (!exp) return
       const delay = exp.getTime() - Date.now() - SESSION_WARNING_LEAD_MS
@@ -116,11 +116,14 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       localStorage.setItem('user', JSON.stringify(response.user))
       localStorage.setItem('role_template', JSON.stringify(response.role_template))
       localStorage.setItem('allowed_scopes', JSON.stringify(response.allowed_scopes))
+      if (response.session_expires_at) {
+        scheduleSessionWarning(null, new Date(response.session_expires_at))
+      }
     } catch (error) {
       console.error('Failed to fetch current user:', error)
       logout()
     }
-  }, [logout])
+  }, [logout, scheduleSessionWarning])
 
   useEffect(() => {
     // Check if user is already logged in.
@@ -189,6 +192,9 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
           localStorage.setItem('user', JSON.stringify(response.user))
           localStorage.setItem('role_template', JSON.stringify(response.role_template))
           localStorage.setItem('allowed_scopes', JSON.stringify(response.allowed_scopes))
+          if (response.session_expires_at) {
+            scheduleSessionWarning(null, new Date(response.session_expires_at))
+          }
         })
         .catch(() => {
           // No valid session — remain unauthenticated
@@ -235,6 +241,10 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     if (response.token) {
       localStorage.setItem('auth_token', response.token)
       scheduleSessionWarning(response.token)
+    } else if (response.expires_in) {
+      // Cookie-only session: no token in body, but backend renewed the HttpOnly cookie.
+      // Use expires_in (seconds) to reschedule the warning timer.
+      scheduleSessionWarning(null, new Date(Date.now() + response.expires_in * 1000))
     }
   }
   silentRefreshRef.current = silentRefresh

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -245,6 +245,10 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       // Cookie-only session: no token in body, but backend renewed the HttpOnly cookie.
       // Use expires_in (seconds) to reschedule the warning timer.
       scheduleSessionWarning(null, new Date(Date.now() + response.expires_in * 1000))
+    } else {
+      // Backend returned neither a token nor expires_in — session state is unknown.
+      clearWarningTimer()
+      setSessionExpiresAt(null)
     }
   }
   silentRefreshRef.current = silentRefresh

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -195,12 +195,14 @@ class ApiClient {
     user: import('../types').User
     role_template: import('../types').RoleTemplateInfo | null
     allowed_scopes: string[]
+    session_expires_at: string | null
   }> {
     const response = await this.client.get('/api/v1/auth/me')
     return {
       user: response.data.user,
       role_template: response.data.role_template || null,
       allowed_scopes: response.data.allowed_scopes || [],
+      session_expires_at: response.data.session_expires_at || null,
     }
   }
 


### PR DESCRIPTION
## Summary

- `getCurrentUserWithRole` now returns `session_expires_at` from the `/auth/me` response
- `scheduleSessionWarning` accepts an optional explicit `expiresAt: Date` (no JWT needed)
- `fetchCurrentUser` and the fresh-cookie init path both schedule the warning timer after a successful `/auth/me`
- `silentRefresh` reschedules the timer from `expires_in` when no token is in the refresh response body

## Problem (see #299)

The session-expiry warning dialog and silent-refresh timer were only armed for JWT/localStorage sessions. Cookie-based OIDC sessions — the primary auth path — never called `scheduleSessionWarning`, so users were silently logged out without the 2-minute advance warning or a silent-refresh attempt.

Root cause: HttpOnly cookie expiry is not accessible to JavaScript, and `scheduleSessionWarning` previously required a JWT string to extract the `exp` claim.

## Fix

The backend now returns `session_expires_at` in the `/auth/me` response (populated from JWT claims already in the gin context — see backend PR sethbacon/terraform-registry-backend#394). The frontend uses this timestamp to arm the warning timer regardless of auth path.

## Dependencies

Requires backend PR sethbacon/terraform-registry-backend#394 to be deployed before this is effective. Until then, `session_expires_at` will be absent from the response and the behaviour is unchanged (no regression).

## Test plan

- [ ] Log in via OIDC (cookie session, no `auth_token` in localStorage)
- [ ] Confirm `scheduleSessionWarning` is called — `sessionExpiresAt` in AuthContext should be non-null
- [ ] Fast-forward system clock to within 2 minutes of expiry — confirm warning dialog appears
- [ ] Confirm silent refresh re-arms the timer after a successful token refresh

Closes #299