### PR TITLE
fix(ci): add blocking Trivy image scan to the release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,6 +131,17 @@ jobs:
           secrets: |
             node_auth_token=${{ secrets.GITHUB_TOKEN }}
 
+      - name: Trivy image scan (published digest)
+        # Scan the real pushed digest for OS-package and dependency CVEs
+        # before it's attested/signed.
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: image
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
+          severity: HIGH,CRITICAL
+          exit-code: 1
+          format: table
+
       - name: Attest build provenance (SLSA)
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:


### PR DESCRIPTION
## Summary
- This repo builds and pushes a Docker image on every release with no container-vulnerability scan of the published artifact at all (npm audit / OSV / CodeQL cover only the source).
- Adds a Trivy image scan of the real pushed digest, blocking (`exit-code: 1`) on HIGH/CRITICAL, placed before the attest/SBOM/sign steps so a vulnerable image never gets signed — mirrors terraform-registry-backend's release.yml pattern exactly.
- Found via an audit of Trivy coverage across all repos that produce a Docker image.

## Test plan
- [x] YAML validated (`yaml.safe_load` + `actionlint`).
- [x] `aquasecurity/trivy-action` pinned to the same SHA already used in terraform-registry-backend (`ed142fd0...` / v0.36.0).