### PR TITLE
fix: don't prefix "Error undefined:" on RepositoryBrowser network failures

### DIFF
--- a/frontend/src/components/RepositoryBrowser.tsx
+++ b/frontend/src/components/RepositoryBrowser.tsx
@@ -33,6 +33,20 @@ import type { SCMRepository, SCMTag, SCMBranch } from '../types/scm'
 import apiClient from '../services/api'
 import { getErrorMessage, getErrorStatus } from '../utils/errors'
 
+/**
+ * Composes a server error message with its HTTP status, or falls back to the
+ * default message when there's no server message (e.g. a network failure with
+ * no response, where status is undefined and there's nothing to prefix).
+ */
+function formatApiError(
+  status: number | undefined,
+  serverMessage: string,
+  defaultMessage: string,
+): string {
+  if (!serverMessage) return defaultMessage
+  return status != null ? `Error ${status}: ${serverMessage}` : serverMessage
+}
+
 interface RepositoryBrowserProps {
   providerId: string
   onRepositorySelect?: (repository: SCMRepository) => void
@@ -79,9 +93,11 @@ const RepositoryBrowser: React.FC<RepositoryBrowserProps> = ({
         )
       } else {
         setError(
-          serverMessage
-            ? `Error ${status}: ${serverMessage}`
-            : `Failed to load repositories (HTTP ${status ?? 'unknown'})`,
+          formatApiError(
+            status,
+            serverMessage,
+            `Failed to load repositories (HTTP ${status ?? 'unknown'})`,
+          ),
         )
       }
     } finally {
@@ -108,9 +124,11 @@ const RepositoryBrowser: React.FC<RepositoryBrowserProps> = ({
         const serverMessage = getErrorMessage(err, '')
         console.error('[RepositoryBrowser] loadTagsAndBranches failed', err)
         setError(
-          serverMessage
-            ? `Error ${status}: ${serverMessage}`
-            : `Failed to load tags and branches (HTTP ${status ?? 'unknown'})`,
+          formatApiError(
+            status,
+            serverMessage,
+            `Failed to load tags and branches (HTTP ${status ?? 'unknown'})`,
+          ),
         )
         setTags([])
         setBranches([])

--- a/frontend/src/components/__tests__/RepositoryBrowser.test.tsx
+++ b/frontend/src/components/__tests__/RepositoryBrowser.test.tsx
@@ -187,8 +187,19 @@ describe('RepositoryBrowser', () => {
     listSCMRepositoriesMock.mockRejectedValue(makeAxiosError(500, 'server down'))
     render(<RepositoryBrowser providerId="scm-1" />)
     await waitFor(() => {
-      expect(screen.getByText(/server down/i)).toBeInTheDocument()
+      expect(screen.getByText('Error 500: server down')).toBeInTheDocument()
     })
+  })
+
+  it('does not prefix "Error undefined:" on a network failure with no HTTP response', async () => {
+    listSCMRepositoriesMock.mockRejectedValue(new AxiosError('Network Error'))
+    render(<RepositoryBrowser providerId="scm-1" />)
+    await waitFor(() => {
+      expect(
+        screen.getByText('Unable to reach the server — check your connection and try again.'),
+      ).toBeInTheDocument()
+    })
+    expect(screen.queryByText(/error undefined/i)).not.toBeInTheDocument()
   })
 
   it('hides repos that do not match nameFilter and shows the hidden-count alert', async () => {


### PR DESCRIPTION
## Summary
Fixes #497 (filed as a follow-up from PR #495's review).

Both `loadRepositories` and `loadTagsAndBranches` in `RepositoryBrowser.tsx` composed `` `Error ${status}: ${serverMessage}` `` whenever `getErrorMessage()` returned a truthy value, without checking whether `status` (from `getErrorStatus()`) was actually defined. For a true network failure (offline, DNS failure, CORS, timeout — no HTTP response at all), `status` is `undefined`, so users saw **"Error undefined: \<message\>"**.

This wart predates PR #495 (it previously showed "Error undefined: Network Error"); #495 made the underlying message friendlier but didn't touch this composition bug, which is why it's a separate PR.

- Extracted the identical composition pattern (duplicated at both call sites) into a shared `formatApiError(status, serverMessage, defaultMessage)` helper that skips the `Error ${status}:` prefix when there's no status.
- Both call sites now use the helper instead of the inline ternary.

## Test plan
- [x] Added `does not prefix "Error undefined:" on a network failure with no HTTP response` — asserts the exact friendly message with no prefix.
- [x] Tightened the existing 500-status test to assert the exact `"Error 500: server down"` text (previously only checked a substring), pinning the still-correct prefixed case.
- [x] `vitest run src/components/__tests__/RepositoryBrowser.test.tsx` — 18/18 passed.
- [x] `npx tsc --noEmit` — no new errors (pre-existing, unrelated `@sethbacon/terraform-suite-ui` module-resolution errors present identically on `main`).
- [x] `eslint` — clean.
- [x] `prettier --check` — clean (caught and fixed one formatting issue locally before pushing).