### PR TITLE
feat: generate and attest an SBOM for the published release image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,6 +138,21 @@ jobs:
           subject-digest: ${{ steps.build.outputs.digest }}
           push-to-registry: true
 
+      - name: Generate SBOM (Syft)
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
+          format: spdx-json
+          output-file: sbom.spdx.json
+
+      - name: Attest SBOM
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          sbom-path: sbom.spdx.json
+          push-to-registry: true
+
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -120,4 +120,5 @@ matching `v*.*.*` with a "Restrict deletions" rule.
 - `rehype-sanitize` for Markdown rendering (XSS mitigation)
 - Scheduled weekly security workflow with auto-issue on failure
 - **SLSA provenance attestation** on Docker images via `actions/attest-build-provenance`
+- **SBOM (SPDX) generation and attestation** on Docker images via Syft (`anchore/sbom-action`) and `actions/attest-sbom`
 - **Cosign keyless signing** on Docker images via Sigstore (verify with `cosign verify`)


### PR DESCRIPTION
## Summary
Fixes #470 (medium severity, OWASP A08:2021). `release.yml` signs (cosign keyless) and attests SLSA build-provenance for the release image but generated no SBOM — a gap given the otherwise mature signing infrastructure.

Added two steps alongside the existing provenance attestation, in the same style (explicit `attest-*` action, not buildx's native `provenance: true`/`sbom: true` flags) so all three attestations — provenance, SBOM, signature — stay equally visible in the workflow log rather than mixing generation styles:

- **`Generate SBOM (Syft)`** — `anchore/sbom-action` scans the just-pushed image **by its digest** (not a floating tag, to guarantee it's scanning exactly what was built/signed) and produces an SPDX JSON document. Reuses the `docker/login-action` credentials already established earlier in the same job — no new registry auth needed.
- **`Attest SBOM`** — `actions/attest-sbom` attaches that SBOM as an in-toto attestation pushed to the registry, same `subject-name`/`subject-digest` pattern as the existing provenance attestation, under the `id-token`/`attestations` permissions the job already has (no permission changes needed).

Also added a matching bullet to `SECURITY.md`'s "Supply-Chain Security" section, alongside the existing SLSA provenance and cosign signing lines it already documents.

## Verification
- Read both actions' actual `action.yml` files via the GitHub API rather than assuming parameter names — confirmed `anchore/sbom-action`'s `image`/`format`/`output-file` inputs and `actions/attest-sbom`'s `subject-name`/`subject-digest`/`sbom-path`/`push-to-registry` inputs match `attest-build-provenance`'s existing shape exactly.
- Pinned both to their real `v0.24.0`/`v4.1.0` release commit SHAs, resolved via the GitHub API (not guessed), matching this repo's existing pin-every-action-to-a-SHA convention.
- `python3 -c "import yaml; yaml.safe_load(...)"` — valid YAML.
- `actionlint` (this file, then the whole `.github/workflows/` tree) — clean, no warnings.
- Cannot fully exercise the release pipeline itself outside a real tagged release — the actual SBOM generation/attestation will only be provable on the next release run.