### PR TITLE
fix: disclose and exact-pin the @sethbacon/terraform-suite-ui auth package

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -307,6 +307,30 @@ Enhanced error reporter with:
 
 Critical-path pages (HomePage, LoginPage, ModulesPage, ProvidersPage, etc.) are loaded eagerly. Non-critical pages (detail pages, admin pages, API docs) are loaded lazily via `React.lazy()` with `<Suspense fallback={<div>Loading...</div>}>`.
 
+## Shared Suite Package (`@sethbacon/terraform-suite-ui`)
+
+Cross-cutting concerns shared with the other Terraform Suite apps live in the
+private package [`@sethbacon/terraform-suite-ui`](https://github.com/sethbacon/terraform-suite-ui),
+published to the GitHub Packages npm registry and pinned to an **exact**
+version in `package.json` (see the "Shared private package" section of
+`SECURITY.md` for the audit/provenance/update policy — the package carries the
+auth/session provider and is treated as load-bearing security code).
+
+The following local files are thin wrappers or re-exports around it:
+
+| Local file                     | Wraps / re-exports from the package                                 |
+| ------------------------------ | ------------------------------------------------------------------- |
+| `contexts/AuthContext.tsx`     | `AuthProvider`, `useAuth` (session lifecycle, expiry, scopes)       |
+| `contexts/ConsentContext.tsx`  | `ConsentProvider`, `useConsent` (GDPR consent preferences)          |
+| `contexts/ThemeContext.tsx`    | `SuiteThemeProvider`, `useThemeMode` (light/dark, RTL, whitelabel)  |
+| `components/Layout.tsx`        | `SuiteLayout` (sidebar/topbar app shell)                            |
+| `components/Page.tsx`          | `Page` + `PageProps`                                                |
+| `components/PageHeader.tsx`    | `PageHeader` + `PageHeaderProps`                                    |
+| `components/DashboardCard.tsx` | `DashboardCard` + `DashboardCardProps`                              |
+| `components/ConsentBanner.tsx` | `ConsentBanner`                                                     |
+| `components/SuiteSwitcher.tsx` | `SuiteSwitcher` (cross-app switcher)                                |
+| `navigation.tsx`               | `NavItem` / `NavGroup` types for the sidebar config                 |
+
 ## Shared Components
 
 | Component                | Purpose                                                                        |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -122,3 +122,42 @@ matching `v*.*.*` with a "Restrict deletions" rule.
 - **SLSA provenance attestation** on Docker images via `actions/attest-build-provenance`
 - **SBOM (SPDX) generation and attestation** on Docker images via Syft (`anchore/sbom-action`) and `actions/attest-sbom`
 - **Cosign keyless signing** on Docker images via Sigstore (verify with `cosign verify`)
+
+### Shared private package: `@sethbacon/terraform-suite-ui`
+
+This app depends on the private, out-of-tree package
+[`@sethbacon/terraform-suite-ui`](https://github.com/sethbacon/terraform-suite-ui)
+(GitHub Packages npm registry), which carries **load-bearing security code**
+shared across the Terraform Suite apps: the authentication/session provider
+(`SuiteAuthProvider` — session lifecycle, expiry warnings, scope checks),
+the GDPR consent provider, the theme provider, and the app shell/navigation.
+Local files under `src/contexts/` and several `src/components/` are thin
+wrappers around it (see the "Shared Suite Package" section of
+`ARCHITECTURE.md` for the full mapping).
+
+Because a compromised or regressed publish of this package would affect
+authentication in every consuming app, it is subject to the following
+controls:
+
+- **Exact version pin** — `package.json` pins the package to an exact
+  version (no semver range), and `package-lock.json` enforces the tarball's
+  `sha512` integrity. A malicious re-publish of the same version cannot be
+  installed without an integrity failure, and a new version cannot arrive
+  via a routine floating-range install.
+- **Audited** — the package received the same blind security audit
+  methodology as this repo on 2026-07-10 (26 findings: 2 high, 16 medium,
+  remainder low/info). All findings were remediated in
+  [v0.5.3](https://github.com/sethbacon/terraform-suite-ui/releases/tag/v0.5.3)
+  (2026-07-11), which is the version pinned here. The package repo now
+  carries its own `SECURITY.md` and a security-model section in its README.
+- **Upstream supply-chain gates** — the package's own CI runs typecheck,
+  tests, build, and CodeQL; its publish workflow verifies the tarball
+  contains only `dist/` + docs before publishing and attaches a build
+  provenance attestation (`actions/attest-build-provenance`) to each
+  release.
+- **Manual, reviewed updates** — Dependabot does not have credentials for
+  the private registry, so this dependency is deliberately outside
+  Dependabot's reach. Version bumps are manual PRs that must update the
+  exact pin and lockfile together and review the upstream
+  [CHANGELOG](https://github.com/sethbacon/terraform-suite-ui/blob/main/CHANGELOG.md)
+  for auth/consent-relevant changes.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,7 +19,7 @@
         "@mui/icons-material": "^9.0.1",
         "@mui/material": "^9.0.1",
         "@mui/material-pigment-css": "^9.0.1",
-        "@sethbacon/terraform-suite-ui": "^0.5.2",
+        "@sethbacon/terraform-suite-ui": "0.5.3",
         "@tanstack/react-query": "^5.99.2",
         "@tanstack/react-query-devtools": "^5.99.2",
         "@testing-library/dom": "^10.4.1",
@@ -2443,9 +2443,9 @@
       }
     },
     "node_modules/@sethbacon/terraform-suite-ui": {
-      "version": "0.5.2",
-      "resolved": "https://npm.pkg.github.com/download/@sethbacon/terraform-suite-ui/0.5.2/8568bd74c77380d60c8b88ef614fc87f4543aa37",
-      "integrity": "sha512-V1YNkqh5RdxAeFwjmv3bs620sowYB+mG1wKoZtrrKx+JkD1PZy1pcbYGMefrz2dsvzlXliOgzqj26Wek8yCZGg==",
+      "version": "0.5.3",
+      "resolved": "https://npm.pkg.github.com/download/@sethbacon/terraform-suite-ui/0.5.3/8dd70654bf97b72356dd32e7ae36407ee7f0f1af",
+      "integrity": "sha512-i4F+0uvgKectT4B/oAG1n5VWZpd8MHrLQpkl3EcvahnxSXZ0r/4RVkcJVdjgjaGUW6XgFn0LoM6d95rv3CPelQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=24.0.0 <25"
@@ -2455,7 +2455,6 @@
         "@emotion/styled": "^11.0.0",
         "@mui/icons-material": "^9.0.0",
         "@mui/material": "^9.0.0",
-        "@tanstack/react-query": "^5.0.0",
         "i18next": "^24.0.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,7 +31,7 @@
     "@mui/icons-material": "^9.0.1",
     "@mui/material": "^9.0.1",
     "@mui/material-pigment-css": "^9.0.1",
-    "@sethbacon/terraform-suite-ui": "^0.5.2",
+    "@sethbacon/terraform-suite-ui": "0.5.3",
     "@tanstack/react-query": "^5.99.2",
     "@tanstack/react-query-devtools": "^5.99.2",
     "@testing-library/dom": "^10.4.1",

--- a/frontend/src/components/SuiteSwitcher.test.tsx
+++ b/frontend/src/components/SuiteSwitcher.test.tsx
@@ -100,7 +100,13 @@ it('reuses one sibling tab via a stable window name instead of opening a new one
   fireEvent.click(await screen.findByRole('button', { name: /Open Terraform State Manager/i }))
   // Stable target name (the sibling app id) so the browser reuses that one tab;
   // .focus() brings it forward. NOT '_blank' (which spawns a new tab each click).
-  expect(openSpy).toHaveBeenCalledWith('https://tfstate.example.com', 'terraform-state-manager')
+  // noopener,noreferrer added in suite-ui 0.5.3 (audit hardening) severs the
+  // opener relationship so the sibling tab cannot script this one.
+  expect(openSpy).toHaveBeenCalledWith(
+    'https://tfstate.example.com',
+    'terraform-state-manager',
+    'noopener,noreferrer',
+  )
   expect(focus).toHaveBeenCalled()
 })
 


### PR DESCRIPTION
## Summary
Closes out audit finding #472: the private `@sethbacon/terraform-suite-ui` package carries load-bearing security code (the auth/session provider `SuiteAuthProvider`, consent, theming, app shell) but was disclosed in no security doc and floated on `^0.5.2`. The audit's prescribed fix had three parts — audit the package, pin it exactly, disclose it — and the first is now done: **the package received the same blind-audit methodology on 2026-07-10 (26 findings: 2 high, 16 medium, rest low/info), all remediated in [v0.5.3](https://github.com/sethbacon/terraform-suite-ui/releases/tag/v0.5.3)**. This PR completes the remaining two parts.

## Changes
- **Exact pin to the audited release** — `package.json` now pins `0.5.3` (no semver range); the lockfile enforces the tarball's `sha512` integrity. v0.5.3 also dropped `@tanstack/react-query` from its peerDependencies, reflected in the lock entry (no tree change — it remains a direct dependency of this app).
- **`SECURITY.md`** — new "Shared private package" section under Supply-Chain Security: what the package carries, the exact-pin + integrity policy, the audit + remediation release, the package's own supply-chain gates (CI + CodeQL, tarball-content verification before publish, `actions/attest-build-provenance` on each release, gated publish), and the manual update procedure (Dependabot deliberately has no private-registry credentials).
- **`ARCHITECTURE.md`** — new "Shared Suite Package" section with the mapping of local wrapper files to package exports, verified against the actual `import`/`export` statements rather than from memory.

## How the lockfile was updated without registry access
The sandbox has no working credentials for the private registry, so `npm install` couldn't produce the lock entry. Instead:
1. Took the authoritative **sha1 shasum** (`8dd70654…`) and version from the v0.5.3 publish-workflow log in the package repo (npm truncates the sha512 in its output, so that alone wasn't enough)
2. Reproduced the tarball from the `v0.5.3` tag (`npm ci && npm run build && npm pack` — npm pack is deterministic) — **reproduced sha1 matched the published shasum exactly**, proving byte-identity
3. Computed the `sha512` integrity from the byte-identical tarball; its visible prefix/suffix also match the truncated value in the publish log
4. `npm ci --dry-run` passes locally (lock and manifest agree); CI's real `npm ci` against the registry is the authoritative end-to-end integrity check

Fixes #472

## Test plan
- [x] `npm ci --dry-run` — clean (plans the 0.5.2→0.5.3 swap, no lock/manifest mismatch)
- [x] CI `npm ci` + Build + full unit-test suite — the real verification that version, resolved URL, and integrity are correct against the registry
- [x] `markdownlint` — no new findings (one pre-existing table-style nit at ARCHITECTURE.md:99 untouched)