### PR TITLE
fix: load Inter font via @fontsource/inter

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "terraform-registry-frontend",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "terraform-registry-frontend",
-      "version": "2.4.2",
+      "version": "2.4.3",
       "dependencies": {
         "@emotion/cache": "^11.14.0",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
         "@eslint/js": "^10.0.1",
+        "@fontsource/inter": "^5.2.8",
         "@fortawesome/fontawesome-svg-core": "^7.2.0",
         "@fortawesome/free-brands-svg-icons": "^7.2.0",
         "@fortawesome/react-fontawesome": "^3.3.1",
@@ -1224,6 +1225,15 @@
         "@noble/hashes": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@fontsource/inter": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-5.2.8.tgz",
+      "integrity": "sha512-P6r5WnJoKiNVV+zvW2xM13gNdFhAEpQ9dQJHt3naLvfg+LkF2ldgSLiF4T41lf1SQCM9QmkqPTn4TH568IRagg==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@fortawesome/fontawesome-common-types": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,6 +24,7 @@
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
     "@eslint/js": "^10.0.1",
+    "@fontsource/inter": "^5.2.8",
     "@fortawesome/fontawesome-svg-core": "^7.2.0",
     "@fortawesome/free-brands-svg-icons": "^7.2.0",
     "@fortawesome/react-fontawesome": "^3.3.1",

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,3 +1,7 @@
+import '@fontsource/inter/400.css'
+import '@fontsource/inter/500.css'
+import '@fontsource/inter/600.css'
+import '@fontsource/inter/700.css'
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import createCache from '@emotion/cache'


### PR DESCRIPTION
## Summary
- Install `@fontsource/inter` and import weights 400/500/600/700 in `main.tsx`
- Inter was declared in the MUI theme but never loaded — browsers silently fell back to Roboto/system sans-serif

Closes #369

## Test plan
- [ ] `npm run build` — no errors, inter woff2 files appear in `dist/assets/`
- [ ] DevTools → Network → Font filter shows `inter-*.woff2` requests
- [ ] Visual check: body text renders in Inter (compare letter shapes vs Roboto)