### PR TITLE
ci: parallelize unit tests with vitest sharding (4 shards)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,17 +41,51 @@ jobs:
         working-directory: frontend
         run: npx tsc --noEmit
 
-  # ── Unit Tests with Coverage ──────────────────────────
+  # ── Unit Tests — sharded (4 parallel runners) ─────────
   unit-test:
-    name: Unit Tests
+    name: Unit Tests (${{ matrix.shard }}/${{ strategy.job-total }})
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        shard: [1, 2, 3, 4]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup-frontend
 
-      - name: Run tests with coverage
+      - name: Run tests (shard ${{ matrix.shard }}/${{ strategy.job-total }})
         working-directory: frontend
-        run: npm run test:coverage
+        run: >-
+          npx vitest run --coverage --reporter=blob
+          --shard=${{ matrix.shard }}/${{ strategy.job-total }}
+
+      - name: Upload blob report
+        if: always()
+        # v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
+        with:
+          name: vitest-blob-${{ matrix.shard }}
+          path: frontend/.vitest-reports/
+
+  # ── Unit Test Coverage (merge shards) ─────────────────
+  unit-test-coverage:
+    name: Unit Test Coverage
+    runs-on: ubuntu-latest
+    needs: unit-test
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: ./.github/actions/setup-frontend
+
+      - name: Download blob reports
+        # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          pattern: vitest-blob-*
+          path: frontend/.vitest-reports/
+          merge-multiple: true
+
+      - name: Merge reports and generate coverage
+        working-directory: frontend
+        run: npx vitest merge-reports --reporter=verbose .vitest-reports/
 
       - name: Upload coverage report
         if: always()
@@ -174,7 +208,7 @@ jobs:
   e2e-gated:
     name: E2E (gated/manual)
     runs-on: ubuntu-latest
-    needs: [lint, typecheck, unit-test, build, contract-check]
+    needs: [lint, typecheck, unit-test-coverage, build, contract-check]
     # E2E is a required gate: failures block the release pipeline.
     if: >-
       github.event_name == 'workflow_dispatch' || github.event_name ==

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
         run: npx tsc --noEmit
 
   # ── Unit Tests — sharded (4 parallel runners) ─────────
+  # Runs tests only (no coverage) so E2E can start after ~1 min instead of
+  # waiting for the full 4-min coverage run. Coverage is collected separately
+  # in unit-test-coverage below and is still a required check before merge.
   unit-test:
     name: Unit Tests (${{ matrix.shard }}/${{ strategy.job-total }})
     runs-on: ubuntu-latest
@@ -54,44 +57,23 @@ jobs:
 
       - name: Run tests (shard ${{ matrix.shard }}/${{ strategy.job-total }})
         working-directory: frontend
-        # Thresholds zeroed here — each shard only covers ~25% of the suite.
-        # Real thresholds are enforced by the unit-test-coverage merge job.
         run: >-
-          npx vitest run --coverage --reporter=blob
+          npx vitest run
           --shard=${{ matrix.shard }}/${{ strategy.job-total }}
-          --coverage.thresholds.statements=0
-          --coverage.thresholds.branches=0
-          --coverage.thresholds.functions=0
-          --coverage.thresholds.lines=0
 
-      - name: Upload blob report
-        if: always()
-        # v7
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
-        with:
-          name: vitest-blob-${{ matrix.shard }}
-          path: frontend/.vitest-reports/
-
-  # ── Unit Test Coverage (merge shards) ─────────────────
+  # ── Unit Test Coverage ────────────────────────────────
+  # Runs independently of the shards — does not block E2E but is a required
+  # status check, so coverage thresholds are still enforced before merge.
   unit-test-coverage:
     name: Unit Test Coverage
     runs-on: ubuntu-latest
-    needs: unit-test
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup-frontend
 
-      - name: Download blob reports
-        # v8
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
-        with:
-          pattern: vitest-blob-*
-          path: frontend/.vitest-reports/
-          merge-multiple: true
-
-      - name: Merge reports and generate coverage
+      - name: Run tests with coverage
         working-directory: frontend
-        run: npx vitest merge-reports --reporter=verbose .vitest-reports/
+        run: npm run test:coverage
 
       - name: Upload coverage report
         if: always()
@@ -214,7 +196,7 @@ jobs:
   e2e-gated:
     name: E2E (gated/manual)
     runs-on: ubuntu-latest
-    needs: [lint, typecheck, unit-test-coverage, build, contract-check]
+    needs: [lint, typecheck, unit-test, build, contract-check]
     # E2E is a required gate: failures block the release pipeline.
     if: >-
       github.event_name == 'workflow_dispatch' || github.event_name ==

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,9 +42,11 @@ jobs:
         run: npx tsc --noEmit
 
   # ── Unit Tests — sharded (4 parallel runners) ─────────
-  # Runs tests only (no coverage) so E2E can start after ~1 min instead of
-  # waiting for the full 4-min coverage run. Coverage is collected separately
-  # in unit-test-coverage below and is still a required check before merge.
+  # Each shard runs ~25% of tests + collects coverage, writing a blob to
+  # .vitest-reports/blob-<shard>.json with an explicit unique filename so
+  # the merge job can combine them. Coverage thresholds are disabled per
+  # shard (partial coverage will always be below the configured floor);
+  # the unit-test-coverage merge job re-enforces them on the combined data.
   unit-test:
     name: Unit Tests (${{ matrix.shard }}/${{ strategy.job-total }})
     runs-on: ubuntu-latest
@@ -58,22 +60,57 @@ jobs:
       - name: Run tests (shard ${{ matrix.shard }}/${{ strategy.job-total }})
         working-directory: frontend
         run: >-
-          npx vitest run
+          npx vitest run --coverage
+          --reporter=blob
+          --outputFile.blob=.vitest-reports/blob-${{ matrix.shard }}.json
           --shard=${{ matrix.shard }}/${{ strategy.job-total }}
+          --coverage.thresholds.statements=0
+          --coverage.thresholds.branches=0
+          --coverage.thresholds.functions=0
+          --coverage.thresholds.lines=0
 
-  # ── Unit Test Coverage ────────────────────────────────
-  # Runs independently of the shards — does not block E2E but is a required
-  # status check, so coverage thresholds are still enforced before merge.
+      - name: List blob reports (debug)
+        if: always()
+        working-directory: frontend
+        run: ls -la .vitest-reports/ || echo "no .vitest-reports/ directory"
+
+      - name: Upload blob report
+        # v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
+        with:
+          name: vitest-blob-${{ matrix.shard }}
+          path: frontend/.vitest-reports/blob-${{ matrix.shard }}.json
+          if-no-files-found: error
+
+  # ── Unit Test Coverage (merge blob shards) ────────────
+  # Downloads all 4 shard blobs, merges them with `vitest --merge-reports`,
+  # produces combined coverage, applies real thresholds, and updates badge.
   unit-test-coverage:
     name: Unit Test Coverage
     runs-on: ubuntu-latest
+    needs: unit-test
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup-frontend
 
-      - name: Run tests with coverage
+      - name: Download blob reports
+        # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          pattern: vitest-blob-*
+          path: frontend/.vitest-reports/
+          merge-multiple: true
+
+      - name: List downloaded blobs (debug)
         working-directory: frontend
-        run: npm run test:coverage
+        run: ls -la .vitest-reports/
+
+      - name: Merge reports and generate coverage
+        working-directory: frontend
+        # `--merge-reports=<path>` is a CLI flag in vitest v4 (the subcommand
+        # form `vitest merge-reports` is parsed as a test name filter and
+        # falls through to a "no test files found" error).
+        run: npx vitest --merge-reports=.vitest-reports --reporter=verbose
 
       - name: Upload coverage report
         if: always()
@@ -196,7 +233,7 @@ jobs:
   e2e-gated:
     name: E2E (gated/manual)
     runs-on: ubuntu-latest
-    needs: [lint, typecheck, unit-test, build, contract-check]
+    needs: [lint, typecheck, unit-test-coverage, build, contract-check]
     # E2E is a required gate: failures block the release pipeline.
     if: >-
       github.event_name == 'workflow_dispatch' || github.event_name ==

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,9 +54,15 @@ jobs:
 
       - name: Run tests (shard ${{ matrix.shard }}/${{ strategy.job-total }})
         working-directory: frontend
+        # Thresholds zeroed here — each shard only covers ~25% of the suite.
+        # Real thresholds are enforced by the unit-test-coverage merge job.
         run: >-
           npx vitest run --coverage --reporter=blob
           --shard=${{ matrix.shard }}/${{ strategy.job-total }}
+          --coverage.thresholds.statements=0
+          --coverage.thresholds.branches=0
+          --coverage.thresholds.functions=0
+          --coverage.thresholds.lines=0
 
       - name: Upload blob report
         if: always()


### PR DESCRIPTION
## Summary

- Splits the single `unit-test` job into a **4-shard matrix** using `vitest --shard` and `--reporter=blob`
- Adds a `unit-test-coverage` merge job that downloads all blob artifacts, runs `vitest merge-reports`, and produces the combined coverage report + badge update
- Updates `e2e-gated` to depend on `unit-test-coverage` instead of `unit-test`
- Uses `actions/download-artifact@v8` (SHA-pinned) to match existing `upload-artifact@v7`

Expected wall-clock improvement: **~1 min per shard** vs ~4 min today (4× speedup).

## Test plan

- [ ] All 4 `Unit Tests (N/4)` jobs pass in CI
- [ ] `Unit Test Coverage` merge job produces `coverage-report` artifact with valid `coverage-summary.json`
- [ ] Coverage badge updates on push to main (check gist)
- [ ] `E2E (gated/manual)` still runs and gates on `unit-test-coverage`