### PR TITLE
fix: use canonical org scope string and declare missing DSN env vars

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -25,3 +25,9 @@
 # Accepts a Sentry DSN or any URL that accepts POST requests with error payloads.
 # When not set, errors are logged to the browser console only.
 # VITE_ERROR_REPORTING_DSN=https://your-sentry-dsn-or-endpoint
+
+# Sentry DSN for error reporting (preferred over VITE_ERROR_REPORTING_DSN when set).
+# VITE_SENTRY_DSN=https://your-sentry-dsn
+
+# DSN for performance/RUM reporting. Falls back to VITE_ERROR_REPORTING_DSN when not set.
+# VITE_PERFORMANCE_DSN=https://your-performance-dsn-or-endpoint

--- a/frontend/src/pages/admin/OrganizationsPage.tsx
+++ b/frontend/src/pages/admin/OrganizationsPage.tsx
@@ -52,7 +52,7 @@ const OrganizationsPage: React.FC = () => {
   const queryClient = useQueryClient()
   const { allowedScopes } = useAuth()
   const canManage =
-    allowedScopes.includes('admin') || allowedScopes.includes('organizations:manage')
+    allowedScopes.includes('admin') || allowedScopes.includes('organizations:write')
   const [error, setError] = useState<string | null>(null)
 
   // Dialog state

--- a/frontend/src/pages/admin/__tests__/OrganizationsPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/OrganizationsPage.test.tsx
@@ -30,8 +30,10 @@ vi.mock('../../../services/api', () => ({
   },
 }))
 
+let mockAllowedScopes: string[] = ['admin']
+
 vi.mock('../../../contexts/AuthContext', () => ({
-  useAuth: () => ({ allowedScopes: ['admin'], user: { id: 'u1' } }),
+  useAuth: () => ({ allowedScopes: mockAllowedScopes, user: { id: 'u1' } }),
 }))
 
 import OrganizationsPage from '../OrganizationsPage'
@@ -73,6 +75,7 @@ const fakeOrgs = [
 describe('OrganizationsPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockAllowedScopes = ['admin']
   })
 
   it('shows loading spinner initially', () => {
@@ -440,6 +443,48 @@ describe('OrganizationsPage', () => {
     await waitFor(() => expect(updateOrganizationMock).toHaveBeenCalled())
     const callArg = updateOrganizationMock.mock.calls[0][1]
     expect(callArg).not.toHaveProperty('name')
+  })
+
+  // ── canManage scope gate (regression guard for #483) ──────────────────────
+
+  const aliceMember = {
+    user_id: 'u1',
+    organization_id: 'org-1',
+    user_email: 'alice@example.com',
+    user_name: 'Alice',
+    role_template_id: 'rt-admin',
+    role_template_name: 'admin',
+    role_template_display_name: 'Administrator',
+  }
+
+  it('shows member-management UI for the canonical organizations:write scope', async () => {
+    mockAllowedScopes = ['organizations:write']
+    listOrganizationsMock.mockResolvedValue(fakeOrgs)
+    listOrganizationMembersMock.mockResolvedValue([aliceMember])
+    listRoleTemplatesMock.mockResolvedValue([
+      { id: 'rt-admin', name: 'admin', display_name: 'Administrator' },
+    ])
+    renderPage()
+    await waitFor(() => expect(screen.getByText('acme-corp')).toBeInTheDocument())
+    await userEvent.click(screen.getAllByRole('button', { name: /view members/i })[0])
+    await waitFor(() => expect(screen.getByText('Alice')).toBeInTheDocument())
+    expect(screen.getByRole('button', { name: /add.*member/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /remove member/i })).toBeInTheDocument()
+  })
+
+  it('hides member-management UI for the organizations:read scope', async () => {
+    mockAllowedScopes = ['organizations:read']
+    listOrganizationsMock.mockResolvedValue(fakeOrgs)
+    listOrganizationMembersMock.mockResolvedValue([aliceMember])
+    listRoleTemplatesMock.mockResolvedValue([
+      { id: 'rt-admin', name: 'admin', display_name: 'Administrator' },
+    ])
+    renderPage()
+    await waitFor(() => expect(screen.getByText('acme-corp')).toBeInTheDocument())
+    await userEvent.click(screen.getAllByRole('button', { name: /view members/i })[0])
+    await waitFor(() => expect(screen.getByText('Alice')).toBeInTheDocument())
+    expect(screen.queryByRole('button', { name: /add.*member/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /remove member/i })).not.toBeInTheDocument()
   })
 
   it('blocks save and shows field error when name format is invalid', async () => {

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -9,6 +9,8 @@ interface ImportMetaEnv {
   readonly VITE_API_URL?: string
   readonly VITE_USE_MOCK_DATA?: string
   readonly VITE_ERROR_REPORTING_DSN?: string
+  readonly VITE_SENTRY_DSN?: string
+  readonly VITE_PERFORMANCE_DSN?: string
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary
Two small, independent fixes from the open blind-audit issue backlog — both self-contained, no dependency/lockfile changes, no behavior change beyond the fix itself.

- **#483** — `OrganizationsPage.tsx`'s manage gate checked for the scope string `organizations:manage`, which exists nowhere else in the codebase; the RBAC scope catalog (`types/rbac.ts`) and `RolesPage.tsx` both define the canonical scope as `organizations:write`. The mismatch failed safe (over-restrictive — a legitimately provisioned `organizations:write` operator saw a read-only UI) but made the client gate an unreliable mirror of the server's real scopes. Fixed to check the canonical string.
- **#477** — `errorReporting.ts` and `performanceReporting.ts` both read `VITE_SENTRY_DSN` / `VITE_PERFORMANCE_DSN` at runtime, but only `VITE_ERROR_REPORTING_DSN` was declared in `vite-env.d.ts`'s `ImportMetaEnv`, leaving the other two untyped and undocumented. Added both to the type declaration and to `.env.example`.

## Test plan
- [x] `grep` confirms no other reference to `organizations:manage` anywhere in `frontend/`
- [x] `npx tsc --noEmit` — no new errors introduced by either change (pre-existing, unrelated `@sethbacon/terraform-suite-ui` module-resolution errors are present identically on `main`)
- [x] `vitest run` on `errorReporting.test.ts` + `performanceReporting.test.ts` — 26/26 passed
- [x] `OrganizationsPage.test.tsx` fails to load in this sandbox on both `main` and this branch (missing private `@sethbacon/terraform-suite-ui` package) — pre-existing environment gap, not a regression