### PR TITLE
feat(suite): note possible re-auth when opening the sibling app

### DIFF
--- a/frontend/src/components/SuiteSwitcher.test.tsx
+++ b/frontend/src/components/SuiteSwitcher.test.tsx
@@ -37,6 +37,47 @@ it('renders a link when a sibling is active', async () => {
   ).toBeInTheDocument()
 })
 
+it('warns the sibling opens in a new tab until a shared store is confirmed', async () => {
+  vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+    new Response(
+      JSON.stringify({
+        sibling: {
+          app: 'terraform-state-manager',
+          state: 'active',
+          publicUrl: 'https://tfstate.example.com',
+        },
+      }),
+      { status: 200 },
+    ),
+  )
+  render(withQuery(<SuiteSwitcher />))
+  // No sharedStore flag → set expectations that a separate sign-in may be needed.
+  expect(
+    await screen.findByRole('button', { name: /you may need to sign in/i }),
+  ).toBeInTheDocument()
+})
+
+it('drops the sign-in hint when the sibling reports a shared store', async () => {
+  vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+    new Response(
+      JSON.stringify({
+        sibling: {
+          app: 'terraform-state-manager',
+          state: 'active',
+          publicUrl: 'https://tfstate.example.com',
+          sharedStore: true,
+        },
+      }),
+      { status: 200 },
+    ),
+  )
+  render(withQuery(<SuiteSwitcher />))
+  expect(
+    await screen.findByRole('button', { name: 'Open Terraform State Manager' }),
+  ).toBeInTheDocument()
+  expect(screen.queryByRole('button', { name: /sign in/i })).toBeNull()
+})
+
 it('renders nothing when sibling is degraded', async () => {
   vi.spyOn(globalThis, 'fetch').mockResolvedValue(
     new Response(

--- a/frontend/src/components/SuiteSwitcher.tsx
+++ b/frontend/src/components/SuiteSwitcher.tsx
@@ -11,11 +11,17 @@ export function SuiteSwitcher() {
   const { sibling, active } = useSuite()
   if (!active || !sibling?.publicUrl) return null
   const label = LABELS[sibling.app] ?? sibling.app
+  // Until both apps are confirmed to share one identity store + IdP
+  // (sibling.sharedStore), opening the sibling in a new tab may require a
+  // separate sign-in. Set that expectation honestly rather than implying SSO.
+  const title = sibling.sharedStore
+    ? `Open ${label}`
+    : `Open ${label} (opens in a new tab; you may need to sign in)`
   return (
-    <Tooltip title={`Open ${label}`}>
+    <Tooltip title={title}>
       <IconButton
         color="inherit"
-        aria-label={`Open ${label}`}
+        aria-label={title}
         sx={{ mr: 1 }}
         onClick={() => window.open(sibling.publicUrl, '_blank', 'noopener,noreferrer')}
       >

--- a/frontend/src/hooks/useSuite.ts
+++ b/frontend/src/hooks/useSuite.ts
@@ -5,6 +5,12 @@ export interface SuiteSibling {
   state: 'active' | 'degraded' | 'unreachable' | 'unknown'
   publicUrl?: string
   links?: Record<string, string>
+  // Identity provenance from the sibling's manifest. issuer identifies which app
+  // minted its tokens; sharedStore is true only when an operator has confirmed
+  // both apps use one identity store + IdP (single sign-on). Absent/false ⇒ the
+  // switcher warns that opening the sibling may require a separate sign-in.
+  issuer?: string
+  sharedStore?: boolean
 }
 
 async function fetchUIConfig(): Promise<{ sibling: SuiteSibling | null }> {


### PR DESCRIPTION
## What
The app-switcher opened the sibling in a new tab with a bare `Open X` tooltip — implying seamless SSO that doesn't exist yet. Now the tooltip/aria-label reads **"Open X (opens in a new tab; you may need to sign in)"** until both apps are confirmed to share one identity store + IdP.

- `useSuite`'s `SuiteSibling` gains optional `issuer` + `sharedStore` (from the sibling manifest's identity block).
- When `sharedStore` is true the hint is dropped (plain `Open X`).
- The backend doesn't emit `sharedStore` yet, so the honest "may need to sign in" message is what users see — **correct for the current per-app-session reality**. This is the user-facing half of suite-coupling **Phase 1** (SSO honesty); the backend forwarding of `sharedStore` is a trivial follow-up (no-op in Phase 1 since it stays false).

## Tests
2 new `SuiteSwitcher.test.tsx` cases (hint shown when no shared store; hint dropped + plain label when `sharedStore: true`). lint/tsc/build clean; coverage 80.38/74.81/74.48/82.62 (≥ 80/70/70/80).

Parallel TSM-frontend PR uses the identical component.