### PR TITLE
fix(api-docs): apply CSP nonce to Swagger UI override styles

### DIFF
--- a/frontend/src/pages/ApiDocumentation.tsx
+++ b/frontend/src/pages/ApiDocumentation.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import SwaggerUI from 'swagger-ui-react'
 import 'swagger-ui-react/swagger-ui.css'
@@ -406,6 +406,16 @@ const ApiDocumentation: React.FC = () => {
   const theme = useTheme()
   const isDark = theme.palette.mode === 'dark'
 
+  // CSP nonce injected by nginx into <meta name="csp-nonce">. The override
+  // <style> below MUST carry it; otherwise the strict `style-src 'self'
+  // 'nonce-...'` policy blocks the element and strips every Swagger UI theme
+  // override (leaving the bundled light theme). Mirrors the emotion cache nonce
+  // setup in main.tsx; resolves to undefined in dev/tests where no nonce exists.
+  const cspNonce = useMemo(() => {
+    const n = document.querySelector('meta[name="csp-nonce"]')?.getAttribute('content')
+    return n && n !== '__CSP_NONCE__' ? n : undefined
+  }, [])
+
   const [navTags, setNavTags] = useState<NavTag[]>([])
   const [activeTag, setActiveTag] = useState<string>('')
   const specRef = useRef<OpenAPISpec | null>(null)
@@ -613,7 +623,7 @@ const ApiDocumentation: React.FC = () => {
 
         {/* ---- Swagger UI content ---- */}
         <Box ref={contentRef} sx={{ flex: 1, minWidth: 0 }}>
-          <style>{BASE_CSS + (isDark ? DARK_EXTRA : LIGHT_EXTRA)}</style>
+          <style nonce={cspNonce}>{BASE_CSS + (isDark ? DARK_EXTRA : LIGHT_EXTRA)}</style>
 
           <SwaggerUI
             url="/swagger.json"

--- a/frontend/src/pages/__tests__/ApiDocumentation.test.tsx
+++ b/frontend/src/pages/__tests__/ApiDocumentation.test.tsx
@@ -385,4 +385,25 @@ describe('ApiDocumentation', () => {
       '.swagger-ui .scheme-container { background: #1e1e1e !important;',
     )
   })
+
+  // Regression: nginx serves a strict `style-src 'self' 'nonce-...'` CSP. The
+  // injected override <style> must carry that nonce or the browser blocks it,
+  // stripping every theme override (the deployed symptom: an unthemed white
+  // scheme band). The component reads the nonce from <meta name="csp-nonce">.
+  it('applies the CSP nonce from the meta tag to the injected override style', () => {
+    const meta = document.createElement('meta')
+    meta.setAttribute('name', 'csp-nonce')
+    meta.setAttribute('content', 'test-nonce-xyz')
+    document.head.appendChild(meta)
+    try {
+      renderWithTheme()
+      const styleEl = Array.from(document.querySelectorAll('style')).find((el) =>
+        (el.textContent ?? '').includes('.swagger-ui .information-container'),
+      ) as HTMLStyleElement | undefined
+      expect(styleEl).toBeDefined()
+      expect(styleEl?.nonce || styleEl?.getAttribute('nonce') || '').toBe('test-nonce-xyz')
+    } finally {
+      meta.remove()
+    }
+  })
 })


### PR DESCRIPTION
## Summary

Fixes the API documentation (Swagger UI) page rendering with an unthemed white scheme bar and a visible default info header instead of the app's themed dark/light surfaces.

## Root cause

nginx serves a strict `Content-Security-Policy` with `style-src 'self' 'nonce-<per-request>'` (no `'unsafe-inline'`). The component injects a `<style>` element with all of its Swagger UI theme overrides (dark-mode surfaces, hidden info header/topbar, themed scheme bar). That `<style>` had **no nonce**, so the browser blocked it and stripped every override — leaving Swagger UI's bundled light theme regardless of the app's light/dark mode.

This was confirmed on a local UAT stack:

- Console: `Applying inline style violates the following Content Security Policy directive 'style-src 'self' 'nonce-…'' … The action has been blocked.`
- Computed `.scheme-container` background: `rgb(255,255,255)` (broken) → `rgb(30,30,30)` (fixed, dark mode)
- The override stylesheet went from **0 applied rules** (blocked) to **all rules applied** after the fix.

A prior change had added `!important` to these overrides to win the cascade, but that could not help because the entire `<style>` element was being CSP-blocked before any rule could apply.

## Fix

Read the per-request nonce from `<meta name="csp-nonce">` (the same source the Emotion cache already uses in `main.tsx`) and pass it to the injected `<style>`. The nonce resolves to `undefined` in dev/test where no nonce is present, so behaviour there is unchanged.

## Tests

- Added a regression test asserting the injected override `<style>` carries the CSP nonce from the meta tag.
- Verified light and dark mode render correctly on the UAT stack.
- Full `ApiDocumentation` suite passes; ESLint (`--max-warnings 0`) and `tsc --noEmit` clean.
