### PR TITLE
fix: lint-ban dangerouslySetInnerHTML to lock in the JSX-escaping posture

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -33,6 +33,21 @@ export default [
       // TypeScript rules
       '@typescript-eslint/no-explicit-any': 'error',
       '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
+      // XSS defense-in-depth: i18n.ts sets escapeValue:false, which is only safe
+      // while every translated string renders through React JSX auto-escaping.
+      // Banning dangerouslySetInnerHTML locks that invariant in (markdown is
+      // rendered via the rehype-sanitize pipeline in MarkdownRenderer, which
+      // does not need this attribute). See issue #478.
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: "JSXAttribute[name.name='dangerouslySetInnerHTML']",
+          message:
+            'dangerouslySetInnerHTML is banned: i18n escapeValue:false relies on React JSX ' +
+            'escaping as the only XSS barrier for translated/interpolated strings. Render rich ' +
+            'text through MarkdownRenderer (rehype-sanitize) instead.',
+        },
+      ],
       // React hooks — enforce both rules to prevent stale closures and rule violations
       'react-hooks/rules-of-hooks': 'error',
       'react-hooks/exhaustive-deps': 'error',

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -42,6 +42,15 @@ i18n
     },
     interpolation: {
       // React already escapes output — no double-escaping needed.
+      //
+      // SAFETY INVARIANT (issue #478): escapeValue:false is only safe while
+      // every translated string is rendered through React JSX, which escapes
+      // for us. That holds today: locale resources are statically bundled,
+      // there is no <Trans> usage, and dangerouslySetInnerHTML is banned by
+      // lint (no-restricted-syntax in eslint.config.js). If a <Trans>-based
+      // rich-text pattern or any HTML sink for translated/interpolated values
+      // is ever introduced, re-enable escaping for user-supplied interpolation
+      // values (or sanitize them explicitly) as part of that change.
       escapeValue: false,
     },
   })


### PR DESCRIPTION
## Summary
Issue #478 (info, from the 2026-07-09 blind audit) notes that `i18n.ts`'s `escapeValue: false` is safe only because every translated string currently renders through React JSX auto-escaping — and recommends locking that posture in rather than leaving it implicit. This PR implements exactly the audit's suggested fix:

- **`eslint.config.js`** — new `no-restricted-syntax` entry that errors on any `dangerouslySetInnerHTML` JSX attribute, with a message pointing rich-text needs at the sanitized `MarkdownRenderer` pipeline. Zero new dependencies (AST selector, no `eslint-plugin-react` needed).
- **`src/i18n.ts`** — the one-line comment on `escapeValue: false` is expanded to state the full safety invariant: statically bundled locales, no `<Trans>`, lint-banned `dangerouslySetInnerHTML` — and what a future `<Trans>`/HTML-sink change must do about escaping.

## Verification
- Re-confirmed the audit's premises on current `main`: zero `dangerouslySetInnerHTML` and zero `<Trans>`/`shouldUnescape` usages in `src/`
- **Proved the rule fires**: created a probe file with `dangerouslySetInnerHTML`, confirmed eslint errors on it with the intended message (a typo'd AST selector would have silently no-opped), then removed the probe
- `npm run lint` (`eslint . --max-warnings 0`) — clean across the whole repo
- `npx tsc --noEmit` — identical to the pre-existing 20-error baseline (uninstalled private package), no new errors
- Prettier — no drift from the new lines (remaining `eslint.config.js` drift is pre-existing; the repo's format script only covers `src/**`)

No runtime behavior change — this is a lint rule and a comment.

Fixes #478