### PR TITLE
fix(users): keep row action icons on a single row

### DIFF
--- a/frontend/src/pages/admin/UsersPage.tsx
+++ b/frontend/src/pages/admin/UsersPage.tsx
@@ -560,7 +560,7 @@ const UsersPage: React.FC = () => {
                       )}
                     </TableCell>
                     <TableCell>{new Date(user.created_at).toLocaleDateString()}</TableCell>
-                    <TableCell align="right">
+                    <TableCell align="right" sx={{ whiteSpace: 'nowrap' }}>
                       <Tooltip title={t('admin.users.tooltipEdit')}>
                         <IconButton
                           size="small"


### PR DESCRIPTION
The Users table row actions (edit / export / erase / delete) wrapped onto two rows when the Actions column was squeezed. Adds `whiteSpace: nowrap` to the actions cell so the column keeps all actions on one line, matching the State Manager app.

Closes #415.