### PR TITLE
fix(auth): use "Logout" in the session-expiry warning

### DIFF
--- a/frontend/src/components/SessionExpiryWarning.tsx
+++ b/frontend/src/components/SessionExpiryWarning.tsx
@@ -51,7 +51,7 @@ const SessionExpiryWarning: React.FC = () => {
               onClick={logout}
               data-testid="session-expiry-signout"
             >
-              Sign out
+              Logout
             </Button>
           </Stack>
         }


### PR DESCRIPTION
## Summary
The account menu already labels the logout control "Logout", but the session-expiry warning's button hardcoded "Sign out". This aligns it to "Logout" for consistency within the app and with the Terraform State Manager frontend's unified logout UX.

One-word text change; no behavioural change.

## Testing
- `npx vitest run src/components/__tests__/SessionExpiryWarning.test.tsx` - pass (the button is matched by `data-testid`, so unaffected)
- `npx tsc --noEmit` - clean
- `npm run lint` - clean