### PR TITLE
fix: report non-404 getUITheme() failures instead of swallowing them

### DIFF
--- a/frontend/src/services/__tests__/api.test.ts
+++ b/frontend/src/services/__tests__/api.test.ts
@@ -2619,4 +2619,69 @@ describe('ApiClient', () => {
       expect(result.version).toBe('1.0.0')
     })
   })
+
+  // ─── UI Theme (whitelabel) ──────────────────────────────────────────────
+  // getUITheme() must tolerate a 404 (endpoint not implemented by the backend
+  // yet) silently, but report any other failure so a broken theme endpoint
+  // doesn't fail invisibly -- see issue #498.
+  describe('getUITheme', () => {
+    it('returns the theme config on success', async () => {
+      const client = await getApiClient()
+      const theme = { product_name: 'Acme Registry', primary_color: '#5C4EE5' }
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: theme,
+        })
+
+      const result = await client.getUITheme()
+
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/ui/theme')
+      expect(result).toEqual(theme)
+    })
+
+    it('returns null without reporting an error on 404 (endpoint not implemented)', async () => {
+      const client = await getApiClient()
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockRejectedValueOnce({
+          isAxiosError: true,
+          response: { status: 404 },
+        })
+
+      const result = await client.getUITheme()
+
+      expect(result).toBeNull()
+      expect(errorSpy).not.toHaveBeenCalled()
+    })
+
+    it('returns null and reports the error on a non-404 failure', async () => {
+      const client = await getApiClient()
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const serverError = Object.assign(new Error('Internal Server Error'), {
+        isAxiosError: true,
+        response: { status: 500 },
+      })
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockRejectedValueOnce(serverError)
+
+      const result = await client.getUITheme()
+
+      expect(result).toBeNull()
+      expect(errorSpy).toHaveBeenCalledWith('[ErrorReporting]', 'Internal Server Error', {
+        endpoint: '/api/v1/ui/theme',
+      })
+    })
+
+    it('returns null and reports the error on a network failure with no response', async () => {
+      const client = await getApiClient()
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+          new Error('Network Error'),
+        )
+
+      const result = await client.getUITheme()
+
+      expect(result).toBeNull()
+      expect(errorSpy).toHaveBeenCalledWith('[ErrorReporting]', 'Network Error', {
+        endpoint: '/api/v1/ui/theme',
+      })
+    })
+  })
 })

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosInstance, AxiosError, InternalAxiosRequestConfig } from 'axios'
-import { addApiBreadcrumb } from './errorReporting'
+import { addApiBreadcrumb, captureError } from './errorReporting'
 import { clearAuthStorage } from '../utils/authStorage'
 import type { CreateMirrorConfigRequest, UpdateMirrorConfigRequest } from '../types/mirror'
 
@@ -1787,14 +1787,22 @@ class ApiClient {
   /**
    * Fetch the runtime whitelabel theme config from the backend.
    * Returns null if the endpoint does not exist (pre-phase-5 backends) so
-   * callers can gracefully fall back to built-in defaults.
+   * callers can gracefully fall back to built-in defaults. Other failures
+   * (network errors, 5xx, auth) also fall back to defaults -- theming must
+   * never block the app -- but are reported via captureError instead of
+   * being silently treated as "no override".
    */
   async getUITheme(): Promise<import('../types').UIThemeConfig | null> {
     try {
       const response = await this.client.get('/api/v1/ui/theme')
       return response.data as import('../types').UIThemeConfig
-    } catch {
-      // 404 means the backend hasn't implemented the endpoint yet; treat as no override.
+    } catch (error) {
+      if ((error as AxiosError)?.response?.status === 404) {
+        return null
+      }
+      captureError(error instanceof Error ? error : new Error(String(error)), {
+        endpoint: '/api/v1/ui/theme',
+      })
       return null
     }
   }


### PR DESCRIPTION
## Summary
- `getUITheme()`'s bare `catch` treated every failure identically to a 404 (network errors, 5xx, 401s) and silently returned `null`, as if the backend simply hadn't implemented the whitelabel theme endpoint
- Only a 404 actually means "no override, use built-in defaults"; other failures are now reported via `captureError` so a broken theme endpoint is observable in error reporting, instead of vanishing invisibly

## Behavior
Still resolves to `null` on every failure path (theming must never block the app), so `SuiteThemeProvider`'s consumption of `getUITheme()` — which already tolerates a rejected or null-resolving promise and falls back to defaults — needs no change.

Fixes item [20] of #498

## Test plan
- [x] New `describe('getUITheme', ...)` block in `api.test.ts`: success case, 404 (no error reported), 500 (error reported with axios error's `.message`), and a plain network `Error` (error reported)
- [x] `npx vitest run src/services/__tests__/api.test.ts` — 219/219 passing
- [x] `npx tsc --noEmit` — output identical to the pre-existing 20-error baseline (uninstalled private `@sethbacon/terraform-suite-ui` package), no new errors
- [x] `npx eslint` on changed files — clean