### PR TITLE
test: cover DevUserSwitcher's impersonation token-write side effect

### DIFF
--- a/frontend/src/components/__tests__/DevUserSwitcher.test.tsx
+++ b/frontend/src/components/__tests__/DevUserSwitcher.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, fireEvent, within } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 const getDevStatusMock = vi.fn()
@@ -32,6 +32,9 @@ import DevUserSwitcher from '../DevUserSwitcher'
 describe('DevUserSwitcher', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    // Reset in case a previous test mutated the shared mock (e.g. "shows select
+    // user placeholder" below reassigns mockAuth.user).
+    mockAuth.user = { id: 'u1', email: 'admin@example.com', name: 'Admin', primary_role: 'admin' }
   })
 
   it('renders nothing when dev mode is not enabled', async () => {
@@ -73,6 +76,36 @@ describe('DevUserSwitcher', () => {
     })
     // The Select should show the current user
     expect(screen.getByText('Admin')).toBeInTheDocument()
+  })
+
+  it('selecting a user writes the impersonation token to localStorage and reloads', async () => {
+    // The security-relevant side effect (impersonateUser -> token write -> reload)
+    // was previously untested; only the surrounding dev-mode gating/rendering was
+    // covered. vi.spyOn preserves the real Location object (see the CallbackPage
+    // lesson: `{...window.location, reload: vi.fn()}` silently drops origin/href/
+    // etc. because Location's props are prototype getters, not own properties).
+    const reloadSpy = vi.spyOn(window.location, 'reload').mockImplementation(() => {})
+    localStorage.removeItem('auth_token')
+
+    getDevStatusMock.mockResolvedValue({ dev_mode: true })
+    listUsersForImpersonationMock.mockResolvedValue({
+      users: [
+        { id: 'u1', email: 'admin@example.com', name: 'Admin', primary_role: 'admin' },
+        { id: 'u2', email: 'user@example.com', name: 'Regular User', primary_role: 'viewer' },
+      ],
+    })
+    impersonateUserMock.mockResolvedValue({ token: 'impersonation-jwt-for-u2' })
+
+    render(<DevUserSwitcher />)
+    await waitFor(() => expect(screen.getByText(/DEV/)).toBeInTheDocument())
+
+    fireEvent.mouseDown(screen.getByRole('combobox'))
+    const listbox = await screen.findByRole('listbox')
+    fireEvent.click(within(listbox).getByText('Regular User'))
+
+    await waitFor(() => expect(impersonateUserMock).toHaveBeenCalledWith('u2'))
+    await waitFor(() => expect(localStorage.getItem('auth_token')).toBe('impersonation-jwt-for-u2'))
+    expect(reloadSpy).toHaveBeenCalled()
   })
 
   it('renders nothing when dev status endpoint fails', async () => {


### PR DESCRIPTION
## Summary
Fixes #499 (the `DevUserSwitcher` test-coverage item — the other item in that issue, the client-side RBAC route guard, is explicitly informational only per its own text: "Keep the guard as UX... No client change needed").

Per recon, selecting an impersonation target writes the returned JWT to `localStorage['auth_token']` and reloads the page (`DevUserSwitcher.tsx` `handleUserSwitch`, ~lines 58-66). This write path — the actual security-relevant action — was untested; only the surrounding dev-mode gating/rendering was covered by the existing 6 tests.

- New test opens the MUI Select (`fireEvent.mouseDown` + `findByRole('listbox')`, matching this codebase's existing Select-interaction pattern from `StoragePage.test.tsx`), picks a different user, mocks `impersonateUser` to resolve a token, and asserts `localStorage.getItem('auth_token')` is updated and `window.location.reload()` fires.
- Uses `vi.spyOn(window.location, 'reload')` rather than replacing the `Location` object — directly applying the lesson from #488/PR #515: `{...window.location, reload: vi.fn()}` would silently drop `origin`/`href`/etc. since `Location`'s properties are prototype getters, not own enumerable properties.
- Also reset the shared `mockAuth.user` fixture in `beforeEach`: the last test in the file (`shows select user placeholder when current user not in list`) reassigns `mockAuth.user` and nothing previously restored it — a latent test-order hazard for any test added after it, which would have silently broken my new test (and any future one) had I not caught it.

## Test plan
- [x] `vitest run src/components/__tests__/DevUserSwitcher.test.tsx` — 7/7 passed (6 existing + 1 new).
- [x] `npx tsc --noEmit` — same 20 pre-existing, unrelated errors as `main`.
- [x] `eslint` — clean.
- [x] `prettier --check` — clean.