### PR TITLE
fix(scm): unwrap events envelope so webhook panel renders

### DIFF
--- a/frontend/src/services/__tests__/api.test.ts
+++ b/frontend/src/services/__tests__/api.test.ts
@@ -1276,13 +1276,30 @@ describe('ApiClient', () => {
       expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/admin/modules/m1/scm/sync', {})
     })
 
-    it('getWebhookEvents', async () => {
+    it('getWebhookEvents unwraps the events array from the response envelope', async () => {
+      const client = await getApiClient()
+      const sample = [
+        { id: 'e1', event_type: 'tag', state: 'succeeded' },
+        { id: 'e2', event_type: 'push', state: 'failed' },
+      ]
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { events: sample },
+        })
+      const result = await client.getWebhookEvents('m1')
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/modules/m1/scm/events')
+      // Regression: the backend returns { events: [...] } — the client must hand
+      // callers the bare array, not the wrapper, or Array.isArray checks fail
+      // downstream and the UI panel renders empty.
+      expect(result).toEqual(sample)
+    })
+
+    it('getWebhookEvents returns [] when the envelope is missing events', async () => {
       const client = await getApiClient()
         ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-          data: { events: [] },
+          data: {},
         })
-      await client.getWebhookEvents('m1')
-      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/modules/m1/scm/events')
+      const result = await client.getWebhookEvents('m1')
+      expect(result).toEqual([])
     })
   })
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -850,7 +850,8 @@ class ApiClient {
 
   async getWebhookEvents(moduleId: string) {
     const response = await this.client.get(`/api/v1/admin/modules/${moduleId}/scm/events`)
-    return response.data
+    // Backend wraps the list as { events: [...] }; callers expect a bare array.
+    return response.data?.events ?? []
   }
 
   async updateModule(id: string, data: { description?: string; source?: string; namespace?: string }) {


### PR DESCRIPTION
## Summary

- The module detail page's *Webhook Events* panel always rendered "No webhook events recorded yet" because `api.getWebhookEvents` returned the wrapper `{events: [...]}` and `useModuleDetail` ran `Array.isArray` on the object — always false → list reset to `[]`.
- Unwrap `response.data.events` in the client so callers receive a bare array, matching the contract the hook already expects.
- Tighten the api unit test to assert the unwrapped return value and add a coverage case for a missing-envelope response.

Closes #337

## Test plan

- [x] `npm run lint` — clean (zero warnings)
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run src/services/__tests__/api.test.ts src/hooks/__tests__/useModuleDetail.test.ts` — all 221 tests pass (new api regression tests + existing `loadWebhookEvents populates webhookEvents list` hook test)
- [x] `npm run build` — clean
- [ ] Manual: open a module detail page for a module that has webhook deliveries; the panel lists them instead of showing the empty state