### PR TITLE
deps: align Node typings and action-gh-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,7 +151,7 @@ jobs:
 
     steps:
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
         with:
           name: Release ${{ needs.guard.outputs.version }}
           tag_name: ${{ needs.guard.outputs.version }}

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -8,7 +8,7 @@
       "devDependencies": {
         "@axe-core/playwright": "^4.11.3",
         "@playwright/test": "1.60.0",
-        "@types/node": "^25.2.3"
+        "@types/node": "^24"
       },
       "engines": {
         "node": ">=24.0.0 <25"
@@ -44,13 +44,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "25.2.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.3.tgz",
-      "integrity": "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==",
+      "version": "24.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.16.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/axe-core": {
@@ -111,9 +111,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     }

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -13,6 +13,6 @@
   "devDependencies": {
     "@axe-core/playwright": "^4.11.3",
     "@playwright/test": "1.60.0",
-    "@types/node": "^25.2.3"
+    "@types/node": "^24"
   }
 }


### PR DESCRIPTION
- e2e @types/node ^25.2.3 -> ^24 (match the Node 24 floor; frontend is already at ^24)
- release.yml: action-gh-release v3.0.0 -> v3.0.1

No application code or runtime change. The js-yaml override (^4.2.0, CVE-2026-53550 mitigation) is intentionally retained.