### PR TITLE
fix(nav): spell out the `mTLS Certificates` nav label

### DIFF
--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -24,7 +24,7 @@
       "oidcGroupsTooltip": "Map identity provider groups to registry roles",
       "scim": "SCIM",
       "scimTooltip": "SCIM 2.0 user and group provisioning configuration",
-      "mtlsCerts": "mTLS Certs",
+      "mtlsCerts": "mTLS Certificates",
       "mtlsCertsTooltip": "View mTLS client certificate-to-scope mappings",
       "apiKeys": "API Keys",
       "apiKeysTooltip": "Create and manage personal API keys",


### PR DESCRIPTION
Aligns the Identity nav label from **mTLS Certs** to **mTLS Certificates**, matching the page title (already 'mTLS Certificates'), every non-English locale, and the State Manager app.

Closes #414.