### PR TITLE
fix: present binary mirror UX labels consistently in the frontend

### DIFF
--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -21,7 +21,12 @@ export const defaultCommands: CommandPaletteNavItem[] = [
   { label: 'Home', path: '/', group: 'Navigation' },
   { label: 'Modules', path: '/modules', group: 'Navigation' },
   { label: 'Providers', path: '/providers', group: 'Navigation' },
-  { label: 'Terraform Binaries', path: '/terraform-binaries', group: 'Navigation' },
+  {
+    label: 'Hosted Binaries',
+    path: '/terraform-binaries',
+    group: 'Navigation',
+    keywords: ['terraform', 'opentofu', 'binary', 'mirror', 'packer', 'sentinel', 'opa'],
+  },
   { label: 'Admin Dashboard', path: '/admin', scope: 'admin', group: 'Admin' },
   {
     label: 'Organizations',
@@ -40,6 +45,7 @@ export const defaultCommands: CommandPaletteNavItem[] = [
     path: '/admin/terraform-mirror',
     scope: 'mirrors:read',
     group: 'Admin',
+    keywords: ['terraform', 'opentofu', 'binaries', 'config', 'packer', 'sentinel', 'opa'],
   },
   { label: 'Mirror Approvals', path: '/admin/approvals', scope: 'mirrors:read', group: 'Admin' },
   { label: 'Mirror Policies', path: '/admin/policies', scope: 'admin', group: 'Admin' },

--- a/frontend/src/components/__tests__/CommandPalette.test.tsx
+++ b/frontend/src/components/__tests__/CommandPalette.test.tsx
@@ -35,7 +35,7 @@ function setAuth(overrides: { isAuthenticated?: boolean; allowedScopes?: string[
 function renderPalette(open = true) {
   return render(
     <MemoryRouter>
-      <CommandPalette open={open} onClose={() => {}} />
+      <CommandPalette open={open} onClose={() => { }} />
     </MemoryRouter>,
   )
 }
@@ -58,8 +58,9 @@ describe('filterByScope', () => {
     expect(result.find((i) => i.path === '/admin/storage')).toBeUndefined()
   })
 
-  it('points the Terraform Binaries entry at the hosted-binaries route', () => {
-    const entry = defaultCommands.find((i) => i.label === 'Terraform Binaries')
+  it('points the hosted-binaries entry at the hosted-binaries route', () => {
+    const entry = defaultCommands.find((i) => i.path === '/terraform-binaries')
+    expect(entry?.label).toBe('Hosted Binaries')
     expect(entry?.path).toBe('/terraform-binaries')
   })
 })

--- a/frontend/src/components/__tests__/Layout.test.tsx
+++ b/frontend/src/components/__tests__/Layout.test.tsx
@@ -207,7 +207,7 @@ describe('Layout', () => {
     expect(screen.getByText('API Keys')).toBeInTheDocument()
     expect(screen.getByText('Provider Config')).toBeInTheDocument()
     expect(screen.getByText('Approvals')).toBeInTheDocument()
-    expect(screen.getByText('Binaries Config')).toBeInTheDocument()
+    expect(screen.getByText('Binary Mirrors')).toBeInTheDocument()
 
     // Should NOT see admin-only items
     expect(screen.queryByText('OIDC Groups')).not.toBeInTheDocument()

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -33,7 +33,7 @@
       "mirroring": "Spiegelung",
       "providerConfig": "Anbieter-Konfiguration",
       "providerConfigTooltip": "Anbieter-Spiegelquellen und Synchronisierungszeitpläne konfigurieren",
-      "binariesConfig": "Binärdateien – Konfiguration",
+      "binariesConfig": "Binär-Mirrors",
       "binariesConfigTooltip": "Konfigurieren der Quellen für die Binär-Mirrors von Terraform und OpenTofu",
       "approvals": "Zulassungen",
       "approvalsTooltip": "Ausstehende Anträge auf Spiegel-Synchronisierung prüfen und genehmigen",
@@ -1077,7 +1077,7 @@
       "thLastSynced": "Zuletzt synchronisiert"
     },
     "terraformMirror": {
-      "pageTitle": "Spiegelung – Konfiguration der Binärdateien",
+      "pageTitle": "Binär-Mirrors",
       "refresh": "Aktualisieren",
       "addMirror": "Spiegel hinzufügen",
       "cancel": "Abbrechen",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -33,7 +33,7 @@
       "mirroring": "Mirroring",
       "providerConfig": "Provider Config",
       "providerConfigTooltip": "Configure provider mirror sources and sync schedules",
-      "binariesConfig": "Binaries Config",
+      "binariesConfig": "Binary Mirrors",
       "binariesConfigTooltip": "Configure Terraform and OpenTofu binary mirror sources",
       "approvals": "Approvals",
       "approvalsTooltip": "Review and approve pending mirror sync requests",
@@ -1078,7 +1078,7 @@
       "thLastSynced": "Last Synced"
     },
     "terraformMirror": {
-      "pageTitle": "Mirroring — Binaries Config",
+      "pageTitle": "Binary Mirrors",
       "refresh": "Refresh",
       "addMirror": "Add Mirror",
       "cancel": "Cancel",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -33,7 +33,7 @@
       "mirroring": "Duplicación",
       "providerConfig": "Configuración del proveedor",
       "providerConfigTooltip": "Configurar las fuentes de réplica de los proveedores y los horarios de sincronización",
-      "binariesConfig": "Configuración de binarios",
+      "binariesConfig": "Réplicas de binarios",
       "binariesConfigTooltip": "Configurar las fuentes de los repositorios binarios de Terraform y OpenTofu",
       "approvals": "Homologaciones",
       "approvalsTooltip": "Revisar y aprobar las solicitudes de sincronización de réplicas pendientes",
@@ -1077,7 +1077,7 @@
       "thLastSynced": "Última sincronización"
     },
     "terraformMirror": {
-      "pageTitle": "Duplicación — Configuración de archivos binarios",
+      "pageTitle": "Réplicas de binarios",
       "refresh": "Actualizar",
       "addMirror": "Añadir espejo",
       "cancel": "Cancelar",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -33,7 +33,7 @@
       "mirroring": "Mise en miroir",
       "providerConfig": "Configuration du fournisseur",
       "providerConfigTooltip": "Configurer les sources de miroir des fournisseurs et les calendriers de synchronisation",
-      "binariesConfig": "Configuration des fichiers binaires",
+      "binariesConfig": "Miroirs binaires",
       "binariesConfigTooltip": "Configurer les sources des miroirs binaires Terraform et OpenTofu",
       "approvals": "Agréments",
       "approvalsTooltip": "Examiner et approuver les demandes de synchronisation des miroirs en attente",
@@ -1077,7 +1077,7 @@
       "thLastSynced": "Dernière synchronisation"
     },
     "terraformMirror": {
-      "pageTitle": "Mise en miroir — Configuration des fichiers binaires",
+      "pageTitle": "Miroirs binaires",
       "refresh": "Actualiser",
       "addMirror": "Ajouter un miroir",
       "cancel": "Annuler",

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -33,7 +33,7 @@
       "mirroring": "Riflessione",
       "providerConfig": "Configurazione provider",
       "providerConfigTooltip": "Configurare le origini mirror dei provider e le pianificazioni di sincronizzazione",
-      "binariesConfig": "Configurazione dei file binari",
+      "binariesConfig": "Mirror dei file binari",
       "binariesConfigTooltip": "Configurare le fonti dei mirror dei file binari di Terraform e OpenTofu",
       "approvals": "Autorizzazioni",
       "approvalsTooltip": "Esaminare e approvare le richieste di sincronizzazione dei mirror in sospeso",
@@ -1077,7 +1077,7 @@
       "thLastSynced": "Ultima sincronizzazione"
     },
     "terraformMirror": {
-      "pageTitle": "Riflessione — Configurazione dei file binari",
+      "pageTitle": "Mirror dei file binari",
       "refresh": "Aggiorna",
       "addMirror": "Aggiungi mirror",
       "cancel": "Annulla",

--- a/frontend/src/locales/ja/translation.json
+++ b/frontend/src/locales/ja/translation.json
@@ -33,7 +33,7 @@
       "mirroring": "ミラーリング",
       "providerConfig": "プロバイダー設定",
       "providerConfigTooltip": "プロバイダーのミラーソースと同期スケジュールを設定する",
-      "binariesConfig": "バイナリ設定",
+      "binariesConfig": "バイナリミラー",
       "binariesConfigTooltip": "Terraform および OpenTofu のバイナリミラーソースを設定する",
       "approvals": "承認",
       "approvalsTooltip": "保留中のミラー同期リクエストを確認し、承認する",
@@ -1077,7 +1077,7 @@
       "thLastSynced": "最終同期日時"
     },
     "terraformMirror": {
-      "pageTitle": "ミラーリング — バイナリ設定",
+      "pageTitle": "バイナリミラー",
       "refresh": "更新",
       "addMirror": "ミラーを追加",
       "cancel": "キャンセル",

--- a/frontend/src/locales/nb/translation.json
+++ b/frontend/src/locales/nb/translation.json
@@ -33,7 +33,7 @@
       "mirroring": "Speiling",
       "providerConfig": "Leverandørkonfigurasjon",
       "providerConfigTooltip": "Konfigurer leverandørens speilkilder og synkroniseringsplaner",
-      "binariesConfig": "Konfigurasjon av binærfiler",
+      "binariesConfig": "Binærspeil",
       "binariesConfigTooltip": "Konfigurer Terraform og OpenTofu-kildene for binære speil",
       "approvals": "Godkjenninger",
       "approvalsTooltip": "Gjennomgå og godkjenn ventende forespørsler om speilsynkronisering",
@@ -1077,7 +1077,7 @@
       "thLastSynced": "Sist synkronisert"
     },
     "terraformMirror": {
-      "pageTitle": "Speiling — Konfigurasjon av binærfiler",
+      "pageTitle": "Binærspeil",
       "refresh": "Oppdater",
       "addMirror": "Legg til speil",
       "cancel": "Avbryt",

--- a/frontend/src/locales/nl/translation.json
+++ b/frontend/src/locales/nl/translation.json
@@ -33,7 +33,7 @@
       "mirroring": "Spiegelen",
       "providerConfig": "Configuratie van de provider",
       "providerConfigTooltip": "De bronnen van de provider-mirrors en de synchronisatieschema’s configureren",
-      "binariesConfig": "Configuratie van binaire bestanden",
+      "binariesConfig": "Binaire mirrors",
       "binariesConfigTooltip": "Configureer de bronnen voor de binaire mirrors van Terraform en OpenTofu",
       "approvals": "Goedkeuringen",
       "approvalsTooltip": "In behandeling zijnde verzoeken voor spiegelsynchronisatie controleren en goedkeuren",
@@ -1077,7 +1077,7 @@
       "thLastSynced": "Laatst gesynchroniseerd"
     },
     "terraformMirror": {
-      "pageTitle": "Spiegelen — Configuratie van binaire bestanden",
+      "pageTitle": "Binaire mirrors",
       "refresh": "Vernieuwen",
       "addMirror": "Spiegel toevoegen",
       "cancel": "Annuleren",

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -33,7 +33,7 @@
       "mirroring": "Espelhamento",
       "providerConfig": "Configuração do provedor",
       "providerConfigTooltip": "Configurar fontes de espelho do fornecedor e horários de sincronização",
-      "binariesConfig": "Configuração de ficheiros binários",
+      "binariesConfig": "Espelhos de binários",
       "binariesConfigTooltip": "Configurar as fontes dos espelhos binários do Terraform e do OpenTofu",
       "approvals": "Aprovações",
       "approvalsTooltip": "Analisar e aprovar os pedidos de sincronização de espelhos pendentes",
@@ -1077,7 +1077,7 @@
       "thLastSynced": "Última sincronização"
     },
     "terraformMirror": {
-      "pageTitle": "Espelhamento — Configuração de ficheiros binários",
+      "pageTitle": "Espelhos de binários",
       "refresh": "Atualizar",
       "addMirror": "Adicionar espelho",
       "cancel": "Cancelar",

--- a/frontend/src/locales/zh/translation.json
+++ b/frontend/src/locales/zh/translation.json
@@ -33,7 +33,7 @@
       "mirroring": "镜像",
       "providerConfig": "提供商配置",
       "providerConfigTooltip": "配置提供商的镜像源和同步计划",
-      "binariesConfig": "二进制文件配置",
+      "binariesConfig": "二进制镜像",
       "binariesConfigTooltip": "配置 Terraform 和 OpenTofu 二进制镜像源",
       "approvals": "批准",
       "approvalsTooltip": "审核并批准待处理的镜像同步请求",
@@ -1077,7 +1077,7 @@
       "thLastSynced": "最后同步时间"
     },
     "terraformMirror": {
-      "pageTitle": "镜像 — 二进制文件配置",
+      "pageTitle": "二进制镜像",
       "refresh": "刷新",
       "addMirror": "添加镜像",
       "cancel": "取消",

--- a/frontend/src/pages/admin/AuditLogPage.tsx
+++ b/frontend/src/pages/admin/AuditLogPage.tsx
@@ -40,12 +40,22 @@ const RESOURCE_TYPES = [
   { value: 'module', label: 'Module' },
   { value: 'provider', label: 'Provider' },
   { value: 'terraform_binary', label: 'Terraform Binary' },
+  // Hosted binary mirror configs. The backend still emits the legacy
+  // 'terraform_mirror' resource type; surface it consistently as "Binary Mirror".
+  { value: 'terraform_mirror', label: 'Binary Mirror' },
   { value: 'file', label: 'File' },
   { value: 'user', label: 'User' },
   { value: 'mirror', label: 'Mirror' },
   { value: 'api_key', label: 'API Key' },
   { value: 'organization', label: 'Organization' },
 ]
+
+// Maps a raw audit resource_type to its display label (falling back to the raw
+// value for unknown types) so the table column matches the filter dropdown.
+const resourceTypeLabel = (value: string | null | undefined): string => {
+  if (!value) return '—'
+  return RESOURCE_TYPES.find((rt) => rt.value === value)?.label ?? value
+}
 
 const AuditLogPage: React.FC = () => {
   const { t } = useTranslation()
@@ -355,7 +365,7 @@ const AuditLogPage: React.FC = () => {
                         >
                           {log.action}
                         </TableCell>
-                        <TableCell>{log.resource_type ?? '—'}</TableCell>
+                        <TableCell>{resourceTypeLabel(log.resource_type)}</TableCell>
                         <TableCell>
                           {log.user_email ?? log.user_name ?? log.user_id ?? '—'}
                         </TableCell>
@@ -437,7 +447,9 @@ const AuditLogPage: React.FC = () => {
                   >
                     Resource Type
                   </Typography>
-                  <Typography variant="body2">{selectedLog.resource_type ?? '—'}</Typography>
+                  <Typography variant="body2">
+                    {resourceTypeLabel(selectedLog.resource_type)}
+                  </Typography>
                 </Box>
                 <Box>
                   <Typography

--- a/frontend/src/pages/admin/__tests__/AuditLogPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/AuditLogPage.test.tsx
@@ -70,13 +70,13 @@ describe('AuditLogPage', () => {
   })
 
   it('shows loading spinner while fetching', () => {
-    listAuditLogsMock.mockReturnValue(new Promise(() => {}))
+    listAuditLogsMock.mockReturnValue(new Promise(() => { }))
     renderPage()
     expect(screen.getByRole('progressbar')).toBeInTheDocument()
   })
 
   it('renders heading "Audit Logs"', () => {
-    listAuditLogsMock.mockReturnValue(new Promise(() => {}))
+    listAuditLogsMock.mockReturnValue(new Promise(() => { }))
     renderPage()
     expect(screen.getByText('Audit Logs')).toBeInTheDocument()
   })
@@ -94,7 +94,7 @@ describe('AuditLogPage', () => {
   })
 
   it('shows filter controls', () => {
-    listAuditLogsMock.mockReturnValue(new Promise(() => {}))
+    listAuditLogsMock.mockReturnValue(new Promise(() => { }))
     renderPage()
     expect(screen.getByLabelText('Resource Type')).toBeInTheDocument()
     expect(screen.getByLabelText('Action')).toBeInTheDocument()
@@ -102,7 +102,7 @@ describe('AuditLogPage', () => {
   })
 
   it('shows Export button', () => {
-    listAuditLogsMock.mockReturnValue(new Promise(() => {}))
+    listAuditLogsMock.mockReturnValue(new Promise(() => { }))
     renderPage()
     expect(screen.getByText('Export')).toBeInTheDocument()
   })
@@ -223,6 +223,43 @@ describe('AuditLogPage', () => {
     await waitFor(() => {
       expect(listAuditLogsMock).toHaveBeenCalledWith(
         expect.objectContaining({ resource_type: 'module' }),
+      )
+    })
+  })
+
+  it('displays the legacy terraform_mirror resource type as "Binary Mirror"', async () => {
+    listAuditLogsMock.mockResolvedValue({
+      logs: [
+        {
+          id: 'log-bm',
+          created_at: '2025-06-03T09:00:00Z',
+          action: 'POST /api/v1/admin/terraform-mirrors',
+          resource_type: 'terraform_mirror',
+          resource_id: 'cfg-1',
+          user_email: 'admin@example.com',
+          ip_address: '10.0.0.2',
+        },
+      ],
+      pagination: { total: 1, page: 1, per_page: 25 },
+    })
+    renderPage()
+    await waitFor(() =>
+      expect(screen.getByText('POST /api/v1/admin/terraform-mirrors')).toBeInTheDocument(),
+    )
+    // Raw backend value is surfaced consistently as the friendly label.
+    expect(screen.getByText('Binary Mirror')).toBeInTheDocument()
+    expect(screen.queryByText('terraform_mirror')).not.toBeInTheDocument()
+  })
+
+  it('filters by the Binary Mirror option using the legacy backend value', async () => {
+    listAuditLogsMock.mockResolvedValue(fakeLogs)
+    renderPage()
+    await waitFor(() => expect(screen.getByText('POST /api/v1/modules')).toBeInTheDocument())
+    await userEvent.click(screen.getByLabelText('Resource Type'))
+    await userEvent.click(screen.getByRole('option', { name: 'Binary Mirror' }))
+    await waitFor(() => {
+      expect(listAuditLogsMock).toHaveBeenCalledWith(
+        expect.objectContaining({ resource_type: 'terraform_mirror' }),
       )
     })
   })


### PR DESCRIPTION
## Summary

Presents the hosted **binary mirror** feature with consistent UX labels across the frontend, without touching the backend (which intentionally keeps the legacy `terraform_mirror` resource type/naming).

Addresses the #506 UAT note: _"audit logs show resource as `terraform_mirror` — rename as binary mirror"_, and extends the same consistency to the nav, Cmd+K palette, and admin page title.

## Changes

- **Audit log** (`AuditLogPage.tsx`)
  - Maps the legacy `terraform_mirror` resource type to the friendly **"Binary Mirror"** label in the table and detail dialog.
  - Adds a matching **"Binary Mirror"** filter dropdown entry (still filters by the legacy backend value `terraform_mirror`).
  - Other known resource types now render friendly labels too, so the table column matches the dropdown.
- **Cmd+K palette** (`CommandPalette.tsx`)
  - Renames the public **"Terraform Binaries"** entry to **"Hosted Binaries"** to match the main nav.
  - Adds search keywords to the public and admin binary-mirror entries (terraform, opentofu, mirror, packer, sentinel, opa, …).
- **Admin nav + page title** — aligned to **"Binary Mirrors"** across all 10 locales (de, en, es, fr, it, ja, nb, nl, pt, zh). The provider-mirror page title is intentionally left unchanged.

## Backend

No backend changes. The backend continues to emit the legacy `terraform_mirror` resource type; this PR only changes how the frontend presents it.

## Tests

- Updated `Layout.test.tsx` ("Binaries Config" → "Binary Mirrors") and `CommandPalette.test.tsx` (find-by-path, label "Hosted Binaries").
- Added `AuditLogPage` tests for the "Binary Mirror" label display and the legacy-value filter.
- Validation: **65 tests pass** across the affected files, `tsc --noEmit` clean, `eslint --max-warnings 0` clean.
