### PR TITLE
fix: add release-notes links for opa, packer, and sentinel binaries

### DIFF
--- a/frontend/src/pages/TerraformBinaryDetailPage.tsx
+++ b/frontend/src/pages/TerraformBinaryDetailPage.tsx
@@ -165,13 +165,21 @@ const PlatformRows: React.FC<{ mirrorName: string; version: string }> = ({
 // ---------------------------------------------------------------------------
 
 /** Derive the upstream release-notes URL for known tools. Returns null for custom/unknown tools. */
-function getChangelogUrl(tool: string, version: string): string | null {
+export function getChangelogUrl(tool: string, version: string): string | null {
   const v = version.startsWith('v') ? version : `v${version}`
   switch (tool) {
     case 'terraform':
       return `https://github.com/hashicorp/terraform/releases/tag/${v}`
     case 'opentofu':
       return `https://github.com/opentofu/opentofu/releases/tag/${v}`
+    case 'opa':
+      return `https://github.com/open-policy-agent/opa/releases/tag/${v}`
+    case 'packer':
+      return `https://github.com/hashicorp/packer/releases/tag/${v}`
+    case 'sentinel':
+      // Sentinel is closed-source with no per-version GitHub releases; link the
+      // consolidated changelog page instead of a per-version tag.
+      return 'https://developer.hashicorp.com/sentinel/docs/changelog'
     default:
       return null
   }

--- a/frontend/src/pages/__tests__/TerraformBinaryDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/TerraformBinaryDetailPage.test.tsx
@@ -29,7 +29,7 @@ vi.mock('../../contexts/AuthContext', () => ({
   }),
 }))
 
-import TerraformBinaryDetailPage from '../TerraformBinaryDetailPage'
+import TerraformBinaryDetailPage, { getChangelogUrl } from '../TerraformBinaryDetailPage'
 
 function renderPage(path = '/terraform/binaries/terraform') {
   return render(
@@ -245,5 +245,41 @@ describe('TerraformBinaryDetailPage', () => {
     await waitFor(() =>
       expect(screen.getByText(/No versions have been synced yet/)).toBeInTheDocument(),
     )
+  })
+})
+
+describe('getChangelogUrl', () => {
+  it('builds per-version GitHub release tags for terraform and opentofu', () => {
+    expect(getChangelogUrl('terraform', '1.8.0')).toBe(
+      'https://github.com/hashicorp/terraform/releases/tag/v1.8.0',
+    )
+    expect(getChangelogUrl('opentofu', '1.7.0')).toBe(
+      'https://github.com/opentofu/opentofu/releases/tag/v1.7.0',
+    )
+  })
+
+  it('builds per-version GitHub release tags for opa and packer', () => {
+    expect(getChangelogUrl('opa', '0.60.0')).toBe(
+      'https://github.com/open-policy-agent/opa/releases/tag/v0.60.0',
+    )
+    expect(getChangelogUrl('packer', '1.11.0')).toBe(
+      'https://github.com/hashicorp/packer/releases/tag/v1.11.0',
+    )
+  })
+
+  it('links sentinel to the consolidated changelog page (no per-version tag)', () => {
+    expect(getChangelogUrl('sentinel', '0.40.0')).toBe(
+      'https://developer.hashicorp.com/sentinel/docs/changelog',
+    )
+  })
+
+  it('does not double-prefix a version that already starts with v', () => {
+    expect(getChangelogUrl('opa', 'v1.0.0')).toBe(
+      'https://github.com/open-policy-agent/opa/releases/tag/v1.0.0',
+    )
+  })
+
+  it('returns null for unknown/custom tools', () => {
+    expect(getChangelogUrl('custom-tool', '1.0.0')).toBeNull()
   })
 })


### PR DESCRIPTION
## Summary

Hosted-mirror detail views were missing the **release-notes link** for several binaries. Added release-notes links for `opa`, `packer`, and `sentinel` so each hosted binary detail surfaces its upstream release notes consistently with `terraform`/`opentofu`.

## Test plan

- Updated the binary detail tests to cover the new per-tool release-notes links.
- `npx vitest run` green; `npx tsc --noEmit` + `npx eslint` clean.

Closes #392
