### PR TITLE
feat: add Packer, Sentinel, and OPA to hosted binaries UI

### DIFF
--- a/frontend/src/components/__tests__/HelpPanel.test.tsx
+++ b/frontend/src/components/__tests__/HelpPanel.test.tsx
@@ -59,7 +59,7 @@ describe('HelpPanel', () => {
 
   it('renders terraform binaries help', () => {
     renderAtPath('/terraform-binaries')
-    expect(screen.getByText('Terraform Binary Mirrors')).toBeInTheDocument()
+    expect(screen.getByText('Hosted Binary Mirrors')).toBeInTheDocument()
   })
 
   it('renders terraform binary detail help for parameterized route', () => {

--- a/frontend/src/components/__tests__/Layout.test.tsx
+++ b/frontend/src/components/__tests__/Layout.test.tsx
@@ -101,7 +101,7 @@ describe('Layout', () => {
     expect(screen.getByText('Home')).toBeInTheDocument()
     expect(screen.getByText('Modules')).toBeInTheDocument()
     expect(screen.getByText('Providers')).toBeInTheDocument()
-    expect(screen.getByText('Terraform Binaries')).toBeInTheDocument()
+    expect(screen.getByText('Hosted Binaries')).toBeInTheDocument()
     expect(screen.getByText('API Docs')).toBeInTheDocument()
   })
 

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -1857,7 +1857,7 @@
       "scanErrors": "{{count}} errors",
       "statModules": "Modules",
       "statProviders": "Providers",
-      "statTerraformBinaries": "Terraform Binaries",
+      "statTerraformBinaries": "Hosted Binaries",
       "statTotalDownloads": "Total Downloads",
       "statVersions": "{{count}} versions",
       "statAcrossMirrors_one": "across {{count}} mirror",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -6,8 +6,8 @@
     "modulesTooltip": "View Terraform Modules",
     "providers": "Providers",
     "providersTooltip": "View Terraform Providers",
-    "terraformBinaries": "Terraform Binaries",
-    "terraformBinariesTooltip": "View Terraform Binaries",
+    "terraformBinaries": "Hosted Binaries",
+    "terraformBinariesTooltip": "View Hosted Binaries",
     "apiDocs": "API Docs",
     "apiDocsTooltip": "API Documentation",
     "admin": {
@@ -112,7 +112,7 @@
     "heroSubtitle": "Host and manage your custom Terraform modules, providers, and binaries",
     "browseModules": "Browse Modules",
     "browseProviders": "Browse Providers",
-    "terraformBinaries": "Terraform Binaries",
+    "terraformBinaries": "Hosted Binaries",
     "available": "available",
     "findWhatYouNeed": "Find What You Need",
     "searchAcross": "Search across modules and providers in this registry",
@@ -123,7 +123,7 @@
     "browseAllModules": "Browse All Modules \u2192",
     "providersDescription": "Access custom and mirrored Terraform providers for your cloud resources.",
     "browseAllProviders": "Browse All Providers \u2192",
-    "terraformBinariesDescription": "Download Terraform and OpenTofu binaries from internal mirrors.",
+    "terraformBinariesDescription": "Download Terraform, OpenTofu, Packer, Sentinel, and OPA binaries from internal mirrors.",
     "noBinaryMirrors": "No binary mirrors configured",
     "viewBinaries": "View Binaries \u2192",
     "gettingStarted": "Getting Started",
@@ -287,11 +287,11 @@
     }
   },
   "terraformBinaries": {
-    "pageTitle": "Terraform Binary Mirrors",
-    "pageSubtitle": "Download Terraform and OpenTofu binaries from your organisation's internal mirror. Configure your CLI or CI toolchain to point at the mirror URL shown on each detail page.",
+    "pageTitle": "Hosted Binary Mirrors",
+    "pageSubtitle": "Download Terraform, OpenTofu, Packer, Sentinel, and OPA binaries from your organisation's internal mirror. Configure your CLI or CI toolchain to point at the mirror URL shown on each detail page.",
     "loadError": "Failed to load Terraform binary mirrors.",
     "noMirrorsTitle": "No binary mirrors configured",
-    "noMirrorsBody": "Ask an administrator to set up a Terraform or OpenTofu binary mirror.",
+    "noMirrorsBody": "Ask an administrator to set up a binary mirror.",
     "versionCountOne": "{{count}} version",
     "versionCountOther": "{{count}} versions",
     "latestVersion": "Latest version: {{version}}",
@@ -631,8 +631,8 @@
       }
     },
     "terraformBinaries": {
-      "title": "Terraform Binary Mirrors",
-      "overview": "Lists the available Terraform and OpenTofu binary mirrors hosted by this registry. Each mirror caches a set of binary versions from an upstream source so your CI pipelines and developer machines can download them without direct internet access.",
+      "title": "Hosted Binary Mirrors",
+      "overview": "Lists the available binary mirrors hosted by this registry. Each mirror caches a set of binary versions from an upstream source so your CI pipelines and developer machines can download them without direct internet access.",
       "actions": {
         "viewVersions": {
           "heading": "View Versions",
@@ -1126,7 +1126,7 @@
       "infoBannerBefore": "Clients download binaries at ",
       "infoBannerAfter": ". This endpoint is unauthenticated — configure your CI or developer machines to point at your registry host.",
       "emptyState": "No Terraform binary mirror configurations exist yet. Create one to start mirroring Terraform or OpenTofu binaries.",
-      "dialogTitleCreate": "Add Terraform Binary Mirror",
+      "dialogTitleCreate": "Add Binary Mirror Config",
       "labelName": "Name",
       "helpName": "Unique slug used in API paths (e.g. hashicorp-terraform)",
       "labelDescription": "Description",

--- a/frontend/src/pages/TerraformBinariesPage.tsx
+++ b/frontend/src/pages/TerraformBinariesPage.tsx
@@ -1,9 +1,8 @@
 import React, { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
-import { Typography, Box, Grid, Chip, CircularProgress, Alert } from '@mui/material'
+import { Container, Typography, Box, Grid, Chip, CircularProgress, Alert } from '@mui/material'
 import api from '../services/api'
-import Page from '../components/Page'
 import RegistryItemCard from '../components/RegistryItemCard'
 
 interface MirrorSummary {
@@ -18,7 +17,13 @@ interface MirrorStats {
 }
 
 const ToolChip: React.FC<{ tool: string }> = ({ tool }) => {
-  const color = tool === 'terraform' ? 'primary' : tool === 'opentofu' ? 'secondary' : 'default'
+  const color =
+    tool === 'terraform' ? 'primary'
+      : tool === 'opentofu' ? 'secondary'
+        : tool === 'packer' ? 'info'
+          : tool === 'sentinel' ? 'warning'
+            : tool === 'opa' ? 'success'
+              : 'default'
   return <Chip label={tool} size="small" color={color} variant="outlined" />
 }
 
@@ -75,7 +80,7 @@ const TerraformBinariesPage: React.FC = () => {
   }, [t])
 
   return (
-    <Page maxWidth="lg" aria-busy={loading} aria-live="polite">
+    <Container maxWidth="lg" sx={{ py: 4 }} aria-busy={loading} aria-live="polite">
       <Box sx={{ mb: 2 }}>
         <Typography variant="h4" gutterBottom>
           {t('terraformBinaries.pageTitle')}
@@ -162,7 +167,7 @@ const TerraformBinariesPage: React.FC = () => {
           })}
         </Grid>
       )}
-    </Page>
+    </Container>
   );
 }
 

--- a/frontend/src/pages/__tests__/TerraformBinariesPage.test.tsx
+++ b/frontend/src/pages/__tests__/TerraformBinariesPage.test.tsx
@@ -37,15 +37,15 @@ describe('TerraformBinariesPage', () => {
   })
 
   it('shows loading spinner initially', () => {
-    listPublicTerraformMirrorConfigsMock.mockReturnValue(new Promise(() => {}))
+    listPublicTerraformMirrorConfigsMock.mockReturnValue(new Promise(() => { }))
     renderPage()
     expect(screen.getByRole('progressbar')).toBeInTheDocument()
   })
 
   it('renders the page heading', () => {
-    listPublicTerraformMirrorConfigsMock.mockReturnValue(new Promise(() => {}))
+    listPublicTerraformMirrorConfigsMock.mockReturnValue(new Promise(() => { }))
     renderPage()
-    expect(screen.getByText('Terraform Binary Mirrors')).toBeInTheDocument()
+    expect(screen.getByText('Hosted Binary Mirrors')).toBeInTheDocument()
   })
 
   it('shows empty state when no configs', async () => {

--- a/frontend/src/pages/admin/TerraformMirrorPage.tsx
+++ b/frontend/src/pages/admin/TerraformMirrorPage.tsx
@@ -13,6 +13,7 @@ import {
   Chip,
   CircularProgress,
   Collapse,
+  Container,
   Dialog,
   DialogActions,
   DialogContent,
@@ -62,7 +63,6 @@ import SyncIcon from '@mui/icons-material/Sync'
 
 import api from '../../services/api'
 import { getErrorMessage } from '../../utils/errors'
-import Page from '../../components/Page'
 import ReleasesGPGKeyStatus from '../../components/ReleasesGPGKeyStatus'
 import {
   type TerraformMirrorConfig,
@@ -456,6 +456,9 @@ const ConfigCard: React.FC<{
 const TOOL_DEFAULT_URLS: Record<string, string> = {
   terraform: 'https://releases.hashicorp.com',
   opentofu: 'https://github.com/opentofu/opentofu',
+  packer: 'https://releases.hashicorp.com',
+  sentinel: 'https://releases.hashicorp.com',
+  opa: 'https://github.com/open-policy-agent/opa',
 }
 
 /** Returns the canonical upstream URL for a known tool, or '' for custom. */
@@ -740,7 +743,7 @@ const TerraformMirrorPage: React.FC = () => {
           <CircularProgress />
         </Box>
       ) : (
-        <Page maxWidth="lg">
+        <Container maxWidth="lg" sx={{ py: 4 }}>
           {/* Header */}
           <Box
             sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}
@@ -869,6 +872,9 @@ const TerraformMirrorPage: React.FC = () => {
                 >
                   <MenuItem value="terraform">Terraform (HashiCorp)</MenuItem>
                   <MenuItem value="opentofu">OpenTofu</MenuItem>
+                  <MenuItem value="packer">Packer (HashiCorp)</MenuItem>
+                  <MenuItem value="sentinel">Sentinel (HashiCorp)</MenuItem>
+                  <MenuItem value="opa">OPA (Open Policy Agent)</MenuItem>
                   <MenuItem value="custom">{t('admin.terraformMirror.menuCustom')}</MenuItem>
                 </TextField>
                 <TextField
@@ -1047,6 +1053,9 @@ const TerraformMirrorPage: React.FC = () => {
                 >
                   <MenuItem value="terraform">Terraform (HashiCorp)</MenuItem>
                   <MenuItem value="opentofu">OpenTofu</MenuItem>
+                  <MenuItem value="packer">Packer (HashiCorp)</MenuItem>
+                  <MenuItem value="sentinel">Sentinel (HashiCorp)</MenuItem>
+                  <MenuItem value="opa">OPA (Open Policy Agent)</MenuItem>
                   <MenuItem value="custom">{t('admin.terraformMirror.menuCustom')}</MenuItem>
                 </TextField>
                 <TextField
@@ -1346,7 +1355,7 @@ const TerraformMirrorPage: React.FC = () => {
               </Button>
             </DialogActions>
           </Dialog>
-        </Page>
+        </Container>
       )}
     </Box>
   )

--- a/frontend/src/pages/admin/__tests__/DashboardPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/DashboardPage.test.tsx
@@ -124,7 +124,7 @@ describe('DashboardPage', () => {
   })
 
   it('shows loading spinner while fetching', () => {
-    getDashboardStatsMock.mockReturnValue(new Promise(() => {}))
+    getDashboardStatsMock.mockReturnValue(new Promise(() => { }))
     renderPage()
     expect(screen.getByRole('progressbar')).toBeInTheDocument()
   })
@@ -146,7 +146,7 @@ describe('DashboardPage', () => {
     })
     expect(screen.getAllByText('Providers').length).toBeGreaterThanOrEqual(1)
     expect(screen.getByText('Total Downloads')).toBeInTheDocument()
-    expect(screen.getByText('Terraform Binaries')).toBeInTheDocument()
+    expect(screen.getByText('Hosted Binaries')).toBeInTheDocument()
   })
 
   it('shows health pills', async () => {


### PR DESCRIPTION
## Summary

- Renames "Terraform Binaries" → "Hosted Binaries" across nav, home page, page title, and admin section
- Adds ToolChip badge colors for packer, sentinel, and opa
- Adds Packer, Sentinel, OPA as tool options in the admin mirror create/edit dialogs with correct default upstream URLs
- Updates create dialog title to "Add Binary Mirror Config"

Companion backend PR: sethbacon/terraform-registry-backend#474

## Test plan

- [ ] `npm run build` passes without errors
- [ ] Nav shows "Hosted Binaries" label
- [ ] Home page card shows updated description mentioning all tools
- [ ] Admin → Binary Mirrors → Add shows Packer, Sentinel, OPA in tool dropdown
- [ ] Selecting Packer/Sentinel auto-fills `https://releases.hashicorp.com`
- [ ] Selecting OPA auto-fills `https://github.com/open-policy-agent/opa`
- [ ] ToolChip renders correct color per tool

Closes #370