### PR TITLE
refactor(shell): consume SuiteSwitcher from @sethbacon/terraform-suite-ui

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "terraform-registry-frontend",
-  "version": "2.11.0",
+  "version": "2.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "terraform-registry-frontend",
-      "version": "2.11.0",
+      "version": "2.12.0",
       "dependencies": {
         "@emotion/cache": "^11.14.0",
         "@emotion/react": "^11.14.0",
@@ -19,7 +19,7 @@
         "@mui/icons-material": "^9.0.1",
         "@mui/material": "^9.0.1",
         "@mui/material-pigment-css": "^9.0.1",
-        "@sethbacon/terraform-suite-ui": "^0.1.0",
+        "@sethbacon/terraform-suite-ui": "^0.2.0",
         "@tanstack/react-query": "^5.99.2",
         "@tanstack/react-query-devtools": "^5.99.2",
         "@testing-library/dom": "^10.4.1",
@@ -2444,9 +2444,9 @@
       }
     },
     "node_modules/@sethbacon/terraform-suite-ui": {
-      "version": "0.1.0",
-      "resolved": "https://npm.pkg.github.com/download/@sethbacon/terraform-suite-ui/0.1.0/c7e1135950d607ff97ff76aaae984a310c55e86c",
-      "integrity": "sha512-YYJ7tc8QGjOX7QTS4w1wx3p1C7H0Jlt/sYbl6noax6oQayDoJPat8VloNHM8t0xSVRYQhfzk9mBpbhd0XpVurQ==",
+      "version": "0.2.0",
+      "resolved": "https://npm.pkg.github.com/download/@sethbacon/terraform-suite-ui/0.2.0/416775be23e6d9a232e6b946fdabc7407b06d386",
+      "integrity": "sha512-8zk+KRVr3cjAi2/0NC5V3rrJ8AeZQVsTgXRx9p4rOYvbVGuF/FKghfQJQDIE64lUmivt86rrf5VjNAosIadIXQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=24.0.0 <25"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,7 +31,7 @@
     "@mui/icons-material": "^9.0.1",
     "@mui/material": "^9.0.1",
     "@mui/material-pigment-css": "^9.0.1",
-    "@sethbacon/terraform-suite-ui": "^0.1.0",
+    "@sethbacon/terraform-suite-ui": "^0.2.0",
     "@tanstack/react-query": "^5.99.2",
     "@tanstack/react-query-devtools": "^5.99.2",
     "@testing-library/dom": "^10.4.1",

--- a/frontend/src/components/SuiteSwitcher.tsx
+++ b/frontend/src/components/SuiteSwitcher.tsx
@@ -1,12 +1,13 @@
-import AppsIcon from '@mui/icons-material/Apps'
-import { IconButton, Tooltip } from '@mui/material'
 import { useSuite } from '../hooks/useSuite'
+import { SuiteSwitcher as SuiteSwitcherBase } from '@sethbacon/terraform-suite-ui'
 
 const LABELS: Record<string, string> = {
   'terraform-registry': 'Terraform Registry',
   'terraform-state-manager': 'Terraform State Manager',
 }
 
+// Sibling discovery (which app, shared store?) stays app-side via useSuite; the
+// AppBar button + single-tab reuse now live in the shared package's SuiteSwitcher.
 export function SuiteSwitcher() {
   const { sibling, active } = useSuite()
   if (!active || !sibling?.publicUrl) return null
@@ -14,35 +15,17 @@ export function SuiteSwitcher() {
   // Until both apps are confirmed to share one identity store + IdP
   // (sibling.sharedStore), opening the sibling in a new tab may require a
   // separate sign-in. Set that expectation honestly rather than implying SSO.
-  const title = sibling.sharedStore
+  const tooltip = sibling.sharedStore
     ? `Open ${label}`
     : `Open ${label} (opens in a new tab; you may need to sign in)`
+  // Self is the other known suite app; the package claims this tab under that id
+  // before opening the sibling so the sibling reuses one tab (never a third).
+  const selfApp = Object.keys(LABELS).find((a) => a !== sibling.app)
   return (
-    <Tooltip title={title}>
-      <IconButton
-        color="inherit"
-        aria-label={title}
-        sx={{ mr: 1 }}
-        onClick={() => {
-          // Claim this tab's name as our OWN app id before opening the sibling.
-          // The suite has exactly two apps, so "self" is the other entry in
-          // LABELS. Without this the original tab stays unnamed, so the sibling's
-          // switcher can't find it by name and opens a *third* tab — the two apps
-          // then ping-pong between two new tabs while the original is orphaned.
-          // Naming this tab lets the sibling reuse it: only the original + one
-          // sibling tab ever exist.
-          const selfApp = Object.keys(LABELS).find((a) => a !== sibling.app)
-          if (selfApp) window.name = selfApp
-          // Reuse one sibling tab across clicks: a stable window name (the
-          // sibling's app id) re-navigates and refocuses the same tab instead of
-          // spawning a new one each time. The sibling is a trusted first-party
-          // suite app, so we intentionally omit noopener/noreferrer here — those
-          // force a fresh browsing context and would defeat the tab reuse.
-          window.open(sibling.publicUrl, sibling.app)?.focus()
-        }}
-      >
-        <AppsIcon />
-      </IconButton>
-    </Tooltip>
+    <SuiteSwitcherBase
+      links={[{ label, href: sibling.publicUrl, appId: sibling.app }]}
+      tooltip={tooltip}
+      currentAppId={selfApp}
+    />
   )
 }


### PR DESCRIPTION
Consumes the enhanced SuiteSwitcher (suite-ui 0.2.0). The local component keeps its useSuite() sibling discovery + labels + shared-store tooltip and passes the resolved sibling (links with appId + currentAppId) to the package, which renders the button and does the window.name single-tab reuse. No behavior change — the existing SuiteSwitcher tests pass unchanged (8/8); tsc clean.