### PR TITLE
feat(auth): match the State Manager account menu (name + logout icon)

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -25,6 +25,7 @@ import {
 } from '@mui/material'
 import MenuIcon from '@mui/icons-material/Menu'
 import AccountCircle from '@mui/icons-material/AccountCircle'
+import LogoutIcon from '@mui/icons-material/Logout'
 import Dashboard from '@mui/icons-material/Dashboard'
 import ViewModule from '@mui/icons-material/ViewModule'
 import Extension from '@mui/icons-material/Extension'
@@ -783,11 +784,21 @@ const Layout = () => {
                 open={Boolean(anchorEl)}
                 onClose={handleClose}
               >
-                <MenuItem disabled>
-                  <Typography variant="body2">{user?.email}</Typography>
+                <MenuItem disabled sx={{ opacity: 1 }}>
+                  <Box>
+                    <Typography variant="body2">{user?.name}</Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      {user?.email}
+                    </Typography>
+                  </Box>
                 </MenuItem>
                 <Divider />
-                <MenuItem onClick={handleLogout}>{t('header.logout')}</MenuItem>
+                <MenuItem onClick={handleLogout}>
+                  <ListItemIcon>
+                    <LogoutIcon fontSize="small" />
+                  </ListItemIcon>
+                  {t('header.logout')}
+                </MenuItem>
               </Menu>
             </div>
           ) : (

--- a/frontend/src/components/__tests__/Layout.test.tsx
+++ b/frontend/src/components/__tests__/Layout.test.tsx
@@ -120,7 +120,7 @@ describe('Layout', () => {
   })
 
   // 3. Authenticated state — user menu
-  it('shows account icon and user email in menu when authenticated', async () => {
+  it('shows account icon, user name and email in menu when authenticated', async () => {
     const user = userEvent.setup()
     setAuth({
       isAuthenticated: true,
@@ -135,6 +135,7 @@ describe('Layout', () => {
     const accountBtn = screen.getByLabelText('account of current user')
     await user.click(accountBtn)
 
+    expect(screen.getByText('Alice')).toBeInTheDocument()
     expect(screen.getByText('alice@example.com')).toBeInTheDocument()
     expect(screen.getByText('Logout')).toBeInTheDocument()
   })


### PR DESCRIPTION
## Summary
Aligns the registry's account/logout menu with the Terraform State Manager frontend so the two apps present the same logout UX.

- Show the user's **display name** above their email in the account menu (was email only).
- Add a **logout icon** next to "Logout" (was plain text).

No behavioural change to logout itself.

## Testing
- `npx vitest run src/components/__tests__/Layout.test.tsx` - 34 pass (extended the authenticated-menu test to assert the name renders)
- `npx tsc --noEmit` - clean
- `npm run lint` - clean