### PR TITLE
test: add dedicated coverage for clearAuthStorage()'s full key list

### DIFF
--- a/frontend/src/utils/__tests__/authStorage.test.ts
+++ b/frontend/src/utils/__tests__/authStorage.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { AUTH_STORAGE_KEYS, clearAuthStorage } from '../authStorage'
+
+describe('AUTH_STORAGE_KEYS', () => {
+  it('names every known auth-related localStorage key', () => {
+    // Locks in the authoritative set so an accidental deletion from the array
+    // (as opposed to an addition, which the tests below already catch by
+    // iterating the array) is also caught.
+    expect(AUTH_STORAGE_KEYS).toEqual([
+      'auth_token',
+      'user',
+      'role_template',
+      'allowed_scopes',
+      'authorized',
+    ])
+  })
+})
+
+describe('clearAuthStorage', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('removes every key in AUTH_STORAGE_KEYS', () => {
+    AUTH_STORAGE_KEYS.forEach((key) => localStorage.setItem(key, 'seed-value'))
+
+    clearAuthStorage()
+
+    // Iterating the exported array (rather than a hardcoded literal list) means
+    // this test automatically covers any key added to AUTH_STORAGE_KEYS in the
+    // future, so it can't silently pass while a real key goes unverified --
+    // the original gap here was that only 2 of the 5 keys were ever asserted on.
+    AUTH_STORAGE_KEYS.forEach((key) => {
+      expect(localStorage.getItem(key)).toBeNull()
+    })
+  })
+
+  it.each(AUTH_STORAGE_KEYS)('removes "%s" specifically', (key) => {
+    localStorage.setItem(key, 'seed-value')
+    clearAuthStorage()
+    expect(localStorage.getItem(key)).toBeNull()
+  })
+
+  it('is safe to call when no auth keys are present', () => {
+    expect(() => clearAuthStorage()).not.toThrow()
+    AUTH_STORAGE_KEYS.forEach((key) => {
+      expect(localStorage.getItem(key)).toBeNull()
+    })
+  })
+
+  it('does not remove unrelated localStorage keys', () => {
+    localStorage.setItem('unrelated_app_setting', 'keep-me')
+    AUTH_STORAGE_KEYS.forEach((key) => localStorage.setItem(key, 'seed-value'))
+
+    clearAuthStorage()
+
+    expect(localStorage.getItem('unrelated_app_setting')).toBe('keep-me')
+  })
+})


### PR DESCRIPTION
## Summary
Fixes #491. There was no dedicated unit test file for `authStorage.ts` (`find src -path "*__tests__*authStorage*"` returned nothing before this PR). Indirect coverage existed in `api.test.ts` (asserts only `auth_token` and `user` are cleared on 401) and `e2e/tests/auth.spec.ts` (asserts only `authorized` is cleared on logout) — but `role_template` and `allowed_scopes` were never verified to be removed by `clearAuthStorage()` anywhere. On a shared device, a stale `allowed_scopes`/`role_template` entry surviving logout could let a subsequent user's session pick up leftover privilege-adjacent data if any code path trusts `localStorage` over a fresh `/auth/me` call.

New `authStorage.test.ts`, 9 cases:
- Locks in the current 5-key `AUTH_STORAGE_KEYS` set explicitly (catches an accidental deletion from the array).
- Seeds all 5 keys and asserts every one is removed — **iterating the exported array** rather than hardcoding a literal list, so this test automatically extends coverage to any key added to `AUTH_STORAGE_KEYS` in the future. That's the actual fix for the issue's framing ("test breaks if a key is added... without being added to the array") — the original 2-of-5 gap happened precisely because the existing tests hardcoded which keys to check instead of deriving it from the source of truth.
- `it.each` per-key case for granular failure reporting (a future regression on one specific key fails with that key's name, not a generic array-mismatch).
- Safe to call with nothing seeded (no throw).
- Doesn't remove unrelated `localStorage` keys.

## Test plan
- [x] `vitest run src/utils/__tests__/authStorage.test.ts` — 9/9 passed.
- [x] `npx tsc --noEmit` — same 20 pre-existing, unrelated errors as `main`.
- [x] `eslint` — clean.
- [x] `prettier --check` — clean (new file only, no pre-existing drift to worry about).