### PR TITLE
fix: send HSTS from the TLS-terminating nginx config, document the ECS gap

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -61,6 +61,7 @@ We will credit reporters in the release notes unless anonymity is requested.
 - `npm audit --audit-level=high` runs in the Docker build and the scheduled security workflow
 - Markdown rendering is sanitised with `rehype-sanitize` (XSS mitigation)
 - The frontend follows OWASP Top 10 mitigations applicable to SPAs (output encoding, strict CSP via nginx, no `dangerouslySetInnerHTML` outside the sanitised renderer)
+- HSTS (`Strict-Transport-Security`) is sent by `nginx.conf`, which terminates TLS directly. `nginx-ecs.conf.template` (ECS/Cloud Run/ACA) and any deployment that fronts the container with an external reverse proxy/ALB (see `deployments/docker-compose.prod.yml`) deliberately do **not** set it themselves -- HSTS only has effect on the hop that actually terminates TLS, so it must be configured at that edge/ALB, not on the origin container behind it
 - Authentication uses an HttpOnly session cookie set by the backend (no JWT persisted in `localStorage` outside a transitional migration path); mutating requests are protected by a double-submit CSRF token (the `tfr_csrf` cookie echoed in an `X-CSRF-Token` header)
 
 ## Repository Hardening

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -30,6 +30,12 @@ server {
     add_header X-Frame-Options "DENY" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    # This server block terminates TLS directly (see ssl_certificate above), so it is
+    # the right hop to send HSTS from. If you instead front this container with an
+    # external reverse proxy/ALB for TLS termination (as docker-compose.prod.yml
+    # recommends), configure HSTS there instead -- this header never reaches the
+    # browser when this container only serves plain HTTP behind that proxy.
+    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
     # CSP: nonce-based for style-src to avoid 'unsafe-inline' (MUI/Emotion uses nonce)
     # The __CSP_NONCE__ placeholder is replaced per-request by the sub_filter below.
     # In development (without nginx), 'unsafe-inline' is still needed — Vite injects styles directly.


### PR DESCRIPTION
## Summary
Fixes #482. Both `frontend/nginx.conf` and `frontend/nginx-ecs.conf.template` set `X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`, `Content-Security-Policy`, and `Permissions-Policy`, but neither sent `Strict-Transport-Security`. `SECURITY.md`'s "Security Practices" section highlighted the CSP nginx work prominently but was silent on HSTS.

- **`nginx.conf`** terminates TLS directly (`listen 443 ssl`, self-signed certs, HTTP→HTTPS redirect) — the right hop to send HSTS from — so it now does, at `max-age=63072000; includeSubDomains` (2 years, matching the issue's suggested value). Deliberately **no `preload`**: submitting a domain to the browser HSTS preload list is a much larger, effectively irreversible decision that shouldn't be baked into a generic shipped config.
- **`nginx-ecs.conf.template`** (ECS/Cloud Run/ACA) and the `docker-compose.prod.yml` + external-reverse-proxy topology deliberately do **not** get this header added: both only ever receive plain HTTP from an upstream ALB/proxy that terminates TLS itself, and HSTS only has effect on the hop that actually does that — sending it from the origin container would be a no-op at best, misleading at worst. Documented this split posture explicitly in `SECURITY.md` so operators of those deployments know HSTS is their responsibility to configure at the edge/ALB.

## Test plan
- [x] **Real syntax validation**, not just eyeballing: ran the actual `nginx:1.25-alpine` binary (`docker run ... nginx -t`) against the edited config with a throwaway self-signed cert — `nginx: configuration file /etc/nginx/nginx.conf syntax is ok` / `test is successful`.
- [x] **Real end-to-end verification**: started the container from that same config and `curl -I`'d it over a live TLS connection — the response includes `strict-transport-security: max-age=63072000; includeSubDomains`, confirming the header is actually served, not just present in the file.
- [x] Cleaned up the throwaway test container/certs afterward.