### PR TITLE
refactor: rename loadSCMLink to invalidateSCMLink

### DIFF
--- a/frontend/src/hooks/useModuleDetail.ts
+++ b/frontend/src/hooks/useModuleDetail.ts
@@ -451,11 +451,12 @@ export function useModuleDetail() {
   // Handler wrappers (preserve existing call signatures for the page)
   // =========================================================================
 
-  const loadSCMLink = useCallback(
-    (_moduleId: string) => {
-      // SCM link is now loaded via React Query; this is a no-op kept for
-      // backward compatibility with the page component.
-      queryClient.invalidateQueries({ queryKey: queryKeys.modules.scm(_moduleId) })
+  // SCM link data comes from React Query (see query #2 above); this just
+  // forces an immediate refetch after an external event (e.g. the SCM link
+  // wizard completing) instead of waiting for the query to naturally revalidate.
+  const invalidateSCMLink = useCallback(
+    (moduleId: string) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.modules.scm(moduleId) })
     },
     [queryClient],
   )
@@ -657,7 +658,7 @@ export function useModuleDetail() {
     // OCI distribution
     ociEnabled,
     // Handlers
-    loadSCMLink,
+    invalidateSCMLink,
     loadWebhookEvents,
     pollForVersions,
     handleSCMSync,

--- a/frontend/src/pages/ModuleDetailPage.tsx
+++ b/frontend/src/pages/ModuleDetailPage.tsx
@@ -103,7 +103,7 @@ const ModuleDetailPage: React.FC = () => {
     handleRescan,
     moduleDocs,
     docsLoading,
-    loadSCMLink,
+    invalidateSCMLink,
     loadWebhookEvents,
     pollForVersions,
     handleSCMSync,
@@ -614,7 +614,7 @@ const ModuleDetailPage: React.FC = () => {
                     setScmWizardOpen(false)
                     // Reload SCM link immediately, then poll for versions the
                     // background sync will create over the next several seconds.
-                    if (module?.id) loadSCMLink(module.id)
+                    if (module?.id) invalidateSCMLink(module.id)
                     pollForVersions()
                   }}
                   onCancel={() => setScmWizardOpen(false)}

--- a/frontend/src/pages/__tests__/ModuleDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/ModuleDetailPage.test.tsx
@@ -54,7 +54,7 @@ const mockHookReturn = {
   scanNotFound: false,
   moduleDocs: null,
   docsLoading: false,
-  loadSCMLink: vi.fn(),
+  invalidateSCMLink: vi.fn(),
   loadWebhookEvents: vi.fn(),
   pollForVersions: vi.fn(),
   handleSCMSync: vi.fn(),


### PR DESCRIPTION
## Summary
`useModuleDetail.ts`'s `loadSCMLink` doesn't load anything — SCM link data is fetched via React Query (see the hook's query #2). The function's only job is to invalidate that query's cache so it refetches immediately after the SCM link wizard completes, rather than waiting for the query to naturally revalidate. The name and its "no-op kept for backward compatibility" comment were leftover from a prior refactor and no longer describe the actual behavior.

- Renamed `loadSCMLink` → `invalidateSCMLink` in the hook, its one call site (`ModuleDetailPage.tsx`), and the page test's mock hook return value
- No behavior change

Fixes item [30] of #498

## Test plan
- [x] `npx vitest run src/hooks/__tests__/useModuleDetail.test.ts` — 35/35 passing
- [x] `npx tsc --noEmit` — output identical to the pre-existing 20-error baseline (uninstalled private `@sethbacon/terraform-suite-ui` package), no new errors
- [x] `npx eslint` on changed files — clean
- [x] `ModuleDetailPage.test.tsx` cannot run locally (same private-package sandbox limitation as the rest of this session's work) — will verify via CI