### PR TITLE
fix(ci): authenticate npm to GitHub Packages in the release Docker build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,7 @@ jobs:
   docker:
     name: Publish Docker image
     runs-on: ubuntu-latest
-    needs: [ guard, ci ]
+    needs: [guard, ci]
     permissions:
       contents: read
       packages: write # required to push to ghcr.io
@@ -126,6 +126,10 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          # GitHub Packages read token so the Docker build can npm-install the private
+          # @sethbacon/* dependency (consumed via --mount=type=secret in the Dockerfile).
+          secrets: |
+            node_auth_token=${{ secrets.GITHUB_TOKEN }}
 
       - name: Attest build provenance (SLSA)
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
@@ -145,7 +149,7 @@ jobs:
   release:
     name: Publish GitHub Release
     runs-on: ubuntu-latest
-    needs: [ guard, docker ]
+    needs: [guard, docker]
     permissions:
       contents: write # required to create releases
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -13,13 +13,18 @@ WORKDIR /app
 # Copy package files
 COPY package.json package-lock.json .npmrc ./
 
+# NODE_AUTH_TOKEN (a GitHub Packages read token) is injected as a BuildKit secret so npm
+# can install the private @sethbacon/* dependency without baking the token into a layer.
 # Install dependencies (use npm install so lockfile mismatches don't fail in CI for dev)
-RUN npm install --no-audit --no-fund
+RUN --mount=type=secret,id=node_auth_token \
+    NODE_AUTH_TOKEN="$(cat /run/secrets/node_auth_token)" npm install --no-audit --no-fund
 
 # Fix what can be auto-fixed, then gate on production-dependency vulnerabilities only.
 # Dev-only packages (e.g. eslint tooling) are excluded: they are not present
 # in the final nginx image and cannot be force-fixed without breaking build tooling.
-RUN npm audit fix || true && \
+RUN --mount=type=secret,id=node_auth_token \
+    export NODE_AUTH_TOKEN="$(cat /run/secrets/node_auth_token)" && \
+    npm audit fix || true && \
     npm audit --audit-level=high --omit=dev
 
 # Copy source code


### PR DESCRIPTION
The release Docker build failed at npm ci/install with a 401 on @sethbacon/terraform-suite-ui (no GitHub Packages token in the build context), so v2.12.0 published no image. Inject NODE_AUTH_TOKEN as a BuildKit secret in the Dockerfile and pass github.token to docker/build-push-action. Validated locally: image builds, npm installs the private dep, 0 vulns.