### PR TITLE
fix(e2e): wait for settled DOM in version-approvals table test

### DIFF
--- a/e2e/tests/version-approvals.spec.ts
+++ b/e2e/tests/version-approvals.spec.ts
@@ -69,8 +69,15 @@ test.describe('Admin: Version Approvals', () => {
     await page.goto('/admin/version-approvals');
     await waitForLoad(page);
 
+    // Wait for the data query to settle before asserting. waitForLoad alone is
+    // not enough: isVisible() is an instantaneous check, so if the loading
+    // spinner isn't on screen at that exact instant the helper returns early and
+    // we can race ahead of the first render. The table (with its empty-state row)
+    // or a load-error alert is the settled DOM — wait for one to appear.
+    await page.waitForSelector('table, [class*="MuiAlert"]', { timeout: 10_000 });
+
     // Either gated versions are listed in the table, or the "no versions" empty
-    // state is shown — both are valid depending on test-environment data.
+    // state is shown — both render inside the table, so its presence is enough.
     const hasTable = (await page.locator('table').count()) > 0;
     const hasEmpty = await page
       .getByText(/no versions matching this filter/i)


### PR DESCRIPTION
## Problem

The weekly security scan's **E2E (gated/manual)** job started failing on `version-approvals.spec.ts:68 — "renders the version table or an empty state"`:

```
expect(hasTable || hasEmpty).toBe(true)
Expected: true
Received: false
```

The sibling tests in the same file (heading, status tabs, type filter) pass — those elements render *outside* the page's `isLoading ? <spinner> : <Table>` block, so they don't depend on the data query settling. Only the table test does.

## Root cause — a latent test race, not a product bug

The test counted `page.locator('table')` immediately after `waitForLoad()`. `waitForLoad` gates on `locator.isVisible()`, which is an **instantaneous, non-retrying** check — if the loading spinner isn't on screen at that exact instant, the helper returns early and the assertion races ahead of the first render.

This stayed hidden because the E2E backend image is `ghcr.io/sethbacon/terraform-registry-backend:latest` (a floating tag). Until recently `:latest` predated the version-approvals endpoint, so `listVersionApprovals` 404'd, react-query settled to an error state instantly, and the empty table rendered with no loading window to race. Now that `:latest` serves the endpoint (200 after a real `UNION ALL` query), the brief loading window surfaces the race and the table test fails.

The empty-state row renders *inside* the `<table>`, so once the query settles the table is always present — the test simply checked too early.

## Fix

Wait for the settled DOM (the `<table>`, or a load-error `MuiAlert`) with an auto-retrying `waitForSelector` before asserting, matching the proven pattern already used in `approvals.spec.ts`. Test-only change; `VersionApprovalsPage` is unchanged and correct.

## Test plan

- [x] `eslint` / typecheck clean on the changed spec
- [ ] CI E2E (gated) job green on this PR