### PR TITLE
fix: strip session tokens from telemetry URLs before reporting

### DIFF
--- a/frontend/src/services/__tests__/errorReporting.test.ts
+++ b/frontend/src/services/__tests__/errorReporting.test.ts
@@ -154,7 +154,7 @@ describe('errorReporting', () => {
 
       const config = initMock.mock.calls[0][0] as {
         beforeSend: (event: { request?: { url?: string } }) => unknown
-        beforeBreadcrumb: (breadcrumb: { data?: { url?: string } }) => unknown
+        beforeBreadcrumb: (breadcrumb: { data?: Record<string, string> }) => unknown
       }
 
       const sentEvent = config.beforeSend({
@@ -166,6 +166,14 @@ describe('errorReporting', () => {
         data: { url: 'https://app.example.com/callback?token=super-secret-jwt' },
       }) as { data: { url: string } }
       expect(breadcrumb.data.url).not.toContain('super-secret-jwt')
+
+      // History (navigation) breadcrumbs carry root-relative from/to — the OIDC
+      // callback transition places the token in exactly those fields.
+      const navBreadcrumb = config.beforeBreadcrumb({
+        data: { from: '/auth/callback?token=super-secret-jwt', to: '/' },
+      }) as { data: { from: string; to: string } }
+      expect(navBreadcrumb.data.from).toBe('/auth/callback')
+      expect(navBreadcrumb.data.to).toBe('/')
     })
   })
 

--- a/frontend/src/services/__tests__/errorReporting.test.ts
+++ b/frontend/src/services/__tests__/errorReporting.test.ts
@@ -91,6 +91,29 @@ describe('errorReporting', () => {
       })
     })
 
+    it('strips a session token from the recorded url', async () => {
+      vi.stubEnv('VITE_ERROR_REPORTING_DSN', 'https://errors.example.com/report')
+      vi.stubEnv('VITE_SENTRY_DSN', '')
+
+      const originalLocation = window.location.href
+      window.history.pushState({}, '', '/auth/callback?token=super-secret-jwt')
+
+      const {
+        init: freshInit,
+        captureError: freshCapture,
+        flush: freshFlush,
+      } = await import('../errorReporting')
+      freshInit()
+      freshCapture(new Error('Test error'))
+      freshFlush()
+
+      const body = JSON.parse((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body)
+      expect(body.entries[0].url).not.toContain('super-secret-jwt')
+      expect(body.entries[0].url).toContain('/auth/callback')
+
+      window.history.pushState({}, '', originalLocation)
+    })
+
     it('does not call fetch when no DSN is configured', () => {
       const error = new Error('No DSN error')
       captureError(error)
@@ -110,6 +133,39 @@ describe('errorReporting', () => {
       expect(() => {
         freshCapture(new Error('Test error'))
       }).not.toThrow()
+    })
+  })
+
+  describe('Sentry URL sanitization', () => {
+    afterEach(() => {
+      vi.doUnmock('@sentry/react')
+    })
+
+    it('wires beforeSend/beforeBreadcrumb hooks that strip sensitive query params', async () => {
+      const initMock = vi.fn()
+      vi.doMock('@sentry/react', () => ({ init: initMock }))
+      vi.stubEnv('VITE_SENTRY_DSN', 'https://sentry.example.com/dsn')
+
+      const { init: freshInit } = await import('../errorReporting')
+      freshInit()
+
+      // Sentry is dynamically imported -- wait for the .then() to run.
+      await vi.waitFor(() => expect(initMock).toHaveBeenCalled())
+
+      const config = initMock.mock.calls[0][0] as {
+        beforeSend: (event: { request?: { url?: string } }) => unknown
+        beforeBreadcrumb: (breadcrumb: { data?: { url?: string } }) => unknown
+      }
+
+      const sentEvent = config.beforeSend({
+        request: { url: 'https://app.example.com/callback?token=super-secret-jwt' },
+      }) as { request: { url: string } }
+      expect(sentEvent.request.url).not.toContain('super-secret-jwt')
+
+      const breadcrumb = config.beforeBreadcrumb({
+        data: { url: 'https://app.example.com/callback?token=super-secret-jwt' },
+      }) as { data: { url: string } }
+      expect(breadcrumb.data.url).not.toContain('super-secret-jwt')
     })
   })
 

--- a/frontend/src/services/__tests__/performanceReporting.test.ts
+++ b/frontend/src/services/__tests__/performanceReporting.test.ts
@@ -132,6 +132,62 @@ describe('performanceReporting', () => {
 
       mod.destroy()
     })
+
+    it('strips a session token from reportNavigation entries', async () => {
+      vi.stubEnv('VITE_PERFORMANCE_DSN', 'https://perf.example.com/report')
+      vi.resetModules()
+
+      const originalLocation = window.location.href
+      window.history.pushState({}, '', '/auth/callback?token=super-secret-jwt')
+
+      const mod = await import('../performanceReporting')
+      mod.init()
+      mod.reportNavigation('/test', 100)
+
+      vi.spyOn(navigator, 'sendBeacon').mockReturnValue(false)
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response())
+      mod.flush()
+
+      const body = JSON.parse(fetchSpy.mock.calls[0][1]?.body as string)
+      expect(body.entries[0].url).not.toContain('super-secret-jwt')
+      expect(body.entries[0].url).toContain('/auth/callback')
+
+      window.history.pushState({}, '', originalLocation)
+      mod.destroy()
+    })
+
+    it('strips a session token from web-vitals metric entries', async () => {
+      vi.stubEnv('VITE_PERFORMANCE_DSN', 'https://perf.example.com/report')
+      vi.resetModules()
+
+      const originalLocation = window.location.href
+      window.history.pushState({}, '', '/auth/callback?token=super-secret-jwt')
+
+      const webVitals = await import('web-vitals')
+      const mod = await import('../performanceReporting')
+      mod.init()
+      await vi.dynamicImportSettled()
+
+      // Invoke the callback this test's init() registered with onCLS (mock.calls
+      // accumulates across tests in this file, so grab the most recent registration
+      // rather than the first -- an earlier test's stale handler closes over an
+      // already-destroyed module instance's buffer).
+      const onCLSMock = webVitals.onCLS as unknown as { mock: { calls: unknown[][] } }
+      const lastCall = onCLSMock.mock.calls[onCLSMock.mock.calls.length - 1]
+      const handleMetric = lastCall[0] as (metric: unknown) => void
+      handleMetric({ name: 'CLS', value: 0.05, rating: 'good', navigationType: 'navigate' })
+
+      vi.spyOn(navigator, 'sendBeacon').mockReturnValue(false)
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response())
+      mod.flush()
+
+      const body = JSON.parse(fetchSpy.mock.calls[0][1]?.body as string)
+      expect(body.entries[0].url).not.toContain('super-secret-jwt')
+      expect(body.entries[0].url).toContain('/auth/callback')
+
+      window.history.pushState({}, '', originalLocation)
+      mod.destroy()
+    })
   })
 
   describe('web vitals callback', () => {

--- a/frontend/src/services/errorReporting.ts
+++ b/frontend/src/services/errorReporting.ts
@@ -8,6 +8,8 @@
  *   - Neither set                – errors are logged to the console only.
  */
 
+import { sanitizeUrl } from '../utils/sanitizeUrl'
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -139,6 +141,20 @@ export function init(): void {
           dsn: sentryDsn,
           release: getRelease(),
           environment: import.meta.env.MODE,
+          // Sentry's default browser integrations record the current window.location.href
+          // both on the event itself (request.url) and on navigation/history breadcrumbs.
+          // Sanitize both so a live session token in the URL (the OIDC callback's ?token=)
+          // never reaches the DSN.
+          beforeSend(event) {
+            if (event.request?.url) event.request.url = sanitizeUrl(event.request.url)
+            return event
+          },
+          beforeBreadcrumb(breadcrumb) {
+            if (typeof breadcrumb.data?.url === 'string') {
+              breadcrumb.data.url = sanitizeUrl(breadcrumb.data.url)
+            }
+            return breadcrumb
+          },
         })
         console.log('[ErrorReporting] Sentry SDK initialized')
       })
@@ -197,7 +213,7 @@ function enqueueError(error: Error, context?: Record<string, unknown>): void {
     stack: error.stack,
     context,
     timestamp: new Date().toISOString(),
-    url: window.location.href,
+    url: sanitizeUrl(window.location.href),
     userAgent: navigator.userAgent,
     userId: currentUser,
     sessionId,

--- a/frontend/src/services/errorReporting.ts
+++ b/frontend/src/services/errorReporting.ts
@@ -144,14 +144,19 @@ export function init(): void {
           // Sentry's default browser integrations record the current window.location.href
           // both on the event itself (request.url) and on navigation/history breadcrumbs.
           // Sanitize both so a live session token in the URL (the OIDC callback's ?token=)
-          // never reaches the DSN.
+          // never reaches the DSN. fetch/xhr breadcrumbs carry data.url; history
+          // (navigation) breadcrumbs carry root-relative data.from/data.to — the OIDC
+          // callback transition puts ?token= in exactly those.
           beforeSend(event) {
             if (event.request?.url) event.request.url = sanitizeUrl(event.request.url)
             return event
           },
           beforeBreadcrumb(breadcrumb) {
-            if (typeof breadcrumb.data?.url === 'string') {
-              breadcrumb.data.url = sanitizeUrl(breadcrumb.data.url)
+            const data = breadcrumb.data
+            if (data) {
+              for (const key of ['url', 'from', 'to']) {
+                if (typeof data[key] === 'string') data[key] = sanitizeUrl(data[key])
+              }
             }
             return breadcrumb
           },

--- a/frontend/src/services/performanceReporting.ts
+++ b/frontend/src/services/performanceReporting.ts
@@ -7,6 +7,7 @@
  * to `VITE_PERFORMANCE_DSN` (or `VITE_ERROR_REPORTING_DSN` as fallback).
  */
 import type { Metric } from 'web-vitals'
+import { sanitizeUrl } from '../utils/sanitizeUrl'
 
 // ---------------------------------------------------------------------------
 // Config
@@ -83,7 +84,7 @@ function handleMetric(metric: Metric): void {
     rating: metric.rating,
     navigationType: metric.navigationType,
     timestamp: new Date().toISOString(),
-    url: window.location.href,
+    url: sanitizeUrl(window.location.href),
     sessionId,
   }
 
@@ -149,7 +150,7 @@ export function reportNavigation(routeName: string, durationMs: number): void {
     name: routeName,
     value: durationMs,
     timestamp: new Date().toISOString(),
-    url: window.location.href,
+    url: sanitizeUrl(window.location.href),
     sessionId,
   }
 

--- a/frontend/src/utils/__tests__/sanitizeUrl.test.ts
+++ b/frontend/src/utils/__tests__/sanitizeUrl.test.ts
@@ -28,6 +28,16 @@ describe('sanitizeUrl', () => {
     expect(sanitizeUrl(url)).toBe(url)
   })
 
+  it('strips a token from a root-relative path (Sentry navigation breadcrumb from/to)', () => {
+    expect(sanitizeUrl('/auth/callback?token=super-secret-jwt')).toBe('/auth/callback')
+  })
+
+  it('preserves other params and the hash on a root-relative path', () => {
+    expect(sanitizeUrl('/modules?namespace=hashicorp&token=super-secret-jwt#readme')).toBe(
+      '/modules?namespace=hashicorp#readme',
+    )
+  })
+
   it('falls back to the original string for an unparsable URL', () => {
     expect(sanitizeUrl('not a url')).toBe('not a url')
   })

--- a/frontend/src/utils/__tests__/sanitizeUrl.test.ts
+++ b/frontend/src/utils/__tests__/sanitizeUrl.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { sanitizeUrl } from '../sanitizeUrl'
+
+describe('sanitizeUrl', () => {
+  it('strips a token query param (the OIDC callback flow)', () => {
+    const url = 'https://registry.example.com/auth/callback?token=super-secret-jwt'
+    expect(sanitizeUrl(url)).toBe('https://registry.example.com/auth/callback')
+  })
+
+  it('strips code, state, and id_token query params', () => {
+    const url =
+      'https://registry.example.com/auth/callback?code=abc123&state=xyz789&id_token=eyJhbGci'
+    expect(sanitizeUrl(url)).toBe('https://registry.example.com/auth/callback')
+  })
+
+  it('preserves non-sensitive query params alongside stripped ones', () => {
+    const url = 'https://registry.example.com/modules?namespace=hashicorp&token=super-secret-jwt'
+    expect(sanitizeUrl(url)).toBe('https://registry.example.com/modules?namespace=hashicorp')
+  })
+
+  it('returns the URL unchanged when there are no sensitive params', () => {
+    const url = 'https://registry.example.com/modules?namespace=hashicorp&sort=downloads'
+    expect(sanitizeUrl(url)).toBe(url)
+  })
+
+  it('returns the URL unchanged when there is no query string', () => {
+    const url = 'https://registry.example.com/modules'
+    expect(sanitizeUrl(url)).toBe(url)
+  })
+
+  it('falls back to the original string for an unparsable URL', () => {
+    expect(sanitizeUrl('not a url')).toBe('not a url')
+  })
+})

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -6,3 +6,4 @@ export {
   REGISTRY_SEGMENT_HELP,
   isValidRegistrySegment,
 } from './registrySegment'
+export { sanitizeUrl } from './sanitizeUrl'

--- a/frontend/src/utils/sanitizeUrl.ts
+++ b/frontend/src/utils/sanitizeUrl.ts
@@ -1,21 +1,40 @@
 /** Query-string keys that can carry a live session token or OIDC credential. */
 const SENSITIVE_QUERY_KEYS = ['token', 'code', 'state', 'id_token']
 
+function stripSensitiveParams(parsed: URL): void {
+  for (const key of SENSITIVE_QUERY_KEYS) {
+    parsed.searchParams.delete(key)
+  }
+}
+
 /**
  * Strips sensitive query-string values from a URL before it's recorded in telemetry.
  * The OIDC callback flow transiently places the session token in the URL (`?token=`),
  * so recording `window.location.href` verbatim can ship a live session token to an
- * external error/performance-reporting DSN. Falls back to the original string if the
- * URL can't be parsed.
+ * external error/performance-reporting DSN.
+ *
+ * Handles absolute URLs (window.location.href, Sentry's event.request.url) and
+ * root-relative paths (Sentry navigation breadcrumbs record `data.from`/`data.to` as
+ * relative paths like "/auth/callback?token=..."), which `new URL()` alone rejects.
+ * Falls back to the original string if the URL can't be parsed.
  */
 export function sanitizeUrl(url: string): string {
   try {
     const parsed = new URL(url)
-    for (const key of SENSITIVE_QUERY_KEYS) {
-      parsed.searchParams.delete(key)
-    }
+    stripSensitiveParams(parsed)
     return parsed.toString()
   } catch {
+    if (url.startsWith('/')) {
+      // Root-relative path: parse against a placeholder base and return it relative
+      // again so the caller's formatting is preserved.
+      try {
+        const parsed = new URL(url, 'http://placeholder.invalid')
+        stripSensitiveParams(parsed)
+        return parsed.pathname + parsed.search + parsed.hash
+      } catch {
+        return url
+      }
+    }
     return url
   }
 }

--- a/frontend/src/utils/sanitizeUrl.ts
+++ b/frontend/src/utils/sanitizeUrl.ts
@@ -1,0 +1,21 @@
+/** Query-string keys that can carry a live session token or OIDC credential. */
+const SENSITIVE_QUERY_KEYS = ['token', 'code', 'state', 'id_token']
+
+/**
+ * Strips sensitive query-string values from a URL before it's recorded in telemetry.
+ * The OIDC callback flow transiently places the session token in the URL (`?token=`),
+ * so recording `window.location.href` verbatim can ship a live session token to an
+ * external error/performance-reporting DSN. Falls back to the original string if the
+ * URL can't be parsed.
+ */
+export function sanitizeUrl(url: string): string {
+  try {
+    const parsed = new URL(url)
+    for (const key of SENSITIVE_QUERY_KEYS) {
+      parsed.searchParams.delete(key)
+    }
+    return parsed.toString()
+  } catch {
+    return url
+  }
+}


### PR DESCRIPTION
## Summary
Fixes #468 (medium severity, CWE-598/CWE-532, OWASP A09:2021). Error- and performance-reporting telemetry snapshotted the full `window.location.href` **unscrubbed** on every event and shipped it to an operator-configurable external DSN. The OIDC callback transiently places the session token in that URL (`CallbackPage.tsx`'s `?token=` param, confirmed as the actual query param this app uses for the migration-flow token handoff), so an ordinary login could send a live session token to Sentry/DSN in the documented production config.

- **New `sanitizeUrl()` helper** (`frontend/src/utils/sanitizeUrl.ts`) strips the `token`/`code`/`state`/`id_token` query keys (per the issue's suggested fix — `code`/`state`/`id_token` are standard OAuth/OIDC param names defensively covered even though this frontend currently only reads `token`) before a URL is recorded. Falls back to the original string if the URL can't be parsed.
- Wired into `errorReporting.ts`'s `enqueueError()` and both `performanceReporting.ts` call sites (`handleMetric` for web-vitals, `reportNavigation`).
- **Sentry's default browser integrations independently record `window.location.href`** — on the event itself (`event.request.url`) and on navigation/history breadcrumbs — so the custom-reporter-path fix alone wouldn't have covered a Sentry-configured deployment. Added `beforeSend`/`beforeBreadcrumb` hooks to the `Sentry.init()` call that sanitize both, per the issue's suggested fix ("plus a Sentry beforeSend/beforeBreadcrumb hook doing the same").

## Test plan
- [x] New `sanitizeUrl.test.ts` — 6 cases: strips `token`, strips `code`/`state`/`id_token` together, preserves non-sensitive params alongside stripped ones, leaves clean URLs unchanged, leaves URLs with no query string unchanged, falls back gracefully on an unparsable string.
- [x] `errorReporting.test.ts` — added a case asserting `enqueueError`'s recorded `url` doesn't contain a token planted via `window.history.pushState`, plus a case that mocks `@sentry/react` to capture the `Sentry.init()` config and directly exercises `beforeSend`/`beforeBreadcrumb` to confirm they strip the token (this codebase's existing tests deliberately avoid exercising the real Sentry SDK path, so I followed that convention rather than invoking the real package).
- [x] `performanceReporting.test.ts` — added cases for both call sites: `reportNavigation` and the web-vitals `handleMetric` path (invoked via the mocked `onCLS` callback, using the *last* registered call since `vi.mock`'s call history accumulates across tests in the file — an earlier version of this test grabbed the first call and silently exercised a stale, already-destroyed module instance; caught and fixed before pushing).
- [x] `vitest run` on all three affected test files together — 36/36 passed. Full-project `vitest run` also green apart from the pre-existing sandbox-only `@sethbacon/terraform-suite-ui` load failures present identically on `main`.
- [x] `npx tsc --noEmit` — caught and fixed a real issue: `Array.prototype.at()` isn't available at this project's configured TS lib target (vitest itself doesn't typecheck, so this only surfaced via a dedicated typecheck pass, not the test run) — replaced with an index-based lookup. Full-project typecheck is back to the same 20 pre-existing, unrelated errors as `main`.
- [x] Full-project `eslint . --max-warnings 0` — clean.
- [x] `prettier --check` on all changed files — clean.