### PR TITLE
fix: name current tab so suite switcher reuses one sibling tab

### DIFF
--- a/frontend/src/components/SuiteSwitcher.test.tsx
+++ b/frontend/src/components/SuiteSwitcher.test.tsx
@@ -8,7 +8,10 @@ function withQuery(ui: React.ReactNode) {
   return <QueryClientProvider client={qc}>{ui}</QueryClientProvider>
 }
 
-afterEach(() => vi.restoreAllMocks())
+afterEach(() => {
+  vi.restoreAllMocks()
+  window.name = ''
+})
 
 it('renders nothing when no sibling', async () => {
   vi.spyOn(globalThis, 'fetch').mockResolvedValue(
@@ -99,6 +102,27 @@ it('reuses one sibling tab via a stable window name instead of opening a new one
   // .focus() brings it forward. NOT '_blank' (which spawns a new tab each click).
   expect(openSpy).toHaveBeenCalledWith('https://tfstate.example.com', 'terraform-state-manager')
   expect(focus).toHaveBeenCalled()
+})
+
+it('claims this tab under its own app id so the sibling reuses the original tab', async () => {
+  vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+    new Response(
+      JSON.stringify({
+        sibling: {
+          app: 'terraform-state-manager',
+          state: 'active',
+          publicUrl: 'https://tfstate.example.com',
+        },
+      }),
+      { status: 200 },
+    ),
+  )
+  vi.spyOn(window, 'open').mockReturnValue({ focus: vi.fn() } as unknown as Window)
+  render(withQuery(<SuiteSwitcher />))
+  fireEvent.click(await screen.findByRole('button', { name: /Open Terraform State Manager/i }))
+  // Self is the other known suite app; naming this tab lets the sibling's
+  // switcher find and refocus it instead of spawning a third tab.
+  expect(window.name).toBe('terraform-registry')
 })
 
 it('renders nothing when sibling is degraded', async () => {

--- a/frontend/src/components/SuiteSwitcher.tsx
+++ b/frontend/src/components/SuiteSwitcher.tsx
@@ -24,6 +24,15 @@ export function SuiteSwitcher() {
         aria-label={title}
         sx={{ mr: 1 }}
         onClick={() => {
+          // Claim this tab's name as our OWN app id before opening the sibling.
+          // The suite has exactly two apps, so "self" is the other entry in
+          // LABELS. Without this the original tab stays unnamed, so the sibling's
+          // switcher can't find it by name and opens a *third* tab — the two apps
+          // then ping-pong between two new tabs while the original is orphaned.
+          // Naming this tab lets the sibling reuse it: only the original + one
+          // sibling tab ever exist.
+          const selfApp = Object.keys(LABELS).find((a) => a !== sibling.app)
+          if (selfApp) window.name = selfApp
           // Reuse one sibling tab across clicks: a stable window name (the
           // sibling's app id) re-navigates and refocuses the same tab instead of
           // spawning a new one each time. The sibling is a trusted first-party


### PR DESCRIPTION
## Problem

Clicking the suite app-switcher in the first app opened a new tab; clicking the switcher in the second app opened *another* new tab. The two apps then ping-ponged between those two new tabs while the original tab stayed orphaned.

## Cause

The click handler named the tab it *opened* (after the sibling's app id) but never named the **current** tab. So when the sibling's switcher called `window.open(originalAppUrl, originalAppId)`, no tab matched that name and the browser spawned a third tab.

## Fix

Before opening the sibling, each tab now claims its **own** app id as `window.name` (the other entry in `LABELS` \u2014 the suite has exactly two apps). The original tab is then discoverable by name, so the sibling's switcher re-navigates and refocuses it instead of spawning a new tab. Only the original + one sibling tab ever exist.

## Tests

- Added a test asserting the current tab claims its own app id on click, plus a `window.name` reset between tests.
- All `SuiteSwitcher` tests pass; lint clean; no type errors.

Applied identically in the TSM frontend (separate PR).