### PR TITLE
fix(home): match the landing hero to the shared rounded-card style

### DIFF
--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -180,26 +180,25 @@ const HomePage: React.FC = () => {
         </Alert>
       )}
       {/* Hero Section */}
-      <Box
-        sx={{
-          background: 'linear-gradient(135deg, #5C4EE5 0%, #00D9C0 100%)',
-          color: 'white',
-          py: 8,
-          mb: 6,
-        }}
-      >
-        <Container maxWidth="lg">
+      <Container maxWidth="lg" disableGutters>
+        <Box
+          sx={{
+            background: 'linear-gradient(135deg, #5C4EE5 0%, #00D9C0 100%)',
+            color: 'white',
+            borderRadius: 2,
+            px: { xs: 3, md: 6 },
+            py: { xs: 6, md: 8 },
+            mb: 6,
+          }}
+        >
           <Typography
-            variant="h2"
+            variant="h3"
             component="h1"
-            gutterBottom
-            sx={{
-              fontWeight: 'bold',
-            }}
+            sx={{ fontWeight: 'bold', mb: 1.5 }}
           >
             {t('home.heroTitle')}
           </Typography>
-          <Typography variant="h5" sx={{ mb: 4, opacity: 0.9 }}>
+          <Typography variant="h6" sx={{ mb: 4, opacity: 0.9, maxWidth: 720 }}>
             {t('home.heroSubtitle')}
           </Typography>
           <Stack
@@ -257,8 +256,8 @@ const HomePage: React.FC = () => {
               {summaryParts.join(' · ')} {t('home.available')}
             </Typography>
           ) : null}
-        </Container>
-      </Box>
+        </Box>
+      </Container>
       {/* Quick Search */}
       <Container maxWidth="sm" sx={{ mb: 8, textAlign: 'center' }}>
         <Typography


### PR DESCRIPTION
## What

Restyles the registry landing **hero** to match the State Manager's hero — a **rounded gradient card capped at `lg`** instead of a full-bleed, square-cornered, full-width banner.

## Changes (`HomePage.tsx`)

- Wrap the hero in `<Container maxWidth="lg" disableGutters>` so it caps at `lg` (left-aligned, consistent with the rest of the content).
- Add `borderRadius: 2` (rounded corners) and match TSM's padding (`px: { xs: 3, md: 6 }`, `py: { xs: 6, md: 8 }`).
- Align the typography scale to TSM: heading `h2` → `h3`, subtitle `h5` → `h6` (with `maxWidth: 720`).
- The registry-specific content (3 CTAs + live summary line) is unchanged.

## Verification

- Measured on the local dev server at 1600px: hero is now `width: 1200` (lg), `border-radius: 16px`, left-aligned at `x: 264` — matching the TSM hero card.
- `HomePage.test.tsx` 15/15 pass; `tsc` clean.
