### PR TITLE
fix: trigger 401 session-clear/redirect for cookie-only sessions too

### DIFF
--- a/frontend/src/services/__tests__/api.test.ts
+++ b/frontend/src/services/__tests__/api.test.ts
@@ -160,6 +160,26 @@ describe('ApiClient', () => {
       expect(localStorage.getItem('auth_token')).toBeNull()
     })
 
+    it('redirects to /login on 401 for a cookie-only session (no localStorage token)', async () => {
+      // The intended auth model: no auth_token/user ever written to localStorage,
+      // just the HttpOnly auth cookie + the readable tfr_csrf double-submit cookie.
+      document.cookie = 'tfr_csrf=some-csrf-token'
+      await getApiClient()
+
+      const error = {
+        response: { status: 401 },
+        config: { url: '/api/v1/modules/search' },
+        isAxiosError: true,
+      } as AxiosError
+
+      const authRejectedHandler = capturedResRejectedHandlers[0]
+      await expect(authRejectedHandler(error)).rejects.toBe(error)
+      expect(window.location.href).toContain('/login')
+
+      // Clean up so this cookie doesn't leak into later tests.
+      document.cookie = 'tfr_csrf=; Max-Age=0'
+    })
+
     it('does not clear auth for SCM OAuth 401 (repository endpoint)', async () => {
       localStorage.setItem('auth_token', 'valid-token')
       await getApiClient()

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -99,11 +99,17 @@ class ApiClient {
 
           if (!isSCMOAuthFailure) {
             // Only redirect when the user previously had an active session
-            // (token or cached user). Fresh anonymous visitors receive 401 on
-            // probing endpoints like /auth/me — this is expected and should
-            // NOT trigger a redirect so public pages remain accessible.
+            // (legacy token/cached user, or the cookie-only session model). Fresh
+            // anonymous visitors receive 401 on probing endpoints like /auth/me —
+            // this is expected and should NOT trigger a redirect so public pages
+            // remain accessible. The "tfr_csrf" cookie is set only when the backend
+            // issues or refreshes the auth cookie (see middleware/csrf.go) and cleared
+            // on logout, so its presence is a reliable cookie-session signal even
+            // though the HttpOnly auth cookie itself isn't readable from JS.
             const hadSession =
-              !!localStorage.getItem('auth_token') || !!localStorage.getItem('user')
+              !!localStorage.getItem('auth_token') ||
+              !!localStorage.getItem('user') ||
+              !!getCookie('tfr_csrf')
             clearAuthStorage()
             if (hadSession) {
               window.location.href = '/login'


### PR DESCRIPTION
## Summary
Fixes #479. For a user authenticated purely through the intended HttpOnly-cookie + CSRF model (no `auth_token`/`user` ever written to `localStorage`), `hadSession` was always `false`, so a 401 from an expired/revoked cookie session never triggered `clearAuthStorage()` or the redirect to `/login` from the response interceptor. Only users who went through the legacy dev-login/LDAP-login/impersonation paths (which do write to `localStorage`) got the automatic session-expiry recovery — the primary, forward-looking auth model had *weaker* built-in resilience than the deprecated one. A cookie-session user whose session lapses mid-use would just see individual requests start failing with no app-level recovery.

**I verified the fix's premise against the backend** (`terraform-registry-backend/backend/internal/middleware/csrf.go`) rather than assuming: `SetCSRFCookie` is called only from the four login handlers in `auth.go` (not on every anonymous request), and `ClearCSRFCookie` only on logout. That confirms the non-HttpOnly `tfr_csrf` double-submit cookie's presence is a reliable "this browser has (or recently had) a cookie session" signal — the same role `auth_token` plays for the legacy path — so checking it doesn't risk regressing the existing "don't redirect anonymous visitors probing `/auth/me`" behavior that this code deliberately preserves.

- Added `!!getCookie('tfr_csrf')` to the `hadSession` check (the interceptor already has a `getCookie()` helper, used elsewhere in the same file for the CSRF header logic).

## Test plan
- [x] Added `redirects to /login on 401 for a cookie-only session (no localStorage token)` — sets only the `tfr_csrf` cookie (no `localStorage`), asserts `window.location.href` becomes `/login`.
- [x] `vitest run src/services/__tests__/api.test.ts` — 197/197 passed, including all existing 401-handling cases (anonymous-probe no-redirect, SCM OAuth 401 exemptions ×3, legacy-token redirect) — none needed changes, confirming the new cookie check is additive only.
- [x] `npx tsc --noEmit` — no new errors (pre-existing, unrelated `@sethbacon/terraform-suite-ui` module-resolution errors present identically on `main`).
- [x] `eslint` on both changed files — clean.