### PR TITLE
fix: validate backend URLs, add error boundary, and clear query cache on logout

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,6 @@
 import { lazy } from 'react'
 import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { QueryClientProvider } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import { CssBaseline } from '@mui/material'
 import { ThemeProvider } from './contexts/ThemeContext'
@@ -13,6 +13,7 @@ import ConsentBanner from './components/ConsentBanner'
 import TelemetryGate from './components/TelemetryGate'
 import OfflineBanner from './components/OfflineBanner'
 import ErrorBoundary from './components/ErrorBoundary'
+import { queryClient } from './queryClient'
 import LazyRoute from './components/LazyRoute'
 import RouteFocusManager from './components/RouteFocusManager'
 import { ADMIN_ROUTE_SCOPES } from './routeScopes'
@@ -51,16 +52,6 @@ const SecurityScanningPage = lazy(() => import('./pages/admin/SecurityScanningPa
 const NotificationsPage = lazy(() => import('./pages/admin/NotificationsPage'))
 const ComponentShowcase = lazy(() => import('./pages/dev/ComponentShowcase'))
 const SettingsPage = lazy(() => import('./pages/SettingsPage'))
-
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      staleTime: 30_000,
-      retry: 1,
-      refetchOnWindowFocus: false,
-    },
-  },
-})
 
 function App() {
   return (

--- a/frontend/src/components/SuiteSwitcher.tsx
+++ b/frontend/src/components/SuiteSwitcher.tsx
@@ -1,5 +1,6 @@
 import { useSuite } from '../hooks/useSuite'
 import { SuiteSwitcher as SuiteSwitcherBase } from '@sethbacon/terraform-suite-ui'
+import { isSafeExternalUrl } from '../utils/externalUrl'
 
 const LABELS: Record<string, string> = {
   'terraform-registry': 'Terraform Registry',
@@ -10,7 +11,9 @@ const LABELS: Record<string, string> = {
 // AppBar button + single-tab reuse now live in the shared package's SuiteSwitcher.
 export function SuiteSwitcher() {
   const { sibling, active } = useSuite()
-  if (!active || !sibling?.publicUrl) return null
+  // Defense-in-depth: the sibling URL comes from the backend /api/v1/ui/config; validate it at
+  // the app boundary before handing it to the shared switcher's navigation sink.
+  if (!active || !sibling?.publicUrl || !isSafeExternalUrl(sibling.publicUrl)) return null
   const label = LABELS[sibling.app] ?? sibling.app
   // Until both apps are confirmed to share one identity store + IdP
   // (sibling.sharedStore), opening the sibling in a new tab may require a

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -13,6 +13,14 @@ import {
 } from '@sethbacon/terraform-suite-ui'
 import api from '../services/api'
 import { clearAuthStorage } from '../utils/authStorage'
+import { queryClient } from '../queryClient'
+
+// On sign-out, also drop the react-query cache so prior-user admin/query data does not
+// linger in memory until a full page reload (a retention gap on shared/kiosk machines).
+function handleClearStorage(): void {
+  clearAuthStorage()
+  queryClient.clear()
+}
 
 const authApi: AuthApi = {
   getCurrentUser: async (): Promise<MeResponse> => {
@@ -48,7 +56,7 @@ const authApi: AuthApi = {
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   return (
-    <SuiteAuthProvider api={authApi} onClearStorage={clearAuthStorage}>
+    <SuiteAuthProvider api={authApi} onClearStorage={handleClearStorage}>
       {children}
     </SuiteAuthProvider>
   )

--- a/frontend/src/contexts/ThemeContext.tsx
+++ b/frontend/src/contexts/ThemeContext.tsx
@@ -1,16 +1,30 @@
 import type React from 'react'
 import { SuiteThemeProvider, useThemeMode } from '@sethbacon/terraform-suite-ui'
 import apiClient from '../services/api'
+import { isSafeExternalUrl } from '../utils/externalUrl'
 
 const THEME_KEY = 'terraform-registry-theme'
 const DEFAULT_PRODUCT_NAME = 'Terraform Registry'
+
+// Defense-in-depth: the whitelabel URLs come from the backend /api/v1/ui/theme; validate each at
+// the app boundary and drop any that fails, before handing them to the shared theme provider.
+async function getSafeUITheme() {
+  const theme = await apiClient.getUITheme()
+  if (!theme) return theme
+  return {
+    ...theme,
+    logo_url: isSafeExternalUrl(theme.logo_url) ? theme.logo_url : undefined,
+    favicon_url: isSafeExternalUrl(theme.favicon_url) ? theme.favicon_url : undefined,
+    login_hero_url: isSafeExternalUrl(theme.login_hero_url) ? theme.login_hero_url : undefined,
+  }
+}
 
 /** Wraps the shared SuiteThemeProvider with this app's storage key + whitelabel fetch. */
 export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => (
   <SuiteThemeProvider
     storageKey={THEME_KEY}
     defaultProductName={DEFAULT_PRODUCT_NAME}
-    getUITheme={apiClient.getUITheme}
+    getUITheme={getSafeUITheme}
   >
     {children}
   </SuiteThemeProvider>

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -7,6 +7,7 @@ import ReactDOM from 'react-dom/client'
 import createCache from '@emotion/cache'
 import { CacheProvider } from '@emotion/react'
 import App from './App'
+import ErrorBoundary from './components/ErrorBoundary'
 import './index.css'
 import './i18n'
 import { captureError } from './services/errorReporting'
@@ -42,7 +43,9 @@ const emotionCache = createCache({
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <CacheProvider value={emotionCache}>
-      <App />
+      <ErrorBoundary>
+        <App />
+      </ErrorBoundary>
     </CacheProvider>
   </React.StrictMode>,
 )

--- a/frontend/src/queryClient.ts
+++ b/frontend/src/queryClient.ts
@@ -1,0 +1,18 @@
+import { QueryClient } from '@tanstack/react-query'
+
+/**
+ * Shared react-query client.
+ *
+ * Exported from its own module (rather than defined inline in App) so the logout /
+ * onClearStorage path can clear the cache on sign-out — otherwise prior-user admin/query
+ * data lingers in memory until a full page reload, a retention gap on shared/kiosk machines.
+ */
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 30_000,
+      retry: 1,
+      refetchOnWindowFocus: false,
+    },
+  },
+})

--- a/frontend/src/utils/__tests__/externalUrl.test.ts
+++ b/frontend/src/utils/__tests__/externalUrl.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { isSafeExternalUrl } from '../externalUrl'
+
+describe('isSafeExternalUrl', () => {
+  it.each([
+    'https://tsm.example.com',
+    'https://tsm.example.com/path?x=1',
+    'http://localhost:3000',
+    '/relative/path',
+    '#anchor',
+  ])('accepts %s', (value) => {
+    expect(isSafeExternalUrl(value)).toBe(true)
+  })
+
+  it.each([
+    'javascript:alert(1)',
+    'data:text/html,<script>alert(1)</script>',
+    'vbscript:msgbox(1)',
+    'file:///etc/passwd',
+    'mailto:a@b.com',
+    'tel:+15551234567',
+    '//evil.com',
+    '/\\evil.com',
+    '\\\\evil.com',
+    // Embedded tab/newline/CR: the URL parser strips these, normalizing the value to the
+    // protocol-relative "//evil.com" (off-origin redirect) at the sink — must be rejected.
+    '/\t/evil.com',
+    '/\n/evil.com',
+    '/\r/evil.com',
+    '/safe\t//evil.com',
+    '',
+    '   ',
+    null,
+    undefined,
+  ])('rejects %s', (value) => {
+    expect(isSafeExternalUrl(value as string | null | undefined)).toBe(false)
+  })
+
+  it('does not throw and returns false for truthy non-string inputs', () => {
+    expect(isSafeExternalUrl(123 as unknown as string)).toBe(false)
+    expect(isSafeExternalUrl({} as unknown as string)).toBe(false)
+  })
+})

--- a/frontend/src/utils/externalUrl.ts
+++ b/frontend/src/utils/externalUrl.ts
@@ -1,0 +1,35 @@
+/**
+ * App-boundary validator for URLs sourced from the backend / whitelabel config (the
+ * suite-switcher sibling URL and the whitelabel theme logo/hero/favicon URLs) before they are
+ * handed to shared `@sethbacon/terraform-suite-ui` components.
+ *
+ * Defense-in-depth: the app currently trusts the backend config verbatim. This validator parses
+ * with the URL constructor and rejects embedded control characters, so a value the browser would
+ * silently normalize into a protocol-relative off-origin URL (e.g. "/\t/evil.com" -> "//evil.com")
+ * is never passed through to a navigation/resource sink. Allows same-origin-relative paths/hashes
+ * and absolute http(s) URLs only.
+ */
+export function isSafeExternalUrl(value: string | null | undefined): value is string {
+  if (!value || typeof value !== 'string') return false
+  const trimmed = value.trim()
+  if (trimmed === '') return false
+
+  // Reject embedded ASCII control characters (C0 range + DEL). The WHATWG URL parser strips
+  // tab/newline/CR (U+0009/U+000A/U+000D) before parsing, which can turn a "relative-looking"
+  // value into a protocol-relative off-origin URL at the sink.
+  if (/[\u0000-\u001F\u007F]/.test(trimmed)) return false
+
+  // Protocol-relative ("//evil.com") and backslash variants.
+  if (/^[/\\]{2}/.test(trimmed) || /^\/\\/.test(trimmed)) return false
+
+  // Same-origin-relative path or same-page anchor — never carries a scheme, safe.
+  if (/^[/#.]/.test(trimmed)) return true
+
+  // Absolute URL: allow only http(s).
+  try {
+    const url = new URL(trimmed)
+    return url.protocol === 'https:' || url.protocol === 'http:'
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
Consumer-side follow-ups from the 2026-07-13 terraform-suite-ui audit seam analysis.

- Validate backend-sourced URLs (sibling.publicUrl and theme logo/hero/favicon) at the app
  boundary before passing them to the shared UI navigation / image sinks.
- Wrap the app (Theme/Auth/Consent providers) in a top-level error boundary so a provider
  render error can't white-screen the whole app.
- Clear the react-query cache on logout (onClearStorage), not just the localStorage view-state.

Closes #559
Closes #560
Closes #561