### PR TITLE
feat: surface OPA GitHub attestation status ("attested") in mirror UI

### DIFF
--- a/frontend/src/components/ReleasesGPGKeyStatus.tsx
+++ b/frontend/src/components/ReleasesGPGKeyStatus.tsx
@@ -18,6 +18,7 @@ import ErrorIcon from '@mui/icons-material/Error'
 import WarningIcon from '@mui/icons-material/Warning'
 import HelpOutlineIcon from '@mui/icons-material/HelpOutlined'
 import GppMaybeIcon from '@mui/icons-material/GppMaybe'
+import GppGoodIcon from '@mui/icons-material/GppGood'
 import { useTranslation } from 'react-i18next'
 import type { TFunction } from 'i18next'
 import { useReleasesGPGKeyStatus } from '../hooks/useReleasesGPGKeyStatus'
@@ -46,6 +47,8 @@ function StatusIcon({ status }: { status: ReleasesGPGKeyStatus }) {
       return <ErrorIcon fontSize="small" color="error" />
     case 'unsigned':
       return <GppMaybeIcon fontSize="small" color="warning" />
+    case 'attested':
+      return <GppGoodIcon fontSize="small" color="info" />
     default:
       return <HelpOutlineIcon fontSize="small" color="disabled" />
   }
@@ -83,6 +86,15 @@ function KeyRow({ row }: { row: ReleasesGPGKeyStatusView }) {
           // status code, so the reduced assurance is visible (not silent).
           <Tooltip title={t('releasesGpgKeys.unsignedTooltip')}>
             <Chip label={t('releasesGpgKeys.unsignedLabel')} size="small" color="warning" />
+          </Tooltip>
+        ) : row.status === 'attested' ? (
+          // OPA-style tools with verify_github_attestation enabled: checksum
+          // plus a pinned-identity GitHub Artifact Attestation (Sigstore) —
+          // stronger than checksum-only "unsigned", but not a full GPG
+          // signature, so it gets its own distinct chip rather than folding
+          // into either.
+          <Tooltip title={t('releasesGpgKeys.attestedTooltip')}>
+            <Chip label={t('releasesGpgKeys.attestedLabel')} size="small" color="info" />
           </Tooltip>
         ) : (
           <Chip label={row.status} size="small" color={statusColor(row.status)} />

--- a/frontend/src/components/__tests__/ReleasesGPGKeyStatus.test.tsx
+++ b/frontend/src/components/__tests__/ReleasesGPGKeyStatus.test.tsx
@@ -147,4 +147,29 @@ describe('ReleasesGPGKeyStatus', () => {
     expect(screen.getByText('unsigned')).toBeInTheDocument()
     expect(screen.queryByText('unknown')).not.toBeInTheDocument()
   })
+
+  it('renders an attested unsigned-upstream binary row (attestation source, attested status)', async () => {
+    const attestedResponse: ReleasesGPGKeysResponse = {
+      keys: [
+        {
+          tool: 'opa',
+          cache: null,
+          embedded: null,
+          effective_source: 'attestation',
+          expiry_warning_days: 60,
+          status: 'attested',
+        },
+      ],
+    }
+    mockGetReleasesGPGKeys.mockResolvedValue(attestedResponse)
+    renderComponent()
+
+    await waitFor(() => expect(screen.getByText('opa')).toBeInTheDocument())
+    expect(screen.getByText('attestation')).toBeInTheDocument()
+    // Attested (checksum + GitHub Artifact Attestation) is distinct from
+    // both bare "unsigned" and "unknown".
+    expect(screen.getByText('attested')).toBeInTheDocument()
+    expect(screen.queryByText('unsigned')).not.toBeInTheDocument()
+    expect(screen.queryByText('unknown')).not.toBeInTheDocument()
+  })
 })

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -2253,7 +2253,9 @@
     "expiredAgo": "expired {{days}}d ago",
     "days": "{{days}}d",
     "unsignedLabel": "unsigned",
-    "unsignedTooltip": "This tool's upstream publishes no release signature; binaries are verified by checksum only."
+    "unsignedTooltip": "This tool's upstream publishes no release signature; binaries are verified by checksum only.",
+    "attestedLabel": "attested",
+    "attestedTooltip": "This tool's upstream publishes no release signature, but binaries are verified by checksum plus a pinned-identity GitHub Artifact Attestation (Sigstore)."
   },
   "scanFindingsModal": {
     "title": "Scan Findings",

--- a/frontend/src/types/releases_gpg_keys.ts
+++ b/frontend/src/types/releases_gpg_keys.ts
@@ -13,7 +13,7 @@ export interface ReleasesGPGKeyEmbeddedView {
   days_until_expiry?: number | null
 }
 
-export type ReleasesGPGKeyStatus = 'ok' | 'warn' | 'expired' | 'unknown' | 'unsigned'
+export type ReleasesGPGKeyStatus = 'ok' | 'warn' | 'expired' | 'unknown' | 'unsigned' | 'attested'
 
 export interface ReleasesGPGKeyStatusView {
   tool: string
@@ -22,8 +22,11 @@ export interface ReleasesGPGKeyStatusView {
   // 'none' is used for configured binaries with no managed signing key. Tools
   // whose upstream publishes no release signature at all (e.g. opa — checksum
   // only) carry null cache/embedded, a 'none' source, and an 'unsigned' status;
-  // genuinely unclassified tools keep 'unknown'.
-  effective_source: 'cache' | 'embedded' | 'none'
+  // genuinely unclassified tools keep 'unknown'. When such a tool has
+  // verify_github_attestation enabled, it instead carries an 'attestation'
+  // source and 'attested' status — checksum plus a pinned-identity GitHub
+  // Artifact Attestation (Sigstore), distinct from checksum-only 'unsigned'.
+  effective_source: 'cache' | 'embedded' | 'none' | 'attestation'
   expiry_warning_days: number
   status: ReleasesGPGKeyStatus
 }


### PR DESCRIPTION
## Summary
- Closes #437, follow-up to sethbacon/terraform-registry-backend#528 (landed): the admin releases-gpg-keys endpoint now returns `status: "attested"` and `effective_source: "attestation"` for unsigned-upstream tools (OPA today) with `verify_github_attestation` enabled — checksum plus a pinned-identity GitHub Artifact Attestation (Sigstore), distinct from checksum-only `"unsigned"`.
- Extends `ReleasesGPGKeyStatus`/`effective_source` types to match the backend contract exactly (verified against `backend/internal/api/admin/releases_gpg_keys.go`).
- Adds a distinct chip (`GppGood` icon, info color) + tooltip in `ReleasesGPGKeyStatus.tsx`, mirroring the existing `"unsigned"` chip pattern — intentionally **not** GPG-key UI, per the issue's explicit non-goal.
- Adds `attestedLabel`/`attestedTooltip` to the English source strings; other locales pick these up via the existing DeepL `translate.yml` sync on push to main.

## Test plan
- [x] New test proving the attested row renders distinctly from both `"unsigned"` and `"unknown"`.
- [x] Full local verification: typecheck, lint, build, and the full test suite (111 files / 1735 tests) all pass.