### PR TITLE
feat(suite): "Consumed by" panel on module detail (Phase 2 keystone)

### DIFF
--- a/frontend/scripts/contract-check.allowlist.json
+++ b/frontend/scripts/contract-check.allowlist.json
@@ -20,6 +20,11 @@
       "method": "POST",
       "path": "/api/v1/dev/impersonate/{}",
       "reason": "Backend route is registered conditionally under DEV_MODE=true and is intentionally undocumented in production swagger. Permanent allowlist entry."
+    },
+    {
+      "method": "GET",
+      "path": "/api/v1/suite/modules/{}/{}/{}/consumers",
+      "reason": "Suite 'Consumed by' proxy added in terraform-registry-backend#495, which postdates the pinned contract-check image (1.4.0) and currently ships without swagger annotations. Remove once the backend documents the route (adds @Router) AND docker-compose.contract-check.yml is bumped to a release that includes it."
     }
   ]
 }

--- a/frontend/src/components/ConsumedByPanel.tsx
+++ b/frontend/src/components/ConsumedByPanel.tsx
@@ -1,0 +1,97 @@
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+import {
+  Box,
+  Paper,
+  Typography,
+  Divider,
+  Chip,
+  Button,
+  List,
+  ListItem,
+  ListItemText,
+} from '@mui/material'
+import AccountTreeIcon from '@mui/icons-material/AccountTree'
+import OpenInNewIcon from '@mui/icons-material/OpenInNew'
+import type { ModuleConsumer } from '../services/api'
+
+interface ConsumedByPanelProps {
+  active: boolean
+  siblingUrl?: string
+  consumers: ModuleConsumer[]
+}
+
+// Cap the rendered rows so a heavily-consumed module can't produce an unbounded
+// list; the count chip still reflects the true total.
+const MAX_ROWS = 50
+
+const ConsumedByPanel: React.FC<ConsumedByPanelProps> = ({ active, siblingUrl, consumers }) => {
+  const { t } = useTranslation()
+
+  // Hidden entirely when the suite is inactive or nothing consumes the module —
+  // this keeps standalone deployments free of an empty suite panel.
+  if (!active || consumers.length === 0) return null
+
+  return (
+    <Paper sx={{ p: 3, mb: 3 }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+        <AccountTreeIcon fontSize="small" color="action" />
+        <Typography variant="h6">{t('consumedBy.title')}</Typography>
+        <Chip label={consumers.length} size="small" />
+      </Box>
+      <Divider sx={{ my: 2 }} />
+      <Typography variant="body2" sx={{ color: 'text.secondary', mb: 1 }}>
+        {t('consumedBy.subtitle')}
+      </Typography>
+      <List dense disablePadding>
+        {consumers.slice(0, MAX_ROWS).map((c) => (
+          <ListItem key={`${c.source_id}:${c.state_key}`} disableGutters sx={{ py: 0.5 }}>
+            <ListItemText
+              primary={
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                  <Typography variant="body2">
+                    {c.source_name || c.source_id} — {c.state_key}
+                  </Typography>
+                  {c.module_version ? (
+                    <Chip label={c.module_version} size="small" color="info" />
+                  ) : (
+                    <Chip label={t('consumedBy.constraintOnly')} size="small" variant="outlined" />
+                  )}
+                </Box>
+              }
+              secondary={
+                <Typography variant="caption" sx={{ color: 'text.secondary', display: 'block' }}>
+                  {new Date(c.observed_at).toLocaleString()}
+                </Typography>
+              }
+            />
+          </ListItem>
+        ))}
+      </List>
+      {consumers.length > MAX_ROWS && (
+        <Typography variant="caption" sx={{ color: 'text.secondary', mt: 1, display: 'block' }}>
+          {t('consumedBy.showingCount', { shown: MAX_ROWS, total: consumers.length })}
+        </Typography>
+      )}
+      {siblingUrl && (
+        <Box sx={{ mt: 1 }}>
+          <Button
+            size="small"
+            startIcon={<OpenInNewIcon />}
+            onClick={() =>
+              window.open(
+                `${siblingUrl.replace(/\/$/, '')}/sources`,
+                '_blank',
+                'noopener,noreferrer',
+              )
+            }
+          >
+            {t('consumedBy.openInStateManager')}
+          </Button>
+        </Box>
+      )}
+    </Paper>
+  )
+}
+
+export default ConsumedByPanel

--- a/frontend/src/components/__tests__/ConsumedByPanel.test.tsx
+++ b/frontend/src/components/__tests__/ConsumedByPanel.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import ConsumedByPanel from '../ConsumedByPanel'
+import type { ModuleConsumer } from '../../services/api'
+
+const consumers: ModuleConsumer[] = [
+  {
+    source_id: 'src-1',
+    source_name: 'prod-backend',
+    state_key: 'env/prod/network.tfstate',
+    module_version: null,
+    observed_at: '2026-06-01T12:00:00Z',
+  },
+  {
+    source_id: 'src-2',
+    source_name: 'staging-backend',
+    state_key: 'env/staging/app.tfstate',
+    module_version: '1.4.0',
+    observed_at: '2026-06-02T12:00:00Z',
+  },
+]
+
+const defaultProps = {
+  active: true,
+  siblingUrl: 'https://tsm.example.com',
+  consumers,
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('ConsumedByPanel', () => {
+  it('returns null when suite is inactive', () => {
+    const { container } = render(<ConsumedByPanel {...defaultProps} active={false} />)
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('returns null when there are no consumers', () => {
+    const { container } = render(<ConsumedByPanel {...defaultProps} consumers={[]} />)
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('renders the title and consumer count', () => {
+    render(<ConsumedByPanel {...defaultProps} />)
+    expect(screen.getByText('Consumed by')).toBeInTheDocument()
+    expect(screen.getByText('2')).toBeInTheDocument()
+  })
+
+  it('renders each consuming state', () => {
+    render(<ConsumedByPanel {...defaultProps} />)
+    expect(screen.getByText(/prod-backend — env\/prod\/network.tfstate/)).toBeInTheDocument()
+    expect(screen.getByText(/staging-backend — env\/staging\/app.tfstate/)).toBeInTheDocument()
+  })
+
+  it('marks constraint-only entries and shows resolved versions', () => {
+    render(<ConsumedByPanel {...defaultProps} />)
+    expect(screen.getByText('constraint only')).toBeInTheDocument()
+    expect(screen.getByText('1.4.0')).toBeInTheDocument()
+  })
+
+  it('falls back to source_id when source_name is empty', () => {
+    const anon: ModuleConsumer[] = [{ ...consumers[0], source_name: '' }]
+    render(<ConsumedByPanel {...defaultProps} consumers={anon} />)
+    expect(screen.getByText(/src-1 — env\/prod\/network.tfstate/)).toBeInTheDocument()
+  })
+
+  it('opens the State Manager sources page in a new tab', async () => {
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
+    const user = userEvent.setup()
+    render(<ConsumedByPanel {...defaultProps} />)
+    await user.click(screen.getByText('Open in State Manager'))
+    expect(openSpy).toHaveBeenCalledWith(
+      'https://tsm.example.com/sources',
+      '_blank',
+      'noopener,noreferrer',
+    )
+  })
+
+  it('hides the open button when no sibling URL is known', () => {
+    render(<ConsumedByPanel {...defaultProps} siblingUrl={undefined} />)
+    expect(screen.queryByText('Open in State Manager')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/hooks/useModuleDetail.ts
+++ b/frontend/src/hooks/useModuleDetail.ts
@@ -2,9 +2,11 @@ import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import api from '../services/api'
+import type { ModuleConsumer } from '../services/api'
 import { ModuleVersion, ModuleScan, ModuleDoc } from '../types'
 import type { ModuleSCMLink, SCMWebhookEvent } from '../types/scm'
 import { useAuth } from '../contexts/AuthContext'
+import { useSuite } from './useSuite'
 import { REGISTRY_HOST } from '../config'
 import { getErrorMessage, getErrorStatus } from '../utils/errors'
 import { queryKeys } from '../services/queryKeys'
@@ -36,6 +38,7 @@ export function useModuleDetail() {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
   const { isAuthenticated, allowedScopes } = useAuth()
+  const { sibling: suiteSibling, active: suiteActive } = useSuite()
   const canManage =
     isAuthenticated && (allowedScopes.includes('admin') || allowedScopes.includes('modules:write'))
 
@@ -205,6 +208,24 @@ export function useModuleDetail() {
       setWebhookEventsLoaded(true)
     }
   }
+
+  // =========================================================================
+  // 7. Suite "Consumed by" query (states in the sibling State Manager that
+  //    reference this module). Inert unless the suite is active AND the user is
+  //    authenticated — the proxy requires auth and a shared service token, and
+  //    returns an empty list when standalone.
+  // =========================================================================
+  const { data: moduleConsumers = [] } = useQuery<ModuleConsumer[]>({
+    queryKey: queryKeys.modules.consumers(namespace ?? '', name ?? '', system ?? ''),
+    queryFn: async () => {
+      try {
+        return await api.getModuleConsumers(namespace!, name!, system!)
+      } catch {
+        return []
+      }
+    },
+    enabled: moduleQueryEnabled && suiteActive && isAuthenticated,
+  })
 
   // =========================================================================
   // Mutations
@@ -575,6 +596,10 @@ export function useModuleDetail() {
     webhookEventsLoading,
     webhookEventsExpanded,
     setWebhookEventsExpanded,
+    // Suite "Consumed by"
+    moduleConsumers,
+    suiteActive,
+    suiteSiblingUrl: suiteSibling?.publicUrl,
     // Security scan
     moduleScan,
     scanLoading,

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -2009,6 +2009,13 @@
     "showingCount": "Showing 10 of {{total}} events",
     "refresh": "Refresh"
   },
+  "consumedBy": {
+    "title": "Consumed by",
+    "subtitle": "States in State Manager that reference this module.",
+    "constraintOnly": "constraint only",
+    "showingCount": "Showing {{shown}} of {{total}} states",
+    "openInStateManager": "Open in State Manager"
+  },
   "repositoryBrowser": {
     "searchPlaceholder": "Search repositories...",
     "refresh": "Refresh",

--- a/frontend/src/pages/ModuleDetailPage.tsx
+++ b/frontend/src/pages/ModuleDetailPage.tsx
@@ -32,6 +32,7 @@ import Page from '../components/Page'
 import PublishFromSCMWizard from '../components/PublishFromSCMWizard'
 import ModuleDocumentation from '../components/ModuleDocumentation'
 import SecurityScanPanel from '../components/SecurityScanPanel'
+import ConsumedByPanel from '../components/ConsumedByPanel'
 import SCMRepositoryPanel from '../components/SCMRepositoryPanel'
 import WebhookEventsPanel from '../components/WebhookEventsPanel'
 import VersionDetailsPanel from '../components/VersionDetailsPanel'
@@ -119,6 +120,9 @@ const ModuleDetailPage: React.FC = () => {
     handleUpdateDescription,
     handleUpdateNamespace,
     ociEnabled,
+    moduleConsumers,
+    suiteActive,
+    suiteSiblingUrl,
   } = useModuleDetail()
 
   const [editingNamespace, setEditingNamespace] = React.useState(false)
@@ -533,6 +537,12 @@ const ModuleDetailPage: React.FC = () => {
                 scanNotConfigured={scanNotConfigured}
                 onRescan={handleRescan}
                 rescanPending={rescanPending}
+              />
+
+              <ConsumedByPanel
+                active={suiteActive}
+                siblingUrl={suiteSiblingUrl}
+                consumers={moduleConsumers}
               />
             </Box>
           </Box>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -17,6 +17,19 @@ function getCookie(name: string): string {
   return match ? decodeURIComponent(match[1]) : ''
 }
 
+/**
+ * A Terraform State Manager state that references this module, surfaced via the
+ * suite consumers proxy. `module_version` is null when the state only carries a
+ * version constraint (no locked version) — rendered as "constraint only".
+ */
+export interface ModuleConsumer {
+  source_id: string
+  source_name: string
+  state_key: string
+  module_version: string | null
+  observed_at: string
+}
+
 class ApiClient {
   private client: AxiosInstance
 
@@ -857,6 +870,20 @@ class ApiClient {
     const response = await this.client.get(`/api/v1/admin/modules/${moduleId}/scm/events`)
     // Backend wraps the list as { events: [...] }; callers expect a bare array.
     return response.data?.events ?? []
+  }
+
+  async getModuleConsumers(
+    namespace: string,
+    name: string,
+    system: string,
+  ): Promise<ModuleConsumer[]> {
+    // Suite proxy: forwarded to the sibling State Manager when a shared service
+    // token is configured, else returns an empty list. Backend wraps the list
+    // as { consumers: [...] }; callers expect a bare array.
+    const response = await this.client.get(
+      `/api/v1/suite/modules/${namespace}/${name}/${system}/consumers`,
+    )
+    return response.data?.consumers ?? []
   }
 
   async updateModule(

--- a/frontend/src/services/queryKeys.ts
+++ b/frontend/src/services/queryKeys.ts
@@ -20,6 +20,8 @@ export const queryKeys = {
       [...queryKeys.modules._def, 'docs', namespace, name, system, version] as const,
     webhookEvents: (moduleId: string) =>
       [...queryKeys.modules._def, 'webhookEvents', moduleId] as const,
+    consumers: (namespace: string, name: string, system: string) =>
+      [...queryKeys.modules._def, 'consumers', namespace, name, system] as const,
   },
   providers: {
     _def: ['providers'] as const,


### PR DESCRIPTION
## Summary

Completes the **Phase 2 data-integration keystone** on the registry side: the module detail page now shows which **states in the sibling Terraform State Manager** reference the module. This is the read-side counterpart to the TSM provenance capture (TSM #100), query endpoints (TSM #102), and the registry server-proxy ([#495](https://github.com/sethbacon/terraform-registry-backend/pull/495)).

## What changed

- **`api.getModuleConsumers(ns, name, system)`** → `GET /api/v1/suite/modules/{ns}/{name}/{system}/consumers`, unwraps `{ consumers }`, returns `[]` when absent.
- **`useModuleDetail`** fetches consumers via React Query, `enabled` only when the **suite is active AND the user is authenticated** (the proxy requires auth + a shared service token, and returns empty when standalone). Query errors degrade to `[]`.
- **`ConsumedByPanel`** (new, modeled on `WebhookEventsPanel`): renders `null` unless the suite is active and ≥1 state consumes the module — so **standalone deployments see nothing new**. Rows show source/state with a `constraint only` chip when no version is locked; a footer button opens the State Manager **/sources** page in a new tab.
- i18n keys under `consumedBy.*`.

## Honesty note

State Manager has **no per-source route** (`/sources` is one tabbed page; selection is local state), so rows link to `{publicUrl}/sources` rather than a non-existent `/sources/:id` that would hit the catch-all. The source name + state key are shown so the user knows what to look for.

## Activation

Inert by default. Lights up only when an operator sets **`TFR_SUITE_SIBLING_TOKEN` == `TSM_SUITE_SERVICE_TOKEN`** (both default empty = off) and the suite discovery is active.

## Verification

- `eslint --max-warnings 0` ✓
- `tsc --noEmit` ✓
- `vitest run --coverage` — **1578/1578 pass**, global gate **80.38 / 74.94 / 74.5 / 82.6** (floor 80/70/70/80); `ConsumedByPanel.tsx` 100/91.7/100/100.
- `vite build` ✓