### PR TITLE
feat: gate Dependabot auto-merge on real security-alert status

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,8 +1,26 @@
 name: Dependabot Auto-Merge
 
-# Auto-merge Dependabot security PRs that pass CI (patch-level bumps only).
-# This reduces toil for low-risk security fixes while requiring manual review
-# for minor/major version bumps.
+# Two independent Dependabot mechanisms feed this workflow, both opening PRs as
+# github.actor == 'dependabot[bot]' with no first-class signal distinguishing them:
+#   - Security updates: a native GitHub feature (Settings -> Code security) that
+#     reacts to GHSA advisories in real time, always one PR per dependency.
+#   - Version updates: this repo's .github/dependabot.yml biweekly schedule.
+#
+# The only reliable way to tell them apart is fetch-metadata's alert-lookup, which
+# needs a token with "Dependabot alerts: read" -- the ambient secrets.GITHUB_TOKEN
+# is documented as insufficient for that GraphQL lookup. A GitHub App installation
+# token (DEPENDABOT_APP_ID / DEPENDABOT_APP_PRIVATE_KEY secrets) provides that one
+# narrow, read-only permission; see the setup steps in PR #519's description.
+#
+# Once alert-state is known, two distinct policies apply:
+#   - Security-driven fixes (alert-state == OPEN): auto-merge patch OR minor bumps
+#     of direct-production deps. Some advisories are only patched starting at a
+#     minor version if the maintainer didn't backport a fix -- restricting
+#     security auto-merge to patch-only would silently skip exactly the fixes
+#     this automation exists for. Major bumps still always require manual review.
+#   - Routine version bumps (no open alert): auto-merge patch-only,
+#     direct-production only -- unchanged from the original, more conservative
+#     default that isn't specifically security-motivated.
 on:
   pull_request:
 
@@ -12,18 +30,37 @@ permissions:
 
 jobs:
   auto-merge:
-    name: Auto-merge Dependabot (patch security)
+    name: Auto-merge Dependabot
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     steps:
+      - name: Generate a Dependabot-alerts-read token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.DEPENDABOT_APP_ID }}
+          private-key: ${{ secrets.DEPENDABOT_APP_PRIVATE_KEY }}
+
       - name: Fetch Dependabot metadata
         id: metadata
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
+          alert-lookup: true
 
-      - name: Auto-merge patch-level security updates
+      - name: Auto-merge security-driven patch/minor updates
         if: >-
+          steps.metadata.outputs.alert-state == 'OPEN' &&
+          steps.metadata.outputs.dependency-type == 'direct:production' &&
+          steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Auto-merge routine patch-level updates
+        if: >-
+          steps.metadata.outputs.alert-state != 'OPEN' &&
           steps.metadata.outputs.update-type == 'version-update:semver-patch' &&
           steps.metadata.outputs.dependency-type == 'direct:production'
         run: gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
## Summary
Fixes #471. This workflow claimed to auto-merge "security" PRs but never actually verified that — it merged any patch-level, direct-production dependency bump, security-motivated or not. Worse in the other direction: a genuine security fix that needs a **minor** bump (when a maintainer doesn't backport a patch to an old minor line) got zero auto-merge benefit under the patch-only rule, despite being exactly the case this automation exists for.

## What I researched before implementing
- **`alert-lookup` requires an elevated token.** Confirmed via the `dependabot/fetch-metadata` action's README and its compiled source: `alert-state`/`ghsa-id`/`cvss` only populate when `alert-lookup: true` is passed, and that input itself requires a token with **"Dependabot alerts: read"** — `getInput('alert-lookup')` reads an env var that's simply unset without it, so the existing `secrets.GITHUB_TOKEN` would leave `alert-state` empty forever, silently. This is why I didn't just add the check on top of the existing token in an earlier draft — it would have quietly broken *all* auto-merging.
- **No cheaper proxy exists.** This repo runs Dependabot's native **security-updates** feature (`security_and_analysis.dependabot_security_updates: enabled`) *and* the scheduled **version-updates** in `.github/dependabot.yml` (biweekly, grouped) simultaneously, with no first-class signal distinguishing which one opened a given PR. I pulled 15 real historical Dependabot PR bodies and checked for a structural CVE/GHSA marker before assuming one exists — there isn't one (e.g. PR #423, a routine dompurify patch bump, happens to mention "vulnerable dependencies" in upstream changelog text, which would false-positive any text-based heuristic). `alert-lookup` is the only reliable signal.

## What changed
- Added a **`Generate a Dependabot-alerts-read token`** step (`actions/create-github-app-token`, pinned to `v3.2.0`'s commit SHA), scoped **only** to the metadata-fetch step — never exposed to a `run:` step, never used for the actual merge (which still uses the existing `secrets.GITHUB_TOKEN`). Minimal blast radius for a new credential.
- Split the single merge rule into two named, independently-gated policies:
  - **Security-driven** (`alert-state == 'OPEN'`): auto-merges patch **or minor** bumps of direct-production deps — minor is included because some advisories are only patched starting at a minor version.
  - **Routine** (no open alert): stays patch-only, direct-production only — unchanged from the original, more conservative default for non-security-motivated bumps.
  - Both exclude major bumps and dev-only/transitive dependencies, same as before.

## ⚠️ Requires setup before this can auto-merge anything
Until the secrets below exist, the new token-generation step fails closed — Dependabot PRs simply sit unmerged (not a security risk, just a temporary loss of the automation) rather than silently misbehaving:

1. Create a GitHub App: https://github.com/settings/apps/new
   - Repository permissions → **Dependabot alerts: Read-only**
   - Repository permissions → **Pull requests: Read-only**
   - No write permissions needed — the App token only reads metadata, it never merges.
2. Install the App on this repo.
3. Generate a private key for the App (App settings → General → Private keys).
4. Add two repo secrets (Settings → Secrets and variables → Actions):
   - `DEPENDABOT_APP_ID` — the App's ID
   - `DEPENDABOT_APP_PRIVATE_KEY` — the full contents of the generated `.pem` file

A single App can be installed across your other repos too if you want the same capability there later.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — valid YAML.
- [x] `actionlint` (this file, then the whole `.github/workflows/` tree) — clean, no warnings.
- [x] Verified `actions/create-github-app-token`'s pinned SHA (`bcd2ba4...`) resolves to the real `v3.2.0` tag via the GitHub API, not guessed.
- [x] Verified `dependabot/fetch-metadata`'s `alert-state` value casing (`OPEN`/`FIXED`/`DISMISSED`, uppercase) directly from its GraphQL-backed source, not assumed.
- [ ] Cannot be exercised end-to-end by CI (no real Dependabot PR to test against, and the secrets don't exist yet) — will only be provable once the App is installed and the next qualifying Dependabot PR opens.