### PR TITLE
fix: use npm ci and drop in-build npm audit fix in the release Dockerfile

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -15,16 +15,19 @@ COPY package.json package-lock.json .npmrc ./
 
 # NODE_AUTH_TOKEN (a GitHub Packages read token) is injected as a BuildKit secret so npm
 # can install the private @sethbacon/* dependency without baking the token into a layer.
-# Install dependencies (use npm install so lockfile mismatches don't fail in CI for dev)
+# npm ci installs exactly what package-lock.json specifies (matches the CI pattern in
+# .github/actions/setup-frontend, which already requires the lockfile to be in sync).
 RUN --mount=type=secret,id=node_auth_token \
-    NODE_AUTH_TOKEN="$(cat /run/secrets/node_auth_token)" npm install --no-audit --no-fund
+    NODE_AUTH_TOKEN="$(cat /run/secrets/node_auth_token)" npm ci --no-audit --no-fund
 
-# Fix what can be auto-fixed, then gate on production-dependency vulnerabilities only.
-# Dev-only packages (e.g. eslint tooling) are excluded: they are not present
-# in the final nginx image and cannot be force-fixed without breaking build tooling.
+# Gate on production-dependency vulnerabilities only. Dev-only packages (e.g. eslint
+# tooling) are excluded: they are not present in the final nginx image. Deliberately no
+# `npm audit fix` here -- silently mutating the published image's dependency tree at
+# build time would undermine the lockfile integrity npm ci above just established.
+# A vulnerability fix belongs in a PR (Dependabot or manual `npm audit fix` + review)
+# where the lockfile change is reviewed before it ships, not auto-applied in the image.
 RUN --mount=type=secret,id=node_auth_token \
     export NODE_AUTH_TOKEN="$(cat /run/secrets/node_auth_token)" && \
-    npm audit fix || true && \
     npm audit --audit-level=high --omit=dev
 
 # Copy source code


### PR DESCRIPTION
## Summary
Fixes #469 (medium severity, OWASP A08:2021). The release image (`frontend/Dockerfile:18-28`) built with `npm install` (not `npm ci`), and a silent `npm audit fix` could further mutate the dependency tree at build time before the audit gate — undermining lockfile integrity for the published artifact.

The original comment justified `npm install` as tolerating lockfile mismatches "for dev," but **I verified that premise is stale**: `.github/actions/setup-frontend` already runs `npm ci` strictly for every regular CI job (Lint, Typecheck, Build, Unit Tests — `grep -n "npm ci" .github/actions/setup-frontend/action.yml`), so the lockfile is already required to be in sync before the Docker E2E build (same Dockerfile, `VITE_MODE=development`) ever runs. If it weren't in sync, those `npm ci`-based jobs would already be failing.

- `npm install` → `npm ci --no-audit --no-fund` (matches the CI pattern, per the issue's own suggested fix).
- Dropped `npm audit fix || true`. The `npm audit --audit-level=high --omit=dev` gate still runs, but now against the exact reviewed lockfile from git — an unaddressed high/critical vuln now **fails the build loudly** instead of being silently patched away inside the image build. A fix belongs in a reviewed PR (Dependabot or manual `npm audit fix` + review + commit), not auto-applied at image-build time.

## Test plan
- [x] `npm ci --dry-run --no-audit --no-fund` — resolves cleanly against the current `package-lock.json` (no mismatch).
- [x] `docker build --check -f Dockerfile .` — BuildKit's lint-only check mode: "Check complete, no warnings found."
- [x] Could not run a full `docker build` end-to-end in this sandbox (the build needs a `read:packages`-scoped `NODE_AUTH_TOKEN` for the private `@sethbacon/terraform-suite-ui` dependency, which isn't available here) — the two checks above validate the instruction syntax and lockfile compatibility, which are what this change actually touches; recommend a normal CI run on this PR (which does have that credential via `secrets.GITHUB_TOKEN`) as the full confirmation.