### PR TITLE
refactor: extract LazyRoute helper and shared admin route-scope map

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { Suspense, lazy } from 'react'
+import { lazy } from 'react'
 import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
@@ -13,8 +13,9 @@ import ConsentBanner from './components/ConsentBanner'
 import TelemetryGate from './components/TelemetryGate'
 import OfflineBanner from './components/OfflineBanner'
 import ErrorBoundary from './components/ErrorBoundary'
-import ProtectedRoute from './components/ProtectedRoute'
+import LazyRoute from './components/LazyRoute'
 import RouteFocusManager from './components/RouteFocusManager'
+import { ADMIN_ROUTE_SCOPES } from './routeScopes'
 // Critical-path pages loaded eagerly (small, always needed on first visit)
 import HomePage from './pages/HomePage'
 import LoginPage from './pages/LoginPage'
@@ -61,8 +62,6 @@ const queryClient = new QueryClient({
   },
 })
 
-const loader = <div>Loading...</div>
-
 function App() {
   return (
     <ThemeProvider>
@@ -89,124 +88,76 @@ function App() {
                         <Route path="/modules" element={<ModulesPage />} />
                         <Route
                           path="/modules/:namespace/:name/:system"
-                          element={
-                            <ErrorBoundary>
-                              <Suspense fallback={loader}>
-                                <ModuleDetailPage />
-                              </Suspense>
-                            </ErrorBoundary>
-                          }
+                          element={<LazyRoute Component={ModuleDetailPage} />}
                         />
 
                         {/* Providers */}
                         <Route path="/providers" element={<ProvidersPage />} />
                         <Route
                           path="/providers/:namespace/:type"
-                          element={
-                            <ErrorBoundary>
-                              <Suspense fallback={loader}>
-                                <ProviderDetailPage />
-                              </Suspense>
-                            </ErrorBoundary>
-                          }
+                          element={<LazyRoute Component={ProviderDetailPage} />}
                         />
 
                         {/* Terraform Binaries */}
                         <Route path="/terraform-binaries" element={<TerraformBinariesPage />} />
                         <Route
                           path="/terraform-binaries/:name"
-                          element={
-                            <ErrorBoundary>
-                              <Suspense fallback={loader}>
-                                <TerraformBinaryDetailPage />
-                              </Suspense>
-                            </ErrorBoundary>
-                          }
+                          element={<LazyRoute Component={TerraformBinaryDetailPage} />}
                         />
 
                         {/* API Documentation */}
                         <Route
                           path="/api-docs"
-                          element={
-                            <ErrorBoundary>
-                              <Suspense fallback={loader}>
-                                <ApiDocumentation />
-                              </Suspense>
-                            </ErrorBoundary>
-                          }
+                          element={<LazyRoute Component={ApiDocumentation} />}
                         />
 
                         {/* Settings & Privacy */}
-                        <Route
-                          path="/settings"
-                          element={
-                            <ErrorBoundary>
-                              <Suspense fallback={loader}>
-                                <SettingsPage />
-                              </Suspense>
-                            </ErrorBoundary>
-                          }
-                        />
+                        <Route path="/settings" element={<LazyRoute Component={SettingsPage} />} />
 
-                        {/* Admin routes (protected with scope requirements) */}
+                        {/* Admin routes (protected with scope requirements from routeScopes.ts) */}
                         <Route
                           path="/admin"
                           element={
-                            <ProtectedRoute>
-                              <ErrorBoundary>
-                                <Suspense fallback={loader}>
-                                  <DashboardPage />
-                                </Suspense>
-                              </ErrorBoundary>
-                            </ProtectedRoute>
+                            <LazyRoute
+                              Component={DashboardPage}
+                              requiredScope={ADMIN_ROUTE_SCOPES['/admin']}
+                            />
                           }
                         />
                         <Route
                           path="/admin/users"
                           element={
-                            <ProtectedRoute requiredScope="users:read">
-                              <ErrorBoundary>
-                                <Suspense fallback={loader}>
-                                  <UsersPage />
-                                </Suspense>
-                              </ErrorBoundary>
-                            </ProtectedRoute>
+                            <LazyRoute
+                              Component={UsersPage}
+                              requiredScope={ADMIN_ROUTE_SCOPES['/admin/users']}
+                            />
                           }
                         />
                         <Route
                           path="/admin/organizations"
                           element={
-                            <ProtectedRoute requiredScope="organizations:read">
-                              <ErrorBoundary>
-                                <Suspense fallback={loader}>
-                                  <OrganizationsPage />
-                                </Suspense>
-                              </ErrorBoundary>
-                            </ProtectedRoute>
+                            <LazyRoute
+                              Component={OrganizationsPage}
+                              requiredScope={ADMIN_ROUTE_SCOPES['/admin/organizations']}
+                            />
                           }
                         />
                         <Route
                           path="/admin/roles"
                           element={
-                            <ProtectedRoute requiredScope="users:read">
-                              <ErrorBoundary>
-                                <Suspense fallback={loader}>
-                                  <RolesPage />
-                                </Suspense>
-                              </ErrorBoundary>
-                            </ProtectedRoute>
+                            <LazyRoute
+                              Component={RolesPage}
+                              requiredScope={ADMIN_ROUTE_SCOPES['/admin/roles']}
+                            />
                           }
                         />
                         <Route
                           path="/admin/apikeys"
                           element={
-                            <ProtectedRoute>
-                              <ErrorBoundary>
-                                <Suspense fallback={loader}>
-                                  <APIKeysPage />
-                                </Suspense>
-                              </ErrorBoundary>
-                            </ProtectedRoute>
+                            <LazyRoute
+                              Component={APIKeysPage}
+                              requiredScope={ADMIN_ROUTE_SCOPES['/admin/apikeys']}
+                            />
                           }
                         />
                         <Route
@@ -216,181 +167,136 @@ function App() {
                         <Route
                           path="/admin/upload/module"
                           element={
-                            <ProtectedRoute requiredScope="modules:write">
-                              <ErrorBoundary>
-                                <Suspense fallback={loader}>
-                                  <ModuleUploadPage />
-                                </Suspense>
-                              </ErrorBoundary>
-                            </ProtectedRoute>
+                            <LazyRoute
+                              Component={ModuleUploadPage}
+                              requiredScope={ADMIN_ROUTE_SCOPES['/admin/upload/module']}
+                            />
                           }
                         />
                         <Route
                           path="/admin/upload/provider"
                           element={
-                            <ProtectedRoute requiredScope="providers:write">
-                              <ErrorBoundary>
-                                <Suspense fallback={loader}>
-                                  <ProviderUploadPage />
-                                </Suspense>
-                              </ErrorBoundary>
-                            </ProtectedRoute>
+                            <LazyRoute
+                              Component={ProviderUploadPage}
+                              requiredScope={ADMIN_ROUTE_SCOPES['/admin/upload/provider']}
+                            />
                           }
                         />
                         <Route
                           path="/admin/scm-providers"
                           element={
-                            <ProtectedRoute requiredScope="scm:read">
-                              <ErrorBoundary>
-                                <Suspense fallback={loader}>
-                                  <SCMProvidersPage />
-                                </Suspense>
-                              </ErrorBoundary>
-                            </ProtectedRoute>
+                            <LazyRoute
+                              Component={SCMProvidersPage}
+                              requiredScope={ADMIN_ROUTE_SCOPES['/admin/scm-providers']}
+                            />
                           }
                         />
                         <Route
                           path="/admin/mirrors"
                           element={
-                            <ProtectedRoute requiredScope="mirrors:read">
-                              <ErrorBoundary>
-                                <Suspense fallback={loader}>
-                                  <MirrorsPage />
-                                </Suspense>
-                              </ErrorBoundary>
-                            </ProtectedRoute>
+                            <LazyRoute
+                              Component={MirrorsPage}
+                              requiredScope={ADMIN_ROUTE_SCOPES['/admin/mirrors']}
+                            />
                           }
                         />
                         <Route
                           path="/admin/terraform-mirror"
                           element={
-                            <ProtectedRoute requiredScope="mirrors:read">
-                              <ErrorBoundary>
-                                <Suspense fallback={loader}>
-                                  <TerraformMirrorPage />
-                                </Suspense>
-                              </ErrorBoundary>
-                            </ProtectedRoute>
+                            <LazyRoute
+                              Component={TerraformMirrorPage}
+                              requiredScope={ADMIN_ROUTE_SCOPES['/admin/terraform-mirror']}
+                            />
                           }
                         />
                         <Route
                           path="/admin/storage"
                           element={
-                            <ProtectedRoute requiredScope="admin">
-                              <ErrorBoundary>
-                                <Suspense fallback={loader}>
-                                  <StoragePage />
-                                </Suspense>
-                              </ErrorBoundary>
-                            </ProtectedRoute>
+                            <LazyRoute
+                              Component={StoragePage}
+                              requiredScope={ADMIN_ROUTE_SCOPES['/admin/storage']}
+                            />
                           }
                         />
                         <Route
                           path="/admin/approvals"
                           element={
-                            <ProtectedRoute requiredScope="mirrors:read">
-                              <ErrorBoundary>
-                                <Suspense fallback={loader}>
-                                  <ApprovalsPage />
-                                </Suspense>
-                              </ErrorBoundary>
-                            </ProtectedRoute>
+                            <LazyRoute
+                              Component={ApprovalsPage}
+                              requiredScope={ADMIN_ROUTE_SCOPES['/admin/approvals']}
+                            />
                           }
                         />
                         <Route
                           path="/admin/version-approvals"
                           element={
-                            <ProtectedRoute requiredScope="mirrors:read">
-                              <ErrorBoundary>
-                                <Suspense fallback={loader}>
-                                  <VersionApprovalsPage />
-                                </Suspense>
-                              </ErrorBoundary>
-                            </ProtectedRoute>
+                            <LazyRoute
+                              Component={VersionApprovalsPage}
+                              requiredScope={ADMIN_ROUTE_SCOPES['/admin/version-approvals']}
+                            />
                           }
                         />
                         <Route
                           path="/admin/policies"
                           element={
-                            <ProtectedRoute requiredScope="admin">
-                              <ErrorBoundary>
-                                <Suspense fallback={loader}>
-                                  <MirrorPoliciesPage />
-                                </Suspense>
-                              </ErrorBoundary>
-                            </ProtectedRoute>
+                            <LazyRoute
+                              Component={MirrorPoliciesPage}
+                              requiredScope={ADMIN_ROUTE_SCOPES['/admin/policies']}
+                            />
                           }
                         />
                         <Route
                           path="/admin/oidc"
                           element={
-                            <ProtectedRoute requiredScope="admin">
-                              <ErrorBoundary>
-                                <Suspense fallback={loader}>
-                                  <OIDCSettingsPage />
-                                </Suspense>
-                              </ErrorBoundary>
-                            </ProtectedRoute>
+                            <LazyRoute
+                              Component={OIDCSettingsPage}
+                              requiredScope={ADMIN_ROUTE_SCOPES['/admin/oidc']}
+                            />
                           }
                         />
                         <Route
                           path="/admin/scim"
                           element={
-                            <ProtectedRoute requiredScope="admin">
-                              <ErrorBoundary>
-                                <Suspense fallback={loader}>
-                                  <SCIMProvisioningPage />
-                                </Suspense>
-                              </ErrorBoundary>
-                            </ProtectedRoute>
+                            <LazyRoute
+                              Component={SCIMProvisioningPage}
+                              requiredScope={ADMIN_ROUTE_SCOPES['/admin/scim']}
+                            />
                           }
                         />
                         <Route
                           path="/admin/mtls"
                           element={
-                            <ProtectedRoute requiredScope="admin">
-                              <ErrorBoundary>
-                                <Suspense fallback={loader}>
-                                  <MTLSPage />
-                                </Suspense>
-                              </ErrorBoundary>
-                            </ProtectedRoute>
+                            <LazyRoute
+                              Component={MTLSPage}
+                              requiredScope={ADMIN_ROUTE_SCOPES['/admin/mtls']}
+                            />
                           }
                         />
                         <Route
                           path="/admin/audit-logs"
                           element={
-                            <ProtectedRoute requiredScope="audit:read">
-                              <ErrorBoundary>
-                                <Suspense fallback={loader}>
-                                  <AuditLogPage />
-                                </Suspense>
-                              </ErrorBoundary>
-                            </ProtectedRoute>
+                            <LazyRoute
+                              Component={AuditLogPage}
+                              requiredScope={ADMIN_ROUTE_SCOPES['/admin/audit-logs']}
+                            />
                           }
                         />
                         <Route
                           path="/admin/security-scanning"
                           element={
-                            <ProtectedRoute requiredScope="admin">
-                              <ErrorBoundary>
-                                <Suspense fallback={loader}>
-                                  <SecurityScanningPage />
-                                </Suspense>
-                              </ErrorBoundary>
-                            </ProtectedRoute>
+                            <LazyRoute
+                              Component={SecurityScanningPage}
+                              requiredScope={ADMIN_ROUTE_SCOPES['/admin/security-scanning']}
+                            />
                           }
                         />
                         <Route
                           path="/admin/notifications"
                           element={
-                            <ProtectedRoute requiredScope="admin">
-                              <ErrorBoundary>
-                                <Suspense fallback={loader}>
-                                  <NotificationsPage />
-                                </Suspense>
-                              </ErrorBoundary>
-                            </ProtectedRoute>
+                            <LazyRoute
+                              Component={NotificationsPage}
+                              requiredScope={ADMIN_ROUTE_SCOPES['/admin/notifications']}
+                            />
                           }
                         />
 
@@ -398,11 +304,7 @@ function App() {
                         {import.meta.env.DEV && (
                           <Route
                             path="/dev/components"
-                            element={
-                              <Suspense fallback={loader}>
-                                <ComponentShowcase />
-                              </Suspense>
-                            }
+                            element={<LazyRoute Component={ComponentShowcase} />}
                           />
                         )}
 

--- a/frontend/src/components/LazyRoute.tsx
+++ b/frontend/src/components/LazyRoute.tsx
@@ -1,0 +1,39 @@
+import { Suspense } from 'react'
+import type { ComponentType } from 'react'
+import ErrorBoundary from './ErrorBoundary'
+import ProtectedRoute from './ProtectedRoute'
+
+const loader = <div>Loading...</div>
+
+interface LazyRouteProps {
+  Component: ComponentType
+  /**
+   * Omit for a public route (no auth gate). Pass `null` for a route that
+   * requires an authenticated user but no specific scope. Pass a scope
+   * string for a route gated on that scope (via ProtectedRoute).
+   */
+  requiredScope?: string | null
+}
+
+/**
+ * Composes the ErrorBoundary + Suspense (+ optional ProtectedRoute) wrapper
+ * that every lazy-loaded route in App.tsx needs, so route definitions only
+ * specify the component and its scope requirement.
+ */
+const LazyRoute = ({ Component, requiredScope }: LazyRouteProps) => {
+  const body = (
+    <ErrorBoundary>
+      <Suspense fallback={loader}>
+        <Component />
+      </Suspense>
+    </ErrorBoundary>
+  )
+
+  if (requiredScope === undefined) {
+    return body
+  }
+
+  return <ProtectedRoute requiredScope={requiredScope ?? undefined}>{body}</ProtectedRoute>
+}
+
+export default LazyRoute

--- a/frontend/src/navigation.tsx
+++ b/frontend/src/navigation.tsx
@@ -21,6 +21,14 @@ import Security from '@mui/icons-material/Security'
 import History from '@mui/icons-material/History'
 import Notifications from '@mui/icons-material/Notifications'
 import type { NavItem, NavGroup } from '@sethbacon/terraform-suite-ui'
+import { ADMIN_ROUTE_SCOPES } from './routeScopes'
+
+// Reads the scope for an admin nav item from the shared route-scope map
+// (routeScopes.ts) so App.tsx's route guards and this sidebar's item
+// filtering can't drift apart.
+function adminScope(path: string): string | null {
+  return ADMIN_ROUTE_SCOPES[path] ?? null
+}
 
 // Home — shown standalone at the top of the drawer.
 export const homeItem: NavItem = {
@@ -60,7 +68,7 @@ export const adminDashboardItem: NavItem = {
   labelKey: 'nav.admin.dashboard',
   tooltipKey: 'nav.admin.dashboardTooltip',
   icon: <Dashboard />,
-  scope: null,
+  scope: adminScope('/admin'),
 }
 
 // Collapsible, scope-filtered admin groups. The Identity group carries the
@@ -71,41 +79,41 @@ export const adminNavGroups: NavGroup[] = [
     labelKey: 'nav.admin.identity',
     standaloneItem: adminDashboardItem,
     items: [
-      { path: '/admin/organizations', labelKey: 'nav.admin.organizations', tooltipKey: 'nav.admin.organizationsTooltip', icon: <Business />, scope: 'organizations:read' },
-      { path: '/admin/roles', labelKey: 'nav.admin.roles', tooltipKey: 'nav.admin.rolesTooltip', icon: <Badge />, scope: 'users:read' },
-      { path: '/admin/users', labelKey: 'nav.admin.users', tooltipKey: 'nav.admin.usersTooltip', icon: <People />, scope: 'users:read' },
-      { path: '/admin/oidc', labelKey: 'nav.admin.oidcGroups', tooltipKey: 'nav.admin.oidcGroupsTooltip', icon: <ManageAccounts />, scope: 'admin' },
-      { path: '/admin/scim', labelKey: 'nav.admin.scim', tooltipKey: 'nav.admin.scimTooltip', icon: <SyncAlt />, scope: 'admin' },
-      { path: '/admin/mtls', labelKey: 'nav.admin.mtlsCerts', tooltipKey: 'nav.admin.mtlsCertsTooltip', icon: <VerifiedUser />, scope: 'admin' },
-      { path: '/admin/apikeys', labelKey: 'nav.admin.apiKeys', tooltipKey: 'nav.admin.apiKeysTooltip', icon: <Key />, scope: null },
+      { path: '/admin/organizations', labelKey: 'nav.admin.organizations', tooltipKey: 'nav.admin.organizationsTooltip', icon: <Business />, scope: adminScope('/admin/organizations') },
+      { path: '/admin/roles', labelKey: 'nav.admin.roles', tooltipKey: 'nav.admin.rolesTooltip', icon: <Badge />, scope: adminScope('/admin/roles') },
+      { path: '/admin/users', labelKey: 'nav.admin.users', tooltipKey: 'nav.admin.usersTooltip', icon: <People />, scope: adminScope('/admin/users') },
+      { path: '/admin/oidc', labelKey: 'nav.admin.oidcGroups', tooltipKey: 'nav.admin.oidcGroupsTooltip', icon: <ManageAccounts />, scope: adminScope('/admin/oidc') },
+      { path: '/admin/scim', labelKey: 'nav.admin.scim', tooltipKey: 'nav.admin.scimTooltip', icon: <SyncAlt />, scope: adminScope('/admin/scim') },
+      { path: '/admin/mtls', labelKey: 'nav.admin.mtlsCerts', tooltipKey: 'nav.admin.mtlsCertsTooltip', icon: <VerifiedUser />, scope: adminScope('/admin/mtls') },
+      { path: '/admin/apikeys', labelKey: 'nav.admin.apiKeys', tooltipKey: 'nav.admin.apiKeysTooltip', icon: <Key />, scope: adminScope('/admin/apikeys') },
     ],
   },
   {
     key: 'source-control',
     labelKey: 'nav.admin.sourceControl',
     items: [
-      { path: '/admin/scm-providers', labelKey: 'nav.admin.sourceControl', tooltipKey: 'nav.admin.sourceControlTooltip', icon: <GitHub />, scope: 'scm:read' },
+      { path: '/admin/scm-providers', labelKey: 'nav.admin.sourceControl', tooltipKey: 'nav.admin.sourceControlTooltip', icon: <GitHub />, scope: adminScope('/admin/scm-providers') },
     ],
   },
   {
     key: 'mirroring',
     labelKey: 'nav.admin.mirroring',
     items: [
-      { path: '/admin/mirrors', labelKey: 'nav.admin.providerConfig', tooltipKey: 'nav.admin.providerConfigTooltip', icon: <CloudDownload />, scope: 'mirrors:read' },
-      { path: '/admin/terraform-mirror', labelKey: 'nav.admin.binariesConfig', tooltipKey: 'nav.admin.binariesConfigTooltip', icon: <GetApp />, scope: 'mirrors:read' },
-      { path: '/admin/approvals', labelKey: 'nav.admin.approvals', tooltipKey: 'nav.admin.approvalsTooltip', icon: <HourglassEmpty />, scope: 'mirrors:read' },
-      { path: '/admin/version-approvals', labelKey: 'nav.admin.versionApprovals', tooltipKey: 'nav.admin.versionApprovalsTooltip', icon: <HourglassEmpty />, scope: 'mirrors:read' },
-      { path: '/admin/policies', labelKey: 'nav.admin.mirrorPolicies', tooltipKey: 'nav.admin.mirrorPoliciesTooltip', icon: <Policy />, scope: 'admin' },
+      { path: '/admin/mirrors', labelKey: 'nav.admin.providerConfig', tooltipKey: 'nav.admin.providerConfigTooltip', icon: <CloudDownload />, scope: adminScope('/admin/mirrors') },
+      { path: '/admin/terraform-mirror', labelKey: 'nav.admin.binariesConfig', tooltipKey: 'nav.admin.binariesConfigTooltip', icon: <GetApp />, scope: adminScope('/admin/terraform-mirror') },
+      { path: '/admin/approvals', labelKey: 'nav.admin.approvals', tooltipKey: 'nav.admin.approvalsTooltip', icon: <HourglassEmpty />, scope: adminScope('/admin/approvals') },
+      { path: '/admin/version-approvals', labelKey: 'nav.admin.versionApprovals', tooltipKey: 'nav.admin.versionApprovalsTooltip', icon: <HourglassEmpty />, scope: adminScope('/admin/version-approvals') },
+      { path: '/admin/policies', labelKey: 'nav.admin.mirrorPolicies', tooltipKey: 'nav.admin.mirrorPoliciesTooltip', icon: <Policy />, scope: adminScope('/admin/policies') },
     ],
   },
   {
     key: 'system',
     labelKey: 'nav.admin.system',
     items: [
-      { path: '/admin/storage', labelKey: 'nav.admin.storage', tooltipKey: 'nav.admin.storageTooltip', icon: <Storage />, scope: 'admin' },
-      { path: '/admin/security-scanning', labelKey: 'nav.admin.securityScanning', tooltipKey: 'nav.admin.securityScanningTooltip', icon: <Security />, scope: 'admin' },
-      { path: '/admin/notifications', labelKey: 'nav.admin.notifications', tooltipKey: 'nav.admin.notificationsTooltip', icon: <Notifications />, scope: 'admin' },
-      { path: '/admin/audit-logs', labelKey: 'nav.admin.auditLogs', tooltipKey: 'nav.admin.auditLogsTooltip', icon: <History />, scope: 'audit:read' },
+      { path: '/admin/storage', labelKey: 'nav.admin.storage', tooltipKey: 'nav.admin.storageTooltip', icon: <Storage />, scope: adminScope('/admin/storage') },
+      { path: '/admin/security-scanning', labelKey: 'nav.admin.securityScanning', tooltipKey: 'nav.admin.securityScanningTooltip', icon: <Security />, scope: adminScope('/admin/security-scanning') },
+      { path: '/admin/notifications', labelKey: 'nav.admin.notifications', tooltipKey: 'nav.admin.notificationsTooltip', icon: <Notifications />, scope: adminScope('/admin/notifications') },
+      { path: '/admin/audit-logs', labelKey: 'nav.admin.auditLogs', tooltipKey: 'nav.admin.auditLogsTooltip', icon: <History />, scope: adminScope('/admin/audit-logs') },
     ],
   },
 ]

--- a/frontend/src/routeScopes.ts
+++ b/frontend/src/routeScopes.ts
@@ -1,0 +1,31 @@
+// Single source of truth for which scope (if any) each /admin/* route
+// requires. App.tsx (route guards, via LazyRoute) and navigation.tsx
+// (sidebar item filtering) both read from this map instead of each
+// maintaining their own literal scope per path, so the two can't drift
+// out of sync.
+//
+// A value of `null` means the route requires an authenticated user but no
+// specific scope (matches NavItem['scope']'s "always visible to
+// authenticated users" convention).
+export const ADMIN_ROUTE_SCOPES: Record<string, string | null> = {
+  '/admin': null,
+  '/admin/users': 'users:read',
+  '/admin/organizations': 'organizations:read',
+  '/admin/roles': 'users:read',
+  '/admin/apikeys': null,
+  '/admin/upload/module': 'modules:write',
+  '/admin/upload/provider': 'providers:write',
+  '/admin/scm-providers': 'scm:read',
+  '/admin/mirrors': 'mirrors:read',
+  '/admin/terraform-mirror': 'mirrors:read',
+  '/admin/storage': 'admin',
+  '/admin/approvals': 'mirrors:read',
+  '/admin/version-approvals': 'mirrors:read',
+  '/admin/policies': 'admin',
+  '/admin/oidc': 'admin',
+  '/admin/scim': 'admin',
+  '/admin/mtls': 'admin',
+  '/admin/audit-logs': 'audit:read',
+  '/admin/security-scanning': 'admin',
+  '/admin/notifications': 'admin',
+}


### PR DESCRIPTION
## Summary
- Extract a `LazyRoute` component composing the `ErrorBoundary` + `Suspense` (+ optional `ProtectedRoute`) wrapper that was hand-duplicated across 26 route definitions in `App.tsx`
- Add `routeScopes.ts`, a single `ADMIN_ROUTE_SCOPES` map that both `App.tsx` (route guards) and `navigation.tsx` (sidebar item filtering) now read from, replacing two independently-maintained literal scope lists

## Behavior
No functional change — verified every route's `requiredScope` before/after matches, including the two admin routes (`/admin`, `/admin/apikeys`) that are auth-gated but scope-free, and the public lazy routes that had no `ProtectedRoute` wrapper at all. The dev-only `/dev/components` route now also gets an `ErrorBoundary` (previously `Suspense`-only), for consistency with every other lazy route.

Closes #480
Fixes item [26] of #498 (route-scope duplication between `navigation.tsx`/`App.tsx`) — the other five findings in #498 are tracked separately and not part of this PR.

## Test plan
- [x] `npx tsc --noEmit` — 20 pre-existing errors (uninstalled private `@sethbacon/terraform-suite-ui` package), no new errors
- [x] `npx eslint` on changed files — clean
- [x] `npx vitest run` — 1032/1032 passing tests, 0 new failures (37 pre-existing failures are all import-resolution errors from the same uninstalled private package)