### PR TITLE
fix(auth): remove the legacy localStorage JWT path — cookie-only sessions

### DIFF
--- a/frontend/src/components/DevUserSwitcher.tsx
+++ b/frontend/src/components/DevUserSwitcher.tsx
@@ -58,10 +58,9 @@ const DevUserSwitcher = () => {
 
     setSwitching(true)
     try {
-      const result = await apiClient.impersonateUser(targetUserId)
-      // Update the token in localStorage and reload so the auth context picks it up
-      localStorage.setItem('auth_token', result.token)
-      // Reload the page to refresh all data with new user context
+      await apiClient.impersonateUser(targetUserId)
+      // The backend swapped the HttpOnly auth cookie to the impersonated user;
+      // reload the page so the auth context picks up the new session via /auth/me.
       window.location.reload()
     } catch (error) {
       console.error('Failed to impersonate user:', error)

--- a/frontend/src/components/__tests__/DevUserSwitcher.test.tsx
+++ b/frontend/src/components/__tests__/DevUserSwitcher.test.tsx
@@ -78,10 +78,11 @@ describe('DevUserSwitcher', () => {
     expect(screen.getByText('Admin')).toBeInTheDocument()
   })
 
-  it('selecting a user writes the impersonation token to localStorage and reloads', async () => {
-    // The security-relevant side effect (impersonateUser -> token write -> reload)
-    // was previously untested; only the surrounding dev-mode gating/rendering was
-    // covered. vi.spyOn preserves the real Location object (see the CallbackPage
+  it('selecting a user reloads on the backend cookie swap without touching localStorage', async () => {
+    // Cookie-only auth (#467): impersonation swaps the HttpOnly auth cookie
+    // server-side; the token-less response body must never be persisted to
+    // localStorage — the reload alone picks up the new session via /auth/me.
+    // vi.spyOn preserves the real Location object (see the CallbackPage
     // lesson: `{...window.location, reload: vi.fn()}` silently drops origin/href/
     // etc. because Location's props are prototype getters, not own properties).
     const reloadSpy = vi.spyOn(window.location, 'reload').mockImplementation(() => {})
@@ -94,7 +95,10 @@ describe('DevUserSwitcher', () => {
         { id: 'u2', email: 'user@example.com', name: 'Regular User', primary_role: 'viewer' },
       ],
     })
-    impersonateUserMock.mockResolvedValue({ token: 'impersonation-jwt-for-u2' })
+    impersonateUserMock.mockResolvedValue({
+      user: { id: 'u2', email: 'user@example.com', name: 'Regular User' },
+      message: 'impersonation cookie set',
+    })
 
     render(<DevUserSwitcher />)
     await waitFor(() => expect(screen.getByText(/DEV/)).toBeInTheDocument())
@@ -104,8 +108,9 @@ describe('DevUserSwitcher', () => {
     fireEvent.click(within(listbox).getByText('Regular User'))
 
     await waitFor(() => expect(impersonateUserMock).toHaveBeenCalledWith('u2'))
-    await waitFor(() => expect(localStorage.getItem('auth_token')).toBe('impersonation-jwt-for-u2'))
-    expect(reloadSpy).toHaveBeenCalled()
+    await waitFor(() => expect(reloadSpy).toHaveBeenCalled())
+    // Nothing token-shaped may land in client-readable storage.
+    expect(localStorage.getItem('auth_token')).toBeNull()
   })
 
   it('renders nothing when dev status endpoint fails', async () => {

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -34,19 +34,11 @@ const authApi: AuthApi = {
     }
   },
   login: (provider) => api.login(provider),
-  // Registry dev/LDAP logins return a JWT in the body (no cookie is set). Persist it so
-  // the api client attaches it as a Bearer header on the subsequent /me call; logout
-  // clears it via clearAuthStorage (onClearStorage).
-  devLogin: async () => {
-    const r = await api.devLogin()
-    if (r?.token) localStorage.setItem('auth_token', r.token)
-    return r
-  },
-  ldapLogin: async (username, password) => {
-    const r = await api.ldapLogin(username, password)
-    if (r?.token) localStorage.setItem('auth_token', r.token)
-    return r
-  },
+  // Registry dev/LDAP logins set the HttpOnly auth cookie (plus tfr_csrf) via
+  // Set-Cookie on the response — no token in the body, nothing to persist. The
+  // suite AuthProvider resolves the session via the subsequent /auth/me probe.
+  devLogin: () => api.devLogin(),
+  ldapLogin: (username, password) => api.ldapLogin(username, password),
   logout: () => api.logout(),
   refreshToken: async () => {
     const r = await api.refreshToken()

--- a/frontend/src/contexts/__tests__/AuthContext.test.tsx
+++ b/frontend/src/contexts/__tests__/AuthContext.test.tsx
@@ -81,26 +81,27 @@ describe('AuthProvider', () => {
     expect(latest.sessionExpiresSoon).toBe(true)
   })
 
-  it('devLogin establishes a session then re-resolves the user', async () => {
+  it('devLogin establishes a cookie session then re-resolves the user (no localStorage write)', async () => {
     mockApi.getCurrentUserWithRole.mockRejectedValueOnce(new Error('401'))
-    mockApi.devLogin.mockResolvedValue({ token: 't', user: {}, expires_in: 3600 })
+    // Token-less body (#467): the backend sets the HttpOnly cookie via Set-Cookie.
+    mockApi.devLogin.mockResolvedValue({ user: {}, expires_in: 3600 })
     mockApi.getCurrentUserWithRole.mockResolvedValue(me)
     await renderAuth()
     expect(latest.isAuthenticated).toBe(false)
     await act(() => latest.devLogin())
     expect(mockApi.devLogin).toHaveBeenCalled()
-    expect(localStorage.getItem('auth_token')).toBe('t')
+    expect(localStorage.getItem('auth_token')).toBeNull()
     expect(latest.isAuthenticated).toBe(true)
   })
 
-  it('ldapLogin posts credentials then re-resolves the user', async () => {
+  it('ldapLogin posts credentials then re-resolves the user (no localStorage write)', async () => {
     mockApi.getCurrentUserWithRole.mockRejectedValueOnce(new Error('401'))
-    mockApi.ldapLogin.mockResolvedValue({ token: 't' })
+    mockApi.ldapLogin.mockResolvedValue(undefined)
     mockApi.getCurrentUserWithRole.mockResolvedValue(me)
     await renderAuth()
     await act(() => latest.ldapLogin('alice', 'secret'))
     expect(mockApi.ldapLogin).toHaveBeenCalledWith('alice', 'secret')
-    expect(localStorage.getItem('auth_token')).toBe('t')
+    expect(localStorage.getItem('auth_token')).toBeNull()
     expect(latest.isAuthenticated).toBe(true)
   })
 

--- a/frontend/src/pages/ApiDocumentation.tsx
+++ b/frontend/src/pages/ApiDocumentation.tsx
@@ -7,6 +7,7 @@ import 'swagger-ui-react/swagger-ui.css'
 import { Box, Typography, List, ListItem, ListItemButton, ListItemText, Paper } from '@mui/material'
 import { useTheme } from '@mui/material/styles'
 import { enforceSwaggerA11yStyles, getSwaggerThemeCss } from '../utils/swaggerTheme'
+import { getCookie } from '../services/api/http'
 
 // swagger-ui-react's wrapper only forwards a fixed set of props to the
 // underlying SwaggerUIBundle.  tagsSorter is not one of them, so we inject
@@ -91,11 +92,18 @@ const ApiDocumentation: React.FC = () => {
   const contentRef = useRef<HTMLDivElement>(null)
   const mutationObserverRef = useRef<MutationObserver | null>(null)
 
-  // Forward the user's bearer token so "Try it out" works on auth'd endpoints.
+  // "Try it out" auth rides on the HttpOnly session cookie (same-origin fetch
+  // sends it automatically) — no Authorization header is attached client-side.
+  // Echo the non-HttpOnly tfr_csrf cookie as X-CSRF-Token on mutating methods
+  // so those requests pass the double-submit CSRF middleware (mirrors the axios
+  // interceptor in services/api/http.ts).
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- swagger-ui-react's Request type lacks headers
   const requestInterceptor = useCallback((req: any) => {
-    const token = localStorage.getItem('auth_token')
-    if (token) req.headers['Authorization'] = `Bearer ${token}`
+    const method = String(req.method || 'GET').toUpperCase()
+    if (method === 'POST' || method === 'PUT' || method === 'PATCH' || method === 'DELETE') {
+      const csrfToken = getCookie('tfr_csrf')
+      if (csrfToken) req.headers['X-CSRF-Token'] = csrfToken
+    }
     return req
   }, [])
 
@@ -289,7 +297,6 @@ const ApiDocumentation: React.FC = () => {
             deepLinking
             tryItOutEnabled
             requestInterceptor={requestInterceptor}
-            persistAuthorization
             onComplete={onComplete}
             plugins={[TagsSorterPlugin]}
           />

--- a/frontend/src/pages/CallbackPage.tsx
+++ b/frontend/src/pages/CallbackPage.tsx
@@ -22,19 +22,10 @@ const CallbackPage: React.FC = () => {
         return
       }
 
-      // Check URL param first (backward compat / dev mode)
-      const token = searchParams.get('token')
-
-      if (token) {
-        // Legacy migration flow: token passed as a URL parameter. Persist it so the
-        // api client attaches it as a Bearer header until cookie-only migration
-        // completes. AuthContext resolves the session via /auth/me after the reload below.
-        localStorage.setItem('auth_token', token)
-      }
-
-      // New flow: The backend set an HttpOnly cookie during the OIDC callback
-      // redirect. AuthContext will detect the session via /auth/me on mount.
-      // Navigate to the return URL; AuthContext handles the rest.
+      // Cookie-only flow: the backend set an HttpOnly cookie during the OIDC
+      // callback redirect (no token ever transits the URL). AuthContext will
+      // detect the session via /auth/me on mount. Navigate to the return URL;
+      // AuthContext handles the rest.
       const raw = sessionStorage.getItem('returnUrl') || '/'
       sessionStorage.removeItem('returnUrl')
       // Reject absolute and protocol-relative URLs to prevent open redirect.

--- a/frontend/src/pages/__tests__/ApiDocumentation.test.tsx
+++ b/frontend/src/pages/__tests__/ApiDocumentation.test.tsx
@@ -8,7 +8,7 @@ import { ThemeProvider, createTheme } from '@mui/material/styles'
 interface SwaggerProps {
   url: string
   onComplete?: (system: unknown) => void
-  requestInterceptor?: (req: { headers: Record<string, string> }) => unknown
+  requestInterceptor?: (req: { method?: string; headers: Record<string, string> }) => unknown
   plugins?: Array<() => unknown>
 }
 
@@ -243,20 +243,58 @@ describe('ApiDocumentation', () => {
     }
   })
 
-  it('requestInterceptor adds the bearer token when present in localStorage', () => {
-    localStorage.setItem('auth_token', 'tok-abc')
+  // Cookie-only auth (#467): "Try it out" rides on the HttpOnly session cookie
+  // (same-origin fetch sends it automatically). The interceptor must never
+  // re-attach a Bearer header from localStorage, and must echo the tfr_csrf
+  // cookie as X-CSRF-Token on mutating methods for the double-submit check.
+  it('requestInterceptor does not attach Authorization even when a stray legacy token exists in localStorage', () => {
+    localStorage.setItem('auth_token', 'stale-legacy-jwt')
     renderWithTheme()
-    const req = { headers: {} as Record<string, string> }
+    const req = { method: 'GET', headers: {} as Record<string, string> }
     const result = capturedProps?.requestInterceptor?.(req)
     expect(result).toBe(req)
-    expect(req.headers['Authorization']).toBe('Bearer tok-abc')
+    expect(req.headers['Authorization']).toBeUndefined()
   })
 
-  it('requestInterceptor leaves headers untouched when no token is stored', () => {
+  it.each(['POST', 'PUT', 'PATCH', 'DELETE'])(
+    'requestInterceptor echoes tfr_csrf as X-CSRF-Token on %s',
+    (method) => {
+      document.cookie = 'tfr_csrf=swagger-csrf-token; path=/'
+      try {
+        renderWithTheme()
+        const req = { method, headers: {} as Record<string, string> }
+        capturedProps?.requestInterceptor?.(req)
+        expect(req.headers['X-CSRF-Token']).toBe('swagger-csrf-token')
+        expect(req.headers['Authorization']).toBeUndefined()
+      } finally {
+        document.cookie = 'tfr_csrf=; Max-Age=0; path=/'
+      }
+    },
+  )
+
+  it('requestInterceptor omits X-CSRF-Token on GET even when the cookie is present', () => {
+    document.cookie = 'tfr_csrf=swagger-csrf-token; path=/'
+    try {
+      renderWithTheme()
+      const req = { method: 'GET', headers: {} as Record<string, string> }
+      capturedProps?.requestInterceptor?.(req)
+      expect(req.headers['X-CSRF-Token']).toBeUndefined()
+    } finally {
+      document.cookie = 'tfr_csrf=; Max-Age=0; path=/'
+    }
+  })
+
+  it('requestInterceptor leaves headers untouched on a mutating request when no CSRF cookie exists', () => {
     renderWithTheme()
-    const req = { headers: {} as Record<string, string> }
+    const req = { method: 'POST', headers: {} as Record<string, string> }
     capturedProps?.requestInterceptor?.(req)
+    expect(req.headers['X-CSRF-Token']).toBeUndefined()
     expect(req.headers['Authorization']).toBeUndefined()
+  })
+
+  it('does not enable persistAuthorization (nothing auth-shaped may persist to localStorage)', () => {
+    renderWithTheme()
+    expect('persistAuthorization' in ((capturedProps ?? {}) as Record<string, unknown>)).toBe(false)
   })
 
   it('TagsSorterPlugin wraps taggedOperations with a sortBy selector', () => {

--- a/frontend/src/pages/__tests__/CallbackPage.test.tsx
+++ b/frontend/src/pages/__tests__/CallbackPage.test.tsx
@@ -33,7 +33,7 @@ function renderWithParams(search: string) {
 
 describe('CallbackPage', () => {
   it('shows loading spinner initially', () => {
-    renderWithParams('?token=abc123')
+    renderWithParams('')
     expect(screen.getByText('Completing authentication...')).toBeInTheDocument()
   })
 
@@ -52,18 +52,22 @@ describe('CallbackPage', () => {
     })
   })
 
-  it('redirects to home when no token param (cookie-based auth)', async () => {
+  it('redirects to home on the cookie-only callback (no params)', async () => {
     renderWithParams('')
     await waitFor(() => {
       expect(window.location.replace).toHaveBeenCalledWith('/')
     })
   })
 
-  it('stores the token in localStorage when token param is present', async () => {
+  it('never persists a ?token= query param to localStorage (cookie-only, #467)', async () => {
+    // The backend no longer sends ?token= on callbacks. Even if a crafted or
+    // stale URL carries one, it must be ignored — never written to localStorage
+    // — and the navigation away from /auth/callback leaves no token in the URL.
     renderWithParams('?token=jwt-token-123')
     await waitFor(() => {
-      expect(localStorage.getItem('auth_token')).toBe('jwt-token-123')
+      expect(window.location.replace).toHaveBeenCalledWith('/')
     })
+    expect(localStorage.getItem('auth_token')).toBeNull()
   })
 
   it('shows redirecting message on error', async () => {

--- a/frontend/src/pages/__tests__/LoginPage.test.tsx
+++ b/frontend/src/pages/__tests__/LoginPage.test.tsx
@@ -147,7 +147,9 @@ describe('LoginPage', () => {
   })
 
   it('calls ldapLogin and navigates on successful LDAP sign-in', async () => {
-    mockLdapLogin.mockResolvedValue({ token: 'ldap-jwt' })
+    // Cookie-only auth (#467): ldapLogin resolves with no body — the session
+    // arrives via Set-Cookie.
+    mockLdapLogin.mockResolvedValue(undefined)
     mockProviders([{ type: 'ldap', name: 'LDAP' }])
     renderLoginPage()
     const usernameInput = await screen.findByRole('textbox', { name: /username/i })

--- a/frontend/src/services/__tests__/api.test.ts
+++ b/frontend/src/services/__tests__/api.test.ts
@@ -11,7 +11,6 @@ type ResFulfilled = (response: AxiosResponse) => AxiosResponse
 type ResRejected = (error: AxiosError) => unknown
 
 let capturedReqFulfilled: ReqFulfilled
-let capturedResRejected: ResRejected
 let capturedResRejectedHandlers: ResRejected[]
 let mockAxiosInstance: AxiosInstance
 let capturedCreateConfig: Record<string, unknown>
@@ -29,9 +28,7 @@ vi.mock('axios', () => {
         }),
       },
       response: {
-        use: vi.fn((_fulfilled: ResFulfilled, rejected: ResRejected) => {
-          capturedResRejected = rejected
-        }),
+        use: vi.fn(),
       },
     },
   }
@@ -69,7 +66,6 @@ function getApiClient() {
         },
         response: {
           use: vi.fn((_fulfilled: ResFulfilled, rejected: ResRejected) => {
-            capturedResRejected = rejected
             resRejectedHandlers.push(rejected)
             capturedResRejectedHandlers = resRejectedHandlers
           }),
@@ -109,21 +105,16 @@ describe('ApiClient', () => {
   })
 
   // ─── Auth Interceptor ──────────────────────────────────────────────────
+  // Cookie-only auth (#467): the HttpOnly session cookie is the sole ambient
+  // credential. The interceptor must never synthesize an Authorization header
+  // from client-readable storage — any JWT in localStorage is XSS-exfiltratable
+  // and is treated as compromised, not re-attached.
 
-  describe('request interceptor – auth token', () => {
-    it('adds Authorization Bearer header when token exists in localStorage', async () => {
-      localStorage.setItem('auth_token', 'my-jwt-token')
-      await getApiClient()
-
-      const config = {
-        headers: {} as Record<string, string>,
-      } as InternalAxiosRequestConfig
-
-      const result = capturedReqFulfilled(config)
-      expect(result.headers.Authorization).toBe('Bearer my-jwt-token')
-    })
-
-    it('does not add Authorization header when no token is stored', async () => {
+  describe('request interceptor – no Authorization from localStorage', () => {
+    it('does not attach Authorization even when a stray legacy token exists in localStorage', async () => {
+      // Regression guard: a leftover pre-migration JWT in a shared browser
+      // profile must stay inert — never silently promoted to a Bearer header.
+      localStorage.setItem('auth_token', 'stale-legacy-jwt')
       await getApiClient()
 
       const config = {
@@ -134,11 +125,22 @@ describe('ApiClient', () => {
       expect(result.headers.Authorization).toBeUndefined()
     })
 
-    it('does not overwrite an explicit Authorization header set by the caller', async () => {
-      // A stray legacy JWT in localStorage (e.g. left over from a prior session in a
-      // shared browser profile) must not clobber a caller-supplied auth scheme, such
-      // as the Setup Wizard's bootstrap "SetupToken <token>" calls.
-      localStorage.setItem('auth_token', 'my-jwt-token')
+    it('does not add Authorization header when nothing is stored', async () => {
+      await getApiClient()
+
+      const config = {
+        headers: {} as Record<string, string>,
+      } as InternalAxiosRequestConfig
+
+      const result = capturedReqFulfilled(config)
+      expect(result.headers.Authorization).toBeUndefined()
+    })
+
+    it('leaves a caller-supplied Authorization header untouched', async () => {
+      // The Setup Wizard's bootstrap calls set "SetupToken <token>" explicitly
+      // (see setupRequest) — the interceptor must pass it through unmodified,
+      // even with a stray legacy JWT sitting in localStorage.
+      localStorage.setItem('auth_token', 'stale-legacy-jwt')
       await getApiClient()
 
       const config = {
@@ -147,24 +149,6 @@ describe('ApiClient', () => {
 
       const result = capturedReqFulfilled(config)
       expect(result.headers.Authorization).toBe('SetupToken setup-abc123')
-    })
-
-    it('does not overwrite an explicit Authorization header regardless of key casing', async () => {
-      // AxiosHeaders preserves the caller's key casing for property access, so a
-      // lowercase "authorization" would bypass a plain property check -- the guard
-      // must use the case-insensitive .has() to catch it.
-      localStorage.setItem('auth_token', 'my-jwt-token')
-      await getApiClient()
-
-      const { AxiosHeaders } = await vi.importActual<typeof import('axios')>('axios')
-      const config = {
-        headers: AxiosHeaders.concat({}, { authorization: 'SetupToken setup-abc123' }),
-      } as InternalAxiosRequestConfig
-
-      const result = capturedReqFulfilled(config)
-      expect(result.headers.get('Authorization')).toBe('SetupToken setup-abc123')
-      // The broken path would have added a second, canonically-cased key.
-      expect(result.headers.Authorization).toBeUndefined()
     })
   })
 
@@ -279,8 +263,12 @@ describe('ApiClient', () => {
   // ─── 401 Interceptor ──────────────────────────────────────────────────
 
   describe('response interceptor – 401 handling', () => {
-    it('clears auth and redirects to /login on 401 when token exists', async () => {
-      localStorage.setItem('auth_token', 'expired-token')
+    it('does not treat stray legacy localStorage keys as a session (clears them, no redirect)', async () => {
+      // Pre-migration sessions left auth_token/user in localStorage. Those keys
+      // are no longer a session signal — only the tfr_csrf cookie is. A 401
+      // must still sweep them out (one-time cleanup) without redirecting an
+      // otherwise-anonymous visitor to /login.
+      localStorage.setItem('auth_token', 'stale-legacy-jwt')
       localStorage.setItem('user', '{"id":"1"}')
       await getApiClient()
 
@@ -290,16 +278,18 @@ describe('ApiClient', () => {
         isAxiosError: true,
       } as AxiosError
 
-      // window.location.href is mocked by happy-dom
+      window.history.pushState({}, '', '/public-page')
 
       // Use the first response rejected handler (401 auth handler), not the last (breadcrumb handler)
       const authRejectedHandler = capturedResRejectedHandlers[0]
       await expect(authRejectedHandler(error)).rejects.toBe(error)
       expect(localStorage.getItem('auth_token')).toBeNull()
       expect(localStorage.getItem('user')).toBeNull()
+      // No cookie signal → anonymous visitor → no redirect.
+      expect(window.location.href).toContain('/public-page')
     })
 
-    it('does not redirect on 401 when no token exists (public endpoint)', async () => {
+    it('does not redirect on 401 when no session cookie exists (public endpoint)', async () => {
       await getApiClient()
 
       const error = {
@@ -308,14 +298,16 @@ describe('ApiClient', () => {
         isAxiosError: true,
       } as AxiosError
 
-      await expect(capturedResRejected(error)).rejects.toBe(error)
-      // No token to clear - localStorage stays empty
-      expect(localStorage.getItem('auth_token')).toBeNull()
+      window.history.pushState({}, '', '/public-page')
+
+      const authRejectedHandler = capturedResRejectedHandlers[0]
+      await expect(authRejectedHandler(error)).rejects.toBe(error)
+      expect(window.location.href).toContain('/public-page')
     })
 
-    it('redirects to /login on 401 for a cookie-only session (no localStorage token)', async () => {
-      // The intended auth model: no auth_token/user ever written to localStorage,
-      // just the HttpOnly auth cookie + the readable tfr_csrf double-submit cookie.
+    it('redirects to /login on 401 for a cookie session (tfr_csrf present)', async () => {
+      // The auth model: no token is ever written to localStorage, just the
+      // HttpOnly auth cookie + the readable tfr_csrf double-submit cookie.
       document.cookie = 'tfr_csrf=some-csrf-token'
       await getApiClient()
 
@@ -360,47 +352,32 @@ describe('ApiClient', () => {
       expect(window.location.href).toContain('/somewhere-else')
     })
 
-    it('does not clear auth for SCM OAuth 401 (repository endpoint)', async () => {
-      localStorage.setItem('auth_token', 'valid-token')
+    // SCM provider endpoints 401 when the SCM OAuth token has expired — that is
+    // not a user session failure, so the tfr_csrf session signal must survive
+    // (no cookie expiry, no redirect) and the reconnect prompt can render.
+    it.each([
+      ['repository endpoint', '/api/v1/scm-providers/123/repositories'],
+      ['tags endpoint', '/api/v1/scm-providers/456/repositories/owner/repo/tags'],
+      ['branches endpoint', '/api/v1/scm-providers/789/repositories/owner/repo/branches'],
+    ])('does not clear the cookie session for SCM OAuth 401 (%s)', async (_label, url) => {
+      document.cookie = 'tfr_csrf=live-session-csrf; path=/'
       await getApiClient()
 
       const error = {
         response: { status: 401 },
-        config: { url: '/api/v1/scm-providers/123/repositories' },
+        config: { url },
         isAxiosError: true,
       } as AxiosError
 
-      await expect(capturedResRejected(error)).rejects.toBe(error)
-      // Token should NOT be cleared for SCM OAuth failures
-      expect(localStorage.getItem('auth_token')).toBe('valid-token')
-    })
+      window.history.pushState({}, '', '/scm-page')
 
-    it('does not clear auth for SCM OAuth 401 (tags endpoint)', async () => {
-      localStorage.setItem('auth_token', 'valid-token')
-      await getApiClient()
+      const authRejectedHandler = capturedResRejectedHandlers[0]
+      await expect(authRejectedHandler(error)).rejects.toBe(error)
+      // Session signal must NOT be consumed and no redirect issued.
+      expect(document.cookie).toContain('tfr_csrf=live-session-csrf')
+      expect(window.location.href).toContain('/scm-page')
 
-      const error = {
-        response: { status: 401 },
-        config: { url: '/api/v1/scm-providers/456/repositories/owner/repo/tags' },
-        isAxiosError: true,
-      } as AxiosError
-
-      await expect(capturedResRejected(error)).rejects.toBe(error)
-      expect(localStorage.getItem('auth_token')).toBe('valid-token')
-    })
-
-    it('does not clear auth for SCM OAuth 401 (branches endpoint)', async () => {
-      localStorage.setItem('auth_token', 'valid-token')
-      await getApiClient()
-
-      const error = {
-        response: { status: 401 },
-        config: { url: '/api/v1/scm-providers/789/repositories/owner/repo/branches' },
-        isAxiosError: true,
-      } as AxiosError
-
-      await expect(capturedResRejected(error)).rejects.toBe(error)
-      expect(localStorage.getItem('auth_token')).toBe('valid-token')
+      document.cookie = 'tfr_csrf=; Max-Age=0; path=/'
     })
   })
 
@@ -771,14 +748,14 @@ describe('ApiClient', () => {
 
   // ─── Auth ─────────────────────────────────────────────────────────────────
   describe('auth methods', () => {
-    it('refreshToken calls POST /api/v1/auth/refresh', async () => {
+    it('refreshToken calls POST /api/v1/auth/refresh and returns expires_in (no token)', async () => {
       const client = await getApiClient()
         ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-          data: { token: 'new' },
+          data: { expires_in: 900 },
         })
       const result = await client.refreshToken()
       expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/auth/refresh')
-      expect(result.token).toBe('new')
+      expect(result.expires_in).toBe(900)
     })
 
     it('getCurrentUser calls GET /api/v1/auth/me', async () => {
@@ -812,14 +789,14 @@ describe('ApiClient', () => {
       expect(result.allowed_scopes).toEqual([])
     })
 
-    it('devLogin calls POST /api/v1/dev/login', async () => {
+    it('devLogin calls POST /api/v1/dev/login (cookie is set server-side, token-less body)', async () => {
       const client = await getApiClient()
         ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-          data: { token: 'dev-tok' },
+          data: { user: { id: 'u1' }, expires_in: 3600 },
         })
       const result = await client.devLogin()
       expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/dev/login')
-      expect(result.token).toBe('dev-tok')
+      expect(result.expires_in).toBe(3600)
     })
 
     it('getDevStatus calls GET /api/v1/dev/status', async () => {
@@ -842,14 +819,14 @@ describe('ApiClient', () => {
       expect(result.dev_mode).toBe(true)
     })
 
-    it('impersonateUser calls POST /api/v1/dev/impersonate/:id', async () => {
+    it('impersonateUser calls POST /api/v1/dev/impersonate/:id (cookie swap, token-less body)', async () => {
       const client = await getApiClient()
         ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-          data: { token: 'imp-tok', message: 'ok' },
+          data: { user: { id: 'u1', email: 'a@b.com', name: 'A' }, message: 'ok' },
         })
       const result = await client.impersonateUser('u1')
       expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/dev/impersonate/u1')
-      expect(result.token).toBe('imp-tok')
+      expect(result.message).toBe('ok')
     })
   })
 
@@ -2591,17 +2568,16 @@ describe('ApiClient', () => {
       expect(result.providers[1].type).toBe('saml')
     })
 
-    it('ldapLogin calls POST /api/v1/auth/ldap/login with credentials', async () => {
+    it('ldapLogin calls POST /api/v1/auth/ldap/login with credentials (cookie is set server-side)', async () => {
       const client = await getApiClient()
         ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-          data: { token: 'ldap-jwt-token' },
+          data: {},
         })
-      const result = await client.ldapLogin('admin', 'secret')
+      await client.ldapLogin('admin', 'secret')
       expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/auth/ldap/login', {
         username: 'admin',
         password: 'secret',
       })
-      expect(result.token).toBe('ldap-jwt-token')
     })
 
     it('getIdentityGroupMappings calls GET /api/v1/admin/identity/group-mappings', async () => {

--- a/frontend/src/services/api/authApi.ts
+++ b/frontend/src/services/api/authApi.ts
@@ -20,11 +20,11 @@ export async function login(provider: string) {
 
 /**
  * Authenticate via LDAP with username and password.
- * Returns a JWT token on success.
+ * On success the backend sets the HttpOnly auth cookie (plus tfr_csrf); the
+ * response body carries no token.
  */
-export async function ldapLogin(username: string, password: string): Promise<{ token: string }> {
-  const response = await http.post('/api/v1/auth/ldap/login', { username, password })
-  return response.data
+export async function ldapLogin(username: string, password: string): Promise<void> {
+  await http.post('/api/v1/auth/ldap/login', { username, password })
 }
 
 /**
@@ -38,8 +38,8 @@ export function logout() {
   window.location.href = `${API_BASE_URL}/api/v1/auth/logout`
 }
 
-export async function refreshToken(): Promise<{ token: string; expires_in: number }> {
-  const response = await http.post<{ token: string; expires_in: number }>('/api/v1/auth/refresh')
+export async function refreshToken(): Promise<{ expires_in: number }> {
+  const response = await http.post<{ expires_in: number }>('/api/v1/auth/refresh')
   return response.data
 }
 

--- a/frontend/src/services/api/devApi.ts
+++ b/frontend/src/services/api/devApi.ts
@@ -9,8 +9,8 @@ export async function getDevStatus(): Promise<{ dev_mode: boolean; message?: str
   return response.data
 }
 
+// Sets the HttpOnly auth cookie (plus tfr_csrf) via Set-Cookie; no token in the body.
 export async function devLogin(): Promise<{
-  token: string
   user: Record<string, unknown>
   expires_in: number
 }> {
@@ -31,8 +31,8 @@ export async function listUsersForImpersonation(): Promise<{
   return response.data
 }
 
+// Swaps the HttpOnly auth cookie to the impersonated user; no token in the body.
 export async function impersonateUser(userId: string): Promise<{
-  token: string
   user: {
     id: string
     email: string

--- a/frontend/src/services/api/http.ts
+++ b/frontend/src/services/api/http.ts
@@ -16,7 +16,7 @@ const USE_MOCK_DATA = import.meta.env.VITE_USE_MOCK_DATA === 'true'
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000
 
 /** Read a cookie value by name. Returns empty string if not found. */
-function getCookie(name: string): string {
+export function getCookie(name: string): string {
   const match = document.cookie.match(
     new RegExp('(?:^|; )' + name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '=([^;]*)'),
   )
@@ -52,9 +52,9 @@ function getMockResponse(url: string): { data: unknown; status: number } {
 
 /**
  * The single shared Axios instance behind every domain API module. All
- * cross-cutting behavior — auth header fallback, CSRF double-submit echo,
- * 401 session handling, breadcrumb timing — lives in the interceptors below
- * so domain modules stay pure endpoint bindings.
+ * cross-cutting behavior — CSRF double-submit echo, 401 session handling,
+ * breadcrumb timing — lives in the interceptors below so domain modules
+ * stay pure endpoint bindings.
  */
 export const http = axios.create({
   baseURL: API_BASE_URL,
@@ -72,24 +72,6 @@ export const http = axios.create({
 // Request interceptor to add CSRF token on mutating requests
 http.interceptors.request.use(
   (config) => {
-    // For backward compatibility: if an auth token is in localStorage (migration
-    // period), include it as a Bearer header. Once all sessions have migrated to
-    // HttpOnly cookies this block can be removed.
-    // Skip when the caller already set an explicit Authorization header (e.g. the
-    // Setup Wizard's "SetupToken <token>" bootstrap calls) -- a stray legacy JWT in
-    // localStorage must never silently override a caller's own auth scheme.
-    // AxiosHeaders preserves the caller's key casing for property access, so use
-    // the case-insensitive .has() when available (a lowercase "authorization"
-    // would otherwise slip past a plain property check).
-    const legacyToken = localStorage.getItem('auth_token')
-    const hasExplicitAuth =
-      typeof config.headers.has === 'function'
-        ? config.headers.has('Authorization')
-        : !!config.headers.Authorization
-    if (legacyToken && !hasExplicitAuth) {
-      config.headers.Authorization = `Bearer ${legacyToken}`
-    }
-
     // Add CSRF token header on mutating requests. The backend sets a non-HttpOnly
     // "tfr_csrf" cookie; we read it and echo it in X-CSRF-Token so the server can
     // validate the double-submit pattern.
@@ -130,18 +112,15 @@ http.interceptors.response.use(
         (url.includes('/repositories') || url.includes('/tags') || url.includes('/branches'))
 
       if (!isSCMOAuthFailure) {
-        // Only redirect when the user previously had an active session
-        // (legacy token/cached user, or the cookie-only session model). Fresh
-        // anonymous visitors receive 401 on probing endpoints like /auth/me —
-        // this is expected and should NOT trigger a redirect so public pages
-        // remain accessible. The "tfr_csrf" cookie is set only when the backend
-        // issues or refreshes the auth cookie (see middleware/csrf.go) and cleared
-        // on logout, so its presence is a reliable cookie-session signal even
-        // though the HttpOnly auth cookie itself isn't readable from JS.
-        const hadSession =
-          !!localStorage.getItem('auth_token') ||
-          !!localStorage.getItem('user') ||
-          !!getCookie('tfr_csrf')
+        // Only redirect when the user previously had an active cookie session.
+        // Fresh anonymous visitors receive 401 on probing endpoints like
+        // /auth/me — this is expected and should NOT trigger a redirect so
+        // public pages remain accessible. The "tfr_csrf" cookie is set only
+        // when the backend issues or refreshes the auth cookie (see
+        // middleware/csrf.go) and cleared on logout, so its presence is a
+        // reliable session signal even though the HttpOnly auth cookie itself
+        // isn't readable from JS.
+        const hadSession = !!getCookie('tfr_csrf')
         clearAuthStorage()
         // Expire the CSRF cookie so the session signal is ONE-SHOT, exactly like
         // the localStorage keys clearAuthStorage() just removed. Without this, a

--- a/frontend/src/services/api/index.ts
+++ b/frontend/src/services/api/index.ts
@@ -3,8 +3,8 @@
  *
  * The old 1900-line ApiClient god object (issue #474) is split into per-domain
  * modules that all share the single configured axios instance in ./http.ts
- * (interceptors: legacy-token auth fallback, CSRF double-submit echo, 401
- * session handling, error-reporting breadcrumbs).
+ * (interceptors: CSRF double-submit echo, 401 session handling,
+ * error-reporting breadcrumbs).
  *
  * This barrel spreads every domain module into one flat `apiClient` object so
  * the existing `import apiClient from '../services/api'` call sites keep

--- a/frontend/src/utils/__tests__/authStorage.test.ts
+++ b/frontend/src/utils/__tests__/authStorage.test.ts
@@ -2,10 +2,12 @@ import { describe, it, expect, beforeEach } from 'vitest'
 import { AUTH_STORAGE_KEYS, clearAuthStorage } from '../authStorage'
 
 describe('AUTH_STORAGE_KEYS', () => {
-  it('names every known auth-related localStorage key', () => {
+  it('names every known legacy auth-related localStorage key', () => {
     // Locks in the authoritative set so an accidental deletion from the array
     // (as opposed to an addition, which the tests below already catch by
-    // iterating the array) is also caught.
+    // iterating the array) is also caught. Nothing writes these keys anymore
+    // (cookie-only auth, #467) — they exist purely so clearAuthStorage() sweeps
+    // out values persisted by pre-migration sessions.
     expect(AUTH_STORAGE_KEYS).toEqual([
       'auth_token',
       'user',
@@ -21,7 +23,7 @@ describe('clearAuthStorage', () => {
     localStorage.clear()
   })
 
-  it('removes every key in AUTH_STORAGE_KEYS', () => {
+  it('removes every key in AUTH_STORAGE_KEYS (one-time cleanup of legacy sessions)', () => {
     AUTH_STORAGE_KEYS.forEach((key) => localStorage.setItem(key, 'seed-value'))
 
     clearAuthStorage()

--- a/frontend/src/utils/authStorage.ts
+++ b/frontend/src/utils/authStorage.ts
@@ -1,10 +1,15 @@
-/** All localStorage keys belonging to an auth session. */
+/**
+ * All localStorage keys belonging to an auth session. Nothing in the app
+ * WRITES any of these anymore — auth is cookie-only (HttpOnly cookie +
+ * tfr_csrf double-submit). They are kept here purely so clearAuthStorage()
+ * removes stale values left behind by pre-cookie-migration sessions.
+ */
 export const AUTH_STORAGE_KEYS = [
-  'auth_token',
+  'auth_token', // legacy JWT persisted by old sessions; one-time cleanup only
   'user',
   'role_template',
   'allowed_scopes',
-  'authorized', // Swagger UI "Authorize" dialog persists this when persistAuthorization is enabled
+  'authorized', // legacy: Swagger UI "Authorize" persisted this under persistAuthorization
 ] as const
 
 /** Remove every auth-related localStorage key. Call on logout and on 401 session expiry. */


### PR DESCRIPTION
Closes #467. Backend companion: sethbacon/terraform-registry-backend#584 — **merge and deploy the backend first** (dev login/impersonation need its Set-Cookie support before this frontend stops persisting tokens).

## What

Deletes the legacy localStorage-JWT path end to end, leaving HttpOnly-cookie custody as the only session mechanism:

- **`services/api/http.ts`** — the localStorage-Bearer request interceptor is gone; the 401 session-expiry redirect keys solely off the `tfr_csrf` cookie signal (the localStorage flags it used to check are never written anymore).
- **`CallbackPage`** — legacy `?token=` query handling removed (backend OIDC/SAML callbacks have been cookie-only; the param is never sent).
- **`AuthContext`** — dev/LDAP login adapters no longer persist tokens; the suite AuthProvider resolves identity via `/auth/me` on the cookie session.
- **`DevUserSwitcher`** — impersonation relies on the backend swapping the cookie + reload.
- **`ApiDocumentation`** — Swagger "Try it out" no longer injects a Bearer from localStorage and no longer persists authorization to localStorage; mutating requests echo `tfr_csrf` as `X-CSRF-Token` (reusing `getCookie` from the shared http module) so they pass the double-submit CSRF middleware.
- **`authStorage`** — no write path stores tokens; `clearAuthStorage` still removes the legacy key as one-time cleanup for pre-migration sessions.
- **`authApi`/`devApi`** — typed to the token-less contract (`refreshToken → {expires_in}`, `ldapLogin → void`, dev bodies without `token`).

Tests were rewritten to assert the new posture, not just deleted — e.g. the interceptor suite now proves a stray legacy token in localStorage is **not** attached as a Bearer header, and the 401 tests key on the cookie signal.

## Operational note

Treat any token previously persisted to localStorage as compromised: **rotate `TFR_JWT_SECRET`** when this pair deploys. Sessions that only existed as a localStorage token are signed out once (cookie absent) — expected.

## Verification

- tsc clean, eslint clean, full unit suite green (1733 tests).
- Live end-to-end UAT against a backend built from the companion branch: dev login through the real SPA sets `tfr_auth_token` + `tfr_csrf`, `localStorage` contains no token, admin pages operate on the cookie session, impersonation swaps users via cookie (Playwright auth/admin specs).
