### PR TITLE
chore(deps): bump @sethbacon/terraform-suite-ui to ^0.5.2

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "terraform-registry-frontend",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "terraform-registry-frontend",
-      "version": "2.12.0",
+      "version": "2.12.1",
       "dependencies": {
         "@emotion/cache": "^11.14.0",
         "@emotion/react": "^11.14.0",
@@ -19,7 +19,7 @@
         "@mui/icons-material": "^9.0.1",
         "@mui/material": "^9.0.1",
         "@mui/material-pigment-css": "^9.0.1",
-        "@sethbacon/terraform-suite-ui": "^0.5.1",
+        "@sethbacon/terraform-suite-ui": "^0.5.2",
         "@tanstack/react-query": "^5.99.2",
         "@tanstack/react-query-devtools": "^5.99.2",
         "@testing-library/dom": "^10.4.1",
@@ -2444,9 +2444,9 @@
       }
     },
     "node_modules/@sethbacon/terraform-suite-ui": {
-      "version": "0.5.1",
-      "resolved": "https://npm.pkg.github.com/download/@sethbacon/terraform-suite-ui/0.5.1/f5b280123b7c932f6442f6f43b3006f769ad1c70",
-      "integrity": "sha512-ixe3Kb/eG8gLRvnso6E2qxx2GEX8nMRFmVB9Ui9XffXHIM3Dc5GxEciCkSm7YMlsfE0IIZJ7xALiZvbclZ36NA==",
+      "version": "0.5.2",
+      "resolved": "https://npm.pkg.github.com/download/@sethbacon/terraform-suite-ui/0.5.2/8568bd74c77380d60c8b88ef614fc87f4543aa37",
+      "integrity": "sha512-V1YNkqh5RdxAeFwjmv3bs620sowYB+mG1wKoZtrrKx+JkD1PZy1pcbYGMefrz2dsvzlXliOgzqj26Wek8yCZGg==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=24.0.0 <25"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,7 +31,7 @@
     "@mui/icons-material": "^9.0.1",
     "@mui/material": "^9.0.1",
     "@mui/material-pigment-css": "^9.0.1",
-    "@sethbacon/terraform-suite-ui": "^0.5.1",
+    "@sethbacon/terraform-suite-ui": "^0.5.2",
     "@tanstack/react-query": "^5.99.2",
     "@tanstack/react-query-devtools": "^5.99.2",
     "@testing-library/dom": "^10.4.1",


### PR DESCRIPTION
Bumps the shared UI shell to **0.5.2**, which fixes content centering: page-provided nested `<Container>`s now left-align within the shell content area instead of centering (visible on admin pages like /admin/roles).

Package-only change (CSS `margin-left` override in `SuiteLayout`); no app code changes. tsc clean locally; CI runs the full suite.