### PR TITLE
fix(ci): ignore major TypeScript bumps in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,12 @@ updates:
         update-types: [ "version-update:semver-major" ]
       - dependency-name: "@mui/icons-material"
         update-types: [ "version-update:semver-major" ]
+      # Major TypeScript bumps break the toolchain before app code: tsup's
+      # bundled rollup-plugin-dts and @typescript-eslint/typescript-estree
+      # both crash against TS7's changed internals (2026-07-13 incident).
+      # Revisit once both ship TS7-compatible releases.
+      - dependency-name: "typescript"
+        update-types: [ "version-update:semver-major" ]
 
   # ---------------------------------------------------------------------------
   # npm (e2e/)


### PR DESCRIPTION
## Summary
- #550 needed a manual fix because bumping typescript's major version (6→7) broke `@typescript-eslint/typescript-estree`'s bundled code (`ts.Extension.Cjs` undefined against TS7's changed internals) — not something fixable on our side.
- Add `typescript` to the existing major-version ignore list (same pattern as React/MUI) so Dependabot stops proposing bumps guaranteed to fail CI until `@typescript-eslint` ships a TS7-compatible release.

## Test plan
- [x] YAML validated (`yaml.safe_load`).