### PR TITLE
refactor(fe): add shared <Page> wrapper and migrate pages to it

### DIFF
--- a/frontend/src/components/Page.tsx
+++ b/frontend/src/components/Page.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import { Container, type ContainerProps } from '@mui/material'
+
+export interface PageProps extends Omit<ContainerProps, 'maxWidth'> {
+  maxWidth?: ContainerProps['maxWidth']
+}
+
+/** Standard page shell: width-constrained (default 'lg') + vertical padding.
+ *  Forwards sx (merged) and arbitrary props (aria-*, etc.) to MUI Container. */
+const Page: React.FC<PageProps> = ({ maxWidth = 'lg', sx, children, ...rest }) => (
+  <Container maxWidth={maxWidth} sx={{ py: 4, ...sx }} {...rest}>
+    {children}
+  </Container>
+)
+
+export default Page

--- a/frontend/src/pages/ModuleDetailPage.tsx
+++ b/frontend/src/pages/ModuleDetailPage.tsx
@@ -3,7 +3,6 @@ import { useTranslation } from 'react-i18next'
 import { useNavigate, Link as RouterLink } from 'react-router-dom'
 import MarkdownRenderer from '../components/MarkdownRenderer'
 import {
-  Container,
   Typography,
   Box,
   Paper,
@@ -29,6 +28,7 @@ import Warning from '@mui/icons-material/Warning'
 import EditIcon from '@mui/icons-material/Edit'
 import Check from '@mui/icons-material/Check'
 import Close from '@mui/icons-material/Close'
+import Page from '../components/Page'
 import PublishFromSCMWizard from '../components/PublishFromSCMWizard'
 import ModuleDocumentation from '../components/ModuleDocumentation'
 import SecurityScanPanel from '../components/SecurityScanPanel'
@@ -129,14 +129,14 @@ const ModuleDetailPage: React.FC = () => {
       {loading ? (
         <DetailPageSkeleton />
       ) : error || !module ? (
-        <Container maxWidth="xl" sx={{ py: 4 }}>
+        <Page maxWidth="xl">
           <Alert severity="error">{error || 'Module not found'}</Alert>
           <Button startIcon={<ArrowBack />} onClick={() => navigate('/modules')} sx={{ mt: 2 }}>
             Back to Modules
           </Button>
-        </Container>
+        </Page>
       ) : (
-        <Container maxWidth="xl" sx={{ py: 4 }}>
+        <Page maxWidth="xl">
           {/* Breadcrumbs */}
           <Breadcrumbs sx={{ mb: 3 }}>
             <Link
@@ -742,7 +742,7 @@ const ModuleDetailPage: React.FC = () => {
             loading={deprecatingModule}
             data-testid="undeprecate-module-dialog"
           />
-        </Container>
+        </Page>
       )}
     </Box>
   )

--- a/frontend/src/pages/ModulesPage.tsx
+++ b/frontend/src/pages/ModulesPage.tsx
@@ -4,7 +4,6 @@ import { useQuery } from '@tanstack/react-query'
 import { useTranslation } from 'react-i18next'
 import { useDebounce } from '../hooks/useDebounce'
 import {
-  Container,
   Typography,
   Box,
   TextField,
@@ -35,6 +34,7 @@ import api from '../services/api'
 import { queryKeys } from '../services/queryKeys'
 import { Module } from '../types'
 import { useAuth } from '../contexts/AuthContext'
+import Page from '../components/Page'
 import { ProviderIcon, providerDisplayName } from '../components/ProviderIcon'
 import RegistryItemCard from '../components/RegistryItemCard'
 import { RegistryItemGridSkeleton } from '../components/skeletons/RegistryItemCardSkeleton'
@@ -332,7 +332,7 @@ const ModulesPage: React.FC = () => {
   const groupedModules = useMemo(() => groupByProvider(modules), [modules])
 
   return (
-    <Container maxWidth="lg" sx={{ py: 4 }} aria-busy={loading} aria-live="polite">
+    <Page maxWidth="lg" aria-busy={loading} aria-live="polite">
       {/* Header */}
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
         <Box>
@@ -524,7 +524,7 @@ const ModulesPage: React.FC = () => {
           )}
         </>)
       )}
-    </Container>
+    </Page>
   );
 }
 

--- a/frontend/src/pages/ProviderDetailPage.tsx
+++ b/frontend/src/pages/ProviderDetailPage.tsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useParams, useNavigate, useSearchParams } from 'react-router-dom'
 import {
-  Container,
   Typography,
   Box,
   Paper,
@@ -46,6 +45,7 @@ import { getErrorMessage } from '../utils/errors'
 import { Provider, ProviderVersion, ProviderDocEntry } from '../types'
 import { useAuth } from '../contexts/AuthContext'
 import { REGISTRY_HOST } from '../config'
+import Page from '../components/Page'
 import ProviderDocsSidebar from '../components/ProviderDocsSidebar'
 import ProviderDocContent from '../components/ProviderDocContent'
 
@@ -390,14 +390,14 @@ provider "${name}" {
           <CircularProgress />
         </Box>
       ) : error || !provider ? (
-        <Container maxWidth="xl" sx={{ py: 4 }}>
+        <Page maxWidth="xl">
           <Alert severity="error">{error || 'Provider not found'}</Alert>
           <Button startIcon={<ArrowBack />} onClick={() => navigate('/providers')} sx={{ mt: 2 }}>
             Back to Providers
           </Button>
-        </Container>
+        </Page>
       ) : (
-        <Container maxWidth="xl" sx={{ py: 4 }}>
+        <Page maxWidth="xl">
           {/* Breadcrumbs */}
           <Breadcrumbs sx={{ mb: 3 }}>
             <Link
@@ -1090,7 +1090,7 @@ provider "${name}" {
               </Button>
             </DialogActions>
           </Dialog>
-        </Container>
+        </Page>
       )}
     </Box>
   )

--- a/frontend/src/pages/ProvidersPage.tsx
+++ b/frontend/src/pages/ProvidersPage.tsx
@@ -4,7 +4,6 @@ import { useQuery } from '@tanstack/react-query'
 import { useTranslation } from 'react-i18next'
 import { useDebounce } from '../hooks/useDebounce'
 import {
-  Container,
   Typography,
   Box,
   TextField,
@@ -26,6 +25,7 @@ import api from '../services/api'
 import { queryKeys } from '../services/queryKeys'
 import { Provider } from '../types'
 import { useAuth } from '../contexts/AuthContext'
+import Page from '../components/Page'
 import RegistryItemCard from '../components/RegistryItemCard'
 import { RegistryItemGridSkeleton } from '../components/skeletons/RegistryItemCardSkeleton'
 
@@ -199,7 +199,7 @@ const ProvidersPage: React.FC = () => {
   }, [setSearchParams])
 
   return (
-    <Container maxWidth="lg" sx={{ py: 4 }} aria-busy={loading} aria-live="polite">
+    <Page maxWidth="lg" aria-busy={loading} aria-live="polite">
       {/* Header */}
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
         <Box>
@@ -350,7 +350,7 @@ const ProvidersPage: React.FC = () => {
           )}
         </>
       )}
-    </Container>
+    </Page>
   );
 }
 

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,5 +1,6 @@
-import { Box, Container, FormControlLabel, Paper, Switch, Typography } from '@mui/material'
+import { Box, FormControlLabel, Paper, Switch, Typography } from '@mui/material'
 import { useTranslation } from 'react-i18next'
+import Page from '../components/Page'
 import { useConsent } from '../contexts/ConsentContext'
 
 /**
@@ -11,7 +12,7 @@ export default function SettingsPage() {
   const { preferences, updatePreferences } = useConsent()
 
   return (
-    <Container maxWidth="sm" sx={{ py: 4 }}>
+    <Page maxWidth="sm">
       <Typography variant="h4" component="h1" gutterBottom>
         {t('settingsPage.title')}
       </Typography>
@@ -75,6 +76,6 @@ export default function SettingsPage() {
         </a>
         .
       </Typography>
-    </Container>
+    </Page>
   )
 }

--- a/frontend/src/pages/TerraformBinariesPage.tsx
+++ b/frontend/src/pages/TerraformBinariesPage.tsx
@@ -1,8 +1,9 @@
 import React, { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
-import { Container, Typography, Box, Grid, Chip, CircularProgress, Alert } from '@mui/material'
+import { Typography, Box, Grid, Chip, CircularProgress, Alert } from '@mui/material'
 import api from '../services/api'
+import Page from '../components/Page'
 import RegistryItemCard from '../components/RegistryItemCard'
 
 interface MirrorSummary {
@@ -74,7 +75,7 @@ const TerraformBinariesPage: React.FC = () => {
   }, [t])
 
   return (
-    <Container maxWidth="lg" sx={{ py: 4 }} aria-busy={loading} aria-live="polite">
+    <Page maxWidth="lg" aria-busy={loading} aria-live="polite">
       <Box sx={{ mb: 2 }}>
         <Typography variant="h4" gutterBottom>
           {t('terraformBinaries.pageTitle')}
@@ -161,7 +162,7 @@ const TerraformBinariesPage: React.FC = () => {
           })}
         </Grid>
       )}
-    </Container>
+    </Page>
   );
 }
 

--- a/frontend/src/pages/TerraformBinaryDetailPage.tsx
+++ b/frontend/src/pages/TerraformBinaryDetailPage.tsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useParams, useNavigate, Link as RouterLink } from 'react-router-dom'
 import {
-  Container,
   Typography,
   Box,
   Breadcrumbs,
@@ -36,6 +35,7 @@ import ExpandLessIcon from '@mui/icons-material/ExpandLess'
 import CheckCircleIcon from '@mui/icons-material/CheckCircle'
 import ErrorIcon from '@mui/icons-material/Error'
 import OpenInNewIcon from '@mui/icons-material/OpenInNew'
+import Page from '../components/Page'
 import api from '../services/api'
 import { getErrorMessage } from '../utils/errors'
 import {
@@ -482,13 +482,13 @@ const TerraformBinaryDetailPage: React.FC = () => {
   return (
     <Box aria-busy={loading} aria-live="polite">
       {loading ? (
-        <Container>
+        <Page>
           <Box sx={{ display: 'flex', justifyContent: 'center', mt: 8 }}>
             <CircularProgress />
           </Box>
-        </Container>
+        </Page>
       ) : error ? (
-        <Container sx={{ py: 4 }}>
+        <Page>
           <Alert severity="error">{error}</Alert>
           <Button
             sx={{ mt: 2 }}
@@ -497,9 +497,9 @@ const TerraformBinaryDetailPage: React.FC = () => {
           >
             Back to Mirrors
           </Button>
-        </Container>
+        </Page>
       ) : (
-        <Container maxWidth="lg" sx={{ py: 4 }}>
+        <Page maxWidth="lg">
           {/* Breadcrumbs */}
           <Breadcrumbs sx={{ mb: 2 }}>
             <Link component={RouterLink} to="/terraform-binaries" underline="hover" color="inherit">
@@ -696,7 +696,7 @@ const TerraformBinaryDetailPage: React.FC = () => {
               </Button>
             </DialogActions>
           </Dialog>
-        </Container>
+        </Page>
       )}
     </Box>
   )

--- a/frontend/src/pages/admin/APIKeysPage.tsx
+++ b/frontend/src/pages/admin/APIKeysPage.tsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import {
-  Container,
   Typography,
   Box,
   Paper,
@@ -40,6 +39,7 @@ import DeleteIcon from '@mui/icons-material/Delete'
 import AddIcon from '@mui/icons-material/Add'
 import KeyIcon from '@mui/icons-material/Key'
 import EmptyState from '../../components/EmptyState'
+import Page from '../../components/Page'
 import CopyIcon from '@mui/icons-material/ContentCopy'
 import InfoIcon from '@mui/icons-material/Info'
 import EditIcon from '@mui/icons-material/Edit'
@@ -461,7 +461,7 @@ const APIKeysPage: React.FC = () => {
   )
 
   return (
-    <Container maxWidth="lg" sx={{ py: 4 }} aria-busy={loading} aria-live="polite">
+    <Page maxWidth="lg" aria-busy={loading} aria-live="polite">
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
         <Box>
           <Typography variant="h4" gutterBottom>
@@ -973,7 +973,7 @@ credentials "${REGISTRY_HOST}" {
           </Box>
         </Typography>
       </Paper>
-    </Container>
+    </Page>
   )
 }
 

--- a/frontend/src/pages/admin/ApprovalsPage.tsx
+++ b/frontend/src/pages/admin/ApprovalsPage.tsx
@@ -7,7 +7,6 @@ import {
   Card,
   CardContent,
   CardActions,
-  Container,
   Typography,
   Grid,
   Chip,
@@ -28,6 +27,7 @@ import RefreshIcon from '@mui/icons-material/Refresh'
 import CheckCircleIcon from '@mui/icons-material/CheckCircle'
 import CancelIcon from '@mui/icons-material/Cancel'
 import HourglassEmptyIcon from '@mui/icons-material/HourglassEmpty'
+import Page from '../../components/Page'
 import api from '../../services/api'
 import { formatDate } from '../../utils'
 import { MirrorApprovalRequest } from '../../types/rbac'
@@ -180,7 +180,7 @@ const ApprovalsPage: React.FC = () => {
   }
 
   return (
-    <Container maxWidth="lg" sx={{ py: 4 }} aria-busy={loading} aria-live="polite">
+    <Page maxWidth="lg" aria-busy={loading} aria-live="polite">
       {loading ? (
         <Box
           sx={{
@@ -507,7 +507,7 @@ const ApprovalsPage: React.FC = () => {
           </Dialog>
         </>
       )}
-    </Container>
+    </Page>
   )
 }
 

--- a/frontend/src/pages/admin/AuditLogPage.tsx
+++ b/frontend/src/pages/admin/AuditLogPage.tsx
@@ -2,7 +2,6 @@ import React, { useState, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useQuery } from '@tanstack/react-query'
 import {
-  Container,
   Typography,
   Box,
   Paper,
@@ -31,6 +30,7 @@ import {
 import DownloadIcon from '@mui/icons-material/Download'
 import HistoryIcon from '@mui/icons-material/History'
 import EmptyState from '../../components/EmptyState'
+import Page from '../../components/Page'
 import api from '../../services/api'
 import { AuditLog } from '../../types'
 import { queryKeys } from '../../services/queryKeys'
@@ -193,7 +193,7 @@ const AuditLogPage: React.FC = () => {
   }
 
   return (
-    <Container maxWidth="lg" sx={{ py: 4 }} aria-busy={loading} aria-live="polite">
+    <Page maxWidth="lg" aria-busy={loading} aria-live="polite">
       {/* Header */}
       <Box
         sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', mb: 3 }}
@@ -526,7 +526,7 @@ const AuditLogPage: React.FC = () => {
           <Button onClick={() => setDetailOpen(false)}>{t('admin.auditLog.close')}</Button>
         </DialogActions>
       </Dialog>
-    </Container>
+    </Page>
   )
 }
 

--- a/frontend/src/pages/admin/DashboardPage.tsx
+++ b/frontend/src/pages/admin/DashboardPage.tsx
@@ -5,7 +5,6 @@ import { useNavigate } from 'react-router-dom'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { queryKeys } from '../../services/queryKeys'
 import {
-  Container,
   Typography,
   Box,
   Grid,
@@ -42,6 +41,7 @@ import Security from '@mui/icons-material/Security'
 import VpnKey from '@mui/icons-material/VpnKey'
 import api from '../../services/api'
 import { useAuth } from '../../contexts/AuthContext'
+import Page from '../../components/Page'
 import QuotaUsageChart from '../../components/QuotaUsageChart'
 import { useReleasesGPGKeyStatus } from '../../hooks/useReleasesGPGKeyStatus'
 
@@ -840,7 +840,7 @@ const DashboardPage: React.FC = () => {
   ].filter((l) => l.scope === null || hasScope(l.scope))
 
   return (
-    <Container maxWidth="lg" sx={{ py: 4 }} aria-busy={loading} aria-live="polite">
+    <Page maxWidth="lg" aria-busy={loading} aria-live="polite">
       {loading ? (
         <Box sx={{ display: 'flex', justifyContent: 'center', py: 10 }}>
           <CircularProgress />
@@ -1296,7 +1296,7 @@ const DashboardPage: React.FC = () => {
           </Grid>
         </>
       )}
-    </Container>
+    </Page>
   )
 }
 

--- a/frontend/src/pages/admin/MTLSPage.tsx
+++ b/frontend/src/pages/admin/MTLSPage.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { useQuery } from '@tanstack/react-query'
 import {
-  Container,
   Typography,
   Paper,
   Table,
@@ -17,6 +16,7 @@ import {
   Chip,
   Stack,
 } from '@mui/material'
+import Page from '../../components/Page'
 import api from '../../services/api'
 import type { MTLSConfigResponse } from '../../types'
 
@@ -32,7 +32,7 @@ const MTLSPage: React.FC = () => {
   })
 
   return (
-    <Container maxWidth="lg" sx={{ py: 4 }}>
+    <Page maxWidth="lg">
       <Typography variant="h4" gutterBottom>
         mTLS Client Certificate Mappings
       </Typography>
@@ -137,7 +137,7 @@ const MTLSPage: React.FC = () => {
           )}
         </>
       )}
-    </Container>
+    </Page>
   )
 }
 

--- a/frontend/src/pages/admin/MirrorPoliciesPage.tsx
+++ b/frontend/src/pages/admin/MirrorPoliciesPage.tsx
@@ -25,7 +25,6 @@ import {
   FormControl,
   InputLabel,
   IconButton,
-  Container,
 } from '@mui/material'
 import AddIcon from '@mui/icons-material/Add'
 import EditIcon from '@mui/icons-material/Edit'
@@ -34,6 +33,7 @@ import RefreshIcon from '@mui/icons-material/Refresh'
 import CheckCircleIcon from '@mui/icons-material/CheckCircle'
 import BlockIcon from '@mui/icons-material/Block'
 import PlayArrowIcon from '@mui/icons-material/PlayArrow'
+import Page from '../../components/Page'
 import api from '../../services/api'
 import { MirrorPolicy } from '../../types/rbac'
 import { getErrorMessage } from '../../utils/errors'
@@ -225,7 +225,7 @@ const MirrorPoliciesPage: React.FC = () => {
   }
 
   return (
-    <Container maxWidth="lg" sx={{ py: 4 }} aria-busy={loading} aria-live="polite">
+    <Page maxWidth="lg" aria-busy={loading} aria-live="polite">
       {loading ? (
         <Box
           sx={{
@@ -667,7 +667,7 @@ const MirrorPoliciesPage: React.FC = () => {
           </Dialog>
         </>
       )}
-    </Container>
+    </Page>
   )
 }
 

--- a/frontend/src/pages/admin/MirrorsPage.tsx
+++ b/frontend/src/pages/admin/MirrorsPage.tsx
@@ -9,7 +9,6 @@ import {
   Card,
   CardContent,
   CardActions,
-  Container,
   Typography,
   Grid,
   IconButton,
@@ -62,6 +61,7 @@ import ErrorIcon from '@mui/icons-material/Error'
 import ExpandLessIcon from '@mui/icons-material/ExpandLess'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import ScheduleIcon from '@mui/icons-material/Schedule'
+import Page from '../../components/Page'
 import api from '../../services/api'
 import {
   type MirrorConfiguration,
@@ -550,7 +550,7 @@ const MirrorsPage: React.FC = () => {
   }
 
   return (
-    <Container maxWidth="lg" sx={{ py: 4 }} aria-busy={loading} aria-live="polite">
+    <Page maxWidth="lg" aria-busy={loading} aria-live="polite">
       {loading ? (
         <Box
           sx={{
@@ -1187,7 +1187,7 @@ const MirrorsPage: React.FC = () => {
           </Dialog>
         </>
       )}
-    </Container>
+    </Page>
   )
 }
 

--- a/frontend/src/pages/admin/ModuleUploadPage.tsx
+++ b/frontend/src/pages/admin/ModuleUploadPage.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useLocation, useNavigate } from 'react-router-dom'
 import {
-  Container,
   Typography,
   Box,
   Paper,
@@ -22,6 +21,7 @@ import ArrowBack from '@mui/icons-material/ArrowBack'
 import api from '../../services/api'
 import { getErrorMessage } from '../../utils/errors'
 import { isValidRegistrySegment, REGISTRY_SEGMENT_HELP } from '../../utils/registrySegment'
+import Page from '../../components/Page'
 import PublishFromSCMWizard from '../../components/PublishFromSCMWizard'
 import FileDropZone from '../../components/FileDropZone'
 import PolicyResultsPanel from '../../components/PolicyResultsPanel'
@@ -521,7 +521,7 @@ const ModuleUploadPage: React.FC = () => {
   )
 
   return (
-    <Container maxWidth="md" sx={{ py: 4 }}>
+    <Page maxWidth="md">
       <Typography variant="h4" gutterBottom>
         {t('admin.moduleUpload.pageTitle')}
       </Typography>
@@ -539,7 +539,7 @@ const ModuleUploadPage: React.FC = () => {
         {moduleMethod === 'upload' && renderFileUploadForm()}
         {moduleMethod === 'scm' && renderScmMetadataForm()}
       </Paper>
-    </Container>
+    </Page>
   )
 }
 

--- a/frontend/src/pages/admin/OIDCSettingsPage.tsx
+++ b/frontend/src/pages/admin/OIDCSettingsPage.tsx
@@ -3,7 +3,6 @@ import { useTranslation } from 'react-i18next'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import {
   Autocomplete,
-  Container,
   Typography,
   Box,
   Paper,
@@ -37,6 +36,7 @@ import EditIcon from '@mui/icons-material/Edit'
 import DeleteIcon from '@mui/icons-material/Delete'
 import ManageAccountsIcon from '@mui/icons-material/ManageAccounts'
 import SaveIcon from '@mui/icons-material/Save'
+import Page from '../../components/Page'
 import api from '../../services/api'
 import type {
   OIDCConfigResponse,
@@ -182,7 +182,7 @@ const OIDCSettingsPage: React.FC = () => {
   }
 
   return (
-    <Container maxWidth="lg" aria-busy={loading} aria-live="polite">
+    <Page maxWidth="lg" aria-busy={loading} aria-live="polite">
       {loading ? (
         <Box sx={{ display: 'flex', justifyContent: 'center', mt: 8 }}>
           <CircularProgress />
@@ -660,7 +660,7 @@ const OIDCSettingsPage: React.FC = () => {
           )}
         </Paper>
       )}
-    </Container>
+    </Page>
   )
 }
 

--- a/frontend/src/pages/admin/OrganizationsPage.tsx
+++ b/frontend/src/pages/admin/OrganizationsPage.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import {
-  Container,
   Typography,
   Box,
   Paper,
@@ -38,6 +37,7 @@ import DeleteIcon from '@mui/icons-material/Delete'
 import AddIcon from '@mui/icons-material/Add'
 import PeopleIcon from '@mui/icons-material/People'
 import PersonAddIcon from '@mui/icons-material/PersonAdd'
+import Page from '../../components/Page'
 import api from '../../services/api'
 import { Organization, OrganizationMemberWithUser, User } from '../../types'
 import { RoleTemplate } from '../../types/rbac'
@@ -268,7 +268,7 @@ const OrganizationsPage: React.FC = () => {
   }
 
   return (
-    <Container maxWidth="lg" sx={{ py: 4 }}>
+    <Page maxWidth="lg">
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
         <Box>
           <Typography variant="h4" gutterBottom>
@@ -698,7 +698,7 @@ const OrganizationsPage: React.FC = () => {
           </Button>
         </DialogActions>
       </Dialog>
-    </Container>
+    </Page>
   )
 }
 

--- a/frontend/src/pages/admin/ProviderUploadPage.tsx
+++ b/frontend/src/pages/admin/ProviderUploadPage.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate, useLocation } from 'react-router-dom'
 import {
-  Container,
   Typography,
   Box,
   Paper,
@@ -26,6 +25,7 @@ import CloudDownload from '@mui/icons-material/CloudDownload'
 import ArrowBack from '@mui/icons-material/ArrowBack'
 import api from '../../services/api'
 import { getErrorMessage } from '../../utils/errors'
+import Page from '../../components/Page'
 import FileDropZone from '../../components/FileDropZone'
 
 type ProviderMethod = 'choose' | 'upload' | 'mirror'
@@ -333,7 +333,7 @@ const ProviderUploadPage: React.FC = () => {
   )
 
   return (
-    <Container maxWidth="md" sx={{ py: 4 }}>
+    <Page maxWidth="md">
       <Typography variant="h4" gutterBottom>
         {t('admin.providerUpload.pageTitle')}
       </Typography>
@@ -350,7 +350,7 @@ const ProviderUploadPage: React.FC = () => {
         {providerMethod === 'choose' && renderProviderMethodChooser()}
         {providerMethod === 'upload' && renderFileUploadForm()}
       </Paper>
-    </Container>
+    </Page>
   )
 }
 

--- a/frontend/src/pages/admin/RolesPage.tsx
+++ b/frontend/src/pages/admin/RolesPage.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useQuery } from '@tanstack/react-query'
 import {
-  Container,
   Typography,
   Box,
   Paper,
@@ -25,6 +24,7 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import ShieldIcon from '@mui/icons-material/Shield'
 import LockIcon from '@mui/icons-material/Lock'
 import AdminIcon from '@mui/icons-material/AdminPanelSettings'
+import Page from '../../components/Page'
 import api from '../../services/api'
 import { RoleTemplate, AVAILABLE_SCOPES } from '../../types/rbac'
 import { getScopeInfo, getScopeColor } from '../../utils'
@@ -70,7 +70,7 @@ const RolesPage: React.FC = () => {
     }
 
   return (
-    <Container maxWidth="lg" aria-busy={loading} aria-live="polite">
+    <Page maxWidth="lg" aria-busy={loading} aria-live="polite">
       {loading ? (
         <Box
           sx={{
@@ -371,7 +371,7 @@ const RolesPage: React.FC = () => {
           </Paper>
         </>
       )}
-    </Container>
+    </Page>
   )
 }
 

--- a/frontend/src/pages/admin/SCMProvidersPage.tsx
+++ b/frontend/src/pages/admin/SCMProvidersPage.tsx
@@ -24,7 +24,6 @@ import {
   CircularProgress,
   Tooltip,
   Divider,
-  Container,
 } from '@mui/material'
 import AddIcon from '@mui/icons-material/Add'
 import EditIcon from '@mui/icons-material/Edit'
@@ -36,6 +35,7 @@ import CloudIcon from '@mui/icons-material/Cloud'
 import ContentCopyIcon from '@mui/icons-material/ContentCopy'
 import CheckCircleIcon from '@mui/icons-material/CheckCircle'
 import LinkOffIcon from '@mui/icons-material/LinkOff'
+import Page from '../../components/Page'
 import api from '../../services/api'
 import { getErrorMessage } from '../../utils/errors'
 import { useAuth } from '../../contexts/AuthContext'
@@ -334,7 +334,7 @@ const SCMProvidersPage: React.FC = () => {
   }
 
   return (
-    <Container maxWidth="lg" sx={{ py: 4 }} aria-busy={loading} aria-live="polite">
+    <Page maxWidth="lg" aria-busy={loading} aria-live="polite">
       {loading ? (
         <Box
           sx={{
@@ -911,7 +911,7 @@ const SCMProvidersPage: React.FC = () => {
           </Dialog>
         </>
       )}
-    </Container>
+    </Page>
   )
 }
 

--- a/frontend/src/pages/admin/SecurityScanningPage.tsx
+++ b/frontend/src/pages/admin/SecurityScanningPage.tsx
@@ -3,7 +3,6 @@ import { useTranslation } from 'react-i18next'
 import type { TFunction } from 'i18next'
 import { useQuery } from '@tanstack/react-query'
 import {
-  Container,
   Typography,
   Box,
   Paper,
@@ -29,6 +28,7 @@ import HourglassEmpty from '@mui/icons-material/HourglassEmpty'
 import WarningAmber from '@mui/icons-material/WarningAmber'
 import KeyboardArrowDown from '@mui/icons-material/KeyboardArrowDown'
 import KeyboardArrowRight from '@mui/icons-material/KeyboardArrowRight'
+import Page from '../../components/Page'
 import ScanDiagnostics from '../../components/ScanDiagnostics'
 import ScanFindingsModal from '../../components/ScanFindingsModal'
 import api from '../../services/api'
@@ -192,7 +192,7 @@ const SecurityScanningPage: React.FC = () => {
   const error = configError || statsError
 
   return (
-    <Container maxWidth="lg" sx={{ py: 4 }}>
+    <Page maxWidth="lg">
       <Typography
         variant="h4"
         gutterBottom
@@ -750,7 +750,7 @@ const SecurityScanningPage: React.FC = () => {
         loading={findingsModalLoading}
         moduleLabel={findingsModalLabel}
       />
-    </Container>
+    </Page>
   )
 }
 

--- a/frontend/src/pages/admin/StoragePage.tsx
+++ b/frontend/src/pages/admin/StoragePage.tsx
@@ -25,7 +25,6 @@ import {
   Step,
   StepLabel,
   Paper,
-  Container,
   Accordion,
   AccordionSummary,
   AccordionDetails,
@@ -59,6 +58,7 @@ import type {
   StorageMigration,
 } from '../../types'
 import { queryKeys } from '../../services/queryKeys'
+import Page from '../../components/Page'
 import StorageMigrationWizard from '../../components/StorageMigrationWizard'
 
 const StoragePage: React.FC = () => {
@@ -658,7 +658,7 @@ const StoragePage: React.FC = () => {
   )
 
   const renderSetupWizard = () => (
-    <Container maxWidth="lg" sx={{ py: 4 }}>
+    <Page maxWidth="lg">
       <Typography variant="h4" gutterBottom>
         {showAddWizard ? t('admin.storage.titleAdd') : t('admin.storage.titleConfigure')}
       </Typography>
@@ -736,11 +736,11 @@ const StoragePage: React.FC = () => {
           )}
         </Box>
       </Box>
-    </Container>
+    </Page>
   )
 
   const renderExistingConfigs = () => (
-    <Container maxWidth="lg" sx={{ py: 4 }}>
+    <Page maxWidth="lg">
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
         <Box>
           <Typography variant="h4">{t('admin.storage.storageSettings')}</Typography>
@@ -1027,7 +1027,7 @@ const StoragePage: React.FC = () => {
         onClose={() => setMigrationWizardOpen(false)}
         configs={configs}
       />
-    </Container>
+    </Page>
   )
 
   return (

--- a/frontend/src/pages/admin/TerraformMirrorPage.tsx
+++ b/frontend/src/pages/admin/TerraformMirrorPage.tsx
@@ -13,7 +13,6 @@ import {
   Chip,
   CircularProgress,
   Collapse,
-  Container,
   Dialog,
   DialogActions,
   DialogContent,
@@ -63,6 +62,7 @@ import SyncIcon from '@mui/icons-material/Sync'
 
 import api from '../../services/api'
 import { getErrorMessage } from '../../utils/errors'
+import Page from '../../components/Page'
 import ReleasesGPGKeyStatus from '../../components/ReleasesGPGKeyStatus'
 import {
   type TerraformMirrorConfig,
@@ -740,7 +740,7 @@ const TerraformMirrorPage: React.FC = () => {
           <CircularProgress />
         </Box>
       ) : (
-        <Container maxWidth="lg" sx={{ py: 4 }}>
+        <Page maxWidth="lg">
           {/* Header */}
           <Box
             sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}
@@ -1346,7 +1346,7 @@ const TerraformMirrorPage: React.FC = () => {
               </Button>
             </DialogActions>
           </Dialog>
-        </Container>
+        </Page>
       )}
     </Box>
   )

--- a/frontend/src/pages/admin/UsersPage.tsx
+++ b/frontend/src/pages/admin/UsersPage.tsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import {
-  Container,
   Typography,
   Box,
   Paper,
@@ -42,6 +41,7 @@ import PersonIcon from '@mui/icons-material/Person'
 import DownloadIcon from '@mui/icons-material/Download'
 import PrivacyTipIcon from '@mui/icons-material/PrivacyTip'
 import EmptyState from '../../components/EmptyState'
+import Page from '../../components/Page'
 import api from '../../services/api'
 import { useAuth } from '../../contexts/AuthContext'
 import { User, UserMembership, Organization } from '../../types'
@@ -427,7 +427,7 @@ const UsersPage: React.FC = () => {
   )
 
   return (
-    <Container maxWidth="lg" sx={{ py: 4 }}>
+    <Page maxWidth="lg">
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
         <Box>
           <Typography variant="h4" gutterBottom>
@@ -868,7 +868,7 @@ const UsersPage: React.FC = () => {
           </Button>
         </DialogActions>
       </Dialog>
-    </Container>
+    </Page>
   )
 }
 

--- a/frontend/src/pages/admin/VersionApprovalsPage.tsx
+++ b/frontend/src/pages/admin/VersionApprovalsPage.tsx
@@ -8,7 +8,6 @@ import {
   Chip,
   CircularProgress,
   Collapse,
-  Container,
   Dialog,
   DialogActions,
   DialogContent,
@@ -35,6 +34,7 @@ import HourglassEmptyIcon from '@mui/icons-material/HourglassEmpty'
 import VerifiedIcon from '@mui/icons-material/Verified'
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown'
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp'
+import Page from '../../components/Page'
 import api from '../../services/api'
 import { queryKeys } from '../../services/queryKeys'
 import { getErrorMessage } from '../../utils/errors'
@@ -393,7 +393,7 @@ const VersionApprovalsPage: React.FC = () => {
   const bulkPending = bulkApproveMutation.isPending || bulkRejectMutation.isPending
 
   return (
-    <Container maxWidth="lg" sx={{ py: 4 }} aria-busy={isLoading} aria-live="polite">
+    <Page maxWidth="lg" aria-busy={isLoading} aria-live="polite">
       <Box sx={{ mb: 3 }}>
         <Typography variant="h4">{t('admin.versionApprovals.pageTitle')}</Typography>
         <Typography variant="body2" sx={{ color: 'text.secondary' }}>
@@ -616,7 +616,7 @@ const VersionApprovalsPage: React.FC = () => {
           </Button>
         </DialogActions>
       </Dialog>
-    </Container>
+    </Page>
   )
 }
 

--- a/frontend/src/pages/dev/ComponentShowcase.tsx
+++ b/frontend/src/pages/dev/ComponentShowcase.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
-import { Box, Container, Typography, Divider, Paper, Chip, Link, Grid, Alert } from '@mui/material'
+import { Box, Typography, Divider, Paper, Chip, Link, Grid, Alert } from '@mui/material'
+import Page from '../../components/Page'
 import RegistryItemCard from '../../components/RegistryItemCard'
 import MarkdownRenderer from '../../components/MarkdownRenderer'
 import ErrorBoundary from '../../components/ErrorBoundary'
@@ -184,7 +185,7 @@ const ComponentShowcase = () => {
   const [migrationWizardOpen, setMigrationWizardOpen] = useState(false)
 
   return (
-    <Container maxWidth="lg" sx={{ py: 4 }}>
+    <Page maxWidth="lg">
       <Typography variant="h3" gutterBottom>
         Component Showcase
       </Typography>
@@ -510,7 +511,7 @@ const ComponentShowcase = () => {
       }}>
         Route: <code>/dev/components</code> &mdash; available only in development mode.
       </Typography>
-    </Container>
+    </Page>
   );
 }
 


### PR DESCRIPTION
## What

Adds `frontend/src/components/Page.tsx`, a standard page shell that wraps MUI `Container`:

- `maxWidth` prop defaulting to `'lg'` (typed as `ContainerProps['maxWidth']`).
- `sx={{ py: 4 }}` merged with any caller-passed `sx` (caller `sx` wins on key conflicts).
- All other props (`aria-busy`, `aria-live`, `className`, etc.) forwarded to `Container` via `...rest`.

Then migrates every page that renders inside `<Layout>` to use `<Page>` instead of a bare `<Container>`, preserving each page's exact `maxWidth` and forwarding its aria attributes. The redundant `py: 4` is dropped (Page supplies it); any non-`py` sx is preserved.

## Pages converted (final maxWidth)

All previously used a `<Container>` (none were full-bleed); per-page `maxWidth` preserved exactly:

| Page | maxWidth |
| --- | --- |
| pages/ModulesPage.tsx | lg |
| pages/ModuleDetailPage.tsx | xl (x2: error + main) |
| pages/ProvidersPage.tsx | lg |
| pages/ProviderDetailPage.tsx | xl (x2: error + main) |
| pages/TerraformBinariesPage.tsx | lg |
| pages/TerraformBinaryDetailPage.tsx | lg (main) + lg-default (loading & error states, previously bare `<Container>` / `<Container sx={{py:4}}>`) |
| pages/SettingsPage.tsx | sm |
| pages/dev/ComponentShowcase.tsx | lg |
| pages/admin/DashboardPage.tsx | lg |
| pages/admin/UsersPage.tsx | lg |
| pages/admin/OrganizationsPage.tsx | lg |
| pages/admin/RolesPage.tsx | lg (no prior `py`; Page now adds py:4) |
| pages/admin/APIKeysPage.tsx | lg |
| pages/admin/AuditLogPage.tsx | lg |
| pages/admin/SecurityScanningPage.tsx | lg |
| pages/admin/MTLSPage.tsx | lg |
| pages/admin/OIDCSettingsPage.tsx | lg (no prior `py`; Page now adds py:4) |
| pages/admin/SCMProvidersPage.tsx | lg |
| pages/admin/MirrorsPage.tsx | lg |
| pages/admin/MirrorPoliciesPage.tsx | lg |
| pages/admin/ApprovalsPage.tsx | lg |
| pages/admin/VersionApprovalsPage.tsx | lg |
| pages/admin/TerraformMirrorPage.tsx | lg |
| pages/admin/StoragePage.tsx | lg (x2: setup wizard + main) |
| pages/admin/ModuleUploadPage.tsx | md |
| pages/admin/ProviderUploadPage.tsx | md |

None of the converted pages were previously full-bleed — each already had a `<Container>` page wrapper.

## Standalone / full-bleed pages left unchanged

- **Standalone (outside `<Layout>` per App.tsx):** `LoginPage` (`/login`), `CallbackPage` (`/auth/callback`), `SetupWizardPage` (`/setup`) — their existing Containers are untouched.
- **In-Layout but intentionally full-bleed (deviation):** `HomePage` and `ApiDocumentation` were **not** converted. Neither uses a page-level `<Container>`:
  - `HomePage` is a multi-section landing page: its outermost wrapper is a bare `<Box>` whose children are full-width background bands (gradient hero, gray "Getting Started" band). Each band centers content via its own section-level `<Container maxWidth="lg|sm">`. Wrapping the page in a width-constrained `<Page>` would collapse the full-bleed bands, and the inner Containers are section centerers (with varied `mb`/`py`/`textAlign` sx), not page shells.
  - `ApiDocumentation` renders full-bleed via a top-level `<Box sx={{ overflow: 'hidden' }}>` (load-bearing — it clips Swagger UI) with a sticky 200px side nav and full-width Swagger content. Constraining it to lg would regress the intentional full-width layout.

## maxWidth preservation

Confirmed: every converted page passes its original `maxWidth` to `<Page>`. lg pages keep `maxWidth="lg"` explicit; non-lg pages (`xl`, `md`, `sm`) pass their exact value. The only behavioral nuance: `RolesPage` and `OIDCSettingsPage` previously had no `py` on their Container, so they now gain the standard `py: 4` from Page; the three `TerraformBinaryDetailPage` loading/error Containers (one bare, one `sx={{py:4}}`) become the lg default + py:4.

## Quality gate (from `frontend/`)

- `npx tsc --noEmit` — pass
- `npm run lint` (`eslint . --max-warnings 0`) — pass
- `npm test` (`vitest run`) — pass (99 files, 1564 tests)
- `npm run build` (`tsc && vite build`) — pass