### PR TITLE
fix(help): add context help for the Version Approvals page

### DIFF
--- a/frontend/src/components/HelpPanel.tsx
+++ b/frontend/src/components/HelpPanel.tsx
@@ -61,6 +61,15 @@ const HELP_ACTION_KEYS: Record<string, string[]> = {
     'deleteConfig',
   ],
   approvals: ['reviewRequest', 'createRequest', 'filterByStatus', 'mirrorPolicyLink'],
+  versionApprovals: [
+    'whyPending',
+    'statusTabs',
+    'typeFilter',
+    'approveReject',
+    'bulkActions',
+    'auditTrail',
+    'autoApprove',
+  ],
   mirrorPolicies: [
     'createPolicy',
     'allowVsDeny',
@@ -139,6 +148,8 @@ function getHelpContent(pathname: string, t: TStr): HelpContent {
       return makeContent('terraformMirror', t)
     case '/admin/approvals':
       return makeContent('approvals', t)
+    case '/admin/version-approvals':
+      return makeContent('versionApprovals', t)
     case '/admin/policies':
       return makeContent('mirrorPolicies', t)
     case '/admin/security-scanning':

--- a/frontend/src/components/HelpPanel.tsx
+++ b/frontend/src/components/HelpPanel.tsx
@@ -229,7 +229,7 @@ const HelpPanel = () => {
             color: 'text.secondary',
           }}
         >
-          What you can do
+          {t('helpPanel.whatYouCanDo')}
         </Typography>
 
         <List disablePadding sx={{ mt: 0.5 }}>
@@ -264,9 +264,9 @@ const HelpPanel = () => {
             color: 'text.secondary',
           }}
         >
-          Full API reference:{' '}
+          {t('helpPanel.apiReferenceLabel')}{' '}
           <MuiLink component={RouterLink} to="/api-docs" onClick={isMobile ? closeHelp : undefined}>
-            API Docs
+            {t('helpPanel.apiDocsLink')}
           </MuiLink>
         </Typography>
       </Box>

--- a/frontend/src/components/__tests__/HelpPanel.test.tsx
+++ b/frontend/src/components/__tests__/HelpPanel.test.tsx
@@ -142,6 +142,14 @@ describe('HelpPanel', () => {
     expect(screen.getByText('Mirror Policies')).toBeInTheDocument()
   })
 
+  it('renders version approvals help', () => {
+    renderAtPath('/admin/version-approvals')
+    expect(screen.getByText('Version Approvals')).toBeInTheDocument()
+    expect(screen.getByText(/latest approved version/)).toBeInTheDocument()
+    expect(screen.getByText('Bulk Approve / Reject')).toBeInTheDocument()
+    expect(screen.getByText('Auto-Approval')).toBeInTheDocument()
+  })
+
   it('renders default help for unknown paths', () => {
     renderAtPath('/some/unknown/path')
     expect(screen.getByText('Help')).toBeInTheDocument()

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -2079,7 +2079,10 @@
     "downloadsPerDay": "Downloads / Day"
   },
   "helpPanel": {
-    "closeAria": "Close help panel"
+    "closeAria": "Close help panel",
+    "whatYouCanDo": "What you can do",
+    "apiReferenceLabel": "Full API reference:",
+    "apiDocsLink": "API Docs"
   },
   "layout": {
     "mainNavigation": "Main navigation"

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -721,6 +721,40 @@
         }
       }
     },
+    "versionApprovals": {
+      "title": "Version Approvals",
+      "overview": "When a provider or Terraform binary mirror has \"Require approval\" enabled, each newly synced version is held in pending approval and hidden from Terraform clients until an administrator approves it — so \"latest\" means \"latest approved version\". This page is the review queue for those gated versions.",
+      "actions": {
+        "whyPending": {
+          "heading": "Why a Version Is Here",
+          "text": "Versions appear here only for mirrors with \"Require approval\" enabled. A synced version stays hidden from the version listing, network mirror index, and downloads until it is approved. Existing versions and non-gated mirrors are unaffected."
+        },
+        "statusTabs": {
+          "heading": "Status Tabs",
+          "text": "Switch between Pending, Approved, and Rejected to see versions in each state. Pending is the queue that needs action; Rejected versions stay permanently hidden."
+        },
+        "typeFilter": {
+          "heading": "Filter by Type",
+          "text": "Use the Provider / Terraform toggle to narrow the list to mirrored provider versions or Terraform binary versions."
+        },
+        "approveReject": {
+          "heading": "Approve or Reject",
+          "text": "Use the Approve or Reject button on a pending row to open the confirmation dialog. Add optional notes to record why; approving a Terraform version also recomputes which version is \"latest\"."
+        },
+        "bulkActions": {
+          "heading": "Bulk Approve / Reject",
+          "text": "Tick the checkboxes (or the header checkbox to select all) and use Approve Selected / Reject Selected to act on many versions at once. The result reports how many succeeded and lists any failures."
+        },
+        "auditTrail": {
+          "heading": "Audit Trail",
+          "text": "Expand a row to see its approval history — auto-approvals, manual decisions, who acted, any notes, and the rule that matched for auto-approvals."
+        },
+        "autoApprove": {
+          "heading": "Auto-Approval",
+          "text": "A mirror's auto-approve rules (patch_only, gpg_verified, semver_constraint, delay_hours) can approve low-risk versions at sync time so only versions that need review land here. delay_hours approves on a later sync once the version has aged; for Terraform binaries the gpg_verified rule does not apply at discovery time."
+        }
+      }
+    },
     "mirrorPolicies": {
       "title": "Mirror Policies",
       "overview": "Mirror policies control which providers are allowed or denied from being mirrored, and whether mirroring them requires an approval request. Policies are matched by upstream registry URL, namespace pattern, and provider name pattern. Higher-priority policies take precedence when multiple rules match.",


### PR DESCRIPTION
## Summary

Adds context help for the Version Approvals admin page, using the existing route-aware `HelpPanel` drawer (opened from the global help button in the AppBar) — no new component or per-page wiring needed, matching how every other admin page provides help.

- Registers `versionApprovals` content for the `/admin/version-approvals` route (`HELP_ACTION_KEYS` + `getHelpContent` case).
- Help sections: **why a version is pending**, **status tabs**, **type filter**, **approve/reject**, **bulk actions**, **audit trail**, and **auto-approval rules** (including the delay_hours / Terraform-binary gpg caveat).
- Adds the `help.versionApprovals.*` English strings (other locales handled by the translation workflow) and a `HelpPanel` test asserting the route renders the title, overview, and a couple of action headings.

## Testing

`tsc` and `eslint` clean; `HelpPanel` suite passes (30 tests). JSON validated.