### PR TITLE
docs: fix VITE_API_URL guidance -- wrong example, unreachable build-time advice

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,13 +82,13 @@ Frontend configuration is provided via Vite environment variables. All variables
 
 | Variable                   | Default                  | Description                                                                                                                                                          |
 | -------------------------- | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `VITE_API_URL`             | (proxied by Vite in dev) | Backend API base URL for production builds. Example: `https://registry.example.com` or `https://registry.example.com/api/v1` depending on your reverse-proxy layout. |
+| `VITE_API_URL`             | (proxied by Vite in dev) | Backend API **origin** for production builds, e.g. `https://registry.example.com`. Must not include a path: every API call already hardcodes its own `/api/v1/...` prefix, so a path here (e.g. `.../api/v1`) would double it. |
 | `VITE_PROXY_TARGET`        | `http://localhost:8080`  | Backend URL the Vite dev server proxies `/api/*` to. Override for TLS or non-local backend during development.                                                       |
 | `VITE_USE_MOCK_DATA`       | `false`                  | When `true`, the API client returns static mock data instead of calling the backend (offline development).                                                           |
 | `VITE_ERROR_REPORTING_DSN` | _(unset)_                | URL for batched browser error reports (Sentry-compatible DSN or any HTTP endpoint). When unset, errors log to console only.                                          |
 
 In development the Vite proxy handles `/api/*` routing, so no env var is needed locally.
-For Docker / production builds served through nginx, the bundled nginx config proxies `/api/*` to the backend, so `VITE_API_URL` only needs to be set when the frontend is served from a different origin than the backend.
+For Docker / production builds served through nginx, the bundled nginx config already proxies `/api/*` to the backend, so `VITE_API_URL` is normally left unset. Only set it if the frontend is genuinely served from a different origin than the backend -- and note the shipped Content-Security-Policy's `connect-src 'self'` will block that origin's requests unless you also route both through the same reverse proxy (see `nginx-ecs.conf.template`'s `BACKEND_URL` pattern) instead of calling the other origin directly from the browser. This value is compiled into the public JS bundle, so it must stay public-facing -- never an internal-only hostname.
 
 ## Tech Stack
 

--- a/deployments/docker-compose.prod.yml
+++ b/deployments/docker-compose.prod.yml
@@ -7,10 +7,18 @@
 #   REGISTRY_TAG    Image tag, e.g. v1.0.0 (default: latest — pin to an immutable tag in production)
 #
 # Prerequisites:
-#   1. Pull or build the production frontend image
+#   1. Pull the production frontend image (this file uses the published image, not
+#      a local build -- FRONTEND_IMAGE/REGISTRY_TAG select the tag, they do not
+#      rebuild it, so build-time values like VITE_API_URL cannot be reconfigured
+#      here at deploy time).
 #   2. Place a reverse proxy (Traefik, Caddy, nginx) in front of port 80 for TLS termination
-#   3. Ensure the backend stack is reachable; configure VITE_API_URL at build time
-#      if the frontend is served from a different origin than the backend.
+#   3. This image's nginx config proxies /api/* to a backend reachable at the
+#      Docker Compose service name "backend" (see docker-compose.yml, which this
+#      file overrides) -- no frontend-side configuration is needed as long as that
+#      service is on the same network. If your backend genuinely lives at a
+#      different origin, route it through the same reverse proxy instead of
+#      pointing the frontend at it directly: the shipped Content-Security-Policy's
+#      connect-src 'self' blocks direct cross-origin API calls from the browser.
 
 services:
   frontend:

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -3,10 +3,19 @@
 # Copy this file to .env and uncomment the variables you want to override.
 # All values shown are the defaults used when the variable is not set.
 
-# Base URL for API requests.
-# In dev mode (npm run dev), this is empty — requests go through the Vite proxy.
-# In production (Docker/nginx), the nginx config proxies /api/* to the backend.
-# VITE_API_URL=/api/v1
+# Base URL for API requests. Leave unset for the standard deployment: the bundled
+# nginx config already proxies /api/* to the backend, so no value is needed here.
+# Only set this if the frontend is genuinely served from a different origin than
+# the backend (prefer routing both through the same reverse proxy instead --
+# nginx-ecs.conf.template's BACKEND_URL pattern -- which the shipped
+# Content-Security-Policy's connect-src 'self' already supports without changes;
+# a different-origin frontend/backend split will be blocked by that CSP).
+# Must be an origin only (scheme + host[:port]), never a path: every API call
+# already hardcodes its own /api/v1/... prefix, so a path here doubles it
+# (e.g. VITE_API_URL=/api/v1 turns every request into /api/v1/api/v1/...).
+# This value is compiled into the public JS bundle -- keep it public-facing,
+# never an internal-only hostname.
+# VITE_API_URL=https://api.example.com
 
 # Enable mock API responses for offline/disconnected development.
 # When true, the API client returns static mock data instead of calling the backend.


### PR DESCRIPTION
## Summary
Fixes #484, fixes #487. Two independent, compounding bugs in the documented `VITE_API_URL` guidance, plus one related documentation gap.

**Bug 1 — the example value itself was wrong.** `frontend/.env.example`'s sample (`VITE_API_URL=/api/v1`) is a *path*, not an origin. `api.ts`'s call sites already hardcode their own `/api/v1/...` prefix on every request, so literally using that sample value doubles it: `/api/v1/api/v1/auth/providers`, 404ing every request. `README.md`'s second example (`.../api/v1`) had the identical bug. Fixed both to show an origin-only example and explain *why* a path breaks it.

**Bug 2 — the build-time guidance was unreachable.** `deployments/docker-compose.prod.yml` told operators to "configure `VITE_API_URL` at build time if the frontend is served from a different origin than the backend" — but this compose file only references the *published* image (`FRONTEND_IMAGE`/`REGISTRY_TAG` select a tag, they don't rebuild), so there's no build step here to act on that guidance at all. Separately, even if an operator rebuilt with a custom cross-origin `VITE_API_URL`, `nginx.conf`/`nginx-ecs.conf.template`'s CSP hardcodes `connect-src 'self'` with no templating hook for that origin — every request would be blocked by the page's own CSP before it left the browser tab.

I verified the base `docker-compose.yml` (which this file overrides) already defines a `backend` service reachable same-origin via nginx's `proxy_pass` — for the documented usage, `VITE_API_URL` was never actually needed. Replaced the guidance with accurate same-origin-by-default docs and pointed genuine split-origin deployments at the already-CSP-compatible `nginx-ecs.conf.template`/`BACKEND_URL` reverse-proxy pattern, rather than inventing new CSP templating for a topology the repo already discourages.

**Folded in #487** (`VITE_API_URL` baked into the public bundle): added an explicit "keep this public-facing, never an internal-only hostname" note to both `.env.example` and `README.md`, since the same value that's wrong in the other two ways is also the one place an operator might accidentally paste an internal ALB/VPC hostname into a permanently public build artifact.

**Deliberately not done**: automated build-time validation for the public-vs-internal hostname case (#487's "ideally" stretch goal) — there's no reliable way to distinguish an internal-only hostname from a public one without a maintained blocklist that would itself be a source of false positives/negatives. Documentation is the precise, actionable part of the fix.

## Test plan
- [x] `docker compose -f deployments/docker-compose.yml -f deployments/docker-compose.prod.yml config --quiet` — resolves cleanly, confirming the comment-only edit didn't break the compose file and validating my claim that the base file's `backend` service is genuinely reachable same-origin.
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` on the compose file — valid YAML.
- [x] Grepped for any test referencing the old comment text — none found.
- [x] Traced `nginx.conf`'s `location /api/ { proxy_pass http://backend:8080; }` and `api.ts`'s hardcoded `/api/v1/...` call paths directly to confirm the double-prefix bug is real, not a guess.