### PR TITLE
fix(ci): authenticate npm in the e2e test-compose build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,6 +257,10 @@ jobs:
 
       - name: Start test compose
         # Pulls backend from ghcr.io; builds frontend locally
+        env:
+          # GitHub Packages read token so the frontend image build can install the
+          # private @sethbacon/* dep (consumed via the compose build secret).
+          NODE_AUTH_TOKEN: ${{ github.token }}
         run: >-
           docker compose -f deployments/docker-compose.test.yml up -d
 

--- a/deployments/docker-compose.test.yml
+++ b/deployments/docker-compose.test.yml
@@ -94,6 +94,10 @@ services:
         # development enables the Dev Login button so Playwright can log in without real credentials
         # Must match DEV_MODE=true on the backend. Never use in production.
         VITE_MODE: development
+      # GitHub Packages read token so the build can install the private @sethbacon/* dep
+      # (consumed via --mount=type=secret in the Dockerfile).
+      secrets:
+        - node_auth_token
     ports:
       # Playwright expects https://localhost:3000; nginx serves HTTPS on port 443
       # The self-signed cert is baked into the image at build time.
@@ -107,3 +111,9 @@ services:
 volumes:
   postgres-data-test:
     driver: local
+
+# Build-time secret sourced from the NODE_AUTH_TOKEN env var (set by CI to
+# github.token). Lets the frontend image install the private @sethbacon/* dep.
+secrets:
+  node_auth_token:
+    environment: NODE_AUTH_TOKEN


### PR DESCRIPTION
Follow-up to #444. The gated E2E job (also run by the Weekly Security Scan) fails at 'Start test compose' with a 401 on @sethbacon/terraform-suite-ui, because the frontend image build in docker-compose.test.yml had no GitHub Packages token. Add a build secret to the frontend service and pass github.token via NODE_AUTH_TOKEN on the compose step. Validated locally: docker compose build frontend succeeds (npm install, no 401).