### PR TITLE
chore(deps): bump @sethbacon/terraform-suite-ui to 0.5.3

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,7 +19,7 @@
         "@mui/icons-material": "^9.0.1",
         "@mui/material": "^9.0.1",
         "@mui/material-pigment-css": "^9.0.1",
-        "@sethbacon/terraform-suite-ui": "^0.5.2",
+        "@sethbacon/terraform-suite-ui": "^0.5.3",
         "@tanstack/react-query": "^5.99.2",
         "@tanstack/react-query-devtools": "^5.99.2",
         "@testing-library/dom": "^10.4.1",
@@ -2443,9 +2443,9 @@
       }
     },
     "node_modules/@sethbacon/terraform-suite-ui": {
-      "version": "0.5.2",
-      "resolved": "https://npm.pkg.github.com/download/@sethbacon/terraform-suite-ui/0.5.2/8568bd74c77380d60c8b88ef614fc87f4543aa37",
-      "integrity": "sha512-V1YNkqh5RdxAeFwjmv3bs620sowYB+mG1wKoZtrrKx+JkD1PZy1pcbYGMefrz2dsvzlXliOgzqj26Wek8yCZGg==",
+      "version": "0.5.3",
+      "resolved": "https://npm.pkg.github.com/download/@sethbacon/terraform-suite-ui/0.5.3/8dd70654bf97b72356dd32e7ae36407ee7f0f1af",
+      "integrity": "sha512-i4F+0uvgKectT4B/oAG1n5VWZpd8MHrLQpkl3EcvahnxSXZ0r/4RVkcJVdjgjaGUW6XgFn0LoM6d95rv3CPelQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=24.0.0 <25"
@@ -2455,7 +2455,6 @@
         "@emotion/styled": "^11.0.0",
         "@mui/icons-material": "^9.0.0",
         "@mui/material": "^9.0.0",
-        "@tanstack/react-query": "^5.0.0",
         "i18next": "^24.0.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,7 +31,7 @@
     "@mui/icons-material": "^9.0.1",
     "@mui/material": "^9.0.1",
     "@mui/material-pigment-css": "^9.0.1",
-    "@sethbacon/terraform-suite-ui": "^0.5.2",
+    "@sethbacon/terraform-suite-ui": "^0.5.3",
     "@tanstack/react-query": "^5.99.2",
     "@tanstack/react-query-devtools": "^5.99.2",
     "@testing-library/dom": "^10.4.1",

--- a/frontend/src/components/SuiteSwitcher.test.tsx
+++ b/frontend/src/components/SuiteSwitcher.test.tsx
@@ -100,7 +100,13 @@ it('reuses one sibling tab via a stable window name instead of opening a new one
   fireEvent.click(await screen.findByRole('button', { name: /Open Terraform State Manager/i }))
   // Stable target name (the sibling app id) so the browser reuses that one tab;
   // .focus() brings it forward. NOT '_blank' (which spawns a new tab each click).
-  expect(openSpy).toHaveBeenCalledWith('https://tfstate.example.com', 'terraform-state-manager')
+  // noopener,noreferrer is always passed (suite-ui >=0.5.3) so the opened tab
+  // cannot reach back via window.opener.
+  expect(openSpy).toHaveBeenCalledWith(
+    'https://tfstate.example.com',
+    'terraform-state-manager',
+    'noopener,noreferrer',
+  )
   expect(focus).toHaveBeenCalled()
 })
 


### PR DESCRIPTION
## Summary

Bumps `@sethbacon/terraform-suite-ui` from `^0.5.2` to `^0.5.3`.

This release includes the fixes from the [2026-07-10 blind security audit](https://github.com/sethbacon/terraform-suite-ui/pull/42) of the shared UI library:

- `SuiteSwitcher`'s `window.open` now always passes `noopener,noreferrer` (defense-in-depth against reverse-tabnabbing), and validates the target `href` via a new `isSafeUrl()` allowlist.
- `ConsentBanner`/whitelabel favicon/logo/login-hero URLs are validated the same way.
- A negative test now guards `hasScope`/`scopeSatisfied` against a scope-mismatch regression.
- `AuthContextType` gained an `authError` field (network vs. real-logout distinction) and documents `roleTemplate` as display-only.
- The `MAX_TIMEOUT_MS` session-expiry guard now re-arms instead of silently never warning on long sessions.
- Publish-pipeline hardening: environment gate, tag verification, tarball verification, build attestation, `npm audit`/CodeQL/commitlint in CI.
- See the [full release notes](https://github.com/sethbacon/terraform-suite-ui/releases/tag/v0.5.3) for the complete list.

## Changes here

- `frontend/package.json` / `package-lock.json`: version bump.
- `frontend/src/components/SuiteSwitcher.test.tsx`: updated the `window.open` call-signature assertion to include the new `noopener,noreferrer` third argument (behavior change from the library, not a regression in this app).

## Validation

- `npm run build` (tsc + vite build) ✅
- `npm run lint` ✅
- `npm test` — 1727/1727 passing
