### PR TITLE
fix: pin the frontend builder stage's base image to a digest

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,7 +1,7 @@
 # Multi-stage Dockerfile for Terraform Registry Frontend
 
 # Stage 1: Build the React application
-FROM node:24-alpine AS builder
+FROM node:24-alpine@sha256:a0b9bf06e4e6193cf7a0f58816cc935ff8c2a908f81e6f1a95432d679c54fbfd AS builder
 
 # VITE_MODE controls the Vite build mode.
 # Use "development" to enable the Dev Login button for E2E/staging environments.


### PR DESCRIPTION
## Summary
Fixes #481. The final nginx runtime image (`frontend/Dockerfile:37`) is correctly pinned by digest, giving reproducible, tamper-evident base-image resolution. The builder stage that actually compiles the SPA and resolves all npm dependencies (including the private auth-adjacent `@sethbacon/*` package) was pinned only to the floating tag `node:24-alpine`, which Docker Hub can silently repoint to a different image (new patch build, or worst case a compromised push) between builds with no diff in the Dockerfile.

- Pinned to `node:24-alpine@sha256:a0b9bf06e4e6193cf7a0f58816cc935ff8c2a908f81e6f1a95432d679c54fbfd`.
- Resolved via `docker manifest inspect` / `docker pull` (public image, no registry auth needed) and confirmed it's the same digest type as the existing nginx pin — both are `application/vnd.oci.image.index.v1+json` multi-arch index digests, so the pin still resolves to the correct platform at build time on any architecture.
- No further config changes needed: `.github/dependabot.yml` already has a `docker` ecosystem entry for `directory: /frontend` (biweekly), which will keep this digest current automatically, exactly as it already does for the nginx stage's pin.

## Test plan
- [x] `docker pull node:24-alpine@sha256:a0b9bf...` — resolves and pulls successfully.
- [x] `docker manifest inspect` on both the new pin and the existing nginx pin confirms matching `mediaType` (multi-arch index), so this follows the same convention already established in this Dockerfile rather than introducing a different pinning style.
- [x] Confirmed Dependabot's existing `docker` ecosystem config already covers `frontend/Dockerfile` — no new Dependabot config required.