### PR TITLE
fix: don't let a stray legacy JWT clobber an explicit Authorization header

### DIFF
--- a/frontend/src/services/__tests__/api.test.ts
+++ b/frontend/src/services/__tests__/api.test.ts
@@ -121,6 +121,21 @@ describe('ApiClient', () => {
       const result = capturedReqFulfilled(config)
       expect(result.headers.Authorization).toBeUndefined()
     })
+
+    it('does not overwrite an explicit Authorization header set by the caller', async () => {
+      // A stray legacy JWT in localStorage (e.g. left over from a prior session in a
+      // shared browser profile) must not clobber a caller-supplied auth scheme, such
+      // as the Setup Wizard's bootstrap "SetupToken <token>" calls.
+      localStorage.setItem('auth_token', 'my-jwt-token')
+      await getApiClient()
+
+      const config = {
+        headers: { Authorization: 'SetupToken setup-abc123' } as Record<string, string>,
+      } as InternalAxiosRequestConfig
+
+      const result = capturedReqFulfilled(config)
+      expect(result.headers.Authorization).toBe('SetupToken setup-abc123')
+    })
   })
 
   // ─── 401 Interceptor ──────────────────────────────────────────────────

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -53,8 +53,11 @@ class ApiClient {
         // For backward compatibility: if an auth token is in localStorage (migration
         // period), include it as a Bearer header. Once all sessions have migrated to
         // HttpOnly cookies this block can be removed.
+        // Skip when the caller already set an explicit Authorization header (e.g. the
+        // Setup Wizard's "SetupToken <token>" bootstrap calls) -- a stray legacy JWT in
+        // localStorage must never silently override a caller's own auth scheme.
         const legacyToken = localStorage.getItem('auth_token')
-        if (legacyToken) {
+        if (legacyToken && !config.headers.Authorization) {
           config.headers.Authorization = `Bearer ${legacyToken}`
         }
 


### PR DESCRIPTION
## Summary
Fixes #486. The request interceptor in `api.ts` unconditionally set `config.headers.Authorization = \`Bearer \${legacyToken}\`` whenever a legacy JWT was present in `localStorage`, with no check for whether the caller had already set a different `Authorization` value on that specific request.

The Setup Wizard flow (`validateSetupToken`, `testOIDCConfig`, `saveOIDCConfig`, and all other `/api/v1/setup/*` calls) explicitly passes `Authorization: SetupToken <token>` via a per-call config object — but that header was silently overwritten to `Bearer <legacyToken>` if a legacy JWT happened to be sitting in `localStorage` on the same origin (e.g. left over from a prior session in the same browser profile, or a shared-device scenario). `SetupWizardPage.tsx`/`SetupWizardContext.tsx` don't clear `localStorage` before starting the wizard, so there was no mitigation in the calling code — setup-token-authenticated bootstrap calls could silently fail auth.

- One-line guard: skip the legacy-token assignment when `config.headers.Authorization` is already truthy.

## Test plan
- [x] Added `does not overwrite an explicit Authorization header set by the caller` to the existing `describe('request interceptor – auth token')` block — sets a legacy token in `localStorage` **and** a `SetupToken` Authorization header on the request config, asserts the SetupToken header survives.
- [x] `vitest run src/services/__tests__/api.test.ts` — 197/197 passed.
- [x] Also ran the two Setup Wizard test suites alongside it (`SetupWizardContext.test.tsx`, `SetupWizardPage.test.tsx`) since they're the real-world caller of this header — 225/225 passed across all three files.
- [x] `npx tsc --noEmit` — no new errors (pre-existing, unrelated `@sethbacon/terraform-suite-ui` module-resolution errors present identically on `main`).
- [x] `eslint` on both changed files — clean.
- [x] `prettier --check` flags both files, but verified via `git stash` that the same warnings exist on unmodified `main` — pre-existing drift, not introduced by this change, and not CI-gated (only `eslint` runs in CI, not `format:check`), so left untouched to keep the diff surgical.