### PR TITLE
fix: replace params.slotProps with params.InputProps in Autocomplete renderInput

### DIFF
--- a/frontend/src/pages/admin/OIDCSettingsPage.tsx
+++ b/frontend/src/pages/admin/OIDCSettingsPage.tsx
@@ -455,11 +455,11 @@ const OIDCSettingsPage: React.FC = () => {
                       fullWidth
                       slotProps={{
                         input: {
-                          ...params.InputProps,
+                          ...params.slotProps?.input,
                           endAdornment: (
                             <>
                               {orgLoading ? <CircularProgress color="inherit" size={16} /> : null}
-                              {params.InputProps.endAdornment}
+                              {params.slotProps?.input?.endAdornment}
                             </>
                           ),
                         }

--- a/frontend/src/pages/admin/OIDCSettingsPage.tsx
+++ b/frontend/src/pages/admin/OIDCSettingsPage.tsx
@@ -454,6 +454,7 @@ const OIDCSettingsPage: React.FC = () => {
                       helperText="Registry organization name the user will be added to"
                       fullWidth
                       slotProps={{
+                        ...params.slotProps,
                         input: {
                           ...params.slotProps?.input,
                           endAdornment: (

--- a/frontend/src/pages/admin/OIDCSettingsPage.tsx
+++ b/frontend/src/pages/admin/OIDCSettingsPage.tsx
@@ -454,14 +454,12 @@ const OIDCSettingsPage: React.FC = () => {
                       helperText="Registry organization name the user will be added to"
                       fullWidth
                       slotProps={{
-                        ...params.slotProps,
-
                         input: {
-                          ...params.slotProps.input,
+                          ...params.InputProps,
                           endAdornment: (
                             <>
                               {orgLoading ? <CircularProgress color="inherit" size={16} /> : null}
-                              {params.slotProps.input.endAdornment}
+                              {params.InputProps.endAdornment}
                             </>
                           ),
                         }


### PR DESCRIPTION
## Summary

Fixes #330 — consistent crash when opening the Add/Edit Group Mapping dialog on the OIDC Groups page.

`AutocompleteRenderInputParams` does not have a `slotProps` property. The render params expose `InputProps` (the legacy MUI input prop bag containing `endAdornment`, `startAdornment`, etc.) and `inputProps` (native input attributes). The previous code used `params.slotProps.input` which is always `undefined`, causing an immediate `TypeError` on render.

## Change

One file, 4 lines replaced with 2:

```tsx
// Before
slotProps={{
  ...params.slotProps,
  input: {
    ...params.slotProps.input,          // TypeError: Cannot read properties of undefined
    endAdornment: (
      <>
        {orgLoading ? <CircularProgress .../> : null}
        {params.slotProps.input.endAdornment}   // crash
      </>
    ),
  }
}}

// After
slotProps={{
  input: {
    ...params.InputProps,
    endAdornment: (
      <>
        {orgLoading ? <CircularProgress .../> : null}
        {params.InputProps.endAdornment}
      </>
    ),
  }
}}
```

## Test results

- Before: 3 failures, 1515 passed
- After: **1518 passed, 0 failed**

Lint: clean. TypeScript: clean (this also resolves the 3 pre-existing TS errors from `OIDCSettingsPage.tsx` that were blocking the build).