### PR TITLE
fix: remove unused jwt-decode dependency

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "terraform-registry-frontend",
-  "version": "2.12.1",
+  "version": "2.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "terraform-registry-frontend",
-      "version": "2.12.1",
+      "version": "2.15.0",
       "dependencies": {
         "@emotion/cache": "^11.14.0",
         "@emotion/react": "^11.14.0",
@@ -28,7 +28,6 @@
         "globals": "^17.6.0",
         "i18next": "^24.2.3",
         "i18next-browser-languagedetector": "^8.0.5",
-        "jwt-decode": "^4.0.0",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
         "react-i18next": "^15.4.1",
@@ -6483,13 +6482,6 @@
       },
       "engines": {
         "node": ">=4.0"
-      }
-    },
-    "node_modules/jwt-decode": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/keyv": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,7 +40,6 @@
     "globals": "^17.6.0",
     "i18next": "^24.2.3",
     "i18next-browser-languagedetector": "^8.0.5",
-    "jwt-decode": "^4.0.0",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "react-i18next": "^15.4.1",


### PR DESCRIPTION
## Summary
Fixes #476. `jwt-decode` was declared as a runtime dependency but imported nowhere under `src/` — confirmed via `grep -rn "jwt-decode\|jwtDecode" src` (no matches). No code decodes the JWT client-side to derive scopes or identity today, so no authorization decision trusts unverified token claims; this is a strength worth locking in rather than a live bug. Removing the dependency shrinks the supply-chain surface and closes off the footgun of a future contributor wiring it into an auth path — decoded, unverified claims must never gate access; that must stay server-sourced via `/auth/me`.

- Removed `jwt-decode` from `package.json`.
- Ran `npm uninstall jwt-decode --package-lock-only` to regenerate `package-lock.json` correctly (it's a true leaf dependency — no other package in the lock file requires it).

**Incidental, harmless side effect:** `package-lock.json`'s own top-level `version` field was out of sync with `package.json`'s (`2.12.1` vs. the actual current `2.15.0` from the `chore(main): release 2.15.0` PR) — looks like a prior release-please run updated `package.json`/`CHANGELOG.md` but never regenerated the lockfile. `npm uninstall` resynced it as a byproduct of touching the file at all; calling it out so it isn't a surprise in the diff.

## Test plan
- [x] `grep -rn "jwt-decode\|jwtDecode" src` — no matches, confirms it's truly unused.
- [x] `npx tsc --noEmit` — same 20 pre-existing, unrelated `@sethbacon/terraform-suite-ui` module-resolution errors as `main`; nothing new.
- [x] `npx eslint . --max-warnings 0` (full project) — clean.
- [x] `npx vitest run` (full suite) — 959/959 tests passed (37 test *files* fail to even load in this sandbox due to the same pre-existing missing private-package issue, unrelated to this change and present identically on `main`).
- [x] Validated `package-lock.json` is still valid JSON after the edit.