### PR TITLE
fix(ci): correct dependabot schedule interval from biweekly to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
   - package-ecosystem: npm
     directory: /frontend
     schedule:
-      interval: biweekly
+      interval: weekly
       day: monday
       time: "09:00"
       timezone: UTC
@@ -39,7 +39,7 @@ updates:
   - package-ecosystem: npm
     directory: /e2e
     schedule:
-      interval: biweekly
+      interval: weekly
       day: monday
       time: "09:00"
       timezone: UTC
@@ -62,7 +62,7 @@ updates:
   - package-ecosystem: docker
     directory: /frontend
     schedule:
-      interval: biweekly
+      interval: weekly
       day: monday
       time: "09:00"
       timezone: UTC
@@ -80,7 +80,7 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: biweekly
+      interval: weekly
       day: monday
       time: "09:00"
       timezone: UTC


### PR DESCRIPTION
## Summary
- \`schedule.interval: biweekly\` is not a valid Dependabot value — only \`daily\`, \`weekly\`, and \`monthly\` are recognized. This was silently not doing what it looked like it was doing.
- Found while auditing dependabot.yml schedule intervals across all terraform-related repos.

## Test plan
- [x] YAML re-validated as well-formed after the change.
- [x] Diff is a single-value substitution only, no other changes.