### PR TITLE
chore: normalize line endings to LF via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,32 @@
+# Normalize line endings to LF in the repo; check out as-is on all platforms.
+* text=auto eol=lf
+
+# Explicitly LF for common text/source files
+*.ts    text eol=lf
+*.tsx   text eol=lf
+*.js    text eol=lf
+*.jsx   text eol=lf
+*.mjs   text eol=lf
+*.cjs   text eol=lf
+*.json  text eol=lf
+*.css   text eol=lf
+*.scss  text eol=lf
+*.html  text eol=lf
+*.md    text eol=lf
+*.yaml  text eol=lf
+*.yml   text eol=lf
+*.svg   text eol=lf
+*.sh    text eol=lf
+*.env   text eol=lf
+
+# Binary files — never touch line endings
+*.png   binary
+*.jpg   binary
+*.jpeg  binary
+*.gif   binary
+*.ico   binary
+*.webp  binary
+*.woff  binary
+*.woff2 binary
+*.ttf   binary
+*.eot   binary


### PR DESCRIPTION
## Summary

`frontend/docker-entrypoint.sh` (and any other shell script) gets CRLF line endings on Windows git checkouts: this repo has `core.autocrlf=true` and no `.gitattributes` to pin `.sh` to LF. The CR in the `#!/bin/sh` shebang makes nginx fail to exec the entrypoint (`not found`), so a local `docker build` of `frontend/` produces an image whose container crash-loops with **exit 127**. CI builds on Linux (LF), so this only broke local Windows builds.

This adds a `.gitattributes` that pins shell scripts — and all text files — to LF on checkout, mirroring the `.gitattributes` already present in `terraform-state-manager-frontend` for suite consistency. Every blob in the index is already LF, so `git add --renormalize .` produced **no** content changes; the diff is just the new file.

### Verification
- `git check-attr` confirms `frontend/docker-entrypoint.sh` → `text: set, eol: lf`; the working-tree shebang is `#!/bin/sh\n` (LF).
- Isolated repro in the pinned `nginx:1.25-alpine` base: CRLF shebang → `sh: not found`, **exit 127**; LF shebang → **exit 0**.
- `docker build ./frontend` succeeds. Running the image (`--add-host backend:127.0.0.1` so the hardcoded `proxy_pass http://backend:8080` upstream resolves) → container stays **Up** (`ExitCode=0`), nginx workers start, and the healthcheck `GET /` returns **200**. No crash-loop.

## Changelog
- chore: normalize line endings to LF via `.gitattributes`

## Checklist
- [x] PR targets `main`
- [ ] Remote branch will be deleted after merge
- N/A `npm run lint` / `npm run build` — no source files changed (`.gitattributes` only)
