### PR TITLE
fix(ci): retry e2e image pulls to tolerate Docker Hub rate-limit timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,8 +255,28 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Pull test images (retry transient Docker Hub timeouts)
+        # postgres:16-alpine (the postgres + seed-db services) is pulled from
+        # Docker Hub, whose unauthenticated rate limit on shared GitHub runners
+        # intermittently causes "context deadline exceeded" pull timeouts. Because
+        # this E2E is a required release gate, that flake fails the job and blocks
+        # releases. Retry the pull so the subsequent `compose up` finds the images
+        # cached. The backend is pulled from ghcr.io (authenticated above) and the
+        # frontend is built locally, so --ignore-buildable skips it.
+        run: |
+          compose="docker compose -f deployments/docker-compose.test.yml"
+          for attempt in 1 2 3 4 5; do
+            if $compose pull --ignore-buildable; then
+              exit 0
+            fi
+            echo "::warning::Image pull failed (attempt ${attempt}/5); retrying in 15s..."
+            sleep 15
+          done
+          echo "::error::Image pull failed after 5 attempts"
+          exit 1
+
       - name: Start test compose
-        # Pulls backend from ghcr.io; builds frontend locally
+        # Images are pre-pulled above; this builds the frontend and starts everything.
         env:
           # GitHub Packages read token so the frontend image build can install the
           # private @sethbacon/* dep (consumed via the compose build secret).


### PR DESCRIPTION
## What

The gated **E2E** job pulls `postgres:16-alpine` (the `postgres` + `seed-db` services) from Docker Hub. Unauthenticated pulls on shared GitHub runners intermittently time out (`Get "https://registry-1.docker.io/v2/": context deadline exceeded`). Because E2E is a **required release gate** (it runs via `workflow_call` from `release.yml`), that flake fails the job and **blocks releases** — and also trips the weekly security scan into filing false "scan failed" issues (e.g. #441).

## Fix

Add a retrying pre-pull step (`docker compose pull --ignore-buildable`, 5 attempts with backoff) before `compose up`, so transient Docker Hub timeouts are absorbed. The backend still comes from ghcr.io (authenticated); the frontend is built locally and skipped via `--ignore-buildable`.

## Why now

This is a `fix:`, so it also lets release-please cut **v2.12.2** — the release that carries the already-merged `@sethbacon/terraform-suite-ui` **0.5.2** bump (#449), i.e. the page-content left-align fix, into a deployable image. Without a user-facing commit, release-please skipped (no release, no image).
