### PR TITLE
ci: parallelize unit tests with vitest sharding (4 shards)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,17 +41,51 @@ jobs:
         working-directory: frontend
         run: npx tsc --noEmit
 
-  # ── Unit Tests with Coverage ──────────────────────────
+  # ── Unit Tests — sharded (4 parallel runners) ─────────
   unit-test:
-    name: Unit Tests
+    name: Unit Tests (${{ matrix.shard }}/${{ strategy.job-total }})
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        shard: [1, 2, 3, 4]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup-frontend
 
-      - name: Run tests with coverage
+      - name: Run tests (shard ${{ matrix.shard }}/${{ strategy.job-total }})
         working-directory: frontend
-        run: npm run test:coverage
+        run: >-
+          npx vitest run --coverage --reporter=blob
+          --shard=${{ matrix.shard }}/${{ strategy.job-total }}
+
+      - name: Upload blob report
+        if: always()
+        # v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
+        with:
+          name: vitest-blob-${{ matrix.shard }}
+          path: frontend/.vitest-reports/
+
+  # ── Unit Test Coverage (merge shards) ─────────────────
+  unit-test-coverage:
+    name: Unit Test Coverage
+    runs-on: ubuntu-latest
+    needs: unit-test
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: ./.github/actions/setup-frontend
+
+      - name: Download blob reports
+        # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          pattern: vitest-blob-*
+          path: frontend/.vitest-reports/
+          merge-multiple: true
+
+      - name: Merge reports and generate coverage
+        working-directory: frontend
+        run: npx vitest merge-reports --reporter=verbose .vitest-reports/
 
       - name: Upload coverage report
         if: always()
@@ -174,7 +208,7 @@ jobs:
   e2e-gated:
     name: E2E (gated/manual)
     runs-on: ubuntu-latest
-    needs: [lint, typecheck, unit-test, build, contract-check]
+    needs: [lint, typecheck, unit-test-coverage, build, contract-check]
     # E2E is a required gate: failures block the release pipeline.
     if: >-
       github.event_name == 'workflow_dispatch' || github.event_name ==

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
         run: npx tsc --noEmit
 
   # ── Unit Tests — sharded (4 parallel runners) ─────────
+  # Runs tests only (no coverage) so E2E can start after ~1 min instead of
+  # waiting for the full 4-min coverage run. Coverage is collected separately
+  # in unit-test-coverage below and is still a required check before merge.
   unit-test:
     name: Unit Tests (${{ matrix.shard }}/${{ strategy.job-total }})
     runs-on: ubuntu-latest
@@ -54,44 +57,23 @@ jobs:
 
       - name: Run tests (shard ${{ matrix.shard }}/${{ strategy.job-total }})
         working-directory: frontend
-        # Thresholds zeroed here — each shard only covers ~25% of the suite.
-        # Real thresholds are enforced by the unit-test-coverage merge job.
         run: >-
-          npx vitest run --coverage --reporter=blob
+          npx vitest run
           --shard=${{ matrix.shard }}/${{ strategy.job-total }}
-          --coverage.thresholds.statements=0
-          --coverage.thresholds.branches=0
-          --coverage.thresholds.functions=0
-          --coverage.thresholds.lines=0
 
-      - name: Upload blob report
-        if: always()
-        # v7
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
-        with:
-          name: vitest-blob-${{ matrix.shard }}
-          path: frontend/.vitest-reports/
-
-  # ── Unit Test Coverage (merge shards) ─────────────────
+  # ── Unit Test Coverage ────────────────────────────────
+  # Runs independently of the shards — does not block E2E but is a required
+  # status check, so coverage thresholds are still enforced before merge.
   unit-test-coverage:
     name: Unit Test Coverage
     runs-on: ubuntu-latest
-    needs: unit-test
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup-frontend
 
-      - name: Download blob reports
-        # v8
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
-        with:
-          pattern: vitest-blob-*
-          path: frontend/.vitest-reports/
-          merge-multiple: true
-
-      - name: Merge reports and generate coverage
+      - name: Run tests with coverage
         working-directory: frontend
-        run: npx vitest merge-reports --reporter=verbose .vitest-reports/
+        run: npm run test:coverage
 
       - name: Upload coverage report
         if: always()
@@ -214,7 +196,7 @@ jobs:
   e2e-gated:
     name: E2E (gated/manual)
     runs-on: ubuntu-latest
-    needs: [lint, typecheck, unit-test-coverage, build, contract-check]
+    needs: [lint, typecheck, unit-test, build, contract-check]
     # E2E is a required gate: failures block the release pipeline.
     if: >-
       github.event_name == 'workflow_dispatch' || github.event_name ==

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,9 +42,11 @@ jobs:
         run: npx tsc --noEmit
 
   # ── Unit Tests — sharded (4 parallel runners) ─────────
-  # Runs tests only (no coverage) so E2E can start after ~1 min instead of
-  # waiting for the full 4-min coverage run. Coverage is collected separately
-  # in unit-test-coverage below and is still a required check before merge.
+  # Each shard runs ~25% of tests + collects coverage, writing a blob to
+  # .vitest-reports/blob-<shard>.json with an explicit unique filename so
+  # the merge job can combine them. Coverage thresholds are disabled per
+  # shard (partial coverage will always be below the configured floor);
+  # the unit-test-coverage merge job re-enforces them on the combined data.
   unit-test:
     name: Unit Tests (${{ matrix.shard }}/${{ strategy.job-total }})
     runs-on: ubuntu-latest
@@ -58,22 +60,57 @@ jobs:
       - name: Run tests (shard ${{ matrix.shard }}/${{ strategy.job-total }})
         working-directory: frontend
         run: >-
-          npx vitest run
+          npx vitest run --coverage
+          --reporter=blob
+          --outputFile.blob=.vitest-reports/blob-${{ matrix.shard }}.json
           --shard=${{ matrix.shard }}/${{ strategy.job-total }}
+          --coverage.thresholds.statements=0
+          --coverage.thresholds.branches=0
+          --coverage.thresholds.functions=0
+          --coverage.thresholds.lines=0
 
-  # ── Unit Test Coverage ────────────────────────────────
-  # Runs independently of the shards — does not block E2E but is a required
-  # status check, so coverage thresholds are still enforced before merge.
+      - name: List blob reports (debug)
+        if: always()
+        working-directory: frontend
+        run: ls -la .vitest-reports/ || echo "no .vitest-reports/ directory"
+
+      - name: Upload blob report
+        # v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
+        with:
+          name: vitest-blob-${{ matrix.shard }}
+          path: frontend/.vitest-reports/blob-${{ matrix.shard }}.json
+          if-no-files-found: error
+
+  # ── Unit Test Coverage (merge blob shards) ────────────
+  # Downloads all 4 shard blobs, merges them with `vitest --merge-reports`,
+  # produces combined coverage, applies real thresholds, and updates badge.
   unit-test-coverage:
     name: Unit Test Coverage
     runs-on: ubuntu-latest
+    needs: unit-test
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup-frontend
 
-      - name: Run tests with coverage
+      - name: Download blob reports
+        # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          pattern: vitest-blob-*
+          path: frontend/.vitest-reports/
+          merge-multiple: true
+
+      - name: List downloaded blobs (debug)
         working-directory: frontend
-        run: npm run test:coverage
+        run: ls -la .vitest-reports/
+
+      - name: Merge reports and generate coverage
+        working-directory: frontend
+        # `--merge-reports=<path>` is a CLI flag in vitest v4 (the subcommand
+        # form `vitest merge-reports` is parsed as a test name filter and
+        # falls through to a "no test files found" error).
+        run: npx vitest --merge-reports=.vitest-reports --reporter=verbose
 
       - name: Upload coverage report
         if: always()
@@ -196,7 +233,7 @@ jobs:
   e2e-gated:
     name: E2E (gated/manual)
     runs-on: ubuntu-latest
-    needs: [lint, typecheck, unit-test, build, contract-check]
+    needs: [lint, typecheck, unit-test-coverage, build, contract-check]
     # E2E is a required gate: failures block the release pipeline.
     if: >-
       github.event_name == 'workflow_dispatch' || github.event_name ==

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
         # `--merge-reports=<path>` is a CLI flag in vitest v4 (the subcommand
         # form `vitest merge-reports` is parsed as a test name filter and
         # falls through to a "no test files found" error).
-        run: npx vitest --merge-reports=.vitest-reports --reporter=verbose
+        run: npx vitest --merge-reports=.vitest-reports --reporter=verbose --coverage
 
       - name: Upload coverage report
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,9 +54,15 @@ jobs:
 
       - name: Run tests (shard ${{ matrix.shard }}/${{ strategy.job-total }})
         working-directory: frontend
+        # Thresholds zeroed here — each shard only covers ~25% of the suite.
+        # Real thresholds are enforced by the unit-test-coverage merge job.
         run: >-
           npx vitest run --coverage --reporter=blob
           --shard=${{ matrix.shard }}/${{ strategy.job-total }}
+          --coverage.thresholds.statements=0
+          --coverage.thresholds.branches=0
+          --coverage.thresholds.functions=0
+          --coverage.thresholds.lines=0
 
       - name: Upload blob report
         if: always()

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -68,7 +68,7 @@ function App() {
           <HelpProvider>
             <AnnouncerProvider>
               <QueryClientProvider client={queryClient}>
-                <Router>
+                <Router future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
                   <RouteFocusManager />
                   <ErrorBoundary>
                     <Routes>

--- a/frontend/src/components/PublishFromSCMWizard.tsx
+++ b/frontend/src/components/PublishFromSCMWizard.tsx
@@ -461,7 +461,7 @@ const PublishFromSCMWizard: React.FC<PublishFromSCMWizardProps> = ({
           <Divider sx={{ my: 3 }} />
 
           <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
-            <Button onClick={onCancel} disabled={loading}>
+            <Button onClick={onCancel}>
               Cancel
             </Button>
             <Box>
@@ -472,7 +472,7 @@ const PublishFromSCMWizard: React.FC<PublishFromSCMWizardProps> = ({
                 <Button
                   variant="contained"
                   onClick={handleComplete}
-                  disabled={loading || !canProceedToNext()}
+                  disabled={!canProceedToNext()}
                 >
                   Link Module
                 </Button>

--- a/frontend/src/components/PublishFromSCMWizard.tsx
+++ b/frontend/src/components/PublishFromSCMWizard.tsx
@@ -158,11 +158,11 @@ const PublishFromSCMWizard: React.FC<PublishFromSCMWizardProps> = ({
 
   const repoNameFilter: RegExp | undefined = moduleSystem
     ? new RegExp(
-        '^terraform-' +
-          moduleSystem.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') +
-          '-[a-z0-9][a-z0-9-]*$',
-        'i',
-      )
+      '^terraform-' +
+      moduleSystem.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') +
+      '-[a-z0-9][a-z0-9-]*$',
+      'i',
+    )
     : undefined
 
   const getStepContent = (step: number) => {

--- a/frontend/src/services/errorReporting.ts
+++ b/frontend/src/services/errorReporting.ts
@@ -55,10 +55,7 @@ const errorBuffer: ErrorEntry[] = []
 // ---------------------------------------------------------------------------
 
 function generateSessionId(): string {
-  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
-    return crypto.randomUUID()
-  }
-  return `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`
+  return crypto.randomUUID()
 }
 
 function addBreadcrumb(crumb: Breadcrumb): void {

--- a/frontend/src/services/performanceReporting.ts
+++ b/frontend/src/services/performanceReporting.ts
@@ -37,11 +37,7 @@ const buffer: PerfEntry[] = []
 // ---------------------------------------------------------------------------
 
 function generateSessionId(): string {
-  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
-    return crypto.randomUUID()
-  }
-  // Fallback for older browsers
-  return `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`
+  return crypto.randomUUID()
 }
 
 /** Send the buffered entries to the configured DSN. */

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -23,91 +23,92 @@ export default defineConfig(async () => {
     : [];
 
   return {
-  plugins: [react(), ...visualizerPlugin],
-  define: {
-    __APP_VERSION__: JSON.stringify(pkg.version),
-  },
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './src'),
+    plugins: [react(), ...visualizerPlugin],
+    define: {
+      __APP_VERSION__: JSON.stringify(pkg.version),
     },
-  },
-  build: {
-    rollupOptions: {
-      output: {
-        manualChunks(id: string) {
-          if (!id.includes('node_modules')) return;
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, './src'),
+      },
+    },
+    build: {
+      chunkSizeWarningLimit: 800,
+      rollupOptions: {
+        output: {
+          manualChunks(id: string) {
+            if (!id.includes('node_modules')) return;
 
-          // Keep explicit checks narrowly scoped and ordered to avoid overlapping
-          // matches that can create circular chunk relationships.
-          if (id.includes('/node_modules/react/') || id.includes('/node_modules/react-dom/')) {
-            return 'react-vendor';
-          }
-          if (id.includes('/node_modules/@mui/icons-material/')) {
-            return 'mui-icons';
-          }
-          if (id.includes('/node_modules/@mui/material/') || id.includes('/node_modules/@emotion/')) {
-            return 'mui';
-          }
-          if (id.includes('/node_modules/react-router-dom/')) {
-            return 'router';
-          }
-          if (id.includes('/node_modules/react-markdown/') || id.includes('/node_modules/remark-gfm/')) {
-            return 'markdown';
-          }
-          if (id.includes('/node_modules/swagger-ui-react/') || id.includes('/node_modules/swagger-ui-dist/')) {
-            return 'swagger-ui';
-          }
-          // Leave other node_modules to Rollup's default chunking to avoid circular chunks
+            // Keep explicit checks narrowly scoped and ordered to avoid overlapping
+            // matches that can create circular chunk relationships.
+            if (id.includes('/node_modules/react/') || id.includes('/node_modules/react-dom/')) {
+              return 'react-vendor';
+            }
+            if (id.includes('/node_modules/@mui/icons-material/')) {
+              return 'mui-icons';
+            }
+            if (id.includes('/node_modules/@mui/material/') || id.includes('/node_modules/@emotion/')) {
+              return 'mui';
+            }
+            if (id.includes('/node_modules/react-router-dom/')) {
+              return 'router';
+            }
+            if (id.includes('/node_modules/react-markdown/') || id.includes('/node_modules/remark-gfm/')) {
+              return 'markdown';
+            }
+            if (id.includes('/node_modules/swagger-ui-react/') || id.includes('/node_modules/swagger-ui-dist/')) {
+              return 'swagger-ui';
+            }
+            // Leave other node_modules to Rollup's default chunking to avoid circular chunks
+          },
         },
       },
     },
-  },
-  server: {
-    port: 3000,
-    host: 'registry.local',
-    ...(certsExist ? {
-      https: {
-        key: fs.readFileSync(keyPath),
-        cert: fs.readFileSync(certPath),
-      },
-    } : {}),
-    proxy: {
-      // Proxy API and static backend assets to the backend.
-      // When running Vite locally against the Docker stack, the backend is
-      // reachable at http://localhost:8080.  When TLS certs are present the
-      // backend serves HTTPS on localhost:443 and proxyTarget should be
-      // overridden via VITE_PROXY_TARGET.
-      // /api-docs and /api-docs/ are React Router SPA routes and must NOT be
-      // proxied — Vite's SPA fallback handles them.
-      '/swagger.json': {
-        target: proxyTarget,
-        changeOrigin: true,
-        secure: false,
-      },
-      '/swagger.yaml': {
-        target: proxyTarget,
-        changeOrigin: true,
-        secure: false,
-      },
-      // Use /api/ (with slash) so this prefix only matches /api/v1/...
-      // and does NOT accidentally match /api-docs which is a React Router route.
-      '/api/': {
-        target: proxyTarget,
-        changeOrigin: true,
-        secure: false,
-      },
-      '/v1': {
-        target: proxyTarget,
-        changeOrigin: true,
-        secure: false,
-      },
-      '/.well-known': {
-        target: proxyTarget,
-        changeOrigin: true,
-        secure: false,
+    server: {
+      port: 3000,
+      host: 'registry.local',
+      ...(certsExist ? {
+        https: {
+          key: fs.readFileSync(keyPath),
+          cert: fs.readFileSync(certPath),
+        },
+      } : {}),
+      proxy: {
+        // Proxy API and static backend assets to the backend.
+        // When running Vite locally against the Docker stack, the backend is
+        // reachable at http://localhost:8080.  When TLS certs are present the
+        // backend serves HTTPS on localhost:443 and proxyTarget should be
+        // overridden via VITE_PROXY_TARGET.
+        // /api-docs and /api-docs/ are React Router SPA routes and must NOT be
+        // proxied — Vite's SPA fallback handles them.
+        '/swagger.json': {
+          target: proxyTarget,
+          changeOrigin: true,
+          secure: false,
+        },
+        '/swagger.yaml': {
+          target: proxyTarget,
+          changeOrigin: true,
+          secure: false,
+        },
+        // Use /api/ (with slash) so this prefix only matches /api/v1/...
+        // and does NOT accidentally match /api-docs which is a React Router route.
+        '/api/': {
+          target: proxyTarget,
+          changeOrigin: true,
+          secure: false,
+        },
+        '/v1': {
+          target: proxyTarget,
+          changeOrigin: true,
+          secure: false,
+        },
+        '/.well-known': {
+          target: proxyTarget,
+          changeOrigin: true,
+          secure: false,
+        },
       },
     },
-  },
   };
 })


### PR DESCRIPTION
## Summary

- Splits the single `unit-test` job into a 4-shard matrix using `vitest --shard` and `--reporter=blob`. Each shard runs ~25% of the test suite in parallel (~1 min each vs ~4 min serial).
- A follow-on `unit-test-coverage` job downloads all blob reports, merges them with `vitest --merge-reports`, produces combined coverage, enforces thresholds, and updates the badge.
- Fixes CodeQL alerts #1, #2 (insecure randomness) and #7 (trivial conditional); dismisses #3–#6, #8 as false positives.
- Adds React Router v7 future flags to silence repeated console warnings.
- Raises `chunkSizeWarningLimit` to 800 kB to match actual index bundle size (776 kB / 231 kB gzip).

## Key implementation notes

- Vitest v4 dropped the `merge-reports` subcommand; the correct CLI is `--merge-reports=<path>` flag.
- Each shard uses an explicit `--outputFile.blob=.vitest-reports/blob-<n>.json` so upload-artifact can reference a unique filename per shard.
- Coverage thresholds are zeroed on shard steps (partial coverage ~18% would always fail); the merge job re-enforces the real limits (80/70) against combined data.
- `e2e-gated` gates on `unit-test-coverage` (not raw shards) so E2E waits for the full coverage gate.

## Test plan

- [ ] All 4 shard jobs pass and upload blob artifacts
- [ ] `Unit Test Coverage` merge job downloads blobs, merges, and enforces thresholds
- [ ] Coverage badge step writes `coverage-summary.json` (requires `--coverage` on the merge command)
- [ ] No React Router future-flag warnings in merge job output
- [ ] Build chunk size warning gone