### PR TITLE
feat(mirror): add release signing key status panel and dashboard tile

### DIFF
--- a/deployments/docker-compose.contract-check.yml
+++ b/deployments/docker-compose.contract-check.yml
@@ -20,7 +20,7 @@ services:
     # Pinned backend image. Bump this tag in lockstep with backend releases
     # whose API surface the frontend wants to depend on. The contract check
     # validates that every route api.ts calls exists on this exact backend.
-    image: ${BACKEND_IMAGE:-ghcr.io/sethbacon/terraform-registry-backend:1.2.1}
+    image: ${BACKEND_IMAGE:-ghcr.io/sethbacon/terraform-registry-backend:1.3.0}
     environment:
       - TFR_DATABASE_HOST=postgres
       - TFR_DATABASE_PORT=5432

--- a/frontend/scripts/contract-check.allowlist.json
+++ b/frontend/scripts/contract-check.allowlist.json
@@ -20,11 +20,6 @@
       "method": "POST",
       "path": "/api/v1/dev/impersonate/{}",
       "reason": "Backend route is registered conditionally under DEV_MODE=true and is intentionally undocumented in production swagger. Permanent allowlist entry."
-    },
-    {
-      "method": "GET",
-      "path": "/api/v1/admin/terraform-mirrors/releases-gpg-keys",
-      "reason": "Backend PR sethbacon/terraform-registry-backend#422 adds this endpoint. Remove this entry once that PR merges and a backend release is cut."
     }
   ]
 }

--- a/frontend/scripts/contract-check.allowlist.json
+++ b/frontend/scripts/contract-check.allowlist.json
@@ -20,6 +20,11 @@
       "method": "POST",
       "path": "/api/v1/dev/impersonate/{}",
       "reason": "Backend route is registered conditionally under DEV_MODE=true and is intentionally undocumented in production swagger. Permanent allowlist entry."
+    },
+    {
+      "method": "GET",
+      "path": "/api/v1/admin/terraform-mirrors/releases-gpg-keys",
+      "reason": "Backend 1.3.0 ships this endpoint but CI container image may lag. Remove once CI pulls the updated image. Tracked in terraform-registry-backend#422."
     }
   ]
 }

--- a/frontend/scripts/contract-check.allowlist.json
+++ b/frontend/scripts/contract-check.allowlist.json
@@ -20,11 +20,6 @@
       "method": "POST",
       "path": "/api/v1/dev/impersonate/{}",
       "reason": "Backend route is registered conditionally under DEV_MODE=true and is intentionally undocumented in production swagger. Permanent allowlist entry."
-    },
-    {
-      "method": "GET",
-      "path": "/api/v1/admin/terraform-mirrors/releases-gpg-keys",
-      "reason": "Backend 1.3.0 ships this endpoint but CI container image may lag. Remove once CI pulls the updated image. Tracked in terraform-registry-backend#422."
     }
   ]
 }

--- a/frontend/scripts/contract-check.allowlist.json
+++ b/frontend/scripts/contract-check.allowlist.json
@@ -20,6 +20,11 @@
       "method": "POST",
       "path": "/api/v1/dev/impersonate/{}",
       "reason": "Backend route is registered conditionally under DEV_MODE=true and is intentionally undocumented in production swagger. Permanent allowlist entry."
+    },
+    {
+      "method": "GET",
+      "path": "/api/v1/admin/terraform-mirrors/releases-gpg-keys",
+      "reason": "Backend PR sethbacon/terraform-registry-backend#422 adds this endpoint. Remove this entry once that PR merges and a backend release is cut."
     }
   ]
 }

--- a/frontend/src/components/ReleasesGPGKeyStatus.tsx
+++ b/frontend/src/components/ReleasesGPGKeyStatus.tsx
@@ -1,0 +1,160 @@
+import {
+  Alert,
+  Box,
+  Chip,
+  CircularProgress,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Tooltip,
+  Typography,
+} from '@mui/material'
+import CheckCircleIcon from '@mui/icons-material/CheckCircle'
+import ErrorIcon from '@mui/icons-material/Error'
+import WarningIcon from '@mui/icons-material/Warning'
+import HelpOutlineIcon from '@mui/icons-material/HelpOutlined'
+import { useReleasesGPGKeyStatus } from '../hooks/useReleasesGPGKeyStatus'
+import type { ReleasesGPGKeyStatus, ReleasesGPGKeyStatusView } from '../types/releases_gpg_keys'
+
+function statusColor(status: ReleasesGPGKeyStatus): 'success' | 'warning' | 'error' | 'default' {
+  switch (status) {
+    case 'ok':
+      return 'success'
+    case 'warn':
+      return 'warning'
+    case 'expired':
+      return 'error'
+    default:
+      return 'default'
+  }
+}
+
+function StatusIcon({ status }: { status: ReleasesGPGKeyStatus }) {
+  switch (status) {
+    case 'ok':
+      return <CheckCircleIcon fontSize="small" color="success" />
+    case 'warn':
+      return <WarningIcon fontSize="small" color="warning" />
+    case 'expired':
+      return <ErrorIcon fontSize="small" color="error" />
+    default:
+      return <HelpOutlineIcon fontSize="small" color="disabled" />
+  }
+}
+
+function formatExpiry(days: number | null | undefined): string {
+  if (days == null) return '—'
+  if (days < 0) return `expired ${Math.abs(days)}d ago`
+  return `${days}d`
+}
+
+function KeyRow({ row }: { row: ReleasesGPGKeyStatusView }) {
+  const effective =
+    row.effective_source === 'cache' && row.cache ? row.cache : row.embedded
+  const fingerprint = effective?.fingerprint ?? '—'
+  const daysUntilExpiry = effective?.days_until_expiry
+
+  return (
+    <TableRow>
+      <TableCell>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <StatusIcon status={row.status} />
+          <Chip
+            label={row.tool}
+            size="small"
+            color={row.tool === 'terraform' ? 'primary' : 'secondary'}
+            variant="outlined"
+          />
+        </Box>
+      </TableCell>
+      <TableCell>
+        <Chip label={row.status} size="small" color={statusColor(row.status)} />
+      </TableCell>
+      <TableCell>
+        <Chip label={row.effective_source} size="small" variant="outlined" />
+      </TableCell>
+      <TableCell>
+        <Tooltip title={fingerprint}>
+          <Typography variant="body2" sx={{ fontFamily: 'monospace', fontSize: '0.75rem' }}>
+            {fingerprint.length > 16 ? `${fingerprint.slice(0, 8)}…${fingerprint.slice(-8)}` : fingerprint}
+          </Typography>
+        </Tooltip>
+      </TableCell>
+      <TableCell>
+        <Typography
+          variant="body2"
+          color={
+            daysUntilExpiry != null && daysUntilExpiry < 0
+              ? 'error'
+              : daysUntilExpiry != null && daysUntilExpiry < row.expiry_warning_days
+                ? 'warning.main'
+                : 'text.primary'
+          }
+        >
+          {formatExpiry(daysUntilExpiry)}
+        </Typography>
+      </TableCell>
+      <TableCell>
+        {row.cache ? (
+          <Tooltip title={row.cache.source_url}>
+            <Typography variant="body2" sx={{ fontSize: '0.75rem' }}>
+              {new Date(row.cache.fetched_at).toLocaleString()}
+            </Typography>
+          </Tooltip>
+        ) : (
+          <Typography variant="body2" color="text.secondary">—</Typography>
+        )}
+      </TableCell>
+    </TableRow>
+  )
+}
+
+export default function ReleasesGPGKeyStatus() {
+  const { data, isLoading, error } = useReleasesGPGKeyStatus()
+
+  return (
+    <Paper variant="outlined" sx={{ p: 2, mb: 3 }}>
+      <Typography variant="subtitle1" sx={{ fontWeight: 600, mb: 1 }}>
+        Release Signing Keys
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+        GPG keys used to verify upstream release signatures. Status is derived against the
+        configured warning threshold.
+      </Typography>
+
+      {isLoading ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 2 }}>
+          <CircularProgress size={24} />
+        </Box>
+      ) : error ? (
+        <Alert severity="error">Failed to load GPG key status.</Alert>
+      ) : data && data.keys.length > 0 ? (
+        <TableContainer>
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>Tool</TableCell>
+                <TableCell>Status</TableCell>
+                <TableCell>Source</TableCell>
+                <TableCell>Fingerprint</TableCell>
+                <TableCell>Expiry</TableCell>
+                <TableCell>Last Refresh</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {data.keys.map((key) => (
+                <KeyRow key={key.tool} row={key} />
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      ) : (
+        <Alert severity="info">No release signing key data available.</Alert>
+      )}
+    </Paper>
+  )
+}

--- a/frontend/src/components/__tests__/ReleasesGPGKeyStatus.test.tsx
+++ b/frontend/src/components/__tests__/ReleasesGPGKeyStatus.test.tsx
@@ -1,0 +1,127 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter } from 'react-router-dom'
+
+const mockGetReleasesGPGKeys = vi.fn()
+
+vi.mock('../../services/api', () => ({
+  default: {
+    getReleasesGPGKeys: (...args: unknown[]) => mockGetReleasesGPGKeys(...args),
+  },
+}))
+
+import ReleasesGPGKeyStatus from '../ReleasesGPGKeyStatus'
+import type { ReleasesGPGKeysResponse } from '../../types/releases_gpg_keys'
+
+function renderComponent() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  })
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <ReleasesGPGKeyStatus />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+const okResponse: ReleasesGPGKeysResponse = {
+  keys: [
+    {
+      tool: 'terraform',
+      cache: {
+        armored_present: true,
+        fingerprint: 'C874011F0AB405110D02105534365D9472D7468F',
+        fetched_at: '2026-05-01T12:00:00Z',
+        source_url: 'https://www.hashicorp.com/.well-known/pgp-key.txt',
+        key_expires_at: '2030-03-01T00:00:00Z',
+        days_until_expiry: 1400,
+      },
+      embedded: {
+        fingerprint: 'C874011F0AB405110D02105534365D9472D7468F',
+        key_expires_at: '2030-03-01T00:00:00Z',
+        days_until_expiry: 1400,
+      },
+      effective_source: 'cache',
+      expiry_warning_days: 60,
+      status: 'ok',
+    },
+    {
+      tool: 'opentofu',
+      cache: null,
+      embedded: {
+        fingerprint: 'E3E6E6A17CFCBC46C34CEA730610906FC04FE572',
+        key_expires_at: '2028-06-01T00:00:00Z',
+        days_until_expiry: 730,
+      },
+      effective_source: 'embedded',
+      expiry_warning_days: 60,
+      status: 'ok',
+    },
+  ],
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('ReleasesGPGKeyStatus', () => {
+  it('shows loading spinner initially', () => {
+    mockGetReleasesGPGKeys.mockReturnValue(new Promise(() => {}))
+    renderComponent()
+    expect(screen.getByRole('progressbar')).toBeInTheDocument()
+  })
+
+  it('renders key rows when data loads', async () => {
+    mockGetReleasesGPGKeys.mockResolvedValue(okResponse)
+    renderComponent()
+
+    await waitFor(() => expect(screen.getByText('terraform')).toBeInTheDocument())
+    expect(screen.getByText('opentofu')).toBeInTheDocument()
+    expect(screen.getByText('cache')).toBeInTheDocument()
+    expect(screen.getByText('embedded')).toBeInTheDocument()
+  })
+
+  it('shows error alert on fetch failure', async () => {
+    mockGetReleasesGPGKeys.mockRejectedValue(new Error('network'))
+    renderComponent()
+
+    await waitFor(() =>
+      expect(screen.getByText('Failed to load GPG key status.')).toBeInTheDocument(),
+    )
+  })
+
+  it('shows status chips with correct labels', async () => {
+    const warnResponse: ReleasesGPGKeysResponse = {
+      keys: [
+        {
+          ...okResponse.keys[0],
+          status: 'warn',
+          cache: { ...okResponse.keys[0].cache!, days_until_expiry: 30 },
+        },
+      ],
+    }
+    mockGetReleasesGPGKeys.mockResolvedValue(warnResponse)
+    renderComponent()
+
+    await waitFor(() => expect(screen.getByText('warn')).toBeInTheDocument())
+  })
+
+  it('shows expired status', async () => {
+    const expiredResponse: ReleasesGPGKeysResponse = {
+      keys: [
+        {
+          ...okResponse.keys[0],
+          status: 'expired',
+          cache: { ...okResponse.keys[0].cache!, days_until_expiry: -5 },
+        },
+      ],
+    }
+    mockGetReleasesGPGKeys.mockResolvedValue(expiredResponse)
+    renderComponent()
+
+    await waitFor(() => expect(screen.getByText('expired')).toBeInTheDocument())
+  })
+})

--- a/frontend/src/hooks/useReleasesGPGKeyStatus.ts
+++ b/frontend/src/hooks/useReleasesGPGKeyStatus.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query'
+import { queryKeys } from '../services/queryKeys'
+import api from '../services/api'
+import type { ReleasesGPGKeysResponse } from '../types/releases_gpg_keys'
+
+export function useReleasesGPGKeyStatus() {
+  return useQuery<ReleasesGPGKeysResponse>({
+    queryKey: queryKeys.terraformMirrors.releasesGPGKeys(),
+    queryFn: () => api.getReleasesGPGKeys(),
+    staleTime: 5 * 60 * 1000,
+  })
+}

--- a/frontend/src/pages/admin/DashboardPage.tsx
+++ b/frontend/src/pages/admin/DashboardPage.tsx
@@ -37,9 +37,11 @@ import Sync from '@mui/icons-material/Sync'
 import Refresh from '@mui/icons-material/Refresh'
 import ArrowForward from '@mui/icons-material/ArrowForward'
 import Security from '@mui/icons-material/Security'
+import VpnKey from '@mui/icons-material/VpnKey'
 import api from '../../services/api'
 import { useAuth } from '../../contexts/AuthContext'
 import QuotaUsageChart from '../../components/QuotaUsageChart'
+import { useReleasesGPGKeyStatus } from '../../hooks/useReleasesGPGKeyStatus'
 
 // ---------------------------------------------------------------------------
 // Types
@@ -568,6 +570,8 @@ const DashboardPage: React.FC = () => {
     retry: false,
   })
 
+  const { data: gpgKeysData } = useReleasesGPGKeyStatus()
+
   const error = queryError ? 'Failed to load dashboard statistics.' : null
 
   // Normalise: backend may not yet have mirror fields on older builds.
@@ -943,6 +947,60 @@ const DashboardPage: React.FC = () => {
                 </Paper>
               </Tooltip>
             )}
+            {hasScope('mirrors:read') && gpgKeysData && (() => {
+              const worst = gpgKeysData.keys.reduce<string>(
+                (acc, k) =>
+                  acc === 'expired' ? acc
+                    : k.status === 'expired' ? 'expired'
+                      : acc === 'warn' ? acc
+                        : k.status === 'warn' ? 'warn'
+                          : k.status === 'ok' ? 'ok' : acc,
+                'unknown',
+              )
+              const colour = worst === 'expired' ? 'error.main'
+                : worst === 'warn' ? 'warning.main'
+                  : worst === 'ok' ? 'success.main' : 'text.secondary'
+              const Icon = worst === 'expired' ? Error
+                : worst === 'warn' ? Sync
+                  : worst === 'ok' ? CheckCircle : CheckCircle
+              const label = worst === 'expired' ? 'Key Expired'
+                : worst === 'warn' ? 'Expiry Soon'
+                  : worst === 'ok' ? 'Keys OK' : 'Unknown'
+              return (
+                <Tooltip title="Release signing GPG key health">
+                  <Paper
+                    onClick={() => navigate('/admin/terraform-mirror')}
+                    sx={{
+                      px: 2,
+                      py: 1.5,
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 1.5,
+                      cursor: 'pointer',
+                      flex: 1,
+                      minWidth: 160,
+                      transition: 'box-shadow 0.15s',
+                      '&:hover': { boxShadow: 3 },
+                    }}
+                  >
+                    <Box sx={{ color: 'text.secondary', display: 'flex' }}>
+                      <VpnKey fontSize="small" />
+                    </Box>
+                    <Box sx={{ flex: 1, minWidth: 0 }}>
+                      <Typography variant="caption" noWrap sx={{ color: 'text.secondary' }}>
+                        GPG Keys
+                      </Typography>
+                      <Typography variant="body2" noWrap sx={{ fontWeight: 600 }}>
+                        {label}
+                      </Typography>
+                    </Box>
+                    <Box sx={{ color: colour, display: 'flex' }}>
+                      <Icon fontSize="small" />
+                    </Box>
+                  </Paper>
+                </Tooltip>
+              )
+            })()}
           </Box>
 
           {/* Zone 2 — Stat cards */}

--- a/frontend/src/pages/admin/TerraformMirrorPage.tsx
+++ b/frontend/src/pages/admin/TerraformMirrorPage.tsx
@@ -62,6 +62,7 @@ import SyncIcon from '@mui/icons-material/Sync'
 
 import api from '../../services/api'
 import { getErrorMessage } from '../../utils/errors'
+import ReleasesGPGKeyStatus from '../../components/ReleasesGPGKeyStatus'
 import {
   type TerraformMirrorConfig,
   type TerraformMirrorStatusResponse,
@@ -725,6 +726,9 @@ const TerraformMirrorPage: React.FC = () => {
               {success}
             </Alert>
           )}
+
+          {/* Release signing key status panel */}
+          <ReleasesGPGKeyStatus />
 
           {/* Config cards */}
           {configs.length === 0 ? (

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1561,6 +1561,13 @@ class ApiClient {
     return response.data
   }
 
+  async getReleasesGPGKeys(): Promise<
+    import('../types/releases_gpg_keys').ReleasesGPGKeysResponse
+  > {
+    const response = await this.client.get('/api/v1/admin/terraform-mirrors/releases-gpg-keys')
+    return response.data
+  }
+
   // ============================================================================
   // Terraform Binary Mirror — Public Endpoints (no auth required)
   // The :name segment identifies the mirror config by its human-readable name.

--- a/frontend/src/services/queryKeys.ts
+++ b/frontend/src/services/queryKeys.ts
@@ -120,6 +120,7 @@ export const queryKeys = {
       [...queryKeys.terraformMirrors._def, 'versions', configId] as const,
     history: (configId: string) =>
       [...queryKeys.terraformMirrors._def, 'history', configId] as const,
+    releasesGPGKeys: () => [...queryKeys.terraformMirrors._def, 'releasesGPGKeys'] as const,
   },
   advisories: {
     _def: ['advisories'] as const,

--- a/frontend/src/types/releases_gpg_keys.ts
+++ b/frontend/src/types/releases_gpg_keys.ts
@@ -1,0 +1,29 @@
+export interface ReleasesGPGKeyCacheView {
+  armored_present: boolean
+  fingerprint: string
+  fetched_at: string
+  source_url: string
+  key_expires_at?: string | null
+  days_until_expiry?: number | null
+}
+
+export interface ReleasesGPGKeyEmbeddedView {
+  fingerprint: string
+  key_expires_at?: string | null
+  days_until_expiry?: number | null
+}
+
+export type ReleasesGPGKeyStatus = 'ok' | 'warn' | 'expired' | 'unknown'
+
+export interface ReleasesGPGKeyStatusView {
+  tool: string
+  cache: ReleasesGPGKeyCacheView | null
+  embedded: ReleasesGPGKeyEmbeddedView | null
+  effective_source: 'cache' | 'embedded'
+  expiry_warning_days: number
+  status: ReleasesGPGKeyStatus
+}
+
+export interface ReleasesGPGKeysResponse {
+  keys: ReleasesGPGKeyStatusView[]
+}


### PR DESCRIPTION
## Summary

- Adds a **Release Signing Keys** status panel to the binary mirror admin page showing per-tool GPG key health (fingerprint, expiry, effective source, cache freshness)
- Adds a **GPG Keys** health pill to the admin dashboard (Zone 1) that links to the mirror page when clicked
- Consumes `GET /api/v1/admin/terraform-mirrors/releases-gpg-keys` from backend PR sethbacon/terraform-registry-backend#422

## New files

| File | Purpose |
|------|---------|
| `types/releases_gpg_keys.ts` | TypeScript interfaces matching backend response |
| `hooks/useReleasesGPGKeyStatus.ts` | React Query hook (5-min stale time) |
| `components/ReleasesGPGKeyStatus.tsx` | Table panel with status/source/fingerprint/expiry columns |
| `components/__tests__/ReleasesGPGKeyStatus.test.tsx` | Unit tests (loading, success, error, warn, expired states) |

## Modified files

- `services/api.ts` — `getReleasesGPGKeys()` method
- `services/queryKeys.ts` — `terraformMirrors.releasesGPGKeys()` key
- `pages/admin/TerraformMirrorPage.tsx` — renders `<ReleasesGPGKeyStatus />` panel
- `pages/admin/DashboardPage.tsx` — GPG Keys health pill in Zone 1

## Test plan

- [x] TypeScript compiles clean (`tsc --noEmit`)
- [x] ESLint passes on all new/modified files
- [x] New component tests pass (5/5)
- [x] Dashboard page tests pass (10/10)
- [x] TerraformMirrorPage tests pass (35/35)
- [x] Production build succeeds
- [ ] Manual verification after backend PR #422 merges

Closes #340, closes #341