### PR TITLE
fix(contract-check): pin backend image to 1.4.0

### DIFF
--- a/deployments/docker-compose.contract-check.yml
+++ b/deployments/docker-compose.contract-check.yml
@@ -20,7 +20,7 @@ services:
     # Pinned backend image. Bump this tag in lockstep with backend releases
     # whose API surface the frontend wants to depend on. The contract check
     # validates that every route api.ts calls exists on this exact backend.
-    image: ${BACKEND_IMAGE:-ghcr.io/sethbacon/terraform-registry-backend:1.3.0}
+    image: ${BACKEND_IMAGE:-ghcr.io/sethbacon/terraform-registry-backend:1.4.0}
     environment:
       - TFR_DATABASE_HOST=postgres
       - TFR_DATABASE_PORT=5432

--- a/frontend/scripts/contract-check.ts
+++ b/frontend/scripts/contract-check.ts
@@ -261,12 +261,13 @@ async function main() {
       const why = backendKeys.has(k) ? 'now exists on backend' : 'frontend no longer calls it'
       console.error(`  - ${k}  (${why})`)
     }
-    process.exit(1)
+    process.exitCode = 1
+    return
   }
 
   if (missing.length === 0) {
     console.log(`\nOK: every frontend route exists on backend (or is on the allowlist).`)
-    process.exit(0)
+    return
   }
 
   console.error(`\nFAIL: ${missing.length} frontend route(s) have no matching backend route:\n`)
@@ -285,10 +286,14 @@ async function main() {
   console.error(
     `If a missing route is intentional and being tracked elsewhere, add an entry to\nfrontend/scripts/contract-check.allowlist.json with the linked issue URL as the reason.`,
   )
-  process.exit(1)
+  process.exitCode = 1
 }
 
+// Set the exit code and let the process drain naturally. Calling process.exit()
+// while the global fetch (undici) socket is still closing aborts the process on
+// Windows with "Assertion failed: !(handle->flags & UV_HANDLE_CLOSING)", which
+// would fail the check even on success.
 main().catch((err) => {
   console.error('contract-check failed:', err)
-  process.exit(2)
+  process.exitCode = 2
 })


### PR DESCRIPTION
## Summary

The `contract-check` CI job spins up the backend at a **pinned image tag** and verifies every route `api.ts` calls exists on it. The version-approvals admin page (#352) added 7 routes (`/api/v1/admin/version-approvals*`) that landed in **backend 1.4.0**, but `deployments/docker-compose.contract-check.yml` still pinned **1.3.0** — so the check failed on those routes after #352 merged.

- Bump the pinned backend image `1.3.0 → 1.4.0` (released; image confirmed present on ghcr). Validated locally against a 1.4.0-equivalent backend: contract check passes with **no missing routes** and **no allowlist entries needed**.
- Also stop calling `process.exit()` in the script. Exiting while the global `fetch` (undici) socket is still closing aborts the process on Windows with `Assertion failed: !(handle->flags & UV_HANDLE_CLOSING)`, failing the check even on success. Set `process.exitCode` and return so the process drains and exits cleanly with the correct code.

## Why not the allowlist

The allowlist bridges the gap when the frontend calls a route the pinned backend lacks. Here the backend route is already released in 1.4.0, so the correct fix is the lockstep pin bump the compose file documents — allowlisting would immediately go stale against 1.4.0 and fail.