### PR TITLE
fix(e2e): set TFR_CONFIRM_NON_PRODUCTION for the backend's dev-mode guard

### DIFF
--- a/deployments/docker-compose.test.yml
+++ b/deployments/docker-compose.test.yml
@@ -31,6 +31,10 @@ services:
       - TFR_DATABASE_SSL_MODE=disable
       # DEV_MODE enables /api/v1/dev/login for Playwright fixtures — test/CI only, never production
       - DEV_MODE=true
+      # This stack runs at the default logging.level ("info"), which
+      # devModeProductionGuard (issue #559) can no longer distinguish from a
+      # production deployment left at its default -- confirm explicitly.
+      - TFR_CONFIRM_NON_PRODUCTION=true
       - TFR_SERVER_HOST=0.0.0.0
       - TFR_SERVER_PORT=8080
       # JWT secret required by backend — fixed value for test environment only

--- a/deployments/docker-compose.yml
+++ b/deployments/docker-compose.yml
@@ -82,6 +82,10 @@ services:
       # DEV_MODE enables the /api/v1/dev/login shortcut used by local dev and E2E tests.
       # Must be false in production.
       DEV_MODE: "true"
+      # This stack runs at the default logging.level ("info"), which
+      # devModeProductionGuard (issue #559) can no longer distinguish from a
+      # production deployment left at its default -- confirm explicitly.
+      TFR_CONFIRM_NON_PRODUCTION: "true"
     ports:
       - "8080:8080"
       - "9090:9090"


### PR DESCRIPTION
## Summary
Closes #556 (weekly security scan failure). Root cause: the "E2E (gated/manual)" job fails at "Start test compose" because `deployments-backend-1` exits(1) immediately — nothing wrong in this repo's own code.

terraform-registry-backend#589 added `devModeProductionGuard`: the backend now refuses to start when `DEV_MODE=true` at the default `logging.level` ("info"), unless `TFR_CONFIRM_NON_PRODUCTION=true` is explicitly set. Its own doc comment calls this out directly: *"any downstream repo's compose files that do [run DEV_MODE=true at the info default] must set that variable."* The backend repo's own `docker-compose.yml`/`docker-compose.test.yml` were updated accordingly — this repo's weren't.

Adds `TFR_CONFIRM_NON_PRODUCTION=true` next to the existing `DEV_MODE=true` in both:
- `deployments/docker-compose.test.yml` (E2E/CI, the one that's actually failing)
- `deployments/docker-compose.yml` (local dev stack — same guard, same fix needed)

## Test plan
- [x] Pulled the published `ghcr.io/sethbacon/terraform-registry-backend:latest` image and ran it with `docker-compose.test.yml`'s exact environment locally.
  - **Before:** exits(1) immediately — `"refusing to start: DEV_MODE is enabled with logging.level=\"info\"..."`
  - **After:** boots, connects to postgres, runs migrations, reaches ready state (container health check passes).