### PR TITLE
fix: type release signing-key source as none for unmanaged binaries

### DIFF
--- a/frontend/src/components/__tests__/ReleasesGPGKeyStatus.test.tsx
+++ b/frontend/src/components/__tests__/ReleasesGPGKeyStatus.test.tsx
@@ -124,4 +124,25 @@ describe('ReleasesGPGKeyStatus', () => {
 
     await waitFor(() => expect(screen.getByText('expired')).toBeInTheDocument())
   })
+
+  it('renders an unmanaged-key binary row (none source, unknown status)', async () => {
+    const noneResponse: ReleasesGPGKeysResponse = {
+      keys: [
+        {
+          tool: 'opa',
+          cache: null,
+          embedded: null,
+          effective_source: 'none',
+          expiry_warning_days: 60,
+          status: 'unknown',
+        },
+      ],
+    }
+    mockGetReleasesGPGKeys.mockResolvedValue(noneResponse)
+    renderComponent()
+
+    await waitFor(() => expect(screen.getByText('opa')).toBeInTheDocument())
+    expect(screen.getByText('none')).toBeInTheDocument()
+    expect(screen.getByText('unknown')).toBeInTheDocument()
+  })
 })

--- a/frontend/src/types/releases_gpg_keys.ts
+++ b/frontend/src/types/releases_gpg_keys.ts
@@ -19,7 +19,9 @@ export interface ReleasesGPGKeyStatusView {
   tool: string
   cache: ReleasesGPGKeyCacheView | null
   embedded: ReleasesGPGKeyEmbeddedView | null
-  effective_source: 'cache' | 'embedded'
+  // 'none' is used for configured binaries that have no managed signing key yet
+  // (e.g. opa); such rows carry null cache/embedded and an 'unknown' status.
+  effective_source: 'cache' | 'embedded' | 'none'
   expiry_warning_days: number
   status: ReleasesGPGKeyStatus
 }


### PR DESCRIPTION
## Summary

Frontend companion to the per-binary release signing-key change. The backend now emits a row per configured binary, including unmanaged binaries (e.g. `opa`) with `effective_source: "none"`. This widens the `effective_source` type union to include `'none'` so those rows type-check and render.

The existing `ReleasesGPGKeyStatus` component already renders any number of rows and handles null cache/embedded keys gracefully, so no further component change was required.

## Test plan

- Added a component test rendering an unmanaged-key binary row (`none` source, `unknown` status).
- `npx vitest run` green (6 tests); `npx tsc --noEmit` (0) + `npx eslint` (0) clean.

## Companion

Backend: sethbacon/terraform-registry-backend#507 (PR sethbacon/terraform-registry-backend#511).

Part of #507
