### PR TITLE
fix: update stale E2E logout locator to match the shared AppBar's actual text

### DIFF
--- a/e2e/tests/auth.spec.ts
+++ b/e2e/tests/auth.spec.ts
@@ -71,8 +71,11 @@ test.describe('Logout', () => {
     // Open account menu (top-right AppBar button, aria-label "Account")
     await page.getByRole('button', { name: 'Account' }).click();
 
-    // Click Logout menu item
-    await page.getByRole('menuitem', { name: 'Logout' }).click();
+    // Click the logout menu item. Labelled "Sign out" since #438 moved this menu into
+    // the shared @sethbacon/terraform-suite-ui AppBar, whose SuiteLayout renders
+    // t('auth.signOut', { defaultValue: 'Sign out' }) -- a key this app doesn't
+    // override, so the literal default is what's actually on screen.
+    await page.getByRole('menuitem', { name: 'Sign out' }).click();
 
     // Logout redirects to the backend /auth/logout endpoint which terminates any
     // OIDC SSO session and then redirects back to the frontend home page ('/').


### PR DESCRIPTION
## Summary
E2E's `tests/auth.spec.ts` › `Logout › logout returns user to home page` has failed on **every single CI run since PR #438** (2026-06-28, "UX alignment + consume @sethbacon/terraform-suite-ui") — confirmed by pulling CI logs from that era through today, all showing the identical `Test timeout of 60000ms exceeded ... waiting for getByRole('menuitem', { name: 'Logout' })`. Because the job runs with `--max-failures=1`, every run stops at this one failure and never gets to exercise the rest of the suite past it.

**Root cause**, confirmed directly from the suite-ui package's actual source (fetched via `gh api repos/sethbacon/terraform-suite-ui/...`, since the private npm package can't be installed in a plain sandbox): `SuiteLayout.tsx` renders the logout menu item as `{t('auth.signOut', { defaultValue: 'Sign out' })}`. This app's `translation.json` doesn't define an `auth.signOut` key, so the literal default **"Sign out"** is what's actually on screen — the E2E test's `{ name: 'Logout' }` locator was simply never updated after #438's copy change moved this menu into the shared AppBar.

I checked whether any other E2E assertion references suite-owned UI copy (grepped all spec files for account/settings/support/about/language/theme/consent/help-related locators) — nothing else matches, so this is an isolated, one-line staleness, not a symptom of a broader regression.

**Side note, not addressed here**: this app's own `header.logout: "Sign out"` translation key is now dead/unused since #438 (the real key consumed is `auth.signOut`, which happens to default to the same English text). Minor, pre-existing, out of scope for this fix.

## Test plan
- [x] `npx playwright test --list tests/auth.spec.ts` — file parses cleanly, same 6 tests, only the internal locator changed.
- [x] Verified via GitHub API against the suite-ui repo's actual `SuiteLayout.tsx` source that `t('auth.signOut', { defaultValue: 'Sign out' })` is the real rendered text, rather than guessing from the app's own (unused) translation key.
- [x] Confirmed via historical CI logs (runs going back to `c65f043`, 2026-07-01, and the #438 merge itself) that this is the sole, consistent, long-standing failure — not a new or flaky one.
- [x] The `E2E (gated/manual)` job only runs on `push` to `main` or manual `workflow_dispatch` (not on `pull_request` events — it shows as "skipping" on this PR's own checks, same as every other PR in this batch). To actually verify against a live browser + real backend before merge, I manually dispatched `ci.yml` on this branch (`gh workflow run ci.yml --ref fix/e2e-logout-menu-item-text`) — see run: https://github.com/sethbacon/terraform-registry-frontend/actions/runs/29094699880