### PR TITLE
fix: route Command Palette Terraform Binaries entry to /terraform-binaries

### DIFF
--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -21,7 +21,7 @@ export const defaultCommands: CommandPaletteNavItem[] = [
   { label: 'Home', path: '/', group: 'Navigation' },
   { label: 'Modules', path: '/modules', group: 'Navigation' },
   { label: 'Providers', path: '/providers', group: 'Navigation' },
-  { label: 'Terraform Binaries', path: '/terraform', group: 'Navigation' },
+  { label: 'Terraform Binaries', path: '/terraform-binaries', group: 'Navigation' },
   { label: 'Admin Dashboard', path: '/admin', scope: 'admin', group: 'Admin' },
   {
     label: 'Organizations',

--- a/frontend/src/components/__tests__/CommandPalette.test.tsx
+++ b/frontend/src/components/__tests__/CommandPalette.test.tsx
@@ -57,6 +57,11 @@ describe('filterByScope', () => {
     expect(result.find((i) => i.path === '/admin/users')).toBeDefined()
     expect(result.find((i) => i.path === '/admin/storage')).toBeUndefined()
   })
+
+  it('points the Terraform Binaries entry at the hosted-binaries route', () => {
+    const entry = defaultCommands.find((i) => i.label === 'Terraform Binaries')
+    expect(entry?.path).toBe('/terraform-binaries')
+  })
 })
 
 describe('CommandPalette', () => {


### PR DESCRIPTION
## Summary

The Command Palette (Cmd/Ctrl+K) "Terraform Binaries" entry pointed at a stale/broken route. It now routes to the correct hosted-binaries page at `/terraform-binaries` and uses the correct label.

## Test plan

- Updated Command Palette tests to assert the corrected route/label.
- `npx vitest run` green; `npx tsc --noEmit` + `npx eslint` clean.

Closes #393
