### PR TITLE
fix: make the 401 CSRF session signal one-shot and the auth guard case-insensitive

### DIFF
--- a/frontend/src/services/__tests__/api.test.ts
+++ b/frontend/src/services/__tests__/api.test.ts
@@ -136,6 +136,24 @@ describe('ApiClient', () => {
       const result = capturedReqFulfilled(config)
       expect(result.headers.Authorization).toBe('SetupToken setup-abc123')
     })
+
+    it('does not overwrite an explicit Authorization header regardless of key casing', async () => {
+      // AxiosHeaders preserves the caller's key casing for property access, so a
+      // lowercase "authorization" would bypass a plain property check -- the guard
+      // must use the case-insensitive .has() to catch it.
+      localStorage.setItem('auth_token', 'my-jwt-token')
+      await getApiClient()
+
+      const { AxiosHeaders } = await vi.importActual<typeof import('axios')>('axios')
+      const config = {
+        headers: AxiosHeaders.concat({}, { authorization: 'SetupToken setup-abc123' }),
+      } as InternalAxiosRequestConfig
+
+      const result = capturedReqFulfilled(config)
+      expect(result.headers.get('Authorization')).toBe('SetupToken setup-abc123')
+      // The broken path would have added a second, canonically-cased key.
+      expect(result.headers.Authorization).toBeUndefined()
+    })
   })
 
   // ─── 401 Interceptor ──────────────────────────────────────────────────
@@ -193,6 +211,33 @@ describe('ApiClient', () => {
 
       // Clean up so this cookie doesn't leak into later tests.
       document.cookie = 'tfr_csrf=; Max-Age=0'
+    })
+
+    it('expires the tfr_csrf cookie on 401 so the redirect is one-shot (no reload loop)', async () => {
+      // /login renders inside AuthProvider, which probes /auth/me on mount. If the
+      // cookie survived the first 401, the probe's own 401 would re-trigger the
+      // redirect and reload /login forever. The cookie signal must be consumed,
+      // exactly like clearAuthStorage() consumes the localStorage signals.
+      // path=/ matches how the backend really sets it (SetCSRFCookie, Path: "/").
+      document.cookie = 'tfr_csrf=some-csrf-token; path=/'
+      await getApiClient()
+
+      const error = {
+        response: { status: 401 },
+        config: { url: '/api/v1/auth/me' },
+        isAxiosError: true,
+      } as AxiosError
+
+      const authRejectedHandler = capturedResRejectedHandlers[0]
+      await expect(authRejectedHandler(error)).rejects.toBe(error)
+      // Real browsers remove the cookie on Max-Age=0; happy-dom keeps the name with
+      // an emptied value. Either way the token is gone, which is what getCookie sees.
+      expect(document.cookie).not.toContain('some-csrf-token')
+
+      // A second 401 (the /auth/me probe on the login page itself) must not redirect.
+      window.history.pushState({}, '', '/somewhere-else')
+      await expect(authRejectedHandler(error)).rejects.toBe(error)
+      expect(window.location.href).toContain('/somewhere-else')
     })
 
     it('does not clear auth for SCM OAuth 401 (repository endpoint)', async () => {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -56,8 +56,15 @@ class ApiClient {
         // Skip when the caller already set an explicit Authorization header (e.g. the
         // Setup Wizard's "SetupToken <token>" bootstrap calls) -- a stray legacy JWT in
         // localStorage must never silently override a caller's own auth scheme.
+        // AxiosHeaders preserves the caller's key casing for property access, so use
+        // the case-insensitive .has() when available (a lowercase "authorization"
+        // would otherwise slip past a plain property check).
         const legacyToken = localStorage.getItem('auth_token')
-        if (legacyToken && !config.headers.Authorization) {
+        const hasExplicitAuth =
+          typeof config.headers.has === 'function'
+            ? config.headers.has('Authorization')
+            : !!config.headers.Authorization
+        if (legacyToken && !hasExplicitAuth) {
           config.headers.Authorization = `Bearer ${legacyToken}`
         }
 
@@ -114,6 +121,14 @@ class ApiClient {
               !!localStorage.getItem('user') ||
               !!getCookie('tfr_csrf')
             clearAuthStorage()
+            // Expire the CSRF cookie so the session signal is ONE-SHOT, exactly like
+            // the localStorage keys clearAuthStorage() just removed. Without this, a
+            // session invalidated server-side (revocation, secret rotation, clock
+            // skew) redirects in a loop: /login mounts AuthProvider, which probes
+            // /auth/me, 401s, and re-triggers this handler with the cookie still set.
+            // Safe to clear from JS -- the cookie is non-HttpOnly by design and a dead
+            // session's CSRF token has no value.
+            document.cookie = 'tfr_csrf=; Max-Age=0; path=/'
             if (hadSession) {
               window.location.href = '/login'
             }


### PR DESCRIPTION
## Summary
Two follow-ups from the post-merge review of PRs #502/#503, both in the api-client interceptors.

**Fixes #505 — 401 redirect loop for cookie-only sessions.** The cookie-session redirect added in #503 used `getCookie('tfr_csrf')` as its session signal, but unlike the localStorage signals — consumed by `clearAuthStorage()` on the first 401 — nothing ever cleared the cookie client-side (the backend clears it only on explicit logout). Since `/login` renders inside `AuthProvider`, whose suite provider probes `/auth/me` on mount, a session invalidated server-side (revocation, JWT-secret rotation, backend redeploy, or client/server clock skew — the JWT's 24h `exp` is checked against the server clock while the cookie's 24h `Max-Age` is enforced by the browser clock) would redirect → reload `/login` → probe → 401 → redirect again, looping until the cookie expired (up to 24h). The fix expires `tfr_csrf` in the 401 handler right where `clearAuthStorage()` runs, making the signal one-shot exactly like the legacy path. Safe from JS: the cookie is non-HttpOnly by design and a dead session's CSRF token has no value.

**Fixes #506 — Authorization guard bypassed by header casing.** The #502 guard checked `!config.headers.Authorization`, but `AxiosHeaders` preserves the caller's key casing for property access while `.has()` is case-insensitive (verified empirically against the installed axios). A future caller passing lowercase `authorization:` would slip past the guard and get clobbered by the legacy Bearer token — the exact bug #486 fixed. The guard now uses `config.headers.has('Authorization')` when available, with the plain property check as fallback for non-`AxiosHeaders` configs.

## Test plan
- [x] New test: `expires the tfr_csrf cookie on 401 so the redirect is one-shot (no reload loop)` — plants the cookie with `path=/` (matching the backend's real `SetCSRFCookie`), fires a 401, asserts the token value is gone, then **fires a second 401 and asserts it no longer redirects** (the actual loop-breaking guarantee). Note: this happy-dom version handles `Max-Age=0` by emptying the cookie's value rather than removing it (real browsers remove it) — either way `getCookie` sees `''`, so the assertion checks the value, and the behavioral second-401 assertion doesn't depend on jsdom-vs-browser semantics at all.
- [x] New test: `does not overwrite an explicit Authorization header regardless of key casing` — uses the **real** `AxiosHeaders` (`vi.importActual`, since the module-level axios mock doesn't export it) with a lowercase `authorization:` key; asserts the SetupToken value survives and no canonically-cased `Bearer` key was added (asserting via `.get()` alone would false-pass, since it resolves case-insensitively to the first match).
- [x] `vitest run src/services/__tests__/api.test.ts` — 200/200 passed.
- [x] `SetupWizardContext.test.tsx` (the real caller of explicit Authorization headers) — 11/11 passed.
- [x] `npx tsc --noEmit` — same 20 pre-existing, unrelated errors as `main`; `eslint` clean on both files.
- [x] `prettier` flags both files, but I diffed each against its properly-configured prettier output (`--stdin-filepath`): every difference is in pre-existing code (the `;(config...)` semicolon style and `onUploadProgress` indentation) — none touch this PR's hunks, and prettier isn't CI-gated.