### PR TITLE
test: fix a broken location mock, then cover CallbackPage's open-redirect guard

### DIFF
--- a/frontend/src/pages/__tests__/CallbackPage.test.tsx
+++ b/frontend/src/pages/__tests__/CallbackPage.test.tsx
@@ -5,14 +5,22 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 // Must import after mock setup
 import CallbackPage from '../CallbackPage'
 
-// Mock window.location.replace
+// Mock window.location.replace. Spy on the real Location object rather than
+// replacing it with `{ ...window.location, replace: vi.fn() }`: Location's
+// properties (origin, href, pathname, ...) are getters on its prototype, not
+// own enumerable properties, so a spread copies none of them -- the spread
+// form silently produced a location with origin === undefined, which made
+// CallbackPage's own `new URL(raw, window.location.origin)` throw on every
+// call (invalid base URL) and fall back to '/' unconditionally, regardless of
+// whether the origin-comparison guard would have accepted or rejected `raw`.
+// That masked the open-redirect guard entirely -- every returnUrl, safe or
+// malicious, coincidentally resolved to '/' by way of the catch block instead
+// of via the intended same-origin check.
 beforeEach(() => {
   vi.clearAllMocks()
   localStorage.removeItem('auth_token')
-  Object.defineProperty(window, 'location', {
-    writable: true,
-    value: { ...window.location, replace: vi.fn() },
-  })
+  sessionStorage.removeItem('returnUrl')
+  vi.spyOn(window.location, 'replace').mockImplementation(() => {})
 })
 
 function renderWithParams(search: string) {
@@ -62,6 +70,47 @@ describe('CallbackPage', () => {
     renderWithParams('?error=invalid_request')
     await waitFor(() => {
       expect(screen.getByText('Redirecting to login page...')).toBeInTheDocument()
+    })
+  })
+
+  describe('open-redirect guard (returnUrl)', () => {
+    it('redirects to a legitimate same-origin returnUrl path', async () => {
+      sessionStorage.setItem('returnUrl', '/admin/users')
+      renderWithParams('')
+      await waitFor(() => {
+        expect(window.location.replace).toHaveBeenCalledWith('/admin/users')
+      })
+    })
+
+    it('preserves the query string and hash on a same-origin returnUrl', async () => {
+      sessionStorage.setItem('returnUrl', '/modules?sort=downloads#top')
+      renderWithParams('')
+      await waitFor(() => {
+        expect(window.location.replace).toHaveBeenCalledWith('/modules?sort=downloads#top')
+      })
+    })
+
+    it.each([
+      ['an absolute cross-origin URL', 'https://evil.com'],
+      ['a protocol-relative URL', '//evil.com'],
+      ['a backslash-normalisation bypass', '/\\evil.com'],
+      ['a single-slash scheme bypass', 'https:/evil.com'],
+      ['a javascript: URI', 'javascript:alert(document.cookie)'],
+    ])('falls back to "/" when returnUrl is %s', async (_label, payload) => {
+      sessionStorage.setItem('returnUrl', payload)
+      renderWithParams('')
+      await waitFor(() => {
+        expect(window.location.replace).toHaveBeenCalledWith('/')
+      })
+    })
+
+    it('removes returnUrl from sessionStorage after reading it', async () => {
+      sessionStorage.setItem('returnUrl', '/admin/users')
+      renderWithParams('')
+      await waitFor(() => {
+        expect(window.location.replace).toHaveBeenCalled()
+      })
+      expect(sessionStorage.getItem('returnUrl')).toBeNull()
     })
   })
 })


### PR DESCRIPTION
## Summary
Fixes #488 (medium severity, CWE-601). `CallbackPage.test.tsx`'s only redirect assertion (`redirects to home when no token param`) covered just the default `/` fallback. No test planted a cross-origin payload into `sessionStorage.returnUrl` and asserted `window.location.replace` received a same-origin path — the exact open-redirect bypass techniques this code's own comment says it defends against (`Use URL parsing to catch backslash normalisation bypasses (/\\ → //)`) were entirely unverified.

**While adding that coverage, I found a real bug in the test infrastructure itself**, not just a coverage gap: the file's `window.location` mock replaced the object with `{ ...window.location, replace: vi.fn() }`. `Location`'s properties (`origin`, `href`, `pathname`, ...) are getters on its prototype, not own enumerable properties — I verified this directly (`Object.getOwnPropertyNames(window.location)` returns `[]`) — so the spread silently copied *none* of them. The mocked `location.origin` was `undefined`.

That's not cosmetic: `CallbackPage.tsx`'s own guard does `new URL(raw, window.location.origin)`, and I confirmed `new URL(anything, undefined)` throws `Invalid URL`. So in every existing test, that call **always threw**, always hit the `catch` block, and always fell back to `'/'` — completely independent of whether `raw` was legitimate or malicious. The pre-existing "no token param" test only ever passed because its expected value (`raw` absent → default `/`) happens to equal the catch-fallback value too, so it couldn't distinguish "the guard correctly evaluated same-origin" from "the guard's `new URL()` call never even completed."

- Fixed the mock: `vi.spyOn(window.location, 'replace').mockImplementation(() => {})` instead of replacing the whole object — preserves the real `origin`/`href`/`pathname` so the guard's actual comparison logic runs, while still letting tests intercept and assert on `replace` calls.
- Added 8 new cases in a new `describe('open-redirect guard (returnUrl)', ...)` block: a legitimate same-origin path, one preserving query string + hash, five payload types (`it.each`) that must all fall back to `/` — absolute cross-origin, protocol-relative (`//evil.com`), backslash-normalisation bypass (`/\evil.com`), single-slash scheme bypass (`https:/evil.com`), and a `javascript:` URI (resolves to `origin: null`, also correctly rejected) — and a check that `returnUrl` is removed from `sessionStorage` after being read.

I verified the bypass-payload origin resolutions directly in Node against the real `URL` implementation before writing assertions, rather than guessing: all five resolve to an origin different from `http://localhost:3000`, confirming the source's `resolved.origin === window.location.origin` check is the correct, sufficient defense — this PR just makes that provable by a test for the first time.

## Test plan
- [x] `vitest run src/pages/__tests__/CallbackPage.test.tsx` — 14/14 passed (6 pre-existing + 8 new), including the previously-failing legitimate-path assertions once the mock was fixed (I hit the bug live: my first pass at these tests failed with `expected "vi.fn()" to be called with ['/admin/users']` — that's what led to discovering the root cause instead of just working around it).
- [x] `npx tsc --noEmit` — same 20 pre-existing, unrelated errors as `main`.
- [x] `eslint` — clean.
- [x] `prettier --check` — clean.