### PR TITLE
feat: scanner auto-update settings editor (UI)

### DIFF
--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -1833,7 +1833,20 @@
         "installSuccess": "Installed scanner version {{version}} at {{path}}",
         "installError": "Failed to install scanner",
         "checkError": "Failed to check for scanner updates",
-        "signatureSupported": "This tool supports signature verification"
+        "signatureSupported": "This tool supports signature verification",
+        "autoUpdate": {
+          "title": "Automatic Updates",
+          "description": "Periodically check upstream for newer scanner versions. New versions are downloaded, verified, and filed for approval before activation.",
+          "enabled": "Enable scheduled update checks",
+          "intervalHours": "Check interval (hours)",
+          "requiresApproval": "Require approval before activating",
+          "autoApproveRules": "Auto-approve rules (JSON)",
+          "autoApproveRulesHelp": "Optional JSON rules to auto-approve matching versions (e.g. patch-only). Leave blank to require manual approval.",
+          "autoApproveRulesInvalid": "Must be valid JSON",
+          "save": "Save Auto-Update Settings",
+          "saveSuccess": "Auto-update settings saved.",
+          "saveError": "Failed to save auto-update settings."
+        }
       }
     },
     "scimProvisioning": {

--- a/frontend/src/pages/admin/SecurityScanningPage.tsx
+++ b/frontend/src/pages/admin/SecurityScanningPage.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { TFunction } from 'i18next'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
@@ -25,6 +25,7 @@ import {
   TextField,
   FormControlLabel,
   Checkbox,
+  Switch,
 } from '@mui/material'
 import CheckCircle from '@mui/icons-material/CheckCircle'
 import Error from '@mui/icons-material/Error'
@@ -41,7 +42,7 @@ import api from '../../services/api'
 import { queryKeys } from '../../services/queryKeys'
 import { useAuth } from '../../contexts/AuthContext'
 import { getErrorMessage } from '../../utils/errors'
-import type { ModuleScan, RecentScanEntry, ScannerLatestInfo } from '../../types'
+import type { ModuleScan, RecentScanEntry, ScannerLatestInfo, ScannerAutoUpdateInput } from '../../types'
 
 function statusChip(t: TFunction, status: string, onClick?: () => void) {
   const clickProps = onClick ? { onClick, sx: { cursor: 'pointer' } } : {}
@@ -195,6 +196,46 @@ const SecurityScanningPage: React.FC = () => {
     },
     onError: (err: unknown) => {
       setScannerError(getErrorMessage(err, t('admin.securityScanning.scanner.checkError')))
+    },
+  })
+
+  const [autoUpdateForm, setAutoUpdateForm] = useState<ScannerAutoUpdateInput>({
+    enabled: false,
+    interval_hours: 24,
+    requires_approval: true,
+    auto_approve_rules: '',
+  })
+
+  useEffect(() => {
+    if (config?.auto_update) {
+      setAutoUpdateForm({
+        enabled: config.auto_update.enabled,
+        interval_hours: config.auto_update.interval_hours,
+        requires_approval: config.auto_update.requires_approval,
+        auto_approve_rules: config.auto_update.auto_approve_rules ?? '',
+      })
+    }
+  }, [config?.auto_update])
+
+  const autoApproveRulesTrimmed = autoUpdateForm.auto_approve_rules.trim()
+  let autoUpdateRulesInvalid = false
+  if (autoApproveRulesTrimmed !== '') {
+    try {
+      JSON.parse(autoApproveRulesTrimmed)
+    } catch {
+      autoUpdateRulesInvalid = true
+    }
+  }
+
+  const saveAutoUpdateMutation = useMutation({
+    mutationFn: () => api.saveScannerAutoUpdate(autoUpdateForm),
+    onSuccess: () => {
+      setScannerSuccess(t('admin.securityScanning.scanner.autoUpdate.saveSuccess'))
+      setScannerError(null)
+      queryClient.invalidateQueries({ queryKey: ['scanning'] })
+    },
+    onError: (err: unknown) => {
+      setScannerError(getErrorMessage(err, t('admin.securityScanning.scanner.autoUpdate.saveError')))
     },
   })
 
@@ -559,6 +600,87 @@ const SecurityScanningPage: React.FC = () => {
                   t('admin.securityScanning.scanner.install')
                 )}
               </Button>
+            </Box>
+
+            <Divider sx={{ my: 2 }} />
+            <Typography variant="subtitle1" gutterBottom>
+              {t('admin.securityScanning.scanner.autoUpdate.title')}
+            </Typography>
+            <Typography variant="body2" sx={{ color: 'text.secondary', mb: 2 }}>
+              {t('admin.securityScanning.scanner.autoUpdate.description')}
+            </Typography>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, maxWidth: 480 }}>
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={autoUpdateForm.enabled}
+                    onChange={(e) =>
+                      setAutoUpdateForm({ ...autoUpdateForm, enabled: e.target.checked })
+                    }
+                    disabled={!isAdmin}
+                  />
+                }
+                label={t('admin.securityScanning.scanner.autoUpdate.enabled')}
+              />
+              <TextField
+                label={t('admin.securityScanning.scanner.autoUpdate.intervalHours')}
+                type="number"
+                value={autoUpdateForm.interval_hours}
+                onChange={(e) =>
+                  setAutoUpdateForm({
+                    ...autoUpdateForm,
+                    interval_hours: parseInt(e.target.value) || 24,
+                  })
+                }
+                disabled={!isAdmin}
+                slotProps={{
+                  htmlInput: { min: 1 },
+                }}
+              />
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={autoUpdateForm.requires_approval}
+                    onChange={(e) =>
+                      setAutoUpdateForm({
+                        ...autoUpdateForm,
+                        requires_approval: e.target.checked,
+                      })
+                    }
+                    disabled={!isAdmin}
+                  />
+                }
+                label={t('admin.securityScanning.scanner.autoUpdate.requiresApproval')}
+              />
+              <TextField
+                label={t('admin.securityScanning.scanner.autoUpdate.autoApproveRules')}
+                multiline
+                minRows={3}
+                value={autoUpdateForm.auto_approve_rules}
+                onChange={(e) =>
+                  setAutoUpdateForm({ ...autoUpdateForm, auto_approve_rules: e.target.value })
+                }
+                error={autoUpdateRulesInvalid}
+                helperText={
+                  autoUpdateRulesInvalid
+                    ? t('admin.securityScanning.scanner.autoUpdate.autoApproveRulesInvalid')
+                    : t('admin.securityScanning.scanner.autoUpdate.autoApproveRulesHelp')
+                }
+                disabled={!isAdmin}
+              />
+              <Box>
+                <Button
+                  variant="contained"
+                  disabled={!isAdmin || autoUpdateRulesInvalid || saveAutoUpdateMutation.isPending}
+                  onClick={() => saveAutoUpdateMutation.mutate()}
+                >
+                  {saveAutoUpdateMutation.isPending ? (
+                    <CircularProgress size={20} />
+                  ) : (
+                    t('admin.securityScanning.scanner.autoUpdate.save')
+                  )}
+                </Button>
+              </Box>
             </Box>
           </Paper>
 

--- a/frontend/src/pages/admin/__tests__/SecurityScanningPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/SecurityScanningPage.test.tsx
@@ -9,6 +9,7 @@ const getScanningStatsMock = vi.fn()
 const checkScannerLatestMock = vi.fn()
 const adminInstallScannerMock = vi.fn()
 const triggerScannerCheckMock = vi.fn()
+const saveScannerAutoUpdateMock = vi.fn()
 vi.mock('../../../services/api', () => ({
   default: {
     getScanningConfig: (...args: unknown[]) => getScanningConfigMock(...args),
@@ -16,6 +17,7 @@ vi.mock('../../../services/api', () => ({
     checkScannerLatest: (...args: unknown[]) => checkScannerLatestMock(...args),
     adminInstallScanner: (...args: unknown[]) => adminInstallScannerMock(...args),
     triggerScannerCheck: (...args: unknown[]) => triggerScannerCheckMock(...args),
+    saveScannerAutoUpdate: (...args: unknown[]) => saveScannerAutoUpdateMock(...args),
   },
 }))
 
@@ -48,6 +50,12 @@ const fakeConfig = {
   timeout: '5m',
   worker_count: 2,
   scan_interval_mins: 60,
+  auto_update: {
+    enabled: false,
+    interval_hours: 24,
+    requires_approval: true,
+    auto_approve_rules: '',
+  },
 }
 
 const fakeStats = {
@@ -77,6 +85,7 @@ const fakeStats = {
 describe('SecurityScanningPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    saveScannerAutoUpdateMock.mockResolvedValue(fakeConfig.auto_update)
   })
 
   it('shows loading spinner initially', () => {
@@ -156,6 +165,17 @@ describe('SecurityScanningPage', () => {
     })
     expect(screen.getByRole('button', { name: 'Check for Updates' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Install & Activate' })).toBeInTheDocument()
+  })
+
+  it('renders the Automatic Updates section', async () => {
+    getScanningConfigMock.mockResolvedValue(fakeConfig)
+    getScanningStatsMock.mockResolvedValue(fakeStats)
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('Automatic Updates')).toBeInTheDocument()
+    })
+    expect(screen.getByLabelText('Check interval (hours)')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Save Auto-Update Settings' })).toBeInTheDocument()
   })
 
   // Scanner Health + diagnostics — added in #199

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -960,6 +960,13 @@ class ApiClient {
     return response.data
   }
 
+  async saveScannerAutoUpdate(
+    data: import('../types').ScannerAutoUpdateInput,
+  ): Promise<import('../types').ScannerAutoUpdateSettings> {
+    const response = await this.client.put('/api/v1/admin/scanning/auto-update', data)
+    return response.data
+  }
+
   async getModuleDocs(
     namespace: string,
     name: string,

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -604,6 +604,21 @@ export interface ScanningConfig {
   // Added in backend #263 — optional until backend is updated
   binary_path?: string
   detected_version?: string
+  auto_update?: ScannerAutoUpdateSettings
+}
+
+export interface ScannerAutoUpdateSettings {
+  enabled: boolean
+  interval_hours: number
+  requires_approval: boolean
+  auto_approve_rules?: string
+}
+
+export interface ScannerAutoUpdateInput {
+  enabled: boolean
+  interval_hours: number
+  requires_approval: boolean
+  auto_approve_rules: string
 }
 
 export interface RecentScanEntry {


### PR DESCRIPTION
Follow-up #2 (UI, pairs with backend PR): edit the scheduled scanner auto-update settings from the admin console.

- New Automatic Updates section in the Scanner Tool Management card on the Security Scanning page: enable toggle, check interval (hours), require-approval toggle, and an auto-approve-rules JSON editor with client-side JSON validation.
- api.saveScannerAutoUpdate -> PUT /admin/scanning/auto-update; ScanningConfig.auto_update type + i18n keys.
- Admin-gated (reuses the card's isAdmin check).

tsc + eslint clean; full vitest suite 1591/1591.