### PR TITLE
test: cover javascript:/data: URI XSS bypasses and the real doc-fetch path

### DIFF
--- a/frontend/src/components/__tests__/MarkdownRenderer.test.tsx
+++ b/frontend/src/components/__tests__/MarkdownRenderer.test.tsx
@@ -90,6 +90,34 @@ describe('MarkdownRenderer', () => {
     }
   })
 
+  it('strips a javascript: URI from a markdown link href', () => {
+    renderWithTheme(<MarkdownRenderer>{'[click me](javascript:alert(1))'}</MarkdownRenderer>)
+    const link = screen.getByText('click me')
+    expect(link.tagName).toBe('A')
+    expect(link.getAttribute('href')).toBeNull()
+  })
+
+  it('strips a javascript: URI from a markdown image src', () => {
+    const { container } = renderWithTheme(
+      <MarkdownRenderer>{'![alt text](javascript:alert(1))'}</MarkdownRenderer>,
+    )
+    const img = container.querySelector('img')
+    expect(img).not.toBeNull()
+    expect(img?.getAttribute('src')).toBeNull()
+  })
+
+  it('strips a data:text/html URI from a markdown link href', () => {
+    const { container } = renderWithTheme(
+      <MarkdownRenderer>
+        {'[data payload](data:text/html,<script>alert(1)</script>)'}
+      </MarkdownRenderer>,
+    )
+    const link = screen.getByText('data payload')
+    expect(link.tagName).toBe('A')
+    expect(link.getAttribute('href')).toBeNull()
+    expect(container.querySelectorAll('script').length).toBe(0)
+  })
+
   it('handles empty string content', () => {
     const { container } = renderWithTheme(<MarkdownRenderer>{''}</MarkdownRenderer>)
 

--- a/frontend/src/components/__tests__/ProviderDocContent.test.tsx
+++ b/frontend/src/components/__tests__/ProviderDocContent.test.tsx
@@ -72,4 +72,44 @@ describe('ProviderDocContent', () => {
       expect(screen.getByTestId('markdown')).toHaveTextContent('Plain markdown content.')
     })
   })
+
+  // Every test above mocks MarkdownRenderer to a plain <div>, so none of them exercise
+  // the real sanitizer. Only the isolated MarkdownRenderer unit test does -- a future
+  // change to this fetch-to-render path (e.g. swapping in a different renderer, or
+  // adding rehype-raw) could bypass sanitization with no test catching it end-to-end.
+  // Use the REAL MarkdownRenderer here, through a fresh module instance, to prove the
+  // full ProviderDocContent pipeline (fetch -> strip frontmatter -> render) sanitizes
+  // attacker-controlled README content, not just the isolated component.
+  //
+  // Payload uses markdown link/image syntax, not raw <script>/<img onerror> HTML:
+  // this component has no rehype-raw plugin, so react-markdown never renders raw HTML
+  // nodes at all (verified: they produce zero DOM elements, not sanitized-and-kept
+  // ones) -- raw HTML injection is a non-issue here by construction. The reachable
+  // attack surface is a dangerous protocol in a real markdown link/image URL.
+  describe('end-to-end sanitization (real MarkdownRenderer, not mocked)', () => {
+    it('strips javascript: and data: URIs from fetched README content', async () => {
+      vi.resetModules()
+      vi.doUnmock('../MarkdownRenderer')
+      vi.doMock('../../services/api', () => ({
+        default: { getProviderDocContent: getProviderDocContentMock },
+      }))
+      getProviderDocContentMock.mockResolvedValue({
+        content:
+          '[click me](javascript:alert(1))\n\n![alt text](javascript:alert(1))\n\n[data payload](data:text/html,<script>alert(1)</script>)',
+      })
+
+      const { default: RealProviderDocContent } = await import('../ProviderDocContent')
+      const { container } = render(<RealProviderDocContent {...defaultProps} />)
+
+      await waitFor(() => {
+        expect(container.querySelectorAll('a, img').length).toBeGreaterThan(0)
+      })
+      container.querySelectorAll('a').forEach((a) => {
+        expect(a.getAttribute('href')).toBeNull()
+      })
+      container.querySelectorAll('img').forEach((img) => {
+        expect(img.getAttribute('src')).toBeNull()
+      })
+    })
+  })
 })


### PR DESCRIPTION
## Summary
Fixes #492. The only XSS test in the component tree covered exactly two payload shapes (raw `<script>`, raw `<img onerror>`). `grep -rn "javascript:" src/ --include="*.test.*"` returned zero results across the whole frontend test tree, so the classic markdown-XSS bypass of a `javascript:` URI in a link/image (`[x](javascript:alert(1))`) was never asserted against, despite being one of the standard bypass classes for `react-markdown`/`rehype-sanitize` setups.

**`MarkdownRenderer.test.tsx`** — 3 new cases: `javascript:` href, `javascript:` image src, `data:text/html` href. I verified the actual sanitized output empirically before writing assertions (rather than guessing): `rehype-sanitize`'s default schema strips the `href`/`src` attribute **entirely** for a disallowed protocol — the element still renders, just with no `href`/`src` — so the assertions check `getAttribute(...)` is `null`, not that the value changed to something inert.

**`ProviderDocContent.test.tsx`** — every existing test mocks `MarkdownRenderer` to a plain `<div>`, so *none* of them exercise the real sanitizer; only the isolated unit test did. A future change to this fetch-to-render path (swapping renderers, adding `rehype-raw` somewhere) could bypass sanitization with no test catching it end-to-end — exactly the issue's concern. Added one test that unmocks `MarkdownRenderer` via `vi.resetModules()` + `vi.doUnmock()` (the same pattern `api.test.ts`'s `getApiClient()` helper already uses) and drives real attacker-controlled README content through the full fetch → strip-frontmatter → render pipeline.

**One correction to the issue's own suggested fix**: it named `ModuleDocumentation.test.tsx` as a second integration point to cover, but I checked the actual source and `ModuleDocumentation.tsx` doesn't render markdown at all (`grep -n "MarkdownRenderer" src/components/ModuleDocumentation.tsx` — no match; it's a structured inputs/outputs/providers table). The real second `MarkdownRenderer` consumer besides `MarkdownRenderer.tsx` itself is `ProviderDocContent.tsx` (`ModuleDetailPage.tsx` is the module-README consumer, but it's the large file tracked separately in #102 and out of scope here). I focused the integration test on the component that's actually in the render path.

**A design note on the integration payload**: I initially wrote it with raw `<script>`/`<img onerror>` HTML (mirroring the existing unit test's payload) and the test failed — not because sanitization failed, but because `MarkdownRenderer` has no `rehype-raw` plugin, so `react-markdown` never renders raw HTML nodes *at all* (verified: they produce zero DOM elements, not sanitized-and-kept ones). Raw HTML injection is a non-issue here by construction, stronger than sanitization. I redesigned the payload to use real markdown link/image syntax instead, which *does* produce real elements and is the actually-reachable attack surface.

**Also surfaced, not fixed here** (flagging for a future PR): the pre-existing raw-HTML XSS test's `<img>` assertion loop (`for (const img of imgs) { expect(img.getAttribute('onerror')).toBeNull() }`) is vacuous — `imgs` is always an empty NodeList for that payload (same no-`rehype-raw` reason above), so the loop body never runs and the test has never actually verified anything about `onerror` stripping. `scripts.length === 0` is the only thing that test meaningfully checks.

## Test plan
- [x] `vitest run` on both files together — 25/25 passed (19 + 6).
- [x] Verified the raw-HTML integration payload fails to render any elements at all (confirming the redesign was necessary, not just a preference) before settling on the markdown-syntax payload.
- [x] `npx tsc --noEmit` — same 20 pre-existing, unrelated errors as `main`.
- [x] `eslint` — clean (caught and fixed one real issue: an unused `container` destructure in a test that only needed `screen.getByText`).
- [x] `prettier --check` — clean.