### PR TITLE
fix(csp): map-derive the nonce so emotion styles aren't blocked (parity)

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,3 +1,13 @@
+# Derive the per-request CSP nonce ONCE. A map variable is evaluated lazily and
+# cached for the whole request — surviving the internal redirect to /index.html —
+# so the CSP header and the sub_filter body rewrite see the SAME value. A plain
+# `set $csp_nonce $request_id` re-runs after that redirect and yields a SECOND,
+# different id, so the header nonce and the <meta>/emotion nonce disagree and the
+# browser blocks every injected style.
+map $request_id $csp_nonce {
+    default $request_id;
+}
+
 server {
     listen 80;
     server_name _;
@@ -23,12 +33,14 @@ server {
     # CSP: nonce-based for style-src to avoid 'unsafe-inline' (MUI/Emotion uses nonce)
     # The __CSP_NONCE__ placeholder is replaced per-request by the sub_filter below.
     # In development (without nginx), 'unsafe-inline' is still needed — Vite injects styles directly.
-    set $csp_nonce $request_id;
+    # $csp_nonce is the single per-request value from the map above.
     add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'nonce-$csp_nonce'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none';" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
 
-    # Inject CSP nonce into index.html so the React app can read it
-    sub_filter_once on;
+    # Inject CSP nonce into index.html so the React app can read it. once off =
+    # replace EVERY __CSP_NONCE__ so the <meta> is covered even if another
+    # occurrence precedes it in the document.
+    sub_filter_once off;
     sub_filter '__CSP_NONCE__' '$csp_nonce';
 
     # Upload size limit (matches backend: 100MB modules, 500MB providers)


### PR DESCRIPTION
## Summary

**Proactive parity fix.** The State Manager frontend rendered **unstyled** in AKS UAT because its nonce-based CSP blocked Emotion's `<style>` tags ([terraform-state-manager-frontend#83](https://github.com/sethbacon/terraform-state-manager-frontend/issues/83), fix [#84](https://github.com/sethbacon/terraform-state-manager-frontend/pull/84)). This frontend has the **identical** nginx pattern and will break the same way.

## Root cause

`set $csp_nonce $request_id` re-runs in the rewrite phase after the internal redirect to `/index.html`, so the CSP **response header** and the `sub_filter` **body** rewrite get *different* `$request_id` values on the same request — the header nonce never matches the `<meta>`/Emotion nonce. (Reproduced in the sibling repo: header `c44b…` vs body `3557…`.)

## Fix

- `map $request_id $csp_nonce` (http context) — evaluated once, cached for the request, survives the internal redirect, so header == body.
- `sub_filter_once off` — replace **every** `__CSP_NONCE__` (robust against any earlier occurrence).

(This frontend's `index.html` has no `__CSP_NONCE__` in a comment, so only the header/body mismatch applied here — but the fix is identical for parity.)

## Verification

`nginx -t` ok with the TLS server (self-signed cert); the header==`<meta>` nonce behaviour was proven with an nginx repro in the sibling repo. The companion chart ConfigMap fix is in `terraform-registry-backend`.