### PR TITLE
feat(scm): shared app-credential auth mode in the SCM providers UI

### DIFF
--- a/frontend/scripts/contract-check.allowlist.json
+++ b/frontend/scripts/contract-check.allowlist.json
@@ -25,6 +25,11 @@
       "method": "GET",
       "path": "/api/v1/suite/modules/{}/{}/{}/consumers",
       "reason": "Suite 'Consumed by' proxy added in terraform-registry-backend#495, which postdates the pinned contract-check image (1.4.0) and currently ships without swagger annotations. Remove once the backend documents the route (adds @Router) AND docker-compose.contract-check.yml is bumped to a release that includes it."
+    },
+    {
+      "method": "POST",
+      "path": "/api/v1/scm-providers/{}/verify",
+      "reason": "Shared SCM app-credential verify endpoint added in terraform-registry-backend#519, which postdates the pinned contract-check image (1.4.0). The backend route is documented (has @Router + swagger). Remove once docker-compose.contract-check.yml is bumped to a release that includes it."
     }
   ]
 }

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -1510,7 +1510,21 @@
       "connectToTitle": "Connect to {{name}}",
       "patIntro": "Enter your Bitbucket Data Center Personal Access Token. You can generate one from your Bitbucket account settings under HTTP access tokens.",
       "labelPat": "Personal Access Token",
-      "saveToken": "Save Token"
+      "saveToken": "Save Token",
+      "labelAuthMode": "Authentication",
+      "authModeOAuth": "Per-user OAuth",
+      "authModeApp": "Shared app credential",
+      "helpAuthMode": "App credentials are admin-managed and shared by all users — no per-user Connect is required. Per-user OAuth keeps the legacy flow where each user connects their own account.",
+      "labelGithubAppId": "GitHub App ID",
+      "labelGithubInstallationId": "Installation ID",
+      "labelAppPrivateKey": "Private Key (PEM)",
+      "helpGithubApp": "From your GitHub App settings: the numeric App ID, the Installation ID (from the installation URL), and the app's RSA private key.",
+      "helpAppPrivateKeyKeep": "Leave blank to keep the existing private key",
+      "appCredential": "App credential",
+      "testConnection": "Test connection",
+      "testConnectionOk": "Connection OK",
+      "testConnectionFailed": "Connection failed",
+      "errVerify": "Failed to verify provider"
     },
     "approvals": {
       "pageTitle": "Approval Requests",

--- a/frontend/src/pages/admin/SCMProvidersPage.tsx
+++ b/frontend/src/pages/admin/SCMProvidersPage.tsx
@@ -20,6 +20,7 @@ import {
   MenuItem,
   FormControl,
   InputLabel,
+  FormHelperText,
   Alert,
   CircularProgress,
   Tooltip,
@@ -39,7 +40,12 @@ import Page from '../../components/Page'
 import api from '../../services/api'
 import { getErrorMessage } from '../../utils/errors'
 import { useAuth } from '../../contexts/AuthContext'
-import type { SCMProvider, SCMProviderType, CreateSCMProviderRequest } from '../../types/scm'
+import type {
+  SCMProvider,
+  SCMProviderType,
+  SCMAuthMode,
+  CreateSCMProviderRequest,
+} from '../../types/scm'
 import type { UserMembership } from '../../types'
 import { queryKeys } from '../../services/queryKeys'
 
@@ -72,7 +78,17 @@ const SCMProvidersPage: React.FC = () => {
     client_id: '',
     client_secret: '',
     webhook_secret: '',
+    auth_mode: 'oauth_user',
+    github_app_id: '',
+    github_installation_id: '',
+    app_private_key: '',
   })
+
+  // Per-provider "Test connection" (verify) outcomes for app-mode providers.
+  const [verifyingId, setVerifyingId] = useState<string | null>(null)
+  const [verifyResults, setVerifyResults] = useState<Record<string, { ok: boolean; msg: string }>>(
+    {},
+  )
 
   // Memberships query
   const { data: memberships = [] } = useQuery<UserMembership[]>({
@@ -155,6 +171,10 @@ const SCMProvidersPage: React.FC = () => {
         client_id: formData.client_id,
         client_secret: formData.client_secret,
         webhook_secret: formData.webhook_secret,
+        auth_mode: formData.auth_mode,
+        github_app_id: formData.github_app_id,
+        github_installation_id: formData.github_installation_id,
+        app_private_key: formData.app_private_key,
       })
     },
     onSuccess: () => {
@@ -227,6 +247,35 @@ const SCMProvidersPage: React.FC = () => {
 
   const isPATProvider = (type?: SCMProviderType) => type === 'bitbucket_dc'
 
+  const isAppModeProvider = (p: SCMProvider) =>
+    p.auth_mode === 'entra_app' || p.auth_mode === 'github_app'
+
+  const handleVerify = async (provider: SCMProvider) => {
+    setVerifyingId(provider.id)
+    try {
+      const res = await api.verifySCMProvider(provider.id)
+      setVerifyResults((prev) => ({
+        ...prev,
+        [provider.id]: {
+          ok: !!res.ok,
+          msg: res.ok
+            ? t('admin.scmProviders.testConnectionOk')
+            : t('admin.scmProviders.testConnectionFailed'),
+        },
+      }))
+    } catch (err: unknown) {
+      setVerifyResults((prev) => ({
+        ...prev,
+        [provider.id]: {
+          ok: false,
+          msg: getErrorMessage(err, t('admin.scmProviders.testConnectionFailed')),
+        },
+      }))
+    } finally {
+      setVerifyingId(null)
+    }
+  }
+
   const getCallbackUrl = (providerId: string): string => {
     const baseUrl = window.location.origin
     return `${baseUrl}/api/v1/scm-providers/${providerId}/oauth/callback`
@@ -246,6 +295,10 @@ const SCMProvidersPage: React.FC = () => {
       client_id: '',
       client_secret: '',
       webhook_secret: '',
+      auth_mode: 'oauth_user',
+      github_app_id: '',
+      github_installation_id: '',
+      app_private_key: '',
     })
   }
 
@@ -259,6 +312,10 @@ const SCMProvidersPage: React.FC = () => {
       client_id: provider.client_id,
       client_secret: '', // Don't show existing secret
       webhook_secret: provider.webhook_secret || '',
+      auth_mode: provider.auth_mode || 'oauth_user',
+      github_app_id: provider.github_app_id || '',
+      github_installation_id: provider.github_installation_id || '',
+      app_private_key: '', // Don't show existing private key
     })
   }
 
@@ -529,6 +586,21 @@ const SCMProvidersPage: React.FC = () => {
                           })}
                         </Typography>
                         {(() => {
+                          if (isAppModeProvider(provider)) {
+                            return (
+                              <Box
+                                sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mt: 0.5 }}
+                              >
+                                <CheckCircleIcon sx={{ fontSize: '0.9rem', color: 'info.main' }} />
+                                <Typography
+                                  variant="caption"
+                                  sx={{ color: 'info.main', fontWeight: 600 }}
+                                >
+                                  {t('admin.scmProviders.appCredential')}
+                                </Typography>
+                              </Box>
+                            )
+                          }
                           const status = tokenStatuses[provider.id]
                           if (!status) return null
                           return status.connected ? (
@@ -598,46 +670,73 @@ const SCMProvidersPage: React.FC = () => {
                   </CardContent>
 
                   <CardActions>
-                    <Tooltip
-                      title={
-                        tokenStatuses[provider.id]?.connected
-                          ? provider.provider_type === 'bitbucket_dc'
-                            ? t('admin.scmProviders.tooltipUpdatePat')
-                            : t('admin.scmProviders.tooltipReconnectOauth')
-                          : provider.provider_type === 'bitbucket_dc'
-                            ? t('admin.scmProviders.tooltipConnectPat')
-                            : t('admin.scmProviders.tooltipConnectOauth')
-                      }
-                    >
-                      <IconButton
-                        size="small"
-                        aria-label={t('admin.scmProviders.ariaConnect')}
-                        color="primary"
-                        onClick={() => handleConnect(provider)}
-                      >
-                        <LinkIcon />
-                      </IconButton>
-                    </Tooltip>
-                    {tokenStatuses[provider.id]?.connected && (
-                      <Tooltip title={t('admin.scmProviders.tooltipDisconnect')}>
-                        <IconButton
-                          size="small"
-                          aria-label={t('admin.scmProviders.ariaDisconnect')}
-                          color="warning"
-                          onClick={async () => {
-                            try {
-                              await api.revokeSCMToken(provider.id)
-                              queryClient.invalidateQueries({
-                                queryKey: queryKeys.scmProviders._def,
-                              })
-                            } catch (err: unknown) {
-                              setError(getErrorMessage(err, t('admin.scmProviders.errDisconnect')))
-                            }
-                          }}
+                    {!isAppModeProvider(provider) && (
+                      <>
+                        <Tooltip
+                          title={
+                            tokenStatuses[provider.id]?.connected
+                              ? provider.provider_type === 'bitbucket_dc'
+                                ? t('admin.scmProviders.tooltipUpdatePat')
+                                : t('admin.scmProviders.tooltipReconnectOauth')
+                              : provider.provider_type === 'bitbucket_dc'
+                                ? t('admin.scmProviders.tooltipConnectPat')
+                                : t('admin.scmProviders.tooltipConnectOauth')
+                          }
                         >
-                          <LinkOffIcon />
-                        </IconButton>
-                      </Tooltip>
+                          <IconButton
+                            size="small"
+                            aria-label={t('admin.scmProviders.ariaConnect')}
+                            color="primary"
+                            onClick={() => handleConnect(provider)}
+                          >
+                            <LinkIcon />
+                          </IconButton>
+                        </Tooltip>
+                        {tokenStatuses[provider.id]?.connected && (
+                          <Tooltip title={t('admin.scmProviders.tooltipDisconnect')}>
+                            <IconButton
+                              size="small"
+                              aria-label={t('admin.scmProviders.ariaDisconnect')}
+                              color="warning"
+                              onClick={async () => {
+                                try {
+                                  await api.revokeSCMToken(provider.id)
+                                  queryClient.invalidateQueries({
+                                    queryKey: queryKeys.scmProviders._def,
+                                  })
+                                } catch (err: unknown) {
+                                  setError(
+                                    getErrorMessage(err, t('admin.scmProviders.errDisconnect')),
+                                  )
+                                }
+                              }}
+                            >
+                              <LinkOffIcon />
+                            </IconButton>
+                          </Tooltip>
+                        )}
+                      </>
+                    )}
+                    {isAppModeProvider(provider) && (
+                      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mr: 'auto' }}>
+                        <Button
+                          size="small"
+                          onClick={() => handleVerify(provider)}
+                          disabled={verifyingId === provider.id}
+                        >
+                          {t('admin.scmProviders.testConnection')}
+                        </Button>
+                        {verifyResults[provider.id] && (
+                          <Typography
+                            variant="caption"
+                            sx={{
+                              color: verifyResults[provider.id].ok ? 'success.main' : 'error.main',
+                            }}
+                          >
+                            {verifyResults[provider.id].msg}
+                          </Typography>
+                        )}
+                      </Box>
                     )}
                     <Tooltip title={t('admin.scmProviders.tooltipEdit')}>
                       <IconButton
@@ -735,6 +834,12 @@ const SCMProvidersPage: React.FC = () => {
                         setFormData({
                           ...formData,
                           provider_type: e.target.value as SCMProviderType,
+                          // Reset app-credential fields when the provider type changes
+                          // so an incompatible auth_mode is never submitted.
+                          auth_mode: 'oauth_user',
+                          github_app_id: '',
+                          github_installation_id: '',
+                          app_private_key: '',
                         })
                       }
                     >
@@ -755,6 +860,37 @@ const SCMProvidersPage: React.FC = () => {
                   helperText={t('admin.scmProviders.helpName')}
                 />
 
+                {((editingProvider?.provider_type || formData.provider_type) === 'github' ||
+                  (editingProvider?.provider_type || formData.provider_type) === 'azuredevops') && (
+                    <FormControl fullWidth>
+                      <InputLabel id="auth-mode-label">
+                        {t('admin.scmProviders.labelAuthMode')}
+                      </InputLabel>
+                      <Select
+                        labelId="auth-mode-label"
+                        value={formData.auth_mode || 'oauth_user'}
+                        label={t('admin.scmProviders.labelAuthMode')}
+                        onChange={(e) =>
+                          setFormData({ ...formData, auth_mode: e.target.value as SCMAuthMode })
+                        }
+                      >
+                        <MenuItem value="oauth_user">
+                          {t('admin.scmProviders.authModeOAuth')}
+                        </MenuItem>
+                        <MenuItem
+                          value={
+                            (editingProvider?.provider_type || formData.provider_type) === 'github'
+                              ? 'github_app'
+                              : 'entra_app'
+                          }
+                        >
+                          {t('admin.scmProviders.authModeApp')}
+                        </MenuItem>
+                      </Select>
+                      <FormHelperText>{t('admin.scmProviders.helpAuthMode')}</FormHelperText>
+                    </FormControl>
+                  )}
+
                 {(editingProvider?.provider_type || formData.provider_type) === 'azuredevops' && (
                   <TextField
                     label={t('admin.scmProviders.labelTenantId')}
@@ -768,34 +904,78 @@ const SCMProvidersPage: React.FC = () => {
                   />
                 )}
 
-                {!isPATProvider(editingProvider?.provider_type || formData.provider_type) && (
-                  <>
-                    <TextField
-                      label={getClientIdLabel(
-                        editingProvider?.provider_type || formData.provider_type || 'github',
-                      )}
-                      fullWidth
-                      value={formData.client_id}
-                      onChange={(e) => setFormData({ ...formData, client_id: e.target.value })}
-                      required
-                      helperText={t('admin.scmProviders.helpClientId')}
-                    />
+                {!isPATProvider(editingProvider?.provider_type || formData.provider_type) &&
+                  !(
+                    (editingProvider?.provider_type || formData.provider_type) === 'github' &&
+                    formData.auth_mode === 'github_app'
+                  ) && (
+                    <>
+                      <TextField
+                        label={getClientIdLabel(
+                          editingProvider?.provider_type || formData.provider_type || 'github',
+                        )}
+                        fullWidth
+                        value={formData.client_id}
+                        onChange={(e) => setFormData({ ...formData, client_id: e.target.value })}
+                        required
+                        helperText={t('admin.scmProviders.helpClientId')}
+                      />
 
-                    <TextField
-                      label={getClientSecretLabel(
-                        editingProvider?.provider_type || formData.provider_type || 'github',
-                      )}
-                      type="password"
-                      fullWidth
-                      value={formData.client_secret}
-                      onChange={(e) => setFormData({ ...formData, client_secret: e.target.value })}
-                      required={!editingProvider}
-                      helperText={
-                        editingProvider ? t('admin.scmProviders.helpClientSecretKeep') : ''
-                      }
-                    />
-                  </>
-                )}
+                      <TextField
+                        label={getClientSecretLabel(
+                          editingProvider?.provider_type || formData.provider_type || 'github',
+                        )}
+                        type="password"
+                        fullWidth
+                        value={formData.client_secret}
+                        onChange={(e) => setFormData({ ...formData, client_secret: e.target.value })}
+                        required={!editingProvider}
+                        helperText={
+                          editingProvider ? t('admin.scmProviders.helpClientSecretKeep') : ''
+                        }
+                      />
+                    </>
+                  )}
+
+                {(editingProvider?.provider_type || formData.provider_type) === 'github' &&
+                  formData.auth_mode === 'github_app' && (
+                    <>
+                      <TextField
+                        label={t('admin.scmProviders.labelGithubAppId')}
+                        fullWidth
+                        value={formData.github_app_id}
+                        onChange={(e) =>
+                          setFormData({ ...formData, github_app_id: e.target.value })
+                        }
+                        required
+                      />
+                      <TextField
+                        label={t('admin.scmProviders.labelGithubInstallationId')}
+                        fullWidth
+                        value={formData.github_installation_id}
+                        onChange={(e) =>
+                          setFormData({ ...formData, github_installation_id: e.target.value })
+                        }
+                        required
+                      />
+                      <TextField
+                        label={t('admin.scmProviders.labelAppPrivateKey')}
+                        fullWidth
+                        multiline
+                        minRows={4}
+                        value={formData.app_private_key}
+                        onChange={(e) =>
+                          setFormData({ ...formData, app_private_key: e.target.value })
+                        }
+                        required={!editingProvider}
+                        helperText={
+                          editingProvider
+                            ? t('admin.scmProviders.helpAppPrivateKeyKeep')
+                            : t('admin.scmProviders.helpGithubApp')
+                        }
+                      />
+                    </>
+                  )}
 
                 <TextField
                   label={
@@ -834,12 +1014,20 @@ const SCMProvidersPage: React.FC = () => {
               <Button
                 variant="contained"
                 onClick={editingProvider ? handleUpdate : handleCreate}
-                disabled={
-                  !formData.name ||
-                  (!isPATProvider(formData.provider_type) &&
-                    (!formData.client_id || !formData.client_secret)) ||
-                  (isPATProvider(formData.provider_type) && !formData.base_url)
-                }
+                disabled={(() => {
+                  if (!formData.name) return true
+                  const ptype = editingProvider?.provider_type || formData.provider_type
+                  const authMode = formData.auth_mode || 'oauth_user'
+                  if (isPATProvider(ptype)) return !formData.base_url
+                  if (ptype === 'github' && authMode === 'github_app') {
+                    return (
+                      !formData.github_app_id ||
+                      !formData.github_installation_id ||
+                      (!editingProvider && !formData.app_private_key)
+                    )
+                  }
+                  return !formData.client_id || (!editingProvider && !formData.client_secret)
+                })()}
               >
                 {editingProvider ? t('admin.scmProviders.update') : t('admin.scmProviders.create')}
               </Button>

--- a/frontend/src/pages/admin/__tests__/SCMProvidersPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/SCMProvidersPage.test.tsx
@@ -13,6 +13,7 @@ const deleteSCMProviderMock = vi.fn()
 const initiateSCMOAuthMock = vi.fn()
 const saveSCMTokenMock = vi.fn()
 const revokeSCMTokenMock = vi.fn()
+const verifySCMProviderMock = vi.fn()
 
 vi.mock('../../../services/api', () => ({
   default: {
@@ -25,6 +26,7 @@ vi.mock('../../../services/api', () => ({
     initiateSCMOAuth: (...args: unknown[]) => initiateSCMOAuthMock(...args),
     saveSCMToken: (...args: unknown[]) => saveSCMTokenMock(...args),
     revokeSCMToken: (...args: unknown[]) => revokeSCMTokenMock(...args),
+    verifySCMProvider: (...args: unknown[]) => verifySCMProviderMock(...args),
   },
 }))
 
@@ -88,7 +90,7 @@ describe('SCMProvidersPage', () => {
   })
 
   it('shows loading spinner initially', () => {
-    listSCMProvidersMock.mockReturnValue(new Promise(() => {}))
+    listSCMProvidersMock.mockReturnValue(new Promise(() => { }))
     renderPage()
     expect(screen.getByRole('progressbar')).toBeInTheDocument()
   })
@@ -261,6 +263,57 @@ describe('SCMProvidersPage', () => {
     await userEvent.type(screen.getByLabelText(/Client Secret/i), 'secret-456')
     await userEvent.click(screen.getByRole('button', { name: /^create$/i }))
     await waitFor(() => expect(createSCMProviderMock).toHaveBeenCalled())
+  })
+
+  it('creates a GitHub App provider with app fields and no client secret', async () => {
+    listSCMProvidersMock.mockResolvedValue([])
+    getCurrentUserMembershipsMock.mockResolvedValue(fakeMemberships)
+    createSCMProviderMock.mockResolvedValue({ id: 'gh-app' })
+    renderPage()
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /add provider/i })).toBeInTheDocument(),
+    )
+    await userEvent.click(screen.getByRole('button', { name: /add provider/i }))
+    await waitFor(() => expect(screen.getByText('Add SCM Provider')).toBeInTheDocument())
+    await userEvent.type(screen.getByLabelText(/^Name/i), 'GH App')
+    // provider_type defaults to github; switch to the shared app credential mode.
+    await userEvent.click(screen.getByRole('combobox', { name: /Authentication/i }))
+    await userEvent.click(await screen.findByRole('option', { name: /Shared app credential/i }))
+    await userEvent.type(screen.getByLabelText(/GitHub App ID/i), '12345')
+    await userEvent.type(screen.getByLabelText(/Installation ID/i), '67890')
+    await userEvent.type(screen.getByLabelText(/Private Key/i), 'fake-pem')
+    await userEvent.click(screen.getByRole('button', { name: /^create$/i }))
+    await waitFor(() => expect(createSCMProviderMock).toHaveBeenCalled())
+    const payload = createSCMProviderMock.mock.calls[0][0]
+    expect(payload.auth_mode).toBe('github_app')
+    expect(payload.github_app_id).toBe('12345')
+    expect(payload.github_installation_id).toBe('67890')
+    expect(payload.app_private_key).toBe('fake-pem')
+    // The client secret field is not rendered in app mode, so none is sent.
+    expect(payload.client_secret).toBeFalsy()
+  })
+
+  it('verifies an app-mode provider via Test connection', async () => {
+    const appProvider = [
+      {
+        ...fakeProviders[0],
+        id: 'scm-app',
+        name: 'ADO App',
+        provider_type: 'azuredevops' as const,
+        auth_mode: 'entra_app' as const,
+      },
+    ]
+    listSCMProvidersMock.mockResolvedValue(appProvider)
+    verifySCMProviderMock.mockResolvedValue({ ok: true, expires_at: '2026-01-01T00:00:00Z' })
+    renderPage()
+    await waitFor(() => expect(screen.getByText('ADO App')).toBeInTheDocument())
+    // App-mode providers expose Test connection, not the per-user Connect button.
+    expect(
+      screen.queryByRole('button', { name: /connect scm provider/i }),
+    ).not.toBeInTheDocument()
+    await userEvent.click(screen.getByRole('button', { name: /test connection/i }))
+    await waitFor(() => expect(verifySCMProviderMock).toHaveBeenCalledWith('scm-app'))
+    await waitFor(() => expect(screen.getByText('Connection OK')).toBeInTheDocument())
   })
 
   it('cancels the delete dialog without deleting', async () => {

--- a/frontend/src/services/__tests__/api.test.ts
+++ b/frontend/src/services/__tests__/api.test.ts
@@ -211,7 +211,7 @@ describe('ApiClient', () => {
       const client = await getApiClient()
 
       const mockResponse = { data: { valid: true } }
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce(mockResponse)
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce(mockResponse)
 
       await client.validateSetupToken('my-setup-token')
 
@@ -232,7 +232,7 @@ describe('ApiClient', () => {
       const client = await getApiClient()
 
       const mockResponse = { data: { modules: [], meta: { total: 0 } } }
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce(mockResponse)
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce(mockResponse)
 
       const result = await client.searchModules({ query: 'vpc', limit: 10, offset: 0 })
 
@@ -248,7 +248,7 @@ describe('ApiClient', () => {
       const client = await getApiClient()
 
       const mockResponse = { data: { providers: [], meta: { total: 0 } } }
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce(mockResponse)
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce(mockResponse)
 
       const result = await client.searchProviders({ query: 'aws', limit: 5, offset: 0 })
 
@@ -269,7 +269,7 @@ describe('ApiClient', () => {
           pagination: { page: 1, per_page: 20, total: 1 },
         },
       }
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce(mockResponse)
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce(mockResponse)
 
       const result = await client.listUsers(1, 20)
 
@@ -286,7 +286,7 @@ describe('ApiClient', () => {
       const client = await getApiClient()
 
       const mockResponse = { data: { id: 's1', backend_type: 'local', is_active: true } }
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce(mockResponse)
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce(mockResponse)
 
       const result = await client.getActiveStorageConfig()
 
@@ -334,9 +334,9 @@ describe('ApiClient', () => {
             targets: [],
           },
         ]
-        ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-          data: advisories,
-        })
+          ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+            data: advisories,
+          })
 
         const result = await client.getActiveAdvisories()
 
@@ -348,7 +348,7 @@ describe('ApiClient', () => {
       it('returns empty array when response is not an array', async () => {
         const client = await getApiClient()
 
-        ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: null })
+          ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: null })
 
         const result = await client.getActiveAdvisories()
 
@@ -361,7 +361,7 @@ describe('ApiClient', () => {
         const client = await getApiClient()
 
         const mockResponse = { data: { advisories: [], total: 0 } }
-        ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce(mockResponse)
+          ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce(mockResponse)
 
         const result = await client.listAdminAdvisories()
 
@@ -375,7 +375,7 @@ describe('ApiClient', () => {
         const client = await getApiClient()
 
         const mockResponse = { data: { advisories: [], total: 0 } }
-        ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce(mockResponse)
+          ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce(mockResponse)
 
         await client.listAdminAdvisories('binary')
 
@@ -389,9 +389,9 @@ describe('ApiClient', () => {
       it('calls POST /api/v1/admin/advisories/poll and returns message', async () => {
         const client = await getApiClient()
 
-        ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-          data: { message: 'poll queued' },
-        })
+          ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+            data: { message: 'poll queued' },
+          })
 
         const result = await client.triggerAdvisoryPoll()
 
@@ -405,9 +405,9 @@ describe('ApiClient', () => {
   describe('auth methods', () => {
     it('refreshToken calls POST /api/v1/auth/refresh', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { token: 'new' },
-      })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { token: 'new' },
+        })
       const result = await client.refreshToken()
       expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/auth/refresh')
       expect(result.token).toBe('new')
@@ -415,9 +415,9 @@ describe('ApiClient', () => {
 
     it('getCurrentUser calls GET /api/v1/auth/me', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { user: { id: 'u1', email: 'a@b.com' } },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { user: { id: 'u1', email: 'a@b.com' } },
+        })
       const result = await client.getCurrentUser()
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/auth/me')
       expect(result.id).toBe('u1')
@@ -425,9 +425,9 @@ describe('ApiClient', () => {
 
     it('getCurrentUserWithRole returns user, role_template, allowed_scopes', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { user: { id: 'u1' }, role_template: { id: 'r1' }, allowed_scopes: ['admin'] },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { user: { id: 'u1' }, role_template: { id: 'r1' }, allowed_scopes: ['admin'] },
+        })
       const result = await client.getCurrentUserWithRole()
       expect(result.user.id).toBe('u1')
       expect(result.role_template?.id).toBe('r1')
@@ -436,9 +436,9 @@ describe('ApiClient', () => {
 
     it('getCurrentUserWithRole defaults missing fields', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { user: { id: 'u1' } },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { user: { id: 'u1' } },
+        })
       const result = await client.getCurrentUserWithRole()
       expect(result.role_template).toBeNull()
       expect(result.allowed_scopes).toEqual([])
@@ -446,9 +446,9 @@ describe('ApiClient', () => {
 
     it('devLogin calls POST /api/v1/dev/login', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { token: 'dev-tok' },
-      })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { token: 'dev-tok' },
+        })
       const result = await client.devLogin()
       expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/dev/login')
       expect(result.token).toBe('dev-tok')
@@ -456,9 +456,9 @@ describe('ApiClient', () => {
 
     it('getDevStatus calls GET /api/v1/dev/status', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { dev_mode: true },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { dev_mode: true },
+        })
       const result = await client.getDevStatus()
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/dev/status')
       expect(result.dev_mode).toBe(true)
@@ -466,9 +466,9 @@ describe('ApiClient', () => {
 
     it('listUsersForImpersonation calls GET /api/v1/dev/users', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { users: [], dev_mode: true },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { users: [], dev_mode: true },
+        })
       const result = await client.listUsersForImpersonation()
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/dev/users')
       expect(result.dev_mode).toBe(true)
@@ -476,9 +476,9 @@ describe('ApiClient', () => {
 
     it('impersonateUser calls POST /api/v1/dev/impersonate/:id', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { token: 'imp-tok', message: 'ok' },
-      })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { token: 'imp-tok', message: 'ok' },
+        })
       const result = await client.impersonateUser('u1')
       expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/dev/impersonate/u1')
       expect(result.token).toBe('imp-tok')
@@ -489,9 +489,9 @@ describe('ApiClient', () => {
   describe('module methods', () => {
     it('getModuleVersions', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { versions: [] },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { versions: [] },
+        })
       await client.getModuleVersions('hashicorp', 'consul', 'aws')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith(
         '/v1/modules/hashicorp/consul/aws/versions',
@@ -500,9 +500,9 @@ describe('ApiClient', () => {
 
     it('createModuleRecord', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { id: 'm1' },
-      })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { id: 'm1' },
+        })
       const result = await client.createModuleRecord({
         namespace: 'ns',
         name: 'mod',
@@ -519,9 +519,9 @@ describe('ApiClient', () => {
     it('uploadModule sends FormData', async () => {
       const client = await getApiClient()
       const fd = new FormData()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { ok: true },
-      })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { ok: true },
+        })
       await client.uploadModule(fd)
       expect(mockAxiosInstance.post).toHaveBeenCalledWith(
         '/api/v1/modules',
@@ -532,23 +532,23 @@ describe('ApiClient', () => {
 
     it('getModule', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { id: 'm1' },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { id: 'm1' },
+        })
       await client.getModule('ns', 'mod', 'aws')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/modules/ns/mod/aws')
     })
 
     it('deleteModule', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.deleteModule('ns', 'mod', 'aws')
       expect(mockAxiosInstance.delete).toHaveBeenCalledWith('/api/v1/modules/ns/mod/aws')
     })
 
     it('deleteModuleVersion', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.deleteModuleVersion('ns', 'mod', 'aws', '1.0.0')
       expect(mockAxiosInstance.delete).toHaveBeenCalledWith(
         '/api/v1/modules/ns/mod/aws/versions/1.0.0',
@@ -557,7 +557,7 @@ describe('ApiClient', () => {
 
     it('deprecateModuleVersion with message', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.deprecateModuleVersion('ns', 'mod', 'aws', '1.0.0', 'old')
       expect(mockAxiosInstance.post).toHaveBeenCalledWith(
         '/api/v1/modules/ns/mod/aws/versions/1.0.0/deprecate',
@@ -567,7 +567,7 @@ describe('ApiClient', () => {
 
     it('deprecateModuleVersion without message', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.deprecateModuleVersion('ns', 'mod', 'aws', '1.0.0')
       expect(mockAxiosInstance.post).toHaveBeenCalledWith(
         '/api/v1/modules/ns/mod/aws/versions/1.0.0/deprecate',
@@ -577,7 +577,7 @@ describe('ApiClient', () => {
 
     it('undeprecateModuleVersion', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.undeprecateModuleVersion('ns', 'mod', 'aws', '1.0.0')
       expect(mockAxiosInstance.delete).toHaveBeenCalledWith(
         '/api/v1/modules/ns/mod/aws/versions/1.0.0/deprecate',
@@ -586,7 +586,7 @@ describe('ApiClient', () => {
 
     it('deprecateModule', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.deprecateModule('ns', 'mod', 'aws', { message: 'eol' })
       expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/modules/ns/mod/aws/deprecate', {
         message: 'eol',
@@ -595,14 +595,14 @@ describe('ApiClient', () => {
 
     it('undeprecateModule', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.undeprecateModule('ns', 'mod', 'aws')
       expect(mockAxiosInstance.delete).toHaveBeenCalledWith('/api/v1/modules/ns/mod/aws/deprecate')
     })
 
     it('updateModule', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.updateModule('m1', { description: 'new desc' })
       expect(mockAxiosInstance.put).toHaveBeenCalledWith('/api/v1/admin/modules/m1', {
         description: 'new desc',
@@ -611,9 +611,9 @@ describe('ApiClient', () => {
 
     it('getModuleScan', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { status: 'clean' },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { status: 'clean' },
+        })
       await client.getModuleScan('ns', 'mod', 'aws', '1.0.0')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith(
         '/api/v1/modules/ns/mod/aws/versions/1.0.0/scan',
@@ -622,9 +622,9 @@ describe('ApiClient', () => {
 
     it('getModuleDocs', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { content: '' },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { content: '' },
+        })
       await client.getModuleDocs('ns', 'mod', 'aws', '1.0.0')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith(
         '/api/v1/modules/ns/mod/aws/versions/1.0.0/docs',
@@ -636,9 +636,9 @@ describe('ApiClient', () => {
   describe('provider methods', () => {
     it('getProviderVersions', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { versions: [] },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { versions: [] },
+        })
       await client.getProviderVersions('hashicorp', 'aws')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/v1/providers/hashicorp/aws/versions')
     })
@@ -646,7 +646,7 @@ describe('ApiClient', () => {
     it('uploadProvider sends FormData', async () => {
       const client = await getApiClient()
       const fd = new FormData()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.uploadProvider(fd)
       expect(mockAxiosInstance.post).toHaveBeenCalledWith(
         '/api/v1/providers',
@@ -657,23 +657,23 @@ describe('ApiClient', () => {
 
     it('getProvider', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { id: 'p1' },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { id: 'p1' },
+        })
       await client.getProvider('hashicorp', 'aws')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/providers/hashicorp/aws')
     })
 
     it('deleteProvider', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.deleteProvider('hashicorp', 'aws')
       expect(mockAxiosInstance.delete).toHaveBeenCalledWith('/api/v1/providers/hashicorp/aws')
     })
 
     it('deleteProviderVersion', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.deleteProviderVersion('hashicorp', 'aws', '5.0.0')
       expect(mockAxiosInstance.delete).toHaveBeenCalledWith(
         '/api/v1/providers/hashicorp/aws/versions/5.0.0',
@@ -682,7 +682,7 @@ describe('ApiClient', () => {
 
     it('deprecateProviderVersion with message', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.deprecateProviderVersion('hashicorp', 'aws', '5.0.0', 'old')
       expect(mockAxiosInstance.post).toHaveBeenCalledWith(
         '/api/v1/providers/hashicorp/aws/versions/5.0.0/deprecate',
@@ -692,7 +692,7 @@ describe('ApiClient', () => {
 
     it('deprecateProviderVersion without message', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.deprecateProviderVersion('hashicorp', 'aws', '5.0.0')
       expect(mockAxiosInstance.post).toHaveBeenCalledWith(
         '/api/v1/providers/hashicorp/aws/versions/5.0.0/deprecate',
@@ -702,7 +702,7 @@ describe('ApiClient', () => {
 
     it('undeprecateProviderVersion', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.undeprecateProviderVersion('hashicorp', 'aws', '5.0.0')
       expect(mockAxiosInstance.delete).toHaveBeenCalledWith(
         '/api/v1/providers/hashicorp/aws/versions/5.0.0/deprecate',
@@ -711,9 +711,9 @@ describe('ApiClient', () => {
 
     it('getProviderDocs with all params', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { docs: [] },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { docs: [] },
+        })
       await client.getProviderDocs('hashicorp', 'aws', '5.0.0', 'resources', 'en', 10, 0)
       expect(mockAxiosInstance.get).toHaveBeenCalledWith(
         '/api/v1/providers/hashicorp/aws/versions/5.0.0/docs',
@@ -723,9 +723,9 @@ describe('ApiClient', () => {
 
     it('getProviderDocs without optional params', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { docs: [] },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { docs: [] },
+        })
       await client.getProviderDocs('hashicorp', 'aws', '5.0.0')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith(
         '/api/v1/providers/hashicorp/aws/versions/5.0.0/docs',
@@ -735,9 +735,9 @@ describe('ApiClient', () => {
 
     it('getProviderDocContent', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { content: '# Doc' },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { content: '# Doc' },
+        })
       await client.getProviderDocContent('hashicorp', 'aws', '5.0.0', 'resources', 'aws_instance')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith(
         '/api/v1/providers/hashicorp/aws/versions/5.0.0/docs/resources/aws_instance',
@@ -749,12 +749,12 @@ describe('ApiClient', () => {
   describe('user methods', () => {
     it('searchUsers', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: {
-          users: [{ id: 'u1', email: 'a@b.com', name: 'A', created_at: '', updated_at: '' }],
-          pagination: {},
-        },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: {
+            users: [{ id: 'u1', email: 'a@b.com', name: 'A', created_at: '', updated_at: '' }],
+            pagination: {},
+          },
+        })
       const result = await client.searchUsers('test', 1, 10)
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/users/search', {
         params: { q: 'test', page: 1, per_page: 10 },
@@ -764,18 +764,18 @@ describe('ApiClient', () => {
 
     it('getUser', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { user: { id: 'u1', email: 'a@b.com', name: 'A', created_at: '', updated_at: '' } },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { user: { id: 'u1', email: 'a@b.com', name: 'A', created_at: '', updated_at: '' } },
+        })
       const result = await client.getUser('u1')
       expect(result.id).toBe('u1')
     })
 
     it('createUser', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { user: { id: 'u2', email: 'b@b.com', name: 'B', created_at: '', updated_at: '' } },
-      })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { user: { id: 'u2', email: 'b@b.com', name: 'B', created_at: '', updated_at: '' } },
+        })
       const result = await client.createUser({ email: 'b@b.com', name: 'B' })
       expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/users', {
         email: 'b@b.com',
@@ -786,11 +786,11 @@ describe('ApiClient', () => {
 
     it('updateUser', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: {
-          user: { id: 'u1', email: 'a@b.com', name: 'Updated', created_at: '', updated_at: '' },
-        },
-      })
+        ; (mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: {
+            user: { id: 'u1', email: 'a@b.com', name: 'Updated', created_at: '', updated_at: '' },
+          },
+        })
       const result = await client.updateUser('u1', { name: 'Updated' })
       expect(mockAxiosInstance.put).toHaveBeenCalledWith('/api/v1/users/u1', { name: 'Updated' })
       expect(result.name).toBe('Updated')
@@ -798,18 +798,18 @@ describe('ApiClient', () => {
 
     it('deleteUser', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { ok: true },
-      })
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { ok: true },
+        })
       await client.deleteUser('u1')
       expect(mockAxiosInstance.delete).toHaveBeenCalledWith('/api/v1/users/u1')
     })
 
     it('getUserMemberships', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { memberships: [{ org_id: 'o1' }] },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { memberships: [{ org_id: 'o1' }] },
+        })
       const result = await client.getUserMemberships('u1')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/users/u1/memberships')
       expect(result).toHaveLength(1)
@@ -817,27 +817,27 @@ describe('ApiClient', () => {
 
     it('getCurrentUserMemberships', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { memberships: [] },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { memberships: [] },
+        })
       await client.getCurrentUserMemberships()
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/users/me/memberships')
     })
 
     it('transformUser handles PascalCase fields', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: {
-          user: {
-            ID: 'u1',
-            Email: 'a@b.com',
-            Name: 'A',
-            CreatedAt: '2025-01-01',
-            UpdatedAt: '2025-01-01',
-            RoleTemplateID: 'r1',
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: {
+            user: {
+              ID: 'u1',
+              Email: 'a@b.com',
+              Name: 'A',
+              CreatedAt: '2025-01-01',
+              UpdatedAt: '2025-01-01',
+              RoleTemplateID: 'r1',
+            },
           },
-        },
-      })
+        })
       const result = await client.getUser('u1')
       expect(result.id).toBe('u1')
       expect(result.email).toBe('a@b.com')
@@ -852,21 +852,21 @@ describe('ApiClient', () => {
         role_template_name: 'admin',
         created_at: '2025-01-01',
       }
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: {
-          users: [
-            {
-              id: 'u1',
-              email: 'a@b.com',
-              name: 'A',
-              created_at: '2025-01-01',
-              updated_at: '2025-01-01',
-              memberships: [inlineMembership],
-            },
-          ],
-          pagination: { total: 1, page: 1, per_page: 20 },
-        },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: {
+            users: [
+              {
+                id: 'u1',
+                email: 'a@b.com',
+                name: 'A',
+                created_at: '2025-01-01',
+                updated_at: '2025-01-01',
+                memberships: [inlineMembership],
+              },
+            ],
+            pagination: { total: 1, page: 1, per_page: 20 },
+          },
+        })
       const result = await client.listUsers(1, 20)
       expect(result.users).toHaveLength(1)
       expect(result.users[0].memberships).toHaveLength(1)
@@ -878,13 +878,13 @@ describe('ApiClient', () => {
   describe('organization methods', () => {
     it('listOrganizations', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: {
-          organizations: [
-            { id: 'o1', name: 'org1', display_name: 'Org 1', created_at: '', updated_at: '' },
-          ],
-        },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: {
+            organizations: [
+              { id: 'o1', name: 'org1', display_name: 'Org 1', created_at: '', updated_at: '' },
+            ],
+          },
+        })
       const result = await client.listOrganizations(1, 20)
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/organizations', {
         params: { page: 1, per_page: 20 },
@@ -894,13 +894,13 @@ describe('ApiClient', () => {
 
     it('searchOrganizations', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: {
-          organizations: [
-            { id: 'o1', name: 'org1', display_name: 'Org 1', created_at: '', updated_at: '' },
-          ],
-        },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: {
+            organizations: [
+              { id: 'o1', name: 'org1', display_name: 'Org 1', created_at: '', updated_at: '' },
+            ],
+          },
+        })
       const result = await client.searchOrganizations('org', 1, 10)
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/organizations/search', {
         params: { q: 'org', page: 1, per_page: 10 },
@@ -910,66 +910,66 @@ describe('ApiClient', () => {
 
     it('getOrganization', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: {
-          organization: {
-            id: 'o1',
-            name: 'org1',
-            display_name: 'Org 1',
-            created_at: '',
-            updated_at: '',
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: {
+            organization: {
+              id: 'o1',
+              name: 'org1',
+              display_name: 'Org 1',
+              created_at: '',
+              updated_at: '',
+            },
           },
-        },
-      })
+        })
       const result = await client.getOrganization('o1')
       expect(result.id).toBe('o1')
     })
 
     it('createOrganization', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        status: 201,
-        data: {
-          organization: {
-            id: 'o2',
-            name: 'new',
-            display_name: 'New',
-            created_at: '',
-            updated_at: '',
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          status: 201,
+          data: {
+            organization: {
+              id: 'o2',
+              name: 'new',
+              display_name: 'New',
+              created_at: '',
+              updated_at: '',
+            },
           },
-        },
-      })
+        })
       const result = await client.createOrganization({ name: 'new', display_name: 'New' })
       expect(result.id).toBe('o2')
     })
 
     it('updateOrganization', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: {
-          organization: {
-            id: 'o1',
-            name: 'org1',
-            display_name: 'Updated',
-            created_at: '',
-            updated_at: '',
+        ; (mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: {
+            organization: {
+              id: 'o1',
+              name: 'org1',
+              display_name: 'Updated',
+              created_at: '',
+              updated_at: '',
+            },
           },
-        },
-      })
+        })
       const result = await client.updateOrganization('o1', { display_name: 'Updated' })
       expect(result.display_name).toBe('Updated')
     })
 
     it('deleteOrganization', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.deleteOrganization('o1')
       expect(mockAxiosInstance.delete).toHaveBeenCalledWith('/api/v1/organizations/o1')
     })
 
     it('addOrganizationMember', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.addOrganizationMember('o1', { user_id: 'u1' })
       expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/organizations/o1/members', {
         user_id: 'u1',
@@ -978,7 +978,7 @@ describe('ApiClient', () => {
 
     it('updateOrganizationMember', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.updateOrganizationMember('o1', 'u1', { role_template_id: 'r1' })
       expect(mockAxiosInstance.put).toHaveBeenCalledWith('/api/v1/organizations/o1/members/u1', {
         role_template_id: 'r1',
@@ -987,16 +987,16 @@ describe('ApiClient', () => {
 
     it('removeOrganizationMember', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.removeOrganizationMember('o1', 'u1')
       expect(mockAxiosInstance.delete).toHaveBeenCalledWith('/api/v1/organizations/o1/members/u1')
     })
 
     it('listOrganizationMembers', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { members: [{ user_id: 'u1' }] },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { members: [{ user_id: 'u1' }] },
+        })
       const result = await client.listOrganizationMembers('o1')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/organizations/o1/members')
       expect(result).toHaveLength(1)
@@ -1004,9 +1004,9 @@ describe('ApiClient', () => {
 
     it('transformOrganization throws for undefined org', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { organization: undefined },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { organization: undefined },
+        })
       await expect(client.getOrganization('bad')).rejects.toThrow(
         'Cannot transform undefined organization',
       )
@@ -1017,9 +1017,9 @@ describe('ApiClient', () => {
   describe('API key methods', () => {
     it('listAPIKeys without org filter', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { keys: [{ id: 'k1', name: 'key1', scopes: [], created_at: '' }] },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { keys: [{ id: 'k1', name: 'key1', scopes: [], created_at: '' }] },
+        })
       const result = await client.listAPIKeys()
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/apikeys', { params: {} })
       expect(result).toHaveLength(1)
@@ -1027,9 +1027,9 @@ describe('ApiClient', () => {
 
     it('listAPIKeys with org filter', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { keys: [] },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { keys: [] },
+        })
       await client.listAPIKeys('org-1')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/apikeys', {
         params: { organization_id: 'org-1' },
@@ -1038,9 +1038,9 @@ describe('ApiClient', () => {
 
     it('listAPIKeys normalizes PascalCase keys', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { keys: [{ ID: 'k1', Name: 'mykey', Scopes: ['read'], CreatedAt: '2025-01-01' }] },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { keys: [{ ID: 'k1', Name: 'mykey', Scopes: ['read'], CreatedAt: '2025-01-01' }] },
+        })
       const result = await client.listAPIKeys()
       expect(result[0].id).toBe('k1')
       expect(result[0].name).toBe('mykey')
@@ -1049,9 +1049,9 @@ describe('ApiClient', () => {
 
     it('createAPIKey', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { key: 'secret', id: 'k1' },
-      })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { key: 'secret', id: 'k1' },
+        })
       const data = { name: 'key1', organization_id: 'o1', scopes: ['read'] }
       await client.createAPIKey(data)
       expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/apikeys', data)
@@ -1059,32 +1059,32 @@ describe('ApiClient', () => {
 
     it('getAPIKey', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { id: 'k1' },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { id: 'k1' },
+        })
       await client.getAPIKey('k1')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/apikeys/k1')
     })
 
     it('updateAPIKey', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.updateAPIKey('k1', { name: 'updated' })
       expect(mockAxiosInstance.put).toHaveBeenCalledWith('/api/v1/apikeys/k1', { name: 'updated' })
     })
 
     it('deleteAPIKey', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.deleteAPIKey('k1')
       expect(mockAxiosInstance.delete).toHaveBeenCalledWith('/api/v1/apikeys/k1')
     })
 
     it('rotateAPIKey', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { new_key: 'secret2' },
-      })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { new_key: 'secret2' },
+        })
       await client.rotateAPIKey('k1', 24)
       expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/apikeys/k1/rotate', {
         grace_period_hours: 24,
@@ -1096,14 +1096,14 @@ describe('ApiClient', () => {
   describe('SCM provider methods', () => {
     it('listSCMProviders', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: [] })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: [] })
       await client.listSCMProviders()
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/scm-providers', { params: {} })
     })
 
     it('listSCMProviders with org', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: [] })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: [] })
       await client.listSCMProviders('org-1')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/scm-providers', {
         params: { organization_id: 'org-1' },
@@ -1112,9 +1112,9 @@ describe('ApiClient', () => {
 
     it('createSCMProvider', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { id: 'scm-1' },
-      })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { id: 'scm-1' },
+        })
       await client.createSCMProvider({ organization_id: 'o1', provider_type: 'github', name: 'GH' })
       expect(mockAxiosInstance.post).toHaveBeenCalledWith(
         '/api/v1/scm-providers',
@@ -1124,16 +1124,16 @@ describe('ApiClient', () => {
 
     it('getSCMProvider', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { id: 'scm-1' },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { id: 'scm-1' },
+        })
       await client.getSCMProvider('scm-1')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/scm-providers/scm-1')
     })
 
     it('updateSCMProvider', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.updateSCMProvider('scm-1', { name: 'Updated' })
       expect(mockAxiosInstance.put).toHaveBeenCalledWith('/api/v1/scm-providers/scm-1', {
         name: 'Updated',
@@ -1142,16 +1142,26 @@ describe('ApiClient', () => {
 
     it('deleteSCMProvider', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.deleteSCMProvider('scm-1')
       expect(mockAxiosInstance.delete).toHaveBeenCalledWith('/api/v1/scm-providers/scm-1')
     })
 
+    it('verifySCMProvider', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { ok: true, expires_at: '2026-01-01T00:00:00Z' },
+        })
+      const result = await client.verifySCMProvider('scm-1')
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/scm-providers/scm-1/verify')
+      expect(result.ok).toBe(true)
+    })
+
     it('initiateSCMOAuth', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { redirect_url: 'https://github.com/oauth' },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { redirect_url: 'https://github.com/oauth' },
+        })
       await client.initiateSCMOAuth('scm-1')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith(
         '/api/v1/scm-providers/scm-1/oauth/authorize',
@@ -1160,7 +1170,7 @@ describe('ApiClient', () => {
 
     it('refreshSCMToken', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.refreshSCMToken('scm-1')
       expect(mockAxiosInstance.post).toHaveBeenCalledWith(
         '/api/v1/scm-providers/scm-1/oauth/refresh',
@@ -1169,18 +1179,18 @@ describe('ApiClient', () => {
 
     it('getSCMTokenStatus', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { connected: true },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { connected: true },
+        })
       const result = await client.getSCMTokenStatus('scm-1')
       expect(result.connected).toBe(true)
     })
 
     it('listSCMRepositories', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { repositories: [] },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { repositories: [] },
+        })
       await client.listSCMRepositories('scm-1', 'search')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith(
         '/api/v1/scm-providers/scm-1/repositories',
@@ -1190,9 +1200,9 @@ describe('ApiClient', () => {
 
     it('listSCMRepositoryTags', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { tags: [] },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { tags: [] },
+        })
       await client.listSCMRepositoryTags('scm-1', 'owner', 'repo')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith(
         '/api/v1/scm-providers/scm-1/repositories/owner/repo/tags',
@@ -1201,9 +1211,9 @@ describe('ApiClient', () => {
 
     it('listSCMRepositoryBranches', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { branches: [] },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { branches: [] },
+        })
       await client.listSCMRepositoryBranches('scm-1', 'owner', 'repo')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith(
         '/api/v1/scm-providers/scm-1/repositories/owner/repo/branches',
@@ -1212,7 +1222,7 @@ describe('ApiClient', () => {
 
     it('revokeSCMToken', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.revokeSCMToken('scm-1')
       expect(mockAxiosInstance.delete).toHaveBeenCalledWith(
         '/api/v1/scm-providers/scm-1/oauth/token',
@@ -1221,7 +1231,7 @@ describe('ApiClient', () => {
 
     it('saveSCMToken', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.saveSCMToken('scm-1', 'token123')
       expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/scm-providers/scm-1/token', {
         access_token: 'token123',
@@ -1233,7 +1243,7 @@ describe('ApiClient', () => {
   describe('module SCM linking', () => {
     it('linkModuleToSCM', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.linkModuleToSCM('m1', {
         provider_id: 'scm-1',
         repository_owner: 'org',
@@ -1247,16 +1257,16 @@ describe('ApiClient', () => {
 
     it('getModuleSCMInfo', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { linked: true },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { linked: true },
+        })
       await client.getModuleSCMInfo('m1')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/modules/m1/scm')
     })
 
     it('updateModuleSCMLink', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.updateModuleSCMLink('m1', { auto_publish_enabled: true })
       expect(mockAxiosInstance.put).toHaveBeenCalledWith('/api/v1/admin/modules/m1/scm', {
         auto_publish_enabled: true,
@@ -1265,14 +1275,14 @@ describe('ApiClient', () => {
 
     it('unlinkModuleFromSCM', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.unlinkModuleFromSCM('m1')
       expect(mockAxiosInstance.delete).toHaveBeenCalledWith('/api/v1/admin/modules/m1/scm')
     })
 
     it('triggerManualSync', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.triggerManualSync('m1', { tag_name: 'v1.0.0' })
       expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/admin/modules/m1/scm/sync', {
         tag_name: 'v1.0.0',
@@ -1281,7 +1291,7 @@ describe('ApiClient', () => {
 
     it('triggerManualSync without data', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.triggerManualSync('m1')
       expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/admin/modules/m1/scm/sync', {})
     })
@@ -1292,9 +1302,9 @@ describe('ApiClient', () => {
         { id: 'e1', event_type: 'tag', state: 'succeeded' },
         { id: 'e2', event_type: 'push', state: 'failed' },
       ]
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { events: sample },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { events: sample },
+        })
       const result = await client.getWebhookEvents('m1')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/modules/m1/scm/events')
       // Regression: the backend returns { events: [...] } — the client must hand
@@ -1305,9 +1315,9 @@ describe('ApiClient', () => {
 
     it('getWebhookEvents returns [] when the envelope is missing events', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: {},
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: {},
+        })
       const result = await client.getWebhookEvents('m1')
       expect(result).toEqual([])
     })
@@ -1317,18 +1327,18 @@ describe('ApiClient', () => {
   describe('scanning methods', () => {
     it('getScanningConfig', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { enabled: true },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { enabled: true },
+        })
       await client.getScanningConfig()
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/scanning/config')
     })
 
     it('getScanningStats', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { total: 10 },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { total: 10 },
+        })
       await client.getScanningStats()
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/scanning/stats', {
         params: undefined,
@@ -1337,9 +1347,9 @@ describe('ApiClient', () => {
 
     it('getScanningStats with params', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { total: 5, total_filtered: 5 },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { total: 5, total_filtered: 5 },
+        })
       await client.getScanningStats({ status: 'failed', limit: 10, offset: 0 })
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/scanning/stats', {
         params: { status: 'failed', limit: 10, offset: 0 },
@@ -1351,9 +1361,9 @@ describe('ApiClient', () => {
   describe('dashboard methods', () => {
     it('getDashboardStats', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { modules: {} },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { modules: {} },
+        })
       await client.getDashboardStats()
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/stats/dashboard')
     })
@@ -1363,9 +1373,9 @@ describe('ApiClient', () => {
   describe('mirror methods', () => {
     it('listMirrors', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { mirrors: [{ id: 'mir-1' }] },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { mirrors: [{ id: 'mir-1' }] },
+        })
       const result = await client.listMirrors()
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/mirrors', { params: {} })
       expect(result).toHaveLength(1)
@@ -1373,9 +1383,9 @@ describe('ApiClient', () => {
 
     it('listMirrors enabledOnly', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { mirrors: [] },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { mirrors: [] },
+        })
       await client.listMirrors(true)
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/mirrors', {
         params: { enabled: 'true' },
@@ -1384,18 +1394,18 @@ describe('ApiClient', () => {
 
     it('getMirror', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { id: 'mir-1' },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { id: 'mir-1' },
+        })
       await client.getMirror('mir-1')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/mirrors/mir-1')
     })
 
     it('createMirror', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { id: 'mir-2' },
-      })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { id: 'mir-2' },
+        })
       await client.createMirror({
         name: 'test',
         upstream_registry_url: 'https://registry.terraform.io',
@@ -1408,7 +1418,7 @@ describe('ApiClient', () => {
 
     it('updateMirror', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.updateMirror('mir-1', { name: 'updated' })
       expect(mockAxiosInstance.put).toHaveBeenCalledWith('/api/v1/admin/mirrors/mir-1', {
         name: 'updated',
@@ -1417,14 +1427,14 @@ describe('ApiClient', () => {
 
     it('deleteMirror', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.deleteMirror('mir-1')
       expect(mockAxiosInstance.delete).toHaveBeenCalledWith('/api/v1/admin/mirrors/mir-1')
     })
 
     it('triggerMirrorSync', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.triggerMirrorSync('mir-1', { namespace: 'hashicorp' })
       expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/admin/mirrors/mir-1/sync', {
         namespace: 'hashicorp',
@@ -1433,18 +1443,18 @@ describe('ApiClient', () => {
 
     it('getMirrorStatus', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { status: 'idle' },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { status: 'idle' },
+        })
       await client.getMirrorStatus('mir-1')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/mirrors/mir-1/status')
     })
 
     it('getMirrorProviders', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { providers: ['hashicorp/aws'] },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { providers: ['hashicorp/aws'] },
+        })
       const result = await client.getMirrorProviders('mir-1')
       expect(result).toEqual(['hashicorp/aws'])
     })
@@ -1454,9 +1464,9 @@ describe('ApiClient', () => {
   describe('role template methods', () => {
     it('listRoleTemplates', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: [{ id: 'r1' }],
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: [{ id: 'r1' }],
+        })
       const result = await client.listRoleTemplates()
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/role-templates')
       expect(result).toHaveLength(1)
@@ -1464,18 +1474,18 @@ describe('ApiClient', () => {
 
     it('getRoleTemplate', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { id: 'r1' },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { id: 'r1' },
+        })
       await client.getRoleTemplate('r1')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/role-templates/r1')
     })
 
     it('createRoleTemplate', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { id: 'r2' },
-      })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { id: 'r2' },
+        })
       await client.createRoleTemplate({ name: 'editor', display_name: 'Editor', scopes: ['write'] })
       expect(mockAxiosInstance.post).toHaveBeenCalledWith(
         '/api/v1/admin/role-templates',
@@ -1485,7 +1495,7 @@ describe('ApiClient', () => {
 
     it('updateRoleTemplate', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.updateRoleTemplate('r1', { display_name: 'Updated' })
       expect(mockAxiosInstance.put).toHaveBeenCalledWith('/api/v1/admin/role-templates/r1', {
         display_name: 'Updated',
@@ -1494,7 +1504,7 @@ describe('ApiClient', () => {
 
     it('deleteRoleTemplate', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.deleteRoleTemplate('r1')
       expect(mockAxiosInstance.delete).toHaveBeenCalledWith('/api/v1/admin/role-templates/r1')
     })
@@ -1504,9 +1514,9 @@ describe('ApiClient', () => {
   describe('approval methods', () => {
     it('listApprovalRequests', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: [{ id: 'a1' }],
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: [{ id: 'a1' }],
+        })
       const result = await client.listApprovalRequests({ status: 'pending' })
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/approvals', {
         params: { status: 'pending' },
@@ -1516,25 +1526,25 @@ describe('ApiClient', () => {
 
     it('listApprovalRequests without filters', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: [] })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: [] })
       await client.listApprovalRequests()
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/approvals', { params: {} })
     })
 
     it('getApprovalRequest', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { id: 'a1' },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { id: 'a1' },
+        })
       await client.getApprovalRequest('a1')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/approvals/a1')
     })
 
     it('createApprovalRequest', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { id: 'a2' },
-      })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { id: 'a2' },
+        })
       await client.createApprovalRequest({
         mirror_config_id: 'mir-1',
         provider_namespace: 'hashicorp',
@@ -1547,7 +1557,7 @@ describe('ApiClient', () => {
 
     it('reviewApproval', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.reviewApproval('a1', { status: 'approved', notes: 'lgtm' })
       expect(mockAxiosInstance.put).toHaveBeenCalledWith('/api/v1/admin/approvals/a1/review', {
         status: 'approved',
@@ -1560,16 +1570,16 @@ describe('ApiClient', () => {
   describe('mirror policy methods', () => {
     it('listMirrorPolicies', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: [{ id: 'p1' }],
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: [{ id: 'p1' }],
+        })
       await client.listMirrorPolicies()
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/policies', { params: {} })
     })
 
     it('listMirrorPolicies with org', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: [] })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: [] })
       await client.listMirrorPolicies('org-1')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/policies', {
         params: { organization_id: 'org-1' },
@@ -1578,18 +1588,18 @@ describe('ApiClient', () => {
 
     it('getMirrorPolicy', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { id: 'p1' },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { id: 'p1' },
+        })
       await client.getMirrorPolicy('p1')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/policies/p1')
     })
 
     it('createMirrorPolicy', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { id: 'p2' },
-      })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { id: 'p2' },
+        })
       await client.createMirrorPolicy({ name: 'allow-all', policy_type: 'allow' })
       expect(mockAxiosInstance.post).toHaveBeenCalledWith(
         '/api/v1/admin/policies',
@@ -1599,7 +1609,7 @@ describe('ApiClient', () => {
 
     it('updateMirrorPolicy', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.updateMirrorPolicy('p1', { name: 'updated' })
       expect(mockAxiosInstance.put).toHaveBeenCalledWith('/api/v1/admin/policies/p1', {
         name: 'updated',
@@ -1608,16 +1618,16 @@ describe('ApiClient', () => {
 
     it('deleteMirrorPolicy', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.deleteMirrorPolicy('p1')
       expect(mockAxiosInstance.delete).toHaveBeenCalledWith('/api/v1/admin/policies/p1')
     })
 
     it('evaluateMirrorPolicy', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { allowed: true },
-      })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { allowed: true },
+        })
       await client.evaluateMirrorPolicy(
         { registry: 'https://registry.terraform.io', namespace: 'hashicorp', provider: 'aws' },
         'org-1',
@@ -1634,36 +1644,36 @@ describe('ApiClient', () => {
   describe('storage methods', () => {
     it('getSetupStatus', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { setup_required: false },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { setup_required: false },
+        })
       await client.getSetupStatus()
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/setup/status')
     })
 
     it('listStorageConfigs', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: [{ id: 's1' }],
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: [{ id: 's1' }],
+        })
       await client.listStorageConfigs()
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/storage/configs')
     })
 
     it('getStorageConfig', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { id: 's1' },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { id: 's1' },
+        })
       await client.getStorageConfig('s1')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/storage/configs/s1')
     })
 
     it('createStorageConfig', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { id: 's2' },
-      })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { id: 's2' },
+        })
       await client.createStorageConfig({ backend_type: 's3' } as never)
       expect(mockAxiosInstance.post).toHaveBeenCalledWith(
         '/api/v1/storage/configs',
@@ -1673,7 +1683,7 @@ describe('ApiClient', () => {
 
     it('updateStorageConfig', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.updateStorageConfig('s1', { backend_type: 's3' } as never)
       expect(mockAxiosInstance.put).toHaveBeenCalledWith(
         '/api/v1/storage/configs/s1',
@@ -1683,25 +1693,25 @@ describe('ApiClient', () => {
 
     it('deleteStorageConfig', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.deleteStorageConfig('s1')
       expect(mockAxiosInstance.delete).toHaveBeenCalledWith('/api/v1/storage/configs/s1')
     })
 
     it('activateStorageConfig', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { message: 'activated' },
-      })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { message: 'activated' },
+        })
       await client.activateStorageConfig('s1')
       expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/storage/configs/s1/activate')
     })
 
     it('testStorageConfig', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { success: true, message: 'ok' },
-      })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { success: true, message: 'ok' },
+        })
       await client.testStorageConfig({ backend_type: 'local' } as never)
       expect(mockAxiosInstance.post).toHaveBeenCalledWith(
         '/api/v1/storage/configs/test',
@@ -1711,9 +1721,9 @@ describe('ApiClient', () => {
 
     it('planStorageMigration', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { items: 10 },
-      })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { items: 10 },
+        })
       await client.planStorageMigration('s1', 's2')
       expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/admin/storage/migrations/plan', {
         source_config_id: 's1',
@@ -1723,9 +1733,9 @@ describe('ApiClient', () => {
 
     it('startStorageMigration', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { id: 'mig-1' },
-      })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { id: 'mig-1' },
+        })
       await client.startStorageMigration('s1', 's2')
       expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/admin/storage/migrations', {
         source_config_id: 's1',
@@ -1735,18 +1745,18 @@ describe('ApiClient', () => {
 
     it('getStorageMigration', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { id: 'mig-1' },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { id: 'mig-1' },
+        })
       await client.getStorageMigration('mig-1')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/storage/migrations/mig-1')
     })
 
     it('cancelStorageMigration', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { id: 'mig-1', status: 'cancelled' },
-      })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { id: 'mig-1', status: 'cancelled' },
+        })
       await client.cancelStorageMigration('mig-1')
       expect(mockAxiosInstance.post).toHaveBeenCalledWith(
         '/api/v1/admin/storage/migrations/mig-1/cancel',
@@ -1755,9 +1765,9 @@ describe('ApiClient', () => {
 
     it('listStorageMigrations', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: [{ id: 'mig-1' }],
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: [{ id: 'mig-1' }],
+        })
       await client.listStorageMigrations()
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/storage/migrations')
     })
@@ -1767,9 +1777,9 @@ describe('ApiClient', () => {
   describe('setup wizard methods', () => {
     it('testOIDCConfig', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { success: true },
-      })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { success: true },
+        })
       await client.testOIDCConfig('tok', {
         issuer_url: 'https://auth.example.com',
         client_id: 'id',
@@ -1784,7 +1794,7 @@ describe('ApiClient', () => {
 
     it('saveOIDCConfig', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.saveOIDCConfig('tok', { issuer_url: 'https://auth.example.com' } as never)
       expect(mockAxiosInstance.post).toHaveBeenCalledWith(
         '/api/v1/setup/oidc',
@@ -1795,16 +1805,16 @@ describe('ApiClient', () => {
 
     it('getAdminOIDCConfig', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { issuer_url: 'https://auth.example.com' },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { issuer_url: 'https://auth.example.com' },
+        })
       await client.getAdminOIDCConfig()
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/oidc/config')
     })
 
     it('updateOIDCGroupMapping', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.updateOIDCGroupMapping({ group_claim_name: 'groups' } as never)
       expect(mockAxiosInstance.put).toHaveBeenCalledWith(
         '/api/v1/admin/oidc/group-mapping',
@@ -1814,9 +1824,9 @@ describe('ApiClient', () => {
 
     it('testSetupStorageConfig', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { success: true },
-      })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { success: true },
+        })
       await client.testSetupStorageConfig('tok', { backend_type: 'local' } as never)
       expect(mockAxiosInstance.post).toHaveBeenCalledWith(
         '/api/v1/setup/storage/test',
@@ -1827,9 +1837,9 @@ describe('ApiClient', () => {
 
     it('saveSetupStorageConfig', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { message: 'saved' },
-      })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { message: 'saved' },
+        })
       await client.saveSetupStorageConfig('tok', { backend_type: 'local' } as never)
       expect(mockAxiosInstance.post).toHaveBeenCalledWith(
         '/api/v1/setup/storage',
@@ -1840,9 +1850,9 @@ describe('ApiClient', () => {
 
     it('testScanningConfig', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { success: true },
-      })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { success: true },
+        })
       await client.testScanningConfig('tok', { enabled: true } as never)
       expect(mockAxiosInstance.post).toHaveBeenCalledWith(
         '/api/v1/setup/scanning/test',
@@ -1853,9 +1863,9 @@ describe('ApiClient', () => {
 
     it('saveScanningConfig', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { message: 'saved' },
-      })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { message: 'saved' },
+        })
       await client.saveScanningConfig('tok', { enabled: true } as never)
       expect(mockAxiosInstance.post).toHaveBeenCalledWith(
         '/api/v1/setup/scanning',
@@ -1866,7 +1876,7 @@ describe('ApiClient', () => {
 
     it('configureAdmin', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.configureAdmin('tok', { admin_email: 'admin@example.com' } as never)
       expect(mockAxiosInstance.post).toHaveBeenCalledWith(
         '/api/v1/setup/admin',
@@ -1877,9 +1887,9 @@ describe('ApiClient', () => {
 
     it('completeSetup', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { success: true },
-      })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { success: true },
+        })
       await client.completeSetup('tok')
       expect(mockAxiosInstance.post).toHaveBeenCalledWith(
         '/api/v1/setup/complete',
@@ -1893,9 +1903,9 @@ describe('ApiClient', () => {
   describe('terraform mirror admin methods', () => {
     it('listPublicTerraformMirrorConfigs', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: [{ name: 'tf' }],
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: [{ name: 'tf' }],
+        })
       const result = await client.listPublicTerraformMirrorConfigs()
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/terraform/binaries')
       expect(result).toHaveLength(1)
@@ -1903,25 +1913,25 @@ describe('ApiClient', () => {
 
     it('listPublicTerraformMirrorConfigs handles non-array', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: null })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: null })
       const result = await client.listPublicTerraformMirrorConfigs()
       expect(result).toEqual([])
     })
 
     it('listTerraformMirrorConfigs', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { configs: [] },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { configs: [] },
+        })
       await client.listTerraformMirrorConfigs()
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/terraform-mirrors')
     })
 
     it('createTerraformMirrorConfig', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { id: 'tc-1' },
-      })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { id: 'tc-1' },
+        })
       await client.createTerraformMirrorConfig({ name: 'test', tool: 'terraform' } as never)
       expect(mockAxiosInstance.post).toHaveBeenCalledWith(
         '/api/v1/admin/terraform-mirrors',
@@ -1931,18 +1941,18 @@ describe('ApiClient', () => {
 
     it('getTerraformMirrorConfig', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { id: 'tc-1' },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { id: 'tc-1' },
+        })
       await client.getTerraformMirrorConfig('tc-1')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/terraform-mirrors/tc-1')
     })
 
     it('getTerraformMirrorStatus', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { status: 'idle' },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { status: 'idle' },
+        })
       await client.getTerraformMirrorStatus('tc-1')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith(
         '/api/v1/admin/terraform-mirrors/tc-1/status',
@@ -1951,7 +1961,7 @@ describe('ApiClient', () => {
 
     it('updateTerraformMirrorConfig', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.put as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.updateTerraformMirrorConfig('tc-1', { name: 'updated' } as never)
       expect(mockAxiosInstance.put).toHaveBeenCalledWith(
         '/api/v1/admin/terraform-mirrors/tc-1',
@@ -1961,16 +1971,16 @@ describe('ApiClient', () => {
 
     it('deleteTerraformMirrorConfig', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.deleteTerraformMirrorConfig('tc-1')
       expect(mockAxiosInstance.delete).toHaveBeenCalledWith('/api/v1/admin/terraform-mirrors/tc-1')
     })
 
     it('triggerTerraformMirrorSync', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { message: 'started' },
-      })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { message: 'started' },
+        })
       await client.triggerTerraformMirrorSync('tc-1')
       expect(mockAxiosInstance.post).toHaveBeenCalledWith(
         '/api/v1/admin/terraform-mirrors/tc-1/sync',
@@ -1980,9 +1990,9 @@ describe('ApiClient', () => {
 
     it('listTerraformVersions', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { versions: [] },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { versions: [] },
+        })
       await client.listTerraformVersions('tc-1', { synced: true })
       expect(mockAxiosInstance.get).toHaveBeenCalledWith(
         '/api/v1/admin/terraform-mirrors/tc-1/versions',
@@ -1992,9 +2002,9 @@ describe('ApiClient', () => {
 
     it('listTerraformVersions without filter', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { versions: [] },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { versions: [] },
+        })
       await client.listTerraformVersions('tc-1')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith(
         '/api/v1/admin/terraform-mirrors/tc-1/versions',
@@ -2004,9 +2014,9 @@ describe('ApiClient', () => {
 
     it('getTerraformVersion', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { version: '1.5.0' },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { version: '1.5.0' },
+        })
       await client.getTerraformVersion('tc-1', '1.5.0')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith(
         '/api/v1/admin/terraform-mirrors/tc-1/versions/1.5.0',
@@ -2015,7 +2025,7 @@ describe('ApiClient', () => {
 
     it('deleteTerraformVersion', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.deleteTerraformVersion('tc-1', '1.5.0')
       expect(mockAxiosInstance.delete).toHaveBeenCalledWith(
         '/api/v1/admin/terraform-mirrors/tc-1/versions/1.5.0',
@@ -2024,7 +2034,7 @@ describe('ApiClient', () => {
 
     it('deprecateTerraformVersion', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.deprecateTerraformVersion('tc-1', '1.5.0')
       expect(mockAxiosInstance.post).toHaveBeenCalledWith(
         '/api/v1/admin/terraform-mirrors/tc-1/versions/1.5.0/deprecate',
@@ -2034,7 +2044,7 @@ describe('ApiClient', () => {
 
     it('undeprecateTerraformVersion', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.undeprecateTerraformVersion('tc-1', '1.5.0')
       expect(mockAxiosInstance.delete).toHaveBeenCalledWith(
         '/api/v1/admin/terraform-mirrors/tc-1/versions/1.5.0/deprecate',
@@ -2043,27 +2053,27 @@ describe('ApiClient', () => {
 
     it('listTerraformVersionPlatforms returns array from data', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: [{ os: 'linux', arch: 'amd64' }],
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: [{ os: 'linux', arch: 'amd64' }],
+        })
       const result = await client.listTerraformVersionPlatforms('tc-1', '1.5.0')
       expect(result).toHaveLength(1)
     })
 
     it('listTerraformVersionPlatforms returns platforms from nested', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { platforms: [{ os: 'linux' }] },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { platforms: [{ os: 'linux' }] },
+        })
       const result = await client.listTerraformVersionPlatforms('tc-1', '1.5.0')
       expect(result).toHaveLength(1)
     })
 
     it('getTerraformMirrorHistory', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { history: [] },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { history: [] },
+        })
       await client.getTerraformMirrorHistory('tc-1', 10)
       expect(mockAxiosInstance.get).toHaveBeenCalledWith(
         '/api/v1/admin/terraform-mirrors/tc-1/history',
@@ -2076,18 +2086,18 @@ describe('ApiClient', () => {
   describe('terraform mirror public methods', () => {
     it('listPublicTerraformVersions', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { versions: [] },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { versions: [] },
+        })
       await client.listPublicTerraformVersions('terraform')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/terraform/binaries/terraform/versions')
     })
 
     it('getPublicLatestTerraformVersion', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { version: '1.9.0' },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { version: '1.9.0' },
+        })
       await client.getPublicLatestTerraformVersion('terraform')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith(
         '/terraform/binaries/terraform/versions/latest',
@@ -2096,9 +2106,9 @@ describe('ApiClient', () => {
 
     it('getPublicTerraformVersion', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { version: '1.5.0' },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { version: '1.5.0' },
+        })
       await client.getPublicTerraformVersion('terraform', '1.5.0')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith(
         '/terraform/binaries/terraform/versions/1.5.0',
@@ -2107,9 +2117,9 @@ describe('ApiClient', () => {
 
     it('getTerraformBinaryDownload', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { download_url: 'https://...' },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { download_url: 'https://...' },
+        })
       await client.getTerraformBinaryDownload('terraform', '1.5.0', 'linux', 'amd64')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith(
         '/terraform/binaries/terraform/versions/1.5.0/linux/amd64',
@@ -2121,9 +2131,9 @@ describe('ApiClient', () => {
   describe('audit log methods', () => {
     it('listAuditLogs with filters', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { logs: [], pagination: {} },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { logs: [], pagination: {} },
+        })
       await client.listAuditLogs({ page: 1, per_page: 25, resource_type: 'module' })
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/audit-logs', {
         params: { page: 1, per_page: 25, resource_type: 'module' },
@@ -2132,9 +2142,9 @@ describe('ApiClient', () => {
 
     it('getAuditLog', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { id: 'log-1' },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { id: 'log-1' },
+        })
       await client.getAuditLog('log-1')
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/audit-logs/log-1')
     })
@@ -2142,7 +2152,7 @@ describe('ApiClient', () => {
     it('exportAuditLogsCSV creates download', async () => {
       const client = await getApiClient()
       const createElementSpy = vi.spyOn(document, 'createElement')
-      const revokeURLSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
+      const revokeURLSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => { })
       const createURLSpy = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:url')
       const clickSpy = vi.fn()
       createElementSpy.mockReturnValue({
@@ -2167,7 +2177,7 @@ describe('ApiClient', () => {
     it('exportAuditLogsJSON creates download', async () => {
       const client = await getApiClient()
       const createElementSpy = vi.spyOn(document, 'createElement')
-      const revokeURLSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
+      const revokeURLSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => { })
       const createURLSpy = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:url')
       const clickSpy = vi.fn()
       createElementSpy.mockReturnValue({
@@ -2191,14 +2201,14 @@ describe('ApiClient', () => {
   describe('enterprise identity methods', () => {
     it('getAuthProviders calls GET /api/v1/auth/providers', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: {
-          providers: [
-            { type: 'oidc', name: 'Corporate' },
-            { type: 'saml', name: 'Okta', id: 's1' },
-          ],
-        },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: {
+            providers: [
+              { type: 'oidc', name: 'Corporate' },
+              { type: 'saml', name: 'Okta', id: 's1' },
+            ],
+          },
+        })
       const result = await client.getAuthProviders()
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/auth/providers')
       expect(result.providers).toHaveLength(2)
@@ -2207,9 +2217,9 @@ describe('ApiClient', () => {
 
     it('ldapLogin calls POST /api/v1/auth/ldap/login with credentials', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { token: 'ldap-jwt-token' },
-      })
+        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { token: 'ldap-jwt-token' },
+        })
       const result = await client.ldapLogin('admin', 'secret')
       expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/auth/ldap/login', {
         username: 'admin',
@@ -2220,9 +2230,9 @@ describe('ApiClient', () => {
 
     it('getIdentityGroupMappings calls GET /api/v1/admin/identity/group-mappings', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { saml: { group_mappings: [] }, ldap: { group_mappings: [] } },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { saml: { group_mappings: [] }, ldap: { group_mappings: [] } },
+        })
       const result = await client.getIdentityGroupMappings()
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/identity/group-mappings')
       expect(result).toHaveProperty('saml')
@@ -2231,9 +2241,9 @@ describe('ApiClient', () => {
 
     it('getMTLSConfig calls GET /api/v1/admin/mtls/config', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { enabled: true, client_ca_file: '/ca.pem', mappings: [] },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { enabled: true, client_ca_file: '/ca.pem', mappings: [] },
+        })
       const result = await client.getMTLSConfig()
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/mtls/config')
       expect(result.enabled).toBe(true)
@@ -2244,9 +2254,9 @@ describe('ApiClient', () => {
   describe('version info', () => {
     it('getVersionInfo', async () => {
       const client = await getApiClient()
-      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        data: { version: '1.0.0' },
-      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { version: '1.0.0' },
+        })
       const result = await client.getVersionInfo()
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/version')
       expect(result.version).toBe('1.0.0')

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -69,7 +69,7 @@ class ApiClient {
         }
 
         // Stamp the request start time for breadcrumb duration tracking
-        ;(config as InternalAxiosRequestConfig & { _startTime?: number })._startTime = Date.now()
+        ; (config as InternalAxiosRequestConfig & { _startTime?: number })._startTime = Date.now()
         return config
       },
       (error) => Promise.reject(error),
@@ -268,11 +268,11 @@ class ApiClient {
       },
       onUploadProgress: options?.onUploadProgress
         ? (event) => {
-            if (event.total && event.total > 0) {
-              const percent = Math.round((event.loaded / event.total) * 100)
-              options.onUploadProgress?.(percent)
-            }
+          if (event.total && event.total > 0) {
+            const percent = Math.round((event.loaded / event.total) * 100)
+            options.onUploadProgress?.(percent)
           }
+        }
         : undefined,
     })
     return response.data
@@ -386,11 +386,11 @@ class ApiClient {
       },
       onUploadProgress: options?.onUploadProgress
         ? (event) => {
-            if (event.total && event.total > 0) {
-              const percent = Math.round((event.loaded / event.total) * 100)
-              options.onUploadProgress?.(percent)
-            }
+          if (event.total && event.total > 0) {
+            const percent = Math.round((event.loaded / event.total) * 100)
+            options.onUploadProgress?.(percent)
           }
+        }
         : undefined,
     })
     return response.data
@@ -729,9 +729,14 @@ class ApiClient {
     provider_type: string
     name: string
     base_url?: string | null
+    tenant_id?: string | null
     client_id?: string
     client_secret?: string
     webhook_secret?: string
+    auth_mode?: string
+    github_app_id?: string
+    github_installation_id?: string
+    app_private_key?: string
   }) {
     const response = await this.client.post('/api/v1/scm-providers', data)
     return response.data
@@ -752,6 +757,10 @@ class ApiClient {
       client_secret?: string
       webhook_secret?: string
       is_active?: boolean
+      auth_mode?: string
+      github_app_id?: string
+      github_installation_id?: string
+      app_private_key?: string
     },
   ) {
     const response = await this.client.put(`/api/v1/scm-providers/${id}`, data)
@@ -760,6 +769,14 @@ class ApiClient {
 
   async deleteSCMProvider(id: string) {
     const response = await this.client.delete(`/api/v1/scm-providers/${id}`)
+    return response.data
+  }
+
+  // Verify a provider's shared app credentials by minting a token (app auth modes only)
+  async verifySCMProvider(
+    providerId: string,
+  ): Promise<{ ok: boolean; expires_at?: string | null }> {
+    const response = await this.client.post(`/api/v1/scm-providers/${providerId}/verify`)
     return response.data
   }
 

--- a/frontend/src/types/scm.ts
+++ b/frontend/src/types/scm.ts
@@ -2,6 +2,8 @@
 
 export type SCMProviderType = 'github' | 'azuredevops' | 'gitlab' | 'bitbucket_dc'
 
+export type SCMAuthMode = 'oauth_user' | 'entra_app' | 'github_app'
+
 export interface SCMProvider {
   id: string
   organization_id: string
@@ -14,6 +16,11 @@ export interface SCMProvider {
   is_active: boolean
   created_at: string
   updated_at: string
+  auth_mode?: SCMAuthMode
+  github_app_id?: string | null
+  github_installation_id?: string | null
+  has_client_secret?: boolean
+  has_app_private_key?: boolean
 }
 
 export interface CreateSCMProviderRequest {
@@ -25,6 +32,10 @@ export interface CreateSCMProviderRequest {
   client_id?: string
   client_secret?: string
   webhook_secret?: string
+  auth_mode?: SCMAuthMode
+  github_app_id?: string
+  github_installation_id?: string
+  app_private_key?: string
 }
 
 export interface UpdateSCMProviderRequest {
@@ -35,6 +46,15 @@ export interface UpdateSCMProviderRequest {
   client_secret?: string
   webhook_secret?: string
   is_active?: boolean
+  auth_mode?: SCMAuthMode
+  github_app_id?: string
+  github_installation_id?: string
+  app_private_key?: string
+}
+
+export interface SCMProviderVerifyResult {
+  ok: boolean
+  expires_at?: string | null
 }
 
 export interface SCMOAuthToken {


### PR DESCRIPTION
## Summary

Frontend for the shared SCM app-credential auth mode (backend: terraform-registry-backend PR for `feat/scm-shared-app-credentials`). Lets an admin configure a single, org-shared app credential per SCM provider — Microsoft Entra app for Azure DevOps, GitHub App for GitHub — so users no longer each need to run a personal OAuth Connect.

## Changes

- **types/scm.ts**: `SCMProvider` gains `auth_mode`, `github_app_id`, `github_installation_id`, and read-only `has_client_secret` / `has_app_private_key`; create/update requests gain `auth_mode` + GitHub App fields + `app_private_key`; new `SCMProviderVerifyResult`.
- **services/api.ts**: create/update accept the new fields; new `verifySCMProvider(id)` → `POST /api/v1/scm-providers/{id}/verify`.
- **SCMProvidersPage**:
  - An **Authentication** selector (Per-user OAuth | Shared app credential) shown for GitHub and Azure DevOps.
  - App mode renders the **GitHub App fields** (App ID, Installation ID, Private Key PEM) in place of the OAuth client fields; Azure DevOps app mode reuses the existing Tenant/Client fields as Entra credentials.
  - Each app-mode provider card shows an **App credential** indicator and a **Test connection** button (calls verify) instead of the per-user Connect/Disconnect controls.
  - Submit validation is auth-mode aware (app fields required in app mode; secrets/keys only required on create).
- **i18n**: new `admin.scmProviders` keys (English; other locales fall back).

## Testing

- `tsc --noEmit` clean; `eslint --max-warnings 0` clean on changed files.
- `SCMProvidersPage.test.tsx`: 28 passed, including a GitHub App create (asserts app fields are sent and no client secret leaks) and an app-mode Test connection.
- `api.test.ts`: 187 passed, including `verifySCMProvider`.

## Notes

Per-user OAuth remains the default for existing providers; GitLab/Bitbucket are unchanged. Repository browsing in app mode works via the backend's shared token, so the link/publish wizard needs no per-user connection gate.
