### PR TITLE
refactor(api): use canonical mirror request types in createMirror/updateMirror

### DIFF
--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,6 +1,7 @@
 import axios, { AxiosInstance, AxiosError, InternalAxiosRequestConfig } from 'axios'
 import { addApiBreadcrumb } from './errorReporting'
 import { clearAuthStorage } from '../utils/authStorage'
+import type { CreateMirrorConfigRequest, UpdateMirrorConfigRequest } from '../types/mirror'
 
 // In dev mode, use empty baseURL to use relative paths (goes through Vite proxy)
 // In production, use the configured URL or default to current origin
@@ -979,33 +980,12 @@ class ApiClient {
     return response.data
   }
 
-  async createMirror(data: {
-    name: string
-    description?: string
-    upstream_registry_url: string
-    organization_id?: string
-    namespace_filter?: string[]
-    provider_filter?: string[]
-    enabled?: boolean
-    sync_interval_hours?: number
-  }) {
+  async createMirror(data: CreateMirrorConfigRequest) {
     const response = await this.client.post('/api/v1/admin/mirrors', data)
     return response.data
   }
 
-  async updateMirror(
-    id: string,
-    data: {
-      name?: string
-      description?: string
-      upstream_registry_url?: string
-      organization_id?: string
-      namespace_filter?: string[]
-      provider_filter?: string[]
-      enabled?: boolean
-      sync_interval_hours?: number
-    },
-  ) {
+  async updateMirror(id: string, data: UpdateMirrorConfigRequest) {
     const response = await this.client.put(`/api/v1/admin/mirrors/${id}`, data)
     return response.data
   }


### PR DESCRIPTION
## Summary

`createMirror` / `updateMirror` in `frontend/src/services/api.ts` declared hand-maintained inline parameter shapes that had drifted from the canonical `CreateMirrorConfigRequest` / `UpdateMirrorConfigRequest` types in `frontend/src/types/mirror.ts`.

The inline shapes were missing `version_filter`, `platform_filter`, `requires_approval`, and the `pull_through_enabled` / `pull_through_cache_ttl_hours` / `auto_approve_rules` fields (the last three added in #432). The mirror form already sends these fields, so they were only accepted via structural pass-through with **no type checking**.

This replaces the inline shapes with the canonical request types, making `types/mirror.ts` the single source of truth. `Parameters<typeof api.updateMirror>[1]` in `MirrorsPage.tsx` now resolves to `UpdateMirrorConfigRequest`.

Type-only change — no runtime behavior change. Follow-up to #432.

## Changelog

- refactor: align api.ts mirror create/update params with canonical request types

## Checklist

- [x] `npm run lint` passes
- [x] `npx tsc --noEmit` (typecheck) passes
- [x] `npm test` (unit tests) passes
- [x] `npm run build` succeeds
- [x] PR targets `main`
- [x] Remote branch will be deleted after merge
