### PR TITLE
fix: show a friendly localized message on network errors instead of raw Axios text

### DIFF
--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -179,7 +179,8 @@
     "search": "Search",
     "error": "Error",
     "success": "Success",
-    "warning": "Warning"
+    "warning": "Warning",
+    "networkError": "Unable to reach the server — check your connection and try again."
   },
   "modules": {
     "pageTitle": "Terraform Modules",

--- a/frontend/src/utils/__tests__/errors.test.ts
+++ b/frontend/src/utils/__tests__/errors.test.ts
@@ -42,6 +42,21 @@ describe('getErrorMessage', () => {
     expect(getErrorMessage(error, 'Something went wrong')).toBe('Something went wrong')
   })
 
+  it('returns a friendly localized message when the AxiosError has no response', () => {
+    const error = new AxiosError('Network Error')
+    expect(error.response).toBeUndefined()
+    expect(getErrorMessage(error)).toBe(
+      'Unable to reach the server — check your connection and try again.',
+    )
+  })
+
+  it('prefers the friendly network message over a caller-provided fallback when there is no response', () => {
+    const error = new AxiosError('Network Error')
+    expect(getErrorMessage(error, 'Failed to delete provider. Please try again.')).toBe(
+      'Unable to reach the server — check your connection and try again.',
+    )
+  })
+
   it('extracts message from native Error', () => {
     const error = new Error('File not found')
     expect(getErrorMessage(error)).toBe('File not found')

--- a/frontend/src/utils/errors.ts
+++ b/frontend/src/utils/errors.ts
@@ -1,4 +1,5 @@
 import { AxiosError } from 'axios'
+import i18n from '../i18n'
 
 /**
  * Extracts a human-readable error message from an unknown catch-block value.
@@ -7,7 +8,11 @@ import { AxiosError } from 'axios'
  */
 export function getErrorMessage(err: unknown, fallback = 'An unexpected error occurred'): string {
   if (err instanceof AxiosError) {
-    const serverMessage = (err.response?.data as Record<string, unknown>)?.error
+    // No response at all (offline, DNS failure, CORS, timeout) means err.message is
+    // axios/browser boilerplate like "Network Error" -- show a friendly, localized
+    // message instead of surfacing that raw string to the user.
+    if (!err.response) return i18n.t('common.networkError')
+    const serverMessage = (err.response.data as Record<string, unknown>)?.error
     if (typeof serverMessage === 'string') return serverMessage
     return err.message || fallback
   }


### PR DESCRIPTION
## Summary
Fixes #485. `getErrorMessage()` fell through to `err.message` for any `AxiosError`, which for a true network failure (offline, DNS failure, CORS, timeout — no HTTP response at all) is raw axios/browser boilerplate, typically literally `"Network Error"`. That string was rendered verbatim in upload/admin-page `Alert` components (e.g. `ModuleUploadPage.tsx:121`), unlike the localized `errorBoundary.*` strings used elsewhere in the app.

- Special-cased the `!err.response` branch in `getErrorMessage()` (`frontend/src/utils/errors.ts`) to return a new `common.networkError` translation instead of falling through to `err.message`.
- Added `common.networkError` to `en/translation.json` ("Unable to reach the server — check your connection and try again."). Other locales fall back to English via `fallbackLng: 'en'` until the DeepL translation script catches up, consistent with how other new strings are handled in this repo.
- `getErrorMessage` is a plain utility, not a React component, so it can't use the `useTranslation()` hook — used the same raw `i18n` singleton import (`import i18n from '../i18n'`) that `ErrorBoundary.tsx` already uses outside a hook context.
- The friendly message intentionally overrides the caller-provided `fallback` too — the real problem in a no-response case is connectivity, not the specific failed action, per the issue's suggested fix.

## Test plan
- [x] Added two test cases to `errors.test.ts`: no-response AxiosError → friendly message; friendly message wins over a caller-supplied fallback. `vitest run src/utils/__tests__/errors.test.ts` — 13/13 passed.
- [x] Checked the two other test files constructing `AxiosError` (`RepositoryBrowser.test.tsx`, `useModuleDetail.test.ts`) — both always set `.response`, so they're unaffected; ran all three suites together — 65/65 passed.
- [x] `npx tsc --noEmit` — no new errors (pre-existing, unrelated `@sethbacon/terraform-suite-ui` module-resolution errors are present identically on `main`, not introduced by this change).
- [x] `eslint` on the changed files — clean.
- [x] Verified `frontend/src/locales/en/translation.json` is valid JSON after the edit.