### PR TITLE
fix(modules): make provider sections collapsible in grouped view

### DIFF
--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -186,6 +186,7 @@
     "viewGridAriaLabel": "grid view",
     "viewByProvider": "By Provider",
     "viewByProviderAriaLabel": "grouped by provider",
+    "toggleProviderAriaLabel": "toggle {{provider}} modules",
     "loadError": "Failed to load modules. Please try again.",
     "noResultsTitle": "No modules found",
     "noResultsTryDifferent": "Try a different search query or sort option",

--- a/frontend/src/pages/ModulesPage.tsx
+++ b/frontend/src/pages/ModulesPage.tsx
@@ -21,12 +21,16 @@ import {
   InputLabel,
   Select,
   MenuItem,
+  Collapse,
+  IconButton,
 } from '@mui/material'
 import type { SelectChangeEvent } from '@mui/material'
 import SearchIcon from '@mui/icons-material/Search'
 import CloudUpload from '@mui/icons-material/CloudUpload'
 import ViewModuleIcon from '@mui/icons-material/ViewModule'
 import CategoryIcon from '@mui/icons-material/Category'
+import ExpandMore from '@mui/icons-material/ExpandMore'
+import ExpandLess from '@mui/icons-material/ExpandLess'
 import api from '../services/api'
 import { queryKeys } from '../services/queryKeys'
 import { Module } from '../types'
@@ -54,6 +58,12 @@ function buildSortValue(sort?: string | null, order?: string | null): string {
 /** Parse a URL ?view= value into a validated ViewMode (grouped is the default). */
 function parseViewMode(value: string | null): ViewMode {
   return value === 'grid' ? 'grid' : 'grouped'
+}
+
+/** Parse the ?collapsed= URL value into a set of collapsed provider keys. */
+function parseCollapsed(value: string | null): Set<string> {
+  if (!value) return new Set()
+  return new Set(value.split(',').filter(Boolean))
 }
 
 /** Group an array of modules by their system (provider) field, alphabetically. */
@@ -136,6 +146,13 @@ const ModulesPage: React.FC = () => {
   // Grouped is the default — only grid is persisted as a query param to keep URLs tidy.
   const viewMode: ViewMode = parseViewMode(searchParams.get('view'))
   const limit = viewMode === 'grouped' ? 100 : 12
+
+  // Collapsed provider sections (grouped view) are URL-backed (?collapsed=aws,gcp)
+  // so the state survives reload and is shareable. Default is all expanded.
+  const collapsedProviders = useMemo(
+    () => parseCollapsed(searchParams.get('collapsed')),
+    [searchParams],
+  )
 
   const { sort: apiSort, order: apiOrder } = parseSortValue(sortValue)
 
@@ -234,6 +251,30 @@ const ModulesPage: React.FC = () => {
           { replace: true },
         )
       }
+    },
+    [setSearchParams],
+  )
+
+  const handleToggleProvider = useCallback(
+    (provider: string) => {
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev)
+          const collapsed = parseCollapsed(next.get('collapsed'))
+          if (collapsed.has(provider)) {
+            collapsed.delete(provider)
+          } else {
+            collapsed.add(provider)
+          }
+          if (collapsed.size > 0) {
+            next.set('collapsed', Array.from(collapsed).join(','))
+          } else {
+            next.delete('collapsed')
+          }
+          return next
+        },
+        { replace: true },
+      )
     },
     [setSearchParams],
   )
@@ -401,27 +442,57 @@ const ModulesPage: React.FC = () => {
       ) : viewMode === 'grouped' ? (
         /* ---- Grouped by provider ---- */
         (<>
-          {groupedModules.map(([provider, providerModules]) => (
-            <Box key={provider} sx={{ mb: 5 }}>
-              {/* Provider section header */}
-              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, mb: 2 }}>
-                <ProviderIcon provider={provider} size={28} />
-                <Typography variant="h6" sx={{ fontWeight: 600 }}>
-                  {providerDisplayName(provider)}
-                </Typography>
-                <Chip
-                  label={providerModules.length}
-                  size="small"
-                  color="primary"
-                  variant="outlined"
-                />
+          {groupedModules.map(([provider, providerModules]) => {
+            const isCollapsed = collapsedProviders.has(provider)
+            return (
+              <Box key={provider} sx={{ mb: 5 }}>
+                {/* Provider section header — click to collapse/expand its modules */}
+                <Box
+                  role="button"
+                  tabIndex={0}
+                  aria-expanded={!isCollapsed}
+                  aria-label={t('modules.toggleProviderAriaLabel', {
+                    provider: providerDisplayName(provider),
+                  })}
+                  onClick={() => handleToggleProvider(provider)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault()
+                      handleToggleProvider(provider)
+                    }
+                  }}
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 1.5,
+                    mb: 2,
+                    cursor: 'pointer',
+                    userSelect: 'none',
+                  }}
+                >
+                  <IconButton size="small" tabIndex={-1} aria-hidden="true">
+                    {isCollapsed ? <ExpandMore /> : <ExpandLess />}
+                  </IconButton>
+                  <ProviderIcon provider={provider} size={28} />
+                  <Typography variant="h6" sx={{ fontWeight: 600 }}>
+                    {providerDisplayName(provider)}
+                  </Typography>
+                  <Chip
+                    label={providerModules.length}
+                    size="small"
+                    color="primary"
+                    variant="outlined"
+                  />
+                </Box>
+                <Divider sx={{ mb: 2 }} />
+                <Collapse in={!isCollapsed} unmountOnExit>
+                  <Grid container spacing={3}>
+                    {providerModules.map(renderModuleCard)}
+                  </Grid>
+                </Collapse>
               </Box>
-              <Divider sx={{ mb: 2 }} />
-              <Grid container spacing={3}>
-                {providerModules.map(renderModuleCard)}
-              </Grid>
-            </Box>
-          ))}
+            )
+          })}
           {totalPages > 1 && (
             <Box sx={{ display: 'flex', justifyContent: 'center', mt: 4 }}>
               <Pagination

--- a/frontend/src/pages/__tests__/ModulesPage.test.tsx
+++ b/frontend/src/pages/__tests__/ModulesPage.test.tsx
@@ -295,4 +295,25 @@ describe('ModulesPage', () => {
     await screen.findByText('consul')
     expect(screen.getByLabelText('Sort By')).toBeInTheDocument()
   })
+
+  // -- Collapsible provider sections --
+
+  it('collapses a provider section when its header is clicked', async () => {
+    const user = userEvent.setup()
+    renderWithRoute()
+    await screen.findByText('consul')
+
+    // Click the aws provider header to collapse it (azure stays expanded).
+    await user.click(screen.getByRole('button', { name: /toggle aws modules/i }))
+
+    await waitFor(() => expect(screen.queryByText('consul')).not.toBeInTheDocument())
+    expect(screen.getByText('vault')).toBeInTheDocument()
+  })
+
+  it('starts with a provider collapsed from the ?collapsed= URL param', async () => {
+    renderWithRoute('/modules?collapsed=aws')
+    await screen.findByText('vault')
+    // aws section is collapsed on first render; azure remains visible.
+    expect(screen.queryByText('consul')).not.toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
## What

In the modules **By Provider** view, each provider section header is now collapsible. Clicking a header (e.g. "AWS") collapses just that provider's modules, leaving the rest expanded.

## Details

- Provider headers are now keyboard-operable buttons with a chevron (`ExpandLess`/`ExpandMore` swap, matching the existing Layout collapse pattern) and `aria-expanded` for screen readers.
- The module grid is wrapped in MUI `<Collapse unmountOnExit>`.
- Collapsed providers are persisted in a `?collapsed=aws,gcp` URL param, so the state survives reload and is shareable. Default is all expanded.
- Added `modules.toggleProviderAriaLabel` to the English source locale; the DeepL workflow owns the other locales.

## Tests

- Added 2 tests (click-to-collapse, initial-collapse-from-URL). Full ModulesPage suite passes (20/20).
- `tsc --noEmit` and `eslint` clean.