### PR TITLE
fix(ui): show OPA as unsigned (checksum-only) in release signing keys (#509)

### DIFF
--- a/frontend/src/components/ReleasesGPGKeyStatus.tsx
+++ b/frontend/src/components/ReleasesGPGKeyStatus.tsx
@@ -17,6 +17,7 @@ import CheckCircleIcon from '@mui/icons-material/CheckCircle'
 import ErrorIcon from '@mui/icons-material/Error'
 import WarningIcon from '@mui/icons-material/Warning'
 import HelpOutlineIcon from '@mui/icons-material/HelpOutlined'
+import GppMaybeIcon from '@mui/icons-material/GppMaybe'
 import { useTranslation } from 'react-i18next'
 import type { TFunction } from 'i18next'
 import { useReleasesGPGKeyStatus } from '../hooks/useReleasesGPGKeyStatus'
@@ -43,6 +44,8 @@ function StatusIcon({ status }: { status: ReleasesGPGKeyStatus }) {
       return <WarningIcon fontSize="small" color="warning" />
     case 'expired':
       return <ErrorIcon fontSize="small" color="error" />
+    case 'unsigned':
+      return <GppMaybeIcon fontSize="small" color="warning" />
     default:
       return <HelpOutlineIcon fontSize="small" color="disabled" />
   }
@@ -74,7 +77,16 @@ function KeyRow({ row }: { row: ReleasesGPGKeyStatusView }) {
         </Box>
       </TableCell>
       <TableCell>
-        <Chip label={row.status} size="small" color={statusColor(row.status)} />
+        {row.status === 'unsigned' ? (
+          // OPA-style tools: upstream publishes no signature, so this is verified
+          // by checksum only. Show a labelled, explained chip rather than a bare
+          // status code, so the reduced assurance is visible (not silent).
+          <Tooltip title={t('releasesGpgKeys.unsignedTooltip')}>
+            <Chip label={t('releasesGpgKeys.unsignedLabel')} size="small" color="warning" />
+          </Tooltip>
+        ) : (
+          <Chip label={row.status} size="small" color={statusColor(row.status)} />
+        )}
       </TableCell>
       <TableCell>
         <Chip label={row.effective_source} size="small" variant="outlined" />

--- a/frontend/src/components/__tests__/ReleasesGPGKeyStatus.test.tsx
+++ b/frontend/src/components/__tests__/ReleasesGPGKeyStatus.test.tsx
@@ -125,8 +125,8 @@ describe('ReleasesGPGKeyStatus', () => {
     await waitFor(() => expect(screen.getByText('expired')).toBeInTheDocument())
   })
 
-  it('renders an unmanaged-key binary row (none source, unknown status)', async () => {
-    const noneResponse: ReleasesGPGKeysResponse = {
+  it('renders an unsigned-upstream binary row (none source, unsigned status)', async () => {
+    const unsignedResponse: ReleasesGPGKeysResponse = {
       keys: [
         {
           tool: 'opa',
@@ -134,15 +134,17 @@ describe('ReleasesGPGKeyStatus', () => {
           embedded: null,
           effective_source: 'none',
           expiry_warning_days: 60,
-          status: 'unknown',
+          status: 'unsigned',
         },
       ],
     }
-    mockGetReleasesGPGKeys.mockResolvedValue(noneResponse)
+    mockGetReleasesGPGKeys.mockResolvedValue(unsignedResponse)
     renderComponent()
 
     await waitFor(() => expect(screen.getByText('opa')).toBeInTheDocument())
     expect(screen.getByText('none')).toBeInTheDocument()
-    expect(screen.getByText('unknown')).toBeInTheDocument()
+    // OPA shows as "unsigned" (checksum-only), not the misleading "unknown".
+    expect(screen.getByText('unsigned')).toBeInTheDocument()
+    expect(screen.queryByText('unknown')).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -2160,7 +2160,9 @@
     "thExpiry": "Expiry",
     "thLastRefresh": "Last Refresh",
     "expiredAgo": "expired {{days}}d ago",
-    "days": "{{days}}d"
+    "days": "{{days}}d",
+    "unsignedLabel": "unsigned",
+    "unsignedTooltip": "This tool's upstream publishes no release signature; binaries are verified by checksum only."
   },
   "scanFindingsModal": {
     "title": "Scan Findings",

--- a/frontend/src/types/releases_gpg_keys.ts
+++ b/frontend/src/types/releases_gpg_keys.ts
@@ -13,14 +13,16 @@ export interface ReleasesGPGKeyEmbeddedView {
   days_until_expiry?: number | null
 }
 
-export type ReleasesGPGKeyStatus = 'ok' | 'warn' | 'expired' | 'unknown'
+export type ReleasesGPGKeyStatus = 'ok' | 'warn' | 'expired' | 'unknown' | 'unsigned'
 
 export interface ReleasesGPGKeyStatusView {
   tool: string
   cache: ReleasesGPGKeyCacheView | null
   embedded: ReleasesGPGKeyEmbeddedView | null
-  // 'none' is used for configured binaries that have no managed signing key yet
-  // (e.g. opa); such rows carry null cache/embedded and an 'unknown' status.
+  // 'none' is used for configured binaries with no managed signing key. Tools
+  // whose upstream publishes no release signature at all (e.g. opa — checksum
+  // only) carry null cache/embedded, a 'none' source, and an 'unsigned' status;
+  // genuinely unclassified tools keep 'unknown'.
   effective_source: 'cache' | 'embedded' | 'none'
   expiry_warning_days: number
   status: ReleasesGPGKeyStatus


### PR DESCRIPTION
Frontend half of #509 (backend: terraform-registry-backend#513).

## Why

The admin **Release Signing Keys** table showed OPA — which publishes **no release signature**, only SHA-256 checksums — with status **`unknown`**, which reads like missing data / a problem. The backend now classifies such tools as **`unsigned`** (checksum-only by design).

## Change

- `types`: add `'unsigned'` to `ReleasesGPGKeyStatus`.
- `ReleasesGPGKeyStatus`: render `unsigned` as a **warning chip** with a `GppMaybe` icon and a tooltip — *"upstream publishes no release signature; verified by checksum only"* — visibly distinct from the neutral `unknown`.
- `en` translations: `unsignedLabel` + `unsignedTooltip` (DeepL fills other locales on merge).
- Test updated: the OPA row renders `unsigned`, not `unknown`.

## Verification

`tsc` + `eslint --max-warnings 0` clean; component test 6/6.

Degrades gracefully: until the backend (#513) ships `unsigned`, OPA simply shows its prior status — no breakage.