### PR TITLE
fix(switcher): reuse one sibling tab + move icon left of title

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -670,11 +670,11 @@ const Layout = () => {
               <MenuIcon />
             </IconButton>
           )}
+          {isAuthenticated && <SuiteSwitcher />}
           <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
             {productName}
           </Typography>
           {isAuthenticated && <DevUserSwitcher />}
-          {isAuthenticated && <SuiteSwitcher />}
           <Tooltip title={t('header.quickNav')}>
             <IconButton
               color="inherit"

--- a/frontend/src/components/SuiteSwitcher.test.tsx
+++ b/frontend/src/components/SuiteSwitcher.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, expect, it, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { SuiteSwitcher } from './SuiteSwitcher'
 
@@ -76,6 +76,29 @@ it('drops the sign-in hint when the sibling reports a shared store', async () =>
     await screen.findByRole('button', { name: 'Open Terraform State Manager' }),
   ).toBeInTheDocument()
   expect(screen.queryByRole('button', { name: /sign in/i })).toBeNull()
+})
+
+it('reuses one sibling tab via a stable window name instead of opening a new one', async () => {
+  vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+    new Response(
+      JSON.stringify({
+        sibling: {
+          app: 'terraform-state-manager',
+          state: 'active',
+          publicUrl: 'https://tfstate.example.com',
+        },
+      }),
+      { status: 200 },
+    ),
+  )
+  const focus = vi.fn()
+  const openSpy = vi.spyOn(window, 'open').mockReturnValue({ focus } as unknown as Window)
+  render(withQuery(<SuiteSwitcher />))
+  fireEvent.click(await screen.findByRole('button', { name: /Open Terraform State Manager/i }))
+  // Stable target name (the sibling app id) so the browser reuses that one tab;
+  // .focus() brings it forward. NOT '_blank' (which spawns a new tab each click).
+  expect(openSpy).toHaveBeenCalledWith('https://tfstate.example.com', 'terraform-state-manager')
+  expect(focus).toHaveBeenCalled()
 })
 
 it('renders nothing when sibling is degraded', async () => {

--- a/frontend/src/components/SuiteSwitcher.tsx
+++ b/frontend/src/components/SuiteSwitcher.tsx
@@ -23,7 +23,14 @@ export function SuiteSwitcher() {
         color="inherit"
         aria-label={title}
         sx={{ mr: 1 }}
-        onClick={() => window.open(sibling.publicUrl, '_blank', 'noopener,noreferrer')}
+        onClick={() => {
+          // Reuse one sibling tab across clicks: a stable window name (the
+          // sibling's app id) re-navigates and refocuses the same tab instead of
+          // spawning a new one each time. The sibling is a trusted first-party
+          // suite app, so we intentionally omit noopener/noreferrer here — those
+          // force a fresh browsing context and would defeat the tab reuse.
+          window.open(sibling.publicUrl, sibling.app)?.focus()
+        }}
       >
         <AppsIcon />
       </IconButton>


### PR DESCRIPTION
## Summary

Parity with [terraform-state-manager-frontend#86](https://github.com/sethbacon/terraform-state-manager-frontend/pull/86) — the `SuiteSwitcher` is shared/byte-identical across both frontends. Two UAT comments:

1. **Each click opened a new tab.** `window.open(url, '_blank', 'noopener,noreferrer')` forces a fresh browsing context every click. Switched to a **stable window name** (`sibling.app`) + `.focus()`, so repeated clicks **re-navigate and refocus one** sibling tab.
2. **Icon placement.** Moved `<SuiteSwitcher />` to the **left of the nav title** (it sat after the `flexGrow:1` title; `DevUserSwitcher` stays on the right).

## Security note

Tab reuse requires dropping `noopener`/`noreferrer` (they force a new context). The sibling is a **trusted first-party** suite app (URL from the operator-configured manifest), so the reverse-tabnabbing concern doesn't apply.

## Tests

- New test: click calls `window.open('…','terraform-state-manager')` (stable name, not `_blank`) + focuses the window. Switcher suite green (7/7); `Layout` test green (34/34); `tsc` + `eslint --max-warnings 0` clean.