### PR TITLE
fix(admin): render matched policy name and make org IdP binding visible and clearable

### DIFF
--- a/frontend/src/pages/admin/MirrorPoliciesPage.tsx
+++ b/frontend/src/pages/admin/MirrorPoliciesPage.tsx
@@ -37,7 +37,7 @@ import Page from '../../components/Page'
 import PageHeader from '../../components/PageHeader'
 import PageTitleIcon from '@mui/icons-material/Policy'
 import api from '../../services/api'
-import { MirrorPolicy } from '../../types/rbac'
+import { MirrorPolicy, PolicyEvaluationResult } from '../../types/rbac'
 import { getErrorMessage } from '../../utils/errors'
 import { queryKeys } from '../../services/queryKeys'
 
@@ -83,11 +83,7 @@ const MirrorPoliciesPage: React.FC = () => {
   // Evaluate dialog
   const [evaluateDialogOpen, setEvaluateDialogOpen] = useState(false)
   const [evaluateForm, setEvaluateForm] = useState({ registry: '', namespace: '', provider: '' })
-  const [evaluateResult, setEvaluateResult] = useState<{
-    allowed: boolean
-    matched_policy?: string
-    reason?: string
-  } | null>(null)
+  const [evaluateResult, setEvaluateResult] = useState<PolicyEvaluationResult | null>(null)
   const [evaluating, setEvaluating] = useState(false)
 
   const {
@@ -629,7 +625,7 @@ const MirrorPoliciesPage: React.FC = () => {
                       </strong>
                       {evaluateResult.matched_policy &&
                         t('admin.mirrorPolicies.resultMatchedPolicy', {
-                          policy: evaluateResult.matched_policy,
+                          policy: evaluateResult.matched_policy.name,
                         })}
                       {evaluateResult.reason &&
                         t('admin.mirrorPolicies.resultReason', { reason: evaluateResult.reason })}

--- a/frontend/src/pages/admin/OrganizationsPage.tsx
+++ b/frontend/src/pages/admin/OrganizationsPage.tsx
@@ -129,7 +129,10 @@ const OrganizationsPage: React.FC = () => {
         await api.updateOrganization(editingOrg.id, {
           ...(formData.name !== editingOrg.name ? { name: formData.name } : {}),
           display_name: formData.display_name,
-          idp_type: formData.idp_type || null,
+          // The backend clears the IdP binding only on an explicit empty string;
+          // a JSON null unmarshals to a nil pointer and is silently skipped, so
+          // sending `|| null` here made "None" a no-op (#538).
+          idp_type: formData.idp_type,
           idp_name: formData.idp_name || null,
         })
       } else {

--- a/frontend/src/pages/admin/__tests__/MirrorPoliciesPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/MirrorPoliciesPage.test.tsx
@@ -224,9 +224,12 @@ describe('MirrorPoliciesPage', () => {
 
   it('opens Evaluate dialog and evaluates a policy', async () => {
     listMirrorPoliciesMock.mockResolvedValue(fakePolicies)
+    // matched_policy is a full MirrorPolicy object on the wire (backend
+    // models.PolicyEvaluationResult), not a string — mock the real shape.
     evaluateMirrorPolicyMock.mockResolvedValue({
       allowed: true,
-      matched_policy: 'Allow HashiCorp',
+      requires_approval: false,
+      matched_policy: { ...fakePolicies[0], name: 'Allow HashiCorp' },
       reason: 'namespace matched',
     })
     renderPage()
@@ -243,13 +246,17 @@ describe('MirrorPoliciesPage', () => {
     await userEvent.click(evaluateBtns[evaluateBtns.length - 1])
     await waitFor(() => expect(evaluateMirrorPolicyMock).toHaveBeenCalled())
     await waitFor(() => expect(screen.getByText(/Allowed/)).toBeInTheDocument())
+    // The dialog must render the policy's *name*, not "[object Object]".
+    expect(screen.getByText(/matched policy: Allow HashiCorp/)).toBeInTheDocument()
+    expect(screen.queryByText(/\[object Object\]/)).not.toBeInTheDocument()
   })
 
   it('shows Denied result when evaluate returns allowed:false', async () => {
     listMirrorPoliciesMock.mockResolvedValue(fakePolicies)
     evaluateMirrorPolicyMock.mockResolvedValue({
       allowed: false,
-      matched_policy: 'Deny External',
+      requires_approval: false,
+      matched_policy: { ...fakePolicies[0], name: 'Deny External', policy_type: 'deny' },
       reason: 'blocked',
     })
     renderPage()

--- a/frontend/src/pages/admin/__tests__/OrganizationsPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/OrganizationsPage.test.tsx
@@ -60,6 +60,8 @@ const fakeOrgs = [
     id: 'org-1',
     name: 'acme-corp',
     display_name: 'Acme Corporation',
+    idp_type: 'oidc',
+    idp_name: 'corp-okta',
     created_at: '2025-03-15T10:00:00Z',
     updated_at: '2025-03-15T10:00:00Z',
   },
@@ -67,6 +69,8 @@ const fakeOrgs = [
     id: 'org-2',
     name: 'globex',
     display_name: 'Globex Inc',
+    idp_type: null,
+    idp_name: null,
     created_at: '2025-04-20T08:00:00Z',
     updated_at: '2025-04-20T08:00:00Z',
   },
@@ -230,7 +234,29 @@ describe('OrganizationsPage', () => {
     await waitFor(() =>
       expect(updateOrganizationMock).toHaveBeenCalledWith(
         'org-1',
-        expect.objectContaining({ display_name: 'Acme Corporation' }),
+        // idp_type must round-trip from the fetched org (pre-filled dialog),
+        // proving the API transform no longer drops the binding (#538).
+        expect.objectContaining({ display_name: 'Acme Corporation', idp_type: 'oidc' }),
+      ),
+    )
+  })
+
+  it('clearing the IdP binding sends an explicit empty string, not null', async () => {
+    // The backend only clears on idp_type === ""; null is silently ignored (#538).
+    listOrganizationsMock.mockResolvedValue(fakeOrgs)
+    updateOrganizationMock.mockResolvedValue({})
+    renderPage()
+    await waitFor(() => expect(screen.getByText('acme-corp')).toBeInTheDocument())
+    const editBtns = screen.getAllByRole('button', { name: /edit organization/i })
+    await userEvent.click(editBtns[0])
+    await waitFor(() => expect(screen.getByText('Edit Organization')).toBeInTheDocument())
+    await userEvent.click(screen.getByRole('combobox'))
+    await userEvent.click(await screen.findByRole('option', { name: /any \(no restriction\)/i }))
+    await userEvent.click(screen.getByRole('button', { name: /^save$/i }))
+    await waitFor(() =>
+      expect(updateOrganizationMock).toHaveBeenCalledWith(
+        'org-1',
+        expect.objectContaining({ idp_type: '', idp_name: null }),
       ),
     )
   })
@@ -376,7 +402,7 @@ describe('OrganizationsPage', () => {
   })
 
   it('shows IdP chip without name when idp_name is empty', async () => {
-    const orgsWithIdp = [{ ...fakeOrgs[0], idp_type: 'ldap' }]
+    const orgsWithIdp = [{ ...fakeOrgs[0], idp_type: 'ldap', idp_name: null }]
     listOrganizationsMock.mockResolvedValue(orgsWithIdp)
     renderPage()
     await waitFor(() => expect(screen.getByText('acme-corp')).toBeInTheDocument())

--- a/frontend/src/services/__tests__/api.test.ts
+++ b/frontend/src/services/__tests__/api.test.ts
@@ -1257,7 +1257,15 @@ describe('ApiClient', () => {
         ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
           data: {
             organizations: [
-              { id: 'o1', name: 'org1', display_name: 'Org 1', created_at: '', updated_at: '' },
+              {
+                id: 'o1',
+                name: 'org1',
+                display_name: 'Org 1',
+                idp_type: 'saml',
+                idp_name: 'corp-idp',
+                created_at: '',
+                updated_at: '',
+              },
             ],
           },
         })
@@ -1266,6 +1274,10 @@ describe('ApiClient', () => {
         params: { page: 1, per_page: 20 },
       })
       expect(result).toHaveLength(1)
+      // The transform must pass the IdP binding through — dropping it made the
+      // binding invisible and un-clearable in the admin UI (#538).
+      expect(result[0].idp_type).toBe('saml')
+      expect(result[0].idp_name).toBe('corp-idp')
     })
 
     it('searchOrganizations', async () => {

--- a/frontend/src/services/api/mirrorsApi.ts
+++ b/frontend/src/services/api/mirrorsApi.ts
@@ -6,7 +6,7 @@ import type {
   MirroredProvider,
   UpdateMirrorConfigRequest,
 } from '../../types/mirror'
-import type { MirrorApprovalRequest, MirrorPolicy } from '../../types/rbac'
+import type { MirrorApprovalRequest, MirrorPolicy, PolicyEvaluationResult } from '../../types/rbac'
 
 // Mirror Management
 export async function listMirrors(enabledOnly = false): Promise<MirrorConfiguration[]> {
@@ -165,8 +165,12 @@ export async function evaluateMirrorPolicy(
     provider: string
   },
   organizationId?: string,
-) {
+): Promise<PolicyEvaluationResult> {
   const params = organizationId ? { organization_id: organizationId } : {}
-  const response = await http.post('/api/v1/admin/policies/evaluate', data, { params })
+  const response = await http.post<PolicyEvaluationResult>(
+    '/api/v1/admin/policies/evaluate',
+    data,
+    { params },
+  )
   return response.data
 }

--- a/frontend/src/services/api/organizationsApi.ts
+++ b/frontend/src/services/api/organizationsApi.ts
@@ -18,6 +18,10 @@ function transformOrganization(org: Record<string, unknown>): Organization {
     id: org.id as string,
     name: org.name as string,
     display_name: org.display_name as string,
+    // IdP binding — always present in the wire response (null when unbound).
+    // Dropping these here made the binding invisible in the admin UI (#538).
+    idp_type: (org.idp_type ?? null) as string | null,
+    idp_name: (org.idp_name ?? null) as string | null,
     created_at: org.created_at as string,
     updated_at: org.updated_at as string,
   }


### PR DESCRIPTION
Closes #535. Closes #538.

## Mirror Policies (#535)
The backend returns `matched_policy` as a full `MirrorPolicy` object; the Evaluate dialog typed it as a string and interpolated it into i18n, rendering `[object Object]` on every policy match. The page now uses the shared `PolicyEvaluationResult` type and interpolates `.name`; `evaluateMirrorPolicy` is typed accordingly. The page test mocks the real wire shape and asserts the rendered name (and the absence of `[object Object]`).

## Organizations (#538)
`transformOrganization` dropped `idp_type`/`idp_name`, so the binding chip never rendered and the edit dialog could neither show nor clear a binding — clearing sent `null`, which the backend deliberately ignores (it clears only on explicit `""`, `internal/api/admin/organizations.go:357-372`). The transform now passes both fields through and the page sends the form value directly so `""` reaches the backend.

Tests: transform passthrough (api.test.ts, through the real transform), dialog pre-fill round-trip, and the explicit-`""` clear via the dialog's select.

## Verification
tsc clean · eslint clean · 270 tests across the three affected files · live e2e sanity on policies.spec against the dockerized backend. No file overlap with #542 — mergeable in either order.