### PR TITLE
fix: add a request timeout and offline detection to the API layer

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import { AnnouncerProvider } from './contexts/AnnouncerContext'
 import { ConsentProvider } from './contexts/ConsentContext'
 import Layout from './components/Layout'
 import ConsentBanner from './components/ConsentBanner'
+import OfflineBanner from './components/OfflineBanner'
 import ErrorBoundary from './components/ErrorBoundary'
 import ProtectedRoute from './components/ProtectedRoute'
 import RouteFocusManager from './components/RouteFocusManager'
@@ -417,6 +418,7 @@ function App() {
         </AuthProvider>
         <ConsentBanner />
       </ConsentProvider>
+      <OfflineBanner />
     </ThemeProvider>
   )
 }

--- a/frontend/src/components/OfflineBanner.tsx
+++ b/frontend/src/components/OfflineBanner.tsx
@@ -1,0 +1,23 @@
+import { Snackbar, Alert } from '@mui/material'
+import { useTranslation } from 'react-i18next'
+import { useOnlineStatus } from '../hooks/useOnlineStatus'
+
+/** Persistent top-of-viewport warning shown while the browser reports it is offline. */
+const OfflineBanner: React.FC = () => {
+  const { t } = useTranslation()
+  const isOnline = useOnlineStatus()
+
+  return (
+    <Snackbar
+      open={!isOnline}
+      anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+      sx={{ top: { xs: 8, sm: 16 } }}
+    >
+      <Alert severity="warning" variant="filled" role="status">
+        {t('common.offlineWarning')}
+      </Alert>
+    </Snackbar>
+  )
+}
+
+export default OfflineBanner

--- a/frontend/src/components/__tests__/OfflineBanner.test.tsx
+++ b/frontend/src/components/__tests__/OfflineBanner.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, act, waitFor } from '@testing-library/react'
+import OfflineBanner from '../OfflineBanner'
+
+function setNavigatorOnline(value: boolean) {
+  Object.defineProperty(window.navigator, 'onLine', {
+    configurable: true,
+    value,
+  })
+}
+
+describe('OfflineBanner', () => {
+  afterEach(() => {
+    setNavigatorOnline(true)
+  })
+
+  it('renders nothing while online', () => {
+    setNavigatorOnline(true)
+    render(<OfflineBanner />)
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+  })
+
+  it('shows the offline warning when offline', () => {
+    setNavigatorOnline(false)
+    render(<OfflineBanner />)
+    expect(
+      screen.getByText(
+        "You're offline. Some features may not work until your connection is restored.",
+      ),
+    ).toBeInTheDocument()
+  })
+
+  it('appears on the offline event and disappears on the online event', async () => {
+    setNavigatorOnline(true)
+    render(<OfflineBanner />)
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+
+    act(() => {
+      window.dispatchEvent(new Event('offline'))
+    })
+    expect(screen.getByRole('status')).toBeInTheDocument()
+
+    act(() => {
+      window.dispatchEvent(new Event('online'))
+    })
+    // MUI's Snackbar exit transition keeps the node mounted (fading out) for a
+    // moment after closing, so wait for it to actually leave the DOM.
+    await waitFor(() => expect(screen.queryByRole('status')).not.toBeInTheDocument())
+  })
+})

--- a/frontend/src/hooks/__tests__/useOnlineStatus.test.ts
+++ b/frontend/src/hooks/__tests__/useOnlineStatus.test.ts
@@ -1,0 +1,69 @@
+import { renderHook, act } from '@testing-library/react'
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { useOnlineStatus } from '../useOnlineStatus'
+
+function setNavigatorOnline(value: boolean) {
+  Object.defineProperty(window.navigator, 'onLine', {
+    configurable: true,
+    value,
+  })
+}
+
+describe('useOnlineStatus', () => {
+  afterEach(() => {
+    setNavigatorOnline(true)
+  })
+
+  it('seeds from navigator.onLine (online)', () => {
+    setNavigatorOnline(true)
+    const { result } = renderHook(() => useOnlineStatus())
+    expect(result.current).toBe(true)
+  })
+
+  it('seeds from navigator.onLine (offline)', () => {
+    setNavigatorOnline(false)
+    const { result } = renderHook(() => useOnlineStatus())
+    expect(result.current).toBe(false)
+  })
+
+  it('flips to false on the offline event', () => {
+    setNavigatorOnline(true)
+    const { result } = renderHook(() => useOnlineStatus())
+    expect(result.current).toBe(true)
+
+    act(() => {
+      window.dispatchEvent(new Event('offline'))
+    })
+    expect(result.current).toBe(false)
+  })
+
+  it('flips back to true on the online event', () => {
+    setNavigatorOnline(false)
+    const { result } = renderHook(() => useOnlineStatus())
+    expect(result.current).toBe(false)
+
+    act(() => {
+      window.dispatchEvent(new Event('online'))
+    })
+    expect(result.current).toBe(true)
+  })
+
+  it('removes its event listeners on unmount', () => {
+    const addSpy = vi.spyOn(window, 'addEventListener')
+    const removeSpy = vi.spyOn(window, 'removeEventListener')
+    const { unmount } = renderHook(() => useOnlineStatus())
+
+    const addedTypes = addSpy.mock.calls.map((c) => c[0])
+    expect(addedTypes).toContain('online')
+    expect(addedTypes).toContain('offline')
+
+    unmount()
+
+    const removedTypes = removeSpy.mock.calls.map((c) => c[0])
+    expect(removedTypes).toContain('online')
+    expect(removedTypes).toContain('offline')
+
+    addSpy.mockRestore()
+    removeSpy.mockRestore()
+  })
+})

--- a/frontend/src/hooks/useOnlineStatus.ts
+++ b/frontend/src/hooks/useOnlineStatus.ts
@@ -1,0 +1,19 @@
+import { useState, useEffect } from 'react'
+
+/** Tracks browser connectivity via the online/offline events, seeded from navigator.onLine. */
+export function useOnlineStatus(): boolean {
+  const [isOnline, setIsOnline] = useState(() => navigator.onLine)
+
+  useEffect(() => {
+    const handleOnline = () => setIsOnline(true)
+    const handleOffline = () => setIsOnline(false)
+    window.addEventListener('online', handleOnline)
+    window.addEventListener('offline', handleOffline)
+    return () => {
+      window.removeEventListener('online', handleOnline)
+      window.removeEventListener('offline', handleOffline)
+    }
+  }, [])
+
+  return isOnline
+}

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -179,7 +179,9 @@
     "error": "Error",
     "success": "Success",
     "warning": "Warning",
-    "networkError": "Unable to reach the server — check your connection and try again."
+    "networkError": "Unable to reach the server — check your connection and try again.",
+    "timeoutError": "The request took too long and timed out. Please try again.",
+    "offlineWarning": "You're offline. Some features may not work until your connection is restored."
   },
   "modules": {
     "pageTitle": "Terraform Modules",

--- a/frontend/src/services/__tests__/api.test.ts
+++ b/frontend/src/services/__tests__/api.test.ts
@@ -14,6 +14,7 @@ let capturedReqFulfilled: ReqFulfilled
 let capturedResRejected: ResRejected
 let capturedResRejectedHandlers: ResRejected[]
 let mockAxiosInstance: AxiosInstance
+let capturedCreateConfig: Record<string, unknown>
 
 vi.mock('axios', () => {
   const mockInstance = {
@@ -37,9 +38,10 @@ vi.mock('axios', () => {
 
   return {
     default: {
-      create: vi.fn(() => {
+      create: vi.fn((config: Record<string, unknown>) => {
         // Expose for tests
         mockAxiosInstance = mockInstance as unknown as AxiosInstance
+        capturedCreateConfig = config
         return mockInstance
       }),
     },
@@ -76,8 +78,9 @@ function getApiClient() {
     }
     return {
       default: {
-        create: vi.fn(() => {
+        create: vi.fn((config: Record<string, unknown>) => {
           mockAxiosInstance = mockInstance as unknown as AxiosInstance
+          capturedCreateConfig = config
           return mockInstance
         }),
       },
@@ -94,6 +97,15 @@ describe('ApiClient', () => {
 
   afterEach(() => {
     vi.restoreAllMocks()
+  })
+
+  // ─── Client configuration ──────────────────────────────────────────────
+
+  describe('client configuration', () => {
+    it('sets a default request timeout so a hung backend does not hang forever', async () => {
+      await getApiClient()
+      expect(capturedCreateConfig.timeout).toBe(30_000)
+    })
   })
 
   // ─── Auth Interceptor ──────────────────────────────────────────────────
@@ -755,7 +767,11 @@ describe('ApiClient', () => {
       expect(mockAxiosInstance.post).toHaveBeenCalledWith(
         '/api/v1/modules',
         fd,
-        expect.objectContaining({ headers: { 'Content-Type': 'multipart/form-data' } }),
+        expect.objectContaining({
+          headers: { 'Content-Type': 'multipart/form-data' },
+          // Large archives can legitimately exceed the default request timeout.
+          timeout: 0,
+        }),
       )
     })
 
@@ -880,7 +896,11 @@ describe('ApiClient', () => {
       expect(mockAxiosInstance.post).toHaveBeenCalledWith(
         '/api/v1/providers',
         fd,
-        expect.objectContaining({ headers: { 'Content-Type': 'multipart/form-data' } }),
+        expect.objectContaining({
+          headers: { 'Content-Type': 'multipart/form-data' },
+          // Large archives can legitimately exceed the default request timeout.
+          timeout: 0,
+        }),
       )
     })
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -10,6 +10,12 @@ const API_BASE_URL = import.meta.env.DEV ? '' : import.meta.env.VITE_API_URL || 
 // Only use mock responses when explicitly enabled (e.g., when backend is not running)
 const USE_MOCK_DATA = import.meta.env.VITE_USE_MOCK_DATA === 'true'
 
+// Default request timeout. A hung backend would otherwise leave requests pending
+// indefinitely with no feedback to the user. File uploads (uploadModule,
+// uploadProvider) explicitly opt out with timeout: 0 -- large archives on a slow
+// connection can legitimately take longer than this.
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000
+
 /** Read a cookie value by name. Returns empty string if not found. */
 function getCookie(name: string): string {
   const match = document.cookie.match(
@@ -37,6 +43,7 @@ class ApiClient {
   constructor() {
     this.client = axios.create({
       baseURL: API_BASE_URL,
+      timeout: DEFAULT_REQUEST_TIMEOUT_MS,
       headers: {
         'Content-Type': 'application/json',
       },
@@ -288,6 +295,9 @@ class ApiClient {
     options?: { onUploadProgress?: (percent: number) => void },
   ) {
     const response = await this.client.post('/api/v1/modules', formData, {
+      // Large archives on a slow connection can legitimately exceed the default
+      // request timeout; onUploadProgress gives the user feedback instead.
+      timeout: 0,
       headers: {
         'Content-Type': 'multipart/form-data',
       },
@@ -406,6 +416,9 @@ class ApiClient {
     options?: { onUploadProgress?: (percent: number) => void },
   ) {
     const response = await this.client.post('/api/v1/providers', formData, {
+      // Large archives on a slow connection can legitimately exceed the default
+      // request timeout; onUploadProgress gives the user feedback instead.
+      timeout: 0,
       headers: {
         'Content-Type': 'multipart/form-data',
       },

--- a/frontend/src/utils/__tests__/errors.test.ts
+++ b/frontend/src/utils/__tests__/errors.test.ts
@@ -57,6 +57,14 @@ describe('getErrorMessage', () => {
     )
   })
 
+  it('returns a distinct timeout message for ECONNABORTED, not the generic network message', () => {
+    const error = new AxiosError('timeout of 30000ms exceeded', 'ECONNABORTED')
+    expect(error.response).toBeUndefined()
+    expect(getErrorMessage(error)).toBe(
+      'The request took too long and timed out. Please try again.',
+    )
+  })
+
   it('extracts message from native Error', () => {
     const error = new Error('File not found')
     expect(getErrorMessage(error)).toBe('File not found')

--- a/frontend/src/utils/errors.ts
+++ b/frontend/src/utils/errors.ts
@@ -8,7 +8,11 @@ import i18n from '../i18n'
  */
 export function getErrorMessage(err: unknown, fallback = 'An unexpected error occurred'): string {
   if (err instanceof AxiosError) {
-    // No response at all (offline, DNS failure, CORS, timeout) means err.message is
+    // A request that hit the client-side timeout has no response either, but is a
+    // distinct, more actionable condition than "can't reach the server at all" --
+    // check it first so it doesn't fall into the generic network-error branch below.
+    if (err.code === 'ECONNABORTED') return i18n.t('common.timeoutError')
+    // No response at all (offline, DNS failure, CORS) means err.message is
     // axios/browser boilerplate like "Network Error" -- show a friendly, localized
     // message instead of surfacing that raw string to the user.
     if (!err.response) return i18n.t('common.networkError')


### PR DESCRIPTION
## Summary
Fixes #473 (medium severity). The axios `ApiClient` set no request timeout and the app had no offline detection anywhere — a hung backend left requests pending indefinitely with a generic error and no feedback to the user.

- **Request timeout**: set a 30s default `timeout` on the axios instance (`DEFAULT_REQUEST_TIMEOUT_MS`).
- **Upload exemption**: `uploadModule` and `uploadProvider` explicitly opt out with `timeout: 0` — large module/provider archives on a slow connection can legitimately take longer than 30s, and both already report progress via `onUploadProgress`, so cutting them off at the default would be a regression, not a fix.
- **Distinct timeout message**: `getErrorMessage()` now special-cases `err.code === 'ECONNABORTED'` (axios's timeout error code) with a new, localized `common.timeoutError` string, checked *before* the existing `common.networkError` fallback (added in #495) — a timeout now reads as "the request took too long," not as a generic "can't reach the server."
- **Offline detection**: new `useOnlineStatus()` hook (`navigator.onLine` seeded, `online`/`offline` event-driven) and a lightweight `OfflineBanner` component (MUI `Snackbar`+`Alert`, top-center, `role="status"`), mounted once at the `App` root next to the existing `ConsentBanner`.

## Test plan
- [x] `errors.test.ts` — new case: `ECONNABORTED` returns the distinct timeout message, not the generic network one.
- [x] `useOnlineStatus.test.ts` (new file, 5 cases) — seeds from `navigator.onLine` both ways, flips on `offline`/`online` events, and verifies both listeners are added on mount and removed on unmount.
- [x] `OfflineBanner.test.tsx` (new file, 3 cases) — renders nothing while online, shows the warning while offline, and appears/disappears correctly across live `offline`/`online` events (waits out MUI's Snackbar exit transition rather than asserting synchronously, since the node stays mounted mid-fade).
- [x] `api.test.ts` — new `client configuration` test asserting the axios instance is created with `timeout: 30_000`; extended both existing `uploadModule`/`uploadProvider` "sends FormData" tests to also assert `timeout: 0`.
- [x] `vitest run` on all four affected suites together — 223/223 passed.
- [x] `npx tsc --noEmit` — same 20 pre-existing, unrelated errors as `main`.
- [x] `eslint` — clean on all changed files.
- [x] `prettier --check` flagged 4 files; diffed each against its own prettier-formatted output (`--stdin-filepath`) to separate signal from noise — `api.ts`/`api.test.ts`'s warnings are 100% pre-existing drift (confirmed none of my added lines appear in the diff), while `errors.test.ts`/`OfflineBanner.test.tsx` had two genuinely-too-long lines from my new tests, which I fixed with `prettier --write` and re-verified green.