### PR TITLE
fix: default new binary mirror form to stable-only and requires-approval

### DIFF
--- a/frontend/src/pages/admin/TerraformMirrorPage.tsx
+++ b/frontend/src/pages/admin/TerraformMirrorPage.tsx
@@ -476,10 +476,10 @@ const emptyCreate = (): CreateTerraformMirrorConfigRequest => ({
   tool: 'terraform',
   upstream_url: toolDefaultUrl('terraform'),
   gpg_verify: true,
-  stable_only: false,
+  stable_only: true,
   enabled: true,
   sync_interval_hours: 24,
-  requires_approval: false,
+  requires_approval: true,
 })
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/pages/admin/__tests__/TerraformMirrorPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/TerraformMirrorPage.test.tsx
@@ -80,7 +80,7 @@ describe('TerraformMirrorPage', () => {
   })
 
   it('shows loading spinner initially', () => {
-    listTerraformMirrorConfigsMock.mockReturnValue(new Promise(() => {}))
+    listTerraformMirrorConfigsMock.mockReturnValue(new Promise(() => { }))
     renderPage()
     expect(screen.getByRole('progressbar')).toBeInTheDocument()
   })
@@ -252,6 +252,23 @@ describe('TerraformMirrorPage', () => {
     const createBtn = screen.getByRole('button', { name: /^create$/i })
     await userEvent.click(createBtn)
     await waitFor(() => expect(createMirrorMock).toHaveBeenCalled())
+  })
+
+  it('defaults a new mirror to stable-only and requires-approval', async () => {
+    listTerraformMirrorConfigsMock.mockResolvedValue({ configs: [] })
+    createMirrorMock.mockResolvedValue({ id: 'new-id' })
+    renderPage()
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /add mirror/i })).toBeInTheDocument(),
+    )
+    await userEvent.click(screen.getByRole('button', { name: /add mirror/i }))
+    await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument())
+    await userEvent.type(screen.getByLabelText(/^Name/i), 'defaults-tf')
+    await userEvent.click(screen.getByRole('button', { name: /^create$/i }))
+    await waitFor(() => expect(createMirrorMock).toHaveBeenCalled())
+    expect(createMirrorMock).toHaveBeenCalledWith(
+      expect.objectContaining({ stable_only: true, requires_approval: true }),
+    )
   })
 
   it('shows error when create mirror fails', async () => {


### PR DESCRIPTION
## Summary

Frontend companion to the backend safe-by-default change. The "create binary mirror" form now defaults **stable-only** and **requires-approval** to `true`, matching the new backend defaults so the UI and API agree.

## Test plan

- Added a test asserting a new mirror is created with `stable_only: true` and `requires_approval: true`.
- `npx vitest run` green (39 tests); `npx tsc --noEmit` + `npx eslint` clean.

## Companion

Backend: sethbacon/terraform-registry-backend#508 (PR sethbacon/terraform-registry-backend#510).

Part of #508
