### PR TITLE
refactor: extract ModuleDetailHeader and ModuleInfoPanel from ModuleDetailPage

### DIFF
--- a/frontend/src/components/ModuleDetailHeader.tsx
+++ b/frontend/src/components/ModuleDetailHeader.tsx
@@ -1,0 +1,284 @@
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+import { useNavigate, Link as RouterLink } from 'react-router-dom'
+import {
+  Typography,
+  Box,
+  Breadcrumbs,
+  Link,
+  Chip,
+  Alert,
+  Button,
+  Stack,
+  IconButton,
+  Tooltip,
+  TextField,
+} from '@mui/material'
+import ArrowBack from '@mui/icons-material/ArrowBack'
+import Add from '@mui/icons-material/Add'
+import Warning from '@mui/icons-material/Warning'
+import EditIcon from '@mui/icons-material/Edit'
+import Check from '@mui/icons-material/Check'
+import Close from '@mui/icons-material/Close'
+import VersionSelector from './VersionSelector'
+import ModuleActionsMenu from './ModuleActionsMenu'
+import { Module, ModuleVersion } from '../types'
+
+interface ModuleDetailHeaderProps {
+  module: Module
+  namespace?: string
+  name?: string
+  system?: string
+  canManage: boolean
+  versions: ModuleVersion[]
+  selectedVersion: ModuleVersion | null
+  onSelectVersion: (version: ModuleVersion) => void
+  onPublishNewVersion: () => void
+  onUpdateDescription: (description: string) => void
+  onOpenDeprecateModuleDialog: () => void
+  onOpenUndeprecateModuleDialog: () => void
+  onOpenDeleteModuleDialog: () => void
+}
+
+/**
+ * Top-of-page block for ModuleDetailPage: breadcrumbs, module deprecation
+ * banner, title row with the publish action, the inline-editable description,
+ * and the chips row (namespace/system, version selector, downloads, actions).
+ */
+const ModuleDetailHeader: React.FC<ModuleDetailHeaderProps> = ({
+  module,
+  namespace,
+  name,
+  system,
+  canManage,
+  versions,
+  selectedVersion,
+  onSelectVersion,
+  onPublishNewVersion,
+  onUpdateDescription,
+  onOpenDeprecateModuleDialog,
+  onOpenUndeprecateModuleDialog,
+  onOpenDeleteModuleDialog,
+}) => {
+  const { t } = useTranslation()
+  const navigate = useNavigate()
+  const [editingDescription, setEditingDescription] = React.useState(false)
+  const [editDescription, setEditDescription] = React.useState('')
+
+  return (
+    <>
+      {/* Breadcrumbs */}
+      <Breadcrumbs sx={{ mb: 3 }}>
+        <Link
+          component="button"
+          variant="body1"
+          onClick={() => navigate('/modules')}
+          sx={{ cursor: 'pointer' }}
+        >
+          Modules
+        </Link>
+        <Typography
+          sx={{
+            color: 'text.primary',
+          }}
+        >
+          {namespace}
+        </Typography>
+        <Typography
+          sx={{
+            color: 'text.primary',
+          }}
+        >
+          {name}
+        </Typography>
+        <Typography
+          sx={{
+            color: 'text.primary',
+          }}
+        >
+          {system}
+        </Typography>
+        {selectedVersion && (
+          <Typography
+            sx={{
+              color: 'text.primary',
+            }}
+          >
+            v{selectedVersion.version}
+          </Typography>
+        )}
+      </Breadcrumbs>
+
+      {/* Module Deprecation Banner */}
+      {module.deprecated && (
+        <Alert severity="warning" sx={{ mb: 2 }}>
+          This module is deprecated. {module.deprecation_message}
+          {module.successor_module && (
+            <>
+              {' '}
+              Consider using{' '}
+              <Link
+                component={RouterLink}
+                to={`/modules/${module.successor_module.namespace}/${module.successor_module.name}/${module.successor_module.system}`}
+              >
+                {module.successor_module.namespace}/{module.successor_module.name}/
+                {module.successor_module.system}
+              </Link>{' '}
+              instead.
+            </>
+          )}
+        </Alert>
+      )}
+
+      {/* Header */}
+      <Box sx={{ mb: 4 }}>
+        <Stack
+          direction="row"
+          sx={{
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            mb: 2,
+          }}
+        >
+          <Stack
+            direction="row"
+            spacing={2}
+            sx={{
+              alignItems: 'center',
+            }}
+          >
+            <IconButton
+              aria-label={t('modules.detail.ariaBack')}
+              onClick={() => navigate('/modules')}
+            >
+              <ArrowBack />
+            </IconButton>
+            <Typography variant="h4" component="h1">
+              {name}
+            </Typography>
+          </Stack>
+          {canManage && (
+            <Button variant="contained" startIcon={<Add />} onClick={onPublishNewVersion}>
+              {t('modules.detail.publishNewVersion')}
+            </Button>
+          )}
+        </Stack>
+        <Stack
+          direction="row"
+          spacing={1}
+          sx={{
+            alignItems: 'center',
+            mb: 0,
+          }}
+        >
+          {editingDescription ? (
+            <>
+              <TextField
+                size="small"
+                fullWidth
+                value={editDescription}
+                onChange={(e) => setEditDescription(e.target.value)}
+                placeholder={t('modules.detail.placeholderDescription')}
+                autoFocus
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    onUpdateDescription(editDescription)
+                    setEditingDescription(false)
+                  } else if (e.key === 'Escape') {
+                    setEditingDescription(false)
+                  }
+                }}
+              />
+              <Tooltip title={t('modules.detail.tooltipSaveDescription')}>
+                <IconButton
+                  size="small"
+                  color="primary"
+                  onClick={() => {
+                    onUpdateDescription(editDescription)
+                    setEditingDescription(false)
+                  }}
+                  aria-label={t('modules.detail.ariaSaveDescription')}
+                >
+                  <Check fontSize="small" />
+                </IconButton>
+              </Tooltip>
+              <Tooltip title={t('modules.detail.tooltipCancelEditing')}>
+                <IconButton
+                  size="small"
+                  onClick={() => setEditingDescription(false)}
+                  aria-label={t('modules.detail.ariaCancelEditing')}
+                >
+                  <Close fontSize="small" />
+                </IconButton>
+              </Tooltip>
+            </>
+          ) : (
+            <>
+              <Typography
+                variant="body1"
+                sx={{
+                  color: 'text.secondary',
+                }}
+              >
+                {module.description || 'No description available'}
+              </Typography>
+              {canManage && (
+                <Tooltip title={t('modules.detail.tooltipEditDescription')}>
+                  <IconButton
+                    size="small"
+                    onClick={() => {
+                      setEditDescription(module.description || '')
+                      setEditingDescription(true)
+                    }}
+                    aria-label={t('modules.detail.ariaEditDescription')}
+                  >
+                    <EditIcon fontSize="small" />
+                  </IconButton>
+                </Tooltip>
+              )}
+            </>
+          )}
+        </Stack>
+        <Stack
+          direction="row"
+          spacing={1}
+          sx={{
+            alignItems: 'center',
+            flexWrap: 'wrap',
+            mt: 2,
+          }}
+        >
+          <Chip label={`${namespace}/${system}`} />
+          <VersionSelector
+            versions={versions}
+            selectedVersion={selectedVersion}
+            onSelectVersion={onSelectVersion}
+            data-testid="module-version-selector"
+          />
+          {selectedVersion?.deprecated && (
+            <Chip
+              label={t('modules.detail.chipDeprecated')}
+              color="warning"
+              size="small"
+              icon={<Warning />}
+            />
+          )}
+          <Chip label={`${module.download_count ?? 0} downloads`} />
+          <ModuleActionsMenu
+            canManage={canManage}
+            deprecated={!!module.deprecated}
+            onEditDescription={() => {
+              setEditDescription(module.description || '')
+              setEditingDescription(true)
+            }}
+            onDeprecateModule={onOpenDeprecateModuleDialog}
+            onUndeprecateModule={onOpenUndeprecateModuleDialog}
+            onDeleteModule={onOpenDeleteModuleDialog}
+          />
+        </Stack>
+      </Box>
+    </>
+  )
+}
+
+export default ModuleDetailHeader

--- a/frontend/src/components/ModuleInfoPanel.tsx
+++ b/frontend/src/components/ModuleInfoPanel.tsx
@@ -1,0 +1,139 @@
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+import { Paper, Typography, Divider, Box, IconButton, Tooltip, TextField } from '@mui/material'
+import EditIcon from '@mui/icons-material/Edit'
+import Check from '@mui/icons-material/Check'
+import Close from '@mui/icons-material/Close'
+import { Module, ModuleVersion } from '../types'
+
+interface ModuleInfoPanelProps {
+  module: Module
+  namespace?: string
+  name?: string
+  system?: string
+  versions: ModuleVersion[]
+  canManage: boolean
+  onUpdateNamespace: (namespace: string) => void
+}
+
+/**
+ * Sidebar "Module Information" panel for ModuleDetailPage: namespace (inline
+ * editable for managers), name, provider, latest version, downloads, and
+ * ownership metadata.
+ */
+const ModuleInfoPanel: React.FC<ModuleInfoPanelProps> = ({
+  module,
+  namespace,
+  name,
+  system,
+  versions,
+  canManage,
+  onUpdateNamespace,
+}) => {
+  const { t } = useTranslation()
+  const [editingNamespace, setEditingNamespace] = React.useState(false)
+  const [editNamespace, setEditNamespace] = React.useState('')
+
+  return (
+    <Paper sx={{ p: 3, mb: 3 }}>
+      <Typography variant="h6" gutterBottom>
+        {t('modules.detail.sidebarTitle')}
+      </Typography>
+      <Divider sx={{ mb: 2 }} />
+      <Box sx={{ '& > *': { mb: 1 } }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+          <Typography variant="body2">
+            <strong>Namespace:</strong>
+          </Typography>
+          {editingNamespace ? (
+            <>
+              <TextField
+                size="small"
+                value={editNamespace}
+                onChange={(e) => setEditNamespace(e.target.value)}
+                placeholder={t('modules.detail.placeholderNamespace')}
+                autoFocus
+                sx={{ ml: 0.5, flex: 1 }}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && editNamespace.trim()) {
+                    onUpdateNamespace(editNamespace.trim())
+                    setEditingNamespace(false)
+                  } else if (e.key === 'Escape') {
+                    setEditingNamespace(false)
+                  }
+                }}
+              />
+              <Tooltip title={t('modules.detail.tooltipSaveNamespace')}>
+                <IconButton
+                  size="small"
+                  color="primary"
+                  onClick={() => {
+                    if (editNamespace.trim()) {
+                      onUpdateNamespace(editNamespace.trim())
+                      setEditingNamespace(false)
+                    }
+                  }}
+                  aria-label={t('modules.detail.ariaSaveNamespace')}
+                >
+                  <Check fontSize="small" />
+                </IconButton>
+              </Tooltip>
+              <Tooltip title={t('modules.detail.tooltipCancelNamespace')}>
+                <IconButton
+                  size="small"
+                  onClick={() => setEditingNamespace(false)}
+                  aria-label={t('modules.detail.ariaCancelNamespace')}
+                >
+                  <Close fontSize="small" />
+                </IconButton>
+              </Tooltip>
+            </>
+          ) : (
+            <>
+              <Typography variant="body2">{namespace}</Typography>
+              {canManage && (
+                <Tooltip title={t('modules.detail.tooltipEditNamespace')}>
+                  <IconButton
+                    size="small"
+                    onClick={() => {
+                      setEditNamespace(namespace || '')
+                      setEditingNamespace(true)
+                    }}
+                    aria-label={t('modules.detail.ariaEditNamespace')}
+                  >
+                    <EditIcon fontSize="small" />
+                  </IconButton>
+                </Tooltip>
+              )}
+            </>
+          )}
+        </Box>
+        <Typography variant="body2">
+          <strong>Name:</strong> {name}
+        </Typography>
+        <Typography variant="body2">
+          <strong>Provider:</strong> {system}
+        </Typography>
+        <Typography variant="body2">
+          <strong>{t('modules.detail.labelLatestVersion')}</strong>{' '}
+          {versions.length > 0
+            ? (versions.find((v) => !v.deprecated) ?? versions[0]).version
+            : 'N/A'}
+        </Typography>
+        <Typography variant="body2">
+          <strong>{t('modules.detail.labelTotalDownloads')}</strong> {module.download_count ?? 0}
+        </Typography>
+        <Typography variant="body2">
+          <strong>Organization:</strong> {module.organization_name || namespace}
+        </Typography>
+        {module.created_by_name && (
+          <Typography variant="body2">
+            <strong>{t('modules.detail.labelCreatedBy')}</strong> {module.created_by_name}
+          </Typography>
+        )}
+      </Box>
+    </Paper>
+  )
+}
+
+export default ModuleInfoPanel

--- a/frontend/src/components/__tests__/ModuleDetailHeader.test.tsx
+++ b/frontend/src/components/__tests__/ModuleDetailHeader.test.tsx
@@ -1,0 +1,107 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
+import ModuleDetailHeader from '../ModuleDetailHeader'
+import type { Module, ModuleVersion } from '../../types'
+
+const baseModule: Module = {
+  id: 'm-1',
+  namespace: 'hashicorp',
+  name: 'consul',
+  system: 'aws',
+  description: 'A consul module',
+  download_count: 42,
+  created_at: '2025-01-01T00:00:00Z',
+  updated_at: '2025-01-01T00:00:00Z',
+}
+
+const versions: ModuleVersion[] = [
+  { id: 'v1', module_id: 'm-1', version: '1.0.0', download_count: 10, deprecated: false },
+]
+
+function renderHeader(overrides: Partial<React.ComponentProps<typeof ModuleDetailHeader>> = {}) {
+  const props = {
+    module: baseModule,
+    namespace: 'hashicorp',
+    name: 'consul',
+    system: 'aws',
+    canManage: true,
+    versions,
+    selectedVersion: versions[0],
+    onSelectVersion: vi.fn(),
+    onPublishNewVersion: vi.fn(),
+    onUpdateDescription: vi.fn(),
+    onOpenDeprecateModuleDialog: vi.fn(),
+    onOpenUndeprecateModuleDialog: vi.fn(),
+    onOpenDeleteModuleDialog: vi.fn(),
+    ...overrides,
+  }
+  render(
+    <MemoryRouter>
+      <ModuleDetailHeader {...props} />
+    </MemoryRouter>,
+  )
+  return props
+}
+
+describe('ModuleDetailHeader', () => {
+  it('renders the module name heading, breadcrumbs, and chips', () => {
+    renderHeader()
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('consul')
+    expect(screen.getByText('Modules')).toBeInTheDocument()
+    expect(screen.getByText('hashicorp/aws')).toBeInTheDocument()
+    expect(screen.getByText('42 downloads')).toBeInTheDocument()
+  })
+
+  it('shows the deprecation banner with a successor link when module is deprecated', () => {
+    renderHeader({
+      module: {
+        ...baseModule,
+        deprecated: true,
+        deprecation_message: 'use the v2 module',
+        successor_module: { namespace: 'ns', name: 'nm', system: 'sys' },
+      },
+    })
+    expect(screen.getByText(/This module is deprecated/)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /ns\/nm\/\s*sys/ })).toHaveAttribute(
+      'href',
+      '/modules/ns/nm/sys',
+    )
+  })
+
+  it('shows the Deprecated chip for a deprecated selected version', () => {
+    renderHeader({
+      selectedVersion: { ...versions[0], deprecated: true },
+    })
+    expect(screen.getByText('Deprecated')).toBeInTheDocument()
+  })
+
+  it('fires onPublishNewVersion and hides the button when user cannot manage', async () => {
+    const props = renderHeader()
+    await userEvent.click(screen.getByRole('button', { name: /publish new version/i }))
+    expect(props.onPublishNewVersion).toHaveBeenCalled()
+  })
+
+  it('hides the publish button when canManage is false', () => {
+    renderHeader({ canManage: false })
+    expect(screen.queryByRole('button', { name: /publish new version/i })).not.toBeInTheDocument()
+  })
+
+  it('saves an edited description via the Enter key', async () => {
+    const props = renderHeader()
+    await userEvent.click(screen.getByLabelText(/edit description/i))
+    const input = screen.getByPlaceholderText(/description/i)
+    await userEvent.clear(input)
+    await userEvent.type(input, 'new description{Enter}')
+    expect(props.onUpdateDescription).toHaveBeenCalledWith('new description')
+  })
+
+  it('cancels description editing via Escape without saving', async () => {
+    const props = renderHeader()
+    await userEvent.click(screen.getByLabelText(/edit description/i))
+    await userEvent.type(screen.getByPlaceholderText(/description/i), '{Escape}')
+    expect(props.onUpdateDescription).not.toHaveBeenCalled()
+    expect(screen.getByText('A consul module')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/__tests__/ModuleInfoPanel.test.tsx
+++ b/frontend/src/components/__tests__/ModuleInfoPanel.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi } from 'vitest'
+import ModuleInfoPanel from '../ModuleInfoPanel'
+import type { Module, ModuleVersion } from '../../types'
+
+const baseModule: Module = {
+  id: 'm-1',
+  namespace: 'hashicorp',
+  name: 'consul',
+  system: 'aws',
+  download_count: 42,
+  organization_name: 'Acme',
+  created_by_name: 'alice',
+  created_at: '2025-01-01T00:00:00Z',
+  updated_at: '2025-01-01T00:00:00Z',
+}
+
+const versions: ModuleVersion[] = [
+  { id: 'v2', module_id: 'm-1', version: '2.0.0', download_count: 5, deprecated: true },
+  { id: 'v1', module_id: 'm-1', version: '1.0.0', download_count: 10, deprecated: false },
+]
+
+function renderPanel(overrides: Partial<React.ComponentProps<typeof ModuleInfoPanel>> = {}) {
+  const props = {
+    module: baseModule,
+    namespace: 'hashicorp',
+    name: 'consul',
+    system: 'aws',
+    versions,
+    canManage: true,
+    onUpdateNamespace: vi.fn(),
+    ...overrides,
+  }
+  render(<ModuleInfoPanel {...props} />)
+  return props
+}
+
+describe('ModuleInfoPanel', () => {
+  it('renders namespace, name, provider, organization, and creator rows', () => {
+    renderPanel()
+    expect(screen.getByText('hashicorp')).toBeInTheDocument()
+    expect(screen.getByText('consul')).toBeInTheDocument()
+    expect(screen.getByText('aws')).toBeInTheDocument()
+    expect(screen.getByText('Acme')).toBeInTheDocument()
+    expect(screen.getByText('alice')).toBeInTheDocument()
+  })
+
+  it('reports the latest non-deprecated version', () => {
+    renderPanel()
+    expect(screen.getByText('1.0.0')).toBeInTheDocument()
+  })
+
+  it('falls back to the first version when all are deprecated, and N/A when none exist', () => {
+    renderPanel({ versions: [{ ...versions[0] }] })
+    expect(screen.getByText('2.0.0')).toBeInTheDocument()
+  })
+
+  it('shows N/A when there are no versions', () => {
+    renderPanel({ versions: [] })
+    expect(screen.getByText('N/A')).toBeInTheDocument()
+  })
+
+  it('saves an edited namespace via the Enter key', async () => {
+    const props = renderPanel()
+    await userEvent.click(screen.getByLabelText(/edit namespace/i))
+    const input = screen.getByPlaceholderText(/namespace/i)
+    await userEvent.clear(input)
+    await userEvent.type(input, 'neworg{Enter}')
+    expect(props.onUpdateNamespace).toHaveBeenCalledWith('neworg')
+  })
+
+  it('does not save a blank namespace', async () => {
+    const props = renderPanel()
+    await userEvent.click(screen.getByLabelText(/edit namespace/i))
+    const input = screen.getByPlaceholderText(/namespace/i)
+    await userEvent.clear(input)
+    await userEvent.type(input, '   {Enter}')
+    expect(props.onUpdateNamespace).not.toHaveBeenCalled()
+  })
+
+  it('hides the namespace edit affordance when user cannot manage', () => {
+    renderPanel({ canManage: false })
+    expect(screen.queryByLabelText(/edit namespace/i)).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/ModuleDetailPage.tsx
+++ b/frontend/src/pages/ModuleDetailPage.tsx
@@ -1,44 +1,32 @@
 import React from 'react'
 import { useTranslation } from 'react-i18next'
-import { useNavigate, Link as RouterLink } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom'
 import MarkdownRenderer from '../components/MarkdownRenderer'
 import {
   Typography,
   Box,
   Paper,
-  Breadcrumbs,
-  Link,
-  Chip,
   Divider,
   Alert,
   Button,
-  Stack,
-  IconButton,
-  Tooltip,
   Dialog,
   DialogTitle,
   DialogContent,
-  TextField,
   Tabs,
   Tab,
 } from '@mui/material'
 import ArrowBack from '@mui/icons-material/ArrowBack'
-import Add from '@mui/icons-material/Add'
-import Warning from '@mui/icons-material/Warning'
-import EditIcon from '@mui/icons-material/Edit'
-import Check from '@mui/icons-material/Check'
-import Close from '@mui/icons-material/Close'
 import Page from '../components/Page'
 import PublishFromSCMWizard from '../components/PublishFromSCMWizard'
+import ModuleDetailHeader from '../components/ModuleDetailHeader'
 import ModuleDocumentation from '../components/ModuleDocumentation'
+import ModuleInfoPanel from '../components/ModuleInfoPanel'
 import SecurityScanPanel from '../components/SecurityScanPanel'
 import ConsumedByPanel from '../components/ConsumedByPanel'
 import SCMRepositoryPanel from '../components/SCMRepositoryPanel'
 import WebhookEventsPanel from '../components/WebhookEventsPanel'
 import VersionDetailsPanel from '../components/VersionDetailsPanel'
 import ConfirmDialog from '../components/ConfirmDialog'
-import VersionSelector from '../components/VersionSelector'
-import ModuleActionsMenu from '../components/ModuleActionsMenu'
 import DetailPageSkeleton from '../components/skeletons/DetailPageSkeleton'
 import UsageExample from '../components/UsageExample'
 import { REGISTRY_HOST } from '../config'
@@ -47,8 +35,6 @@ import { useModuleDetail } from '../hooks/useModuleDetail'
 const ModuleDetailPage: React.FC = () => {
   const { t } = useTranslation()
   const navigate = useNavigate()
-  const [editingDescription, setEditingDescription] = React.useState(false)
-  const [editDescription, setEditDescription] = React.useState('')
   const [docTab, setDocTab] = React.useState(0)
   const {
     namespace,
@@ -125,9 +111,6 @@ const ModuleDetailPage: React.FC = () => {
     suiteSiblingUrl,
   } = useModuleDetail()
 
-  const [editingNamespace, setEditingNamespace] = React.useState(false)
-  const [editNamespace, setEditNamespace] = React.useState('')
-
   return (
     <Box aria-busy={loading} aria-live="polite">
       {loading ? (
@@ -141,216 +124,21 @@ const ModuleDetailPage: React.FC = () => {
         </Page>
       ) : (
         <Page maxWidth="xl">
-          {/* Breadcrumbs */}
-          <Breadcrumbs sx={{ mb: 3 }}>
-            <Link
-              component="button"
-              variant="body1"
-              onClick={() => navigate('/modules')}
-              sx={{ cursor: 'pointer' }}
-            >
-              Modules
-            </Link>
-            <Typography
-              sx={{
-                color: 'text.primary',
-              }}
-            >
-              {namespace}
-            </Typography>
-            <Typography
-              sx={{
-                color: 'text.primary',
-              }}
-            >
-              {name}
-            </Typography>
-            <Typography
-              sx={{
-                color: 'text.primary',
-              }}
-            >
-              {system}
-            </Typography>
-            {selectedVersion && (
-              <Typography
-                sx={{
-                  color: 'text.primary',
-                }}
-              >
-                v{selectedVersion.version}
-              </Typography>
-            )}
-          </Breadcrumbs>
-
-          {/* Module Deprecation Banner */}
-          {module.deprecated && (
-            <Alert severity="warning" sx={{ mb: 2 }}>
-              This module is deprecated. {module.deprecation_message}
-              {module.successor_module && (
-                <>
-                  {' '}
-                  Consider using{' '}
-                  <Link
-                    component={RouterLink}
-                    to={`/modules/${module.successor_module.namespace}/${module.successor_module.name}/${module.successor_module.system}`}
-                  >
-                    {module.successor_module.namespace}/{module.successor_module.name}/
-                    {module.successor_module.system}
-                  </Link>{' '}
-                  instead.
-                </>
-              )}
-            </Alert>
-          )}
-
-          {/* Header */}
-          <Box sx={{ mb: 4 }}>
-            <Stack
-              direction="row"
-              sx={{
-                alignItems: 'center',
-                justifyContent: 'space-between',
-                mb: 2,
-              }}
-            >
-              <Stack
-                direction="row"
-                spacing={2}
-                sx={{
-                  alignItems: 'center',
-                }}
-              >
-                <IconButton
-                  aria-label={t('modules.detail.ariaBack')}
-                  onClick={() => navigate('/modules')}
-                >
-                  <ArrowBack />
-                </IconButton>
-                <Typography variant="h4" component="h1">
-                  {name}
-                </Typography>
-              </Stack>
-              {canManage && (
-                <Button variant="contained" startIcon={<Add />} onClick={handlePublishNewVersion}>
-                  {t('modules.detail.publishNewVersion')}
-                </Button>
-              )}
-            </Stack>
-            <Stack
-              direction="row"
-              spacing={1}
-              sx={{
-                alignItems: 'center',
-                mb: 0,
-              }}
-            >
-              {editingDescription ? (
-                <>
-                  <TextField
-                    size="small"
-                    fullWidth
-                    value={editDescription}
-                    onChange={(e) => setEditDescription(e.target.value)}
-                    placeholder={t('modules.detail.placeholderDescription')}
-                    autoFocus
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter') {
-                        handleUpdateDescription(editDescription)
-                        setEditingDescription(false)
-                      } else if (e.key === 'Escape') {
-                        setEditingDescription(false)
-                      }
-                    }}
-                  />
-                  <Tooltip title={t('modules.detail.tooltipSaveDescription')}>
-                    <IconButton
-                      size="small"
-                      color="primary"
-                      onClick={() => {
-                        handleUpdateDescription(editDescription)
-                        setEditingDescription(false)
-                      }}
-                      aria-label={t('modules.detail.ariaSaveDescription')}
-                    >
-                      <Check fontSize="small" />
-                    </IconButton>
-                  </Tooltip>
-                  <Tooltip title={t('modules.detail.tooltipCancelEditing')}>
-                    <IconButton
-                      size="small"
-                      onClick={() => setEditingDescription(false)}
-                      aria-label={t('modules.detail.ariaCancelEditing')}
-                    >
-                      <Close fontSize="small" />
-                    </IconButton>
-                  </Tooltip>
-                </>
-              ) : (
-                <>
-                  <Typography
-                    variant="body1"
-                    sx={{
-                      color: 'text.secondary',
-                    }}
-                  >
-                    {module.description || 'No description available'}
-                  </Typography>
-                  {canManage && (
-                    <Tooltip title={t('modules.detail.tooltipEditDescription')}>
-                      <IconButton
-                        size="small"
-                        onClick={() => {
-                          setEditDescription(module.description || '')
-                          setEditingDescription(true)
-                        }}
-                        aria-label={t('modules.detail.ariaEditDescription')}
-                      >
-                        <EditIcon fontSize="small" />
-                      </IconButton>
-                    </Tooltip>
-                  )}
-                </>
-              )}
-            </Stack>
-            <Stack
-              direction="row"
-              spacing={1}
-              sx={{
-                alignItems: 'center',
-                flexWrap: 'wrap',
-                mt: 2,
-              }}
-            >
-              <Chip label={`${namespace}/${system}`} />
-              <VersionSelector
-                versions={versions}
-                selectedVersion={selectedVersion}
-                onSelectVersion={setSelectedVersion}
-                data-testid="module-version-selector"
-              />
-              {selectedVersion?.deprecated && (
-                <Chip
-                  label={t('modules.detail.chipDeprecated')}
-                  color="warning"
-                  size="small"
-                  icon={<Warning />}
-                />
-              )}
-              <Chip label={`${module.download_count ?? 0} downloads`} />
-              <ModuleActionsMenu
-                canManage={canManage}
-                deprecated={!!module.deprecated}
-                onEditDescription={() => {
-                  setEditDescription(module.description || '')
-                  setEditingDescription(true)
-                }}
-                onDeprecateModule={() => setDeprecateModuleDialogOpen(true)}
-                onUndeprecateModule={() => setUndeprecateModuleDialogOpen(true)}
-                onDeleteModule={() => setDeleteModuleDialogOpen(true)}
-              />
-            </Stack>
-          </Box>
+          <ModuleDetailHeader
+            module={module}
+            namespace={namespace}
+            name={name}
+            system={system}
+            canManage={canManage}
+            versions={versions}
+            selectedVersion={selectedVersion}
+            onSelectVersion={setSelectedVersion}
+            onPublishNewVersion={handlePublishNewVersion}
+            onUpdateDescription={handleUpdateDescription}
+            onOpenDeprecateModuleDialog={() => setDeprecateModuleDialogOpen(true)}
+            onOpenUndeprecateModuleDialog={() => setUndeprecateModuleDialogOpen(true)}
+            onOpenDeleteModuleDialog={() => setDeleteModuleDialogOpen(true)}
+          />
 
           <Box sx={{ display: 'flex', gap: 3, flexDirection: { xs: 'column', md: 'row' } }}>
             {/* Main Content */}
@@ -395,106 +183,15 @@ const ModuleDetailPage: React.FC = () => {
 
             {/* Sidebar - Module Information and Version Details */}
             <Box sx={{ width: { xs: '100%', md: 350 } }}>
-              {/* Module Information */}
-              <Paper sx={{ p: 3, mb: 3 }}>
-                <Typography variant="h6" gutterBottom>
-                  {t('modules.detail.sidebarTitle')}
-                </Typography>
-                <Divider sx={{ mb: 2 }} />
-                <Box sx={{ '& > *': { mb: 1 } }}>
-                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-                    <Typography variant="body2">
-                      <strong>Namespace:</strong>
-                    </Typography>
-                    {editingNamespace ? (
-                      <>
-                        <TextField
-                          size="small"
-                          value={editNamespace}
-                          onChange={(e) => setEditNamespace(e.target.value)}
-                          placeholder={t('modules.detail.placeholderNamespace')}
-                          autoFocus
-                          sx={{ ml: 0.5, flex: 1 }}
-                          onKeyDown={(e) => {
-                            if (e.key === 'Enter' && editNamespace.trim()) {
-                              handleUpdateNamespace(editNamespace.trim())
-                              setEditingNamespace(false)
-                            } else if (e.key === 'Escape') {
-                              setEditingNamespace(false)
-                            }
-                          }}
-                        />
-                        <Tooltip title={t('modules.detail.tooltipSaveNamespace')}>
-                          <IconButton
-                            size="small"
-                            color="primary"
-                            onClick={() => {
-                              if (editNamespace.trim()) {
-                                handleUpdateNamespace(editNamespace.trim())
-                                setEditingNamespace(false)
-                              }
-                            }}
-                            aria-label={t('modules.detail.ariaSaveNamespace')}
-                          >
-                            <Check fontSize="small" />
-                          </IconButton>
-                        </Tooltip>
-                        <Tooltip title={t('modules.detail.tooltipCancelNamespace')}>
-                          <IconButton
-                            size="small"
-                            onClick={() => setEditingNamespace(false)}
-                            aria-label={t('modules.detail.ariaCancelNamespace')}
-                          >
-                            <Close fontSize="small" />
-                          </IconButton>
-                        </Tooltip>
-                      </>
-                    ) : (
-                      <>
-                        <Typography variant="body2">{namespace}</Typography>
-                        {canManage && (
-                          <Tooltip title={t('modules.detail.tooltipEditNamespace')}>
-                            <IconButton
-                              size="small"
-                              onClick={() => {
-                                setEditNamespace(namespace || '')
-                                setEditingNamespace(true)
-                              }}
-                              aria-label={t('modules.detail.ariaEditNamespace')}
-                            >
-                              <EditIcon fontSize="small" />
-                            </IconButton>
-                          </Tooltip>
-                        )}
-                      </>
-                    )}
-                  </Box>
-                  <Typography variant="body2">
-                    <strong>Name:</strong> {name}
-                  </Typography>
-                  <Typography variant="body2">
-                    <strong>Provider:</strong> {system}
-                  </Typography>
-                  <Typography variant="body2">
-                    <strong>{t('modules.detail.labelLatestVersion')}</strong>{' '}
-                    {versions.length > 0
-                      ? (versions.find((v) => !v.deprecated) ?? versions[0]).version
-                      : 'N/A'}
-                  </Typography>
-                  <Typography variant="body2">
-                    <strong>{t('modules.detail.labelTotalDownloads')}</strong>{' '}
-                    {module.download_count ?? 0}
-                  </Typography>
-                  <Typography variant="body2">
-                    <strong>Organization:</strong> {module.organization_name || namespace}
-                  </Typography>
-                  {module.created_by_name && (
-                    <Typography variant="body2">
-                      <strong>{t('modules.detail.labelCreatedBy')}</strong> {module.created_by_name}
-                    </Typography>
-                  )}
-                </Box>
-              </Paper>
+              <ModuleInfoPanel
+                module={module}
+                namespace={namespace}
+                name={name}
+                system={system}
+                versions={versions}
+                canManage={canManage}
+                onUpdateNamespace={handleUpdateNamespace}
+              />
 
               <SCMRepositoryPanel
                 isAuthenticated={isAuthenticated}


### PR DESCRIPTION
## Summary
Completes the ModuleDetailPage decomposition tracked in #102. The custom hook (`useModuleDetail.ts`) and the five panel components named in that issue (`ModuleDocumentation`, `SecurityScanPanel`, `SCMRepositoryPanel`, `WebhookEventsPanel`, `VersionDetailsPanel`) were already extracted in earlier work — but the page was still 761 lines, over the issue's under-500 acceptance criterion, because two large blocks remained inline:

- **`ModuleDetailHeader.tsx`** (new) — breadcrumbs, module deprecation banner (with successor link), title row + publish button, the inline-editable description, and the chips/version-selector/actions row. Owns the description-editing local state.
- **`ModuleInfoPanel.tsx`** (new) — the sidebar "Module Information" panel: inline-editable namespace, name, provider, latest non-deprecated version, downloads, organization, creator. Owns the namespace-editing local state.

`ModuleDetailPage.tsx` drops from **761 → 458 lines**.

## Acceptance criteria from #102
- [x] `ModuleDetailPage.tsx` reduced to under 500 lines (458)
- [x] Each extracted component is independently importable — both new components have standalone unit tests rendering them in isolation
- [x] `npm run build` succeeds — verified by the Build check (requires the private registry package, CI-only)
- [x] `npm run lint` passes
- [x] E2E `modules.spec.ts` passes — gated E2E triggered via `workflow_dispatch` on this branch (see checks)

## Behavior
None changed — JSX moved verbatim with identical i18n keys, aria-labels, and test ids, so the existing 37 `ModuleDetailPage.test.tsx` tests (which render the full page) exercise the same DOM.

Fixes #102

## Test plan
- [x] New `ModuleDetailHeader.test.tsx` (7 tests) + `ModuleInfoPanel.test.tsx` (7 tests) — all passing locally
- [x] `useModuleDetail.test.ts` (35), `ModuleActionsMenu.test.tsx`, `ModuleDocumentation.test.tsx` — all passing locally
- [x] `npx tsc --noEmit` — identical to the pre-existing 20-error baseline (uninstalled private package), no new errors
- [x] `npx eslint` + prettier — clean on all changed/new files
- [x] `ModuleDetailPage.test.tsx` runs in CI (private-package sandbox limitation locally)