### PR TITLE
fix: actually enforce opt-in telemetry consent; document missing cookie/localStorage keys

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -86,19 +86,24 @@ Under GDPR, you have the right to:
 
 ### Cookies
 
-| Cookie                    | Purpose        | Duration |
-| ------------------------- | -------------- | -------- |
-| Session cookie (HttpOnly) | Authentication | Session  |
+| Cookie              | Purpose                                                      | Duration |
+| -------------------- | ------------------------------------------------------------ | -------- |
+| `tfr_auth_token` (HttpOnly) | Authentication session                                 | 24 hours |
+| `tfr_csrf`           | CSRF double-submit token, echoed back in the `X-CSRF-Token` header on mutating requests. Not HttpOnly (must be readable by the frontend) but is not usable on its own without the paired HttpOnly session cookie. | 24 hours |
 
 No third-party tracking cookies are used.
 
 ### Local Storage
 
-The following preferences are stored in the browser's `localStorage`, not as
-cookies:
+The following are stored in the browser's `localStorage`, not as cookies:
 
-| Key                          | Purpose               | Duration   |
-| ---------------------------- | --------------------- | ---------- |
+| Key                           | Purpose                                                             | Duration |
+| ------------------------------ | --------------------------------------------------------------------- | -------- |
+| `auth_token`                   | **Sensitive.** Legacy session JWT, used only during the transitional migration away from `localStorage`-based auth (see `SECURITY.md`); new sessions use the HttpOnly cookie above instead. Cleared on logout or session expiry. | Session  |
+| `user`                         | Cached profile info (id, email, name) for the signed-in user. Cleared on logout or session expiry. | Session  |
+| `role_template`                | Cached role template for the signed-in user. Cleared on logout or session expiry. | Session  |
+| `allowed_scopes`                | Cached authorization scopes for the signed-in user. Cleared on logout or session expiry. | Session  |
+| `authorized`                   | Swagger UI's own "Authorize" dialog state (`/api-docs`), persisted by the third-party `swagger-ui-react` component when a user authorizes a request there. May contain an API key if one was entered. Cleared on logout or session expiry. | Session  |
 | `terraform-registry-theme`   | UI theme (light/dark) | Persistent |
 | `terraform-registry-consent` | Consent preferences   | Persistent |
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import { AnnouncerProvider } from './contexts/AnnouncerContext'
 import { ConsentProvider } from './contexts/ConsentContext'
 import Layout from './components/Layout'
 import ConsentBanner from './components/ConsentBanner'
+import TelemetryGate from './components/TelemetryGate'
 import OfflineBanner from './components/OfflineBanner'
 import ErrorBoundary from './components/ErrorBoundary'
 import ProtectedRoute from './components/ProtectedRoute'
@@ -417,6 +418,7 @@ function App() {
           </HelpProvider>
         </AuthProvider>
         <ConsentBanner />
+        <TelemetryGate />
       </ConsentProvider>
       <OfflineBanner />
     </ThemeProvider>

--- a/frontend/src/components/TelemetryGate.tsx
+++ b/frontend/src/components/TelemetryGate.tsx
@@ -1,0 +1,41 @@
+import { useEffect } from 'react'
+import { useConsent } from '../contexts/ConsentContext'
+import {
+  init as initErrorReporting,
+  destroy as destroyErrorReporting,
+} from '../services/errorReporting'
+import {
+  init as initPerformanceReporting,
+  destroy as destroyPerformanceReporting,
+} from '../services/performanceReporting'
+
+/**
+ * Starts/stops error and performance reporting in lockstep with the user's
+ * consent preferences (PRIVACY.md section 3.3: telemetry is opt-in only).
+ * Renders nothing -- must be mounted inside ConsentProvider.
+ *
+ * Each effect's cleanup calls destroy() on consent withdrawal or unmount, so
+ * this also satisfies "withdraw consent at any time" (PRIVACY.md section 6,
+ * Art 7(3)) without requiring a page reload -- and pairs correctly with React
+ * StrictMode's mount->cleanup->remount dev cycle (double-init would otherwise
+ * leak a second flush timer).
+ */
+const TelemetryGate: React.FC = () => {
+  const { preferences } = useConsent()
+
+  useEffect(() => {
+    if (!preferences.errorReporting) return
+    initErrorReporting()
+    return () => destroyErrorReporting()
+  }, [preferences.errorReporting])
+
+  useEffect(() => {
+    if (!preferences.performanceReporting) return
+    initPerformanceReporting()
+    return () => destroyPerformanceReporting()
+  }, [preferences.performanceReporting])
+
+  return null
+}
+
+export default TelemetryGate

--- a/frontend/src/components/__tests__/TelemetryGate.test.tsx
+++ b/frontend/src/components/__tests__/TelemetryGate.test.tsx
@@ -1,0 +1,123 @@
+import { render, act } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const initErrorReportingMock = vi.fn()
+const destroyErrorReportingMock = vi.fn()
+const initPerformanceReportingMock = vi.fn()
+const destroyPerformanceReportingMock = vi.fn()
+
+vi.mock('../../services/errorReporting', () => ({
+  init: () => initErrorReportingMock(),
+  destroy: () => destroyErrorReportingMock(),
+}))
+
+vi.mock('../../services/performanceReporting', () => ({
+  init: () => initPerformanceReportingMock(),
+  destroy: () => destroyPerformanceReportingMock(),
+}))
+
+let mockPreferences = {
+  essential: true as const,
+  errorReporting: false,
+  performanceReporting: false,
+  analytics: false,
+}
+
+vi.mock('../../contexts/ConsentContext', () => ({
+  useConsent: () => ({ preferences: mockPreferences }),
+}))
+
+import TelemetryGate from '../TelemetryGate'
+
+describe('TelemetryGate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockPreferences = {
+      essential: true,
+      errorReporting: false,
+      performanceReporting: false,
+      analytics: false,
+    }
+  })
+
+  it('renders nothing', () => {
+    const { container } = render(<TelemetryGate />)
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('does not start either reporter when neither is consented to', () => {
+    render(<TelemetryGate />)
+    expect(initErrorReportingMock).not.toHaveBeenCalled()
+    expect(initPerformanceReportingMock).not.toHaveBeenCalled()
+  })
+
+  it('starts only error reporting when only that category is consented to', () => {
+    mockPreferences = { ...mockPreferences, errorReporting: true }
+    render(<TelemetryGate />)
+    expect(initErrorReportingMock).toHaveBeenCalledTimes(1)
+    expect(initPerformanceReportingMock).not.toHaveBeenCalled()
+  })
+
+  it('starts only performance reporting when only that category is consented to', () => {
+    mockPreferences = { ...mockPreferences, performanceReporting: true }
+    render(<TelemetryGate />)
+    expect(initPerformanceReportingMock).toHaveBeenCalledTimes(1)
+    expect(initErrorReportingMock).not.toHaveBeenCalled()
+  })
+
+  it('starts both reporters when both categories are consented to', () => {
+    mockPreferences = { ...mockPreferences, errorReporting: true, performanceReporting: true }
+    render(<TelemetryGate />)
+    expect(initErrorReportingMock).toHaveBeenCalledTimes(1)
+    expect(initPerformanceReportingMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('starts error reporting when consent is granted after initial render (no reload needed)', () => {
+    const { rerender } = render(<TelemetryGate />)
+    expect(initErrorReportingMock).not.toHaveBeenCalled()
+
+    mockPreferences = { ...mockPreferences, errorReporting: true }
+    rerender(<TelemetryGate />)
+    expect(initErrorReportingMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('stops error reporting when consent is withdrawn after being granted (Art 7(3))', () => {
+    mockPreferences = { ...mockPreferences, errorReporting: true }
+    const { rerender } = render(<TelemetryGate />)
+    expect(initErrorReportingMock).toHaveBeenCalledTimes(1)
+    expect(destroyErrorReportingMock).not.toHaveBeenCalled()
+
+    mockPreferences = { ...mockPreferences, errorReporting: false }
+    rerender(<TelemetryGate />)
+    expect(destroyErrorReportingMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('stops performance reporting when consent is withdrawn after being granted', () => {
+    mockPreferences = { ...mockPreferences, performanceReporting: true }
+    const { rerender } = render(<TelemetryGate />)
+    expect(initPerformanceReportingMock).toHaveBeenCalledTimes(1)
+
+    mockPreferences = { ...mockPreferences, performanceReporting: false }
+    rerender(<TelemetryGate />)
+    expect(destroyPerformanceReportingMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('stops both reporters on unmount if consented to', () => {
+    mockPreferences = { ...mockPreferences, errorReporting: true, performanceReporting: true }
+    const { unmount } = render(<TelemetryGate />)
+    act(() => {
+      unmount()
+    })
+    expect(destroyErrorReportingMock).toHaveBeenCalledTimes(1)
+    expect(destroyPerformanceReportingMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not call destroy on unmount if never consented to', () => {
+    const { unmount } = render(<TelemetryGate />)
+    act(() => {
+      unmount()
+    })
+    expect(destroyErrorReportingMock).not.toHaveBeenCalled()
+    expect(destroyPerformanceReportingMock).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -9,12 +9,13 @@ import { CacheProvider } from '@emotion/react'
 import App from './App'
 import './index.css'
 import './i18n'
-import { init as initErrorReporting, captureError } from './services/errorReporting'
-import { init as initPerformanceReporting } from './services/performanceReporting'
+import { captureError } from './services/errorReporting'
 
-initErrorReporting()
-initPerformanceReporting()
-
+// Error/performance reporting are started by <TelemetryGate> once the user has
+// opted in (PRIVACY.md section 3.3) -- not here, unconditionally, before any
+// consent state is even known. captureError() below is still safe to call
+// pre-consent: it always logs to the console, but only transmits externally
+// once init() has set a DSN, which happens exclusively via that opt-in gate.
 window.addEventListener('unhandledrejection', (event) => {
   const error = event.reason instanceof Error ? event.reason : new Error(String(event.reason))
   captureError(error, { type: 'unhandledrejection' })


### PR DESCRIPTION
## Summary
Fixes #475 (medium severity). Two independent gaps flagged by the same issue.

**1. Incomplete cookie/localStorage disclosure.** `PRIVACY.md`'s tables omitted `tfr_csrf` (the CSRF double-submit cookie) and 4 of the 5 legacy auth `localStorage` keys (`auth_token`, `user`, `role_template`, `allowed_scopes` — only `authorized`/theme/consent were listed). Added all of them with accurate purpose/duration, explicitly flagging `auth_token` as **sensitive** (transitional migration path, per `SECURITY.md`).

**2. The "opt-in only" telemetry claim wasn't enforced — I chose to fix the code, not the docs.** `PRIVACY.md` section 3.3 explicitly states telemetry is "opt-in only," and section 4 states its GDPR legal basis is **Consent (Art 6(1)(a))**. But `errorReporting.init()`/`performanceReporting.init()` were both called unconditionally in `main.tsx`, before React even mounts and before any consent state exists. Whenever an operator configures a DSN, telemetry started transmitting on first page load regardless of whether any individual user had actually clicked "opt in" through the consent banner — a real mismatch between the stated legal basis and actual behavior, not just a documentation inaccuracy. Since the docs make a formal, specific GDPR claim that operators may rely on for their own compliance posture, I fixed the code to match the promise rather than downgrading the promise to match the gap.

- Added `<TelemetryGate>`, mounted inside `ConsentProvider` (`App.tsx`), which starts each reporter only when its specific `preferences.errorReporting`/`preferences.performanceReporting` flag is `true` — the shared `@sethbacon/terraform-suite-ui` `ConsentProvider` already tracks these **per-category** (confirmed by reading its actual source), just unused for telemetry gating until now.
- Each effect's cleanup calls `destroy()` on consent withdrawal (dependency change) or unmount, which also makes **"withdraw consent at any time"** (`PRIVACY.md` section 6, Art 7(3)) actually work without a page reload — the previous one-shot `init()` could never have supported that regardless of gating.
- Removed the two unconditional `init()` calls from `main.tsx`. `captureError()`'s `unhandledrejection` handler stays ungated: it always `console.error()`s (harmless, local-only), and only transmits externally once `init()` has set a `dsn`, which now only happens via the consent-gated path.

## Test plan
- [x] New `TelemetryGate.test.tsx`, 10 cases: renders nothing; neither/one/both reporters start per category; starts reactively when consent is granted post-mount (no reload); stops reactively on withdrawal for each category independently; stops both on unmount if consented; does *not* call `destroy()` on unmount if never consented (avoids a spurious call).
- [x] `vitest run` on `TelemetryGate.test.tsx` + `errorReporting.test.ts` + `performanceReporting.test.ts` + `OfflineBanner.test.tsx` (regression check since `App.tsx` was touched) — 43/43 passed.
- [x] `npx tsc --noEmit` — same 20 pre-existing, unrelated errors as `main`.
- [x] `eslint` — clean.
- [x] `prettier --check` — clean (formatted the one genuinely-new file; no pre-existing-file drift to worry about).