### PR TITLE
feat(notifications): channel management UI and per-event controls

### DIFF
--- a/frontend/scripts/contract-check.allowlist.json
+++ b/frontend/scripts/contract-check.allowlist.json
@@ -20,31 +20,6 @@
       "method": "POST",
       "path": "/api/v1/dev/impersonate/{}",
       "reason": "Backend route is registered conditionally under DEV_MODE=true and is intentionally undocumented in production swagger. Permanent allowlist entry."
-    },
-    {
-      "method": "GET",
-      "path": "/api/v1/admin/notifications/channels",
-      "reason": "Notification delivery channels added in backend PR https://github.com/sethbacon/terraform-registry-backend/pull/625 (not yet in the pinned contract-check backend image). Remove once that PR is released and the backend image tag is bumped."
-    },
-    {
-      "method": "POST",
-      "path": "/api/v1/admin/notifications/channels",
-      "reason": "Notification delivery channels added in backend PR https://github.com/sethbacon/terraform-registry-backend/pull/625 (not yet in the pinned contract-check backend image). Remove once that PR is released and the backend image tag is bumped."
-    },
-    {
-      "method": "PUT",
-      "path": "/api/v1/admin/notifications/channels/{}",
-      "reason": "Notification delivery channels added in backend PR https://github.com/sethbacon/terraform-registry-backend/pull/625 (not yet in the pinned contract-check backend image). Remove once that PR is released and the backend image tag is bumped."
-    },
-    {
-      "method": "DELETE",
-      "path": "/api/v1/admin/notifications/channels/{}",
-      "reason": "Notification delivery channels added in backend PR https://github.com/sethbacon/terraform-registry-backend/pull/625 (not yet in the pinned contract-check backend image). Remove once that PR is released and the backend image tag is bumped."
-    },
-    {
-      "method": "POST",
-      "path": "/api/v1/admin/notifications/channels/{}/test",
-      "reason": "Notification delivery channels added in backend PR https://github.com/sethbacon/terraform-registry-backend/pull/625 (not yet in the pinned contract-check backend image). Remove once that PR is released and the backend image tag is bumped."
     }
   ]
 }

--- a/frontend/scripts/contract-check.allowlist.json
+++ b/frontend/scripts/contract-check.allowlist.json
@@ -20,6 +20,31 @@
       "method": "POST",
       "path": "/api/v1/dev/impersonate/{}",
       "reason": "Backend route is registered conditionally under DEV_MODE=true and is intentionally undocumented in production swagger. Permanent allowlist entry."
+    },
+    {
+      "method": "GET",
+      "path": "/api/v1/admin/notifications/channels",
+      "reason": "Notification delivery channels added in backend PR https://github.com/sethbacon/terraform-registry-backend/pull/625 (not yet in the pinned contract-check backend image). Remove once that PR is released and the backend image tag is bumped."
+    },
+    {
+      "method": "POST",
+      "path": "/api/v1/admin/notifications/channels",
+      "reason": "Notification delivery channels added in backend PR https://github.com/sethbacon/terraform-registry-backend/pull/625 (not yet in the pinned contract-check backend image). Remove once that PR is released and the backend image tag is bumped."
+    },
+    {
+      "method": "PUT",
+      "path": "/api/v1/admin/notifications/channels/{}",
+      "reason": "Notification delivery channels added in backend PR https://github.com/sethbacon/terraform-registry-backend/pull/625 (not yet in the pinned contract-check backend image). Remove once that PR is released and the backend image tag is bumped."
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/v1/admin/notifications/channels/{}",
+      "reason": "Notification delivery channels added in backend PR https://github.com/sethbacon/terraform-registry-backend/pull/625 (not yet in the pinned contract-check backend image). Remove once that PR is released and the backend image tag is bumped."
+    },
+    {
+      "method": "POST",
+      "path": "/api/v1/admin/notifications/channels/{}/test",
+      "reason": "Notification delivery channels added in backend PR https://github.com/sethbacon/terraform-registry-backend/pull/625 (not yet in the pinned contract-check backend image). Remove once that PR is released and the backend image tag is bumped."
     }
   ]
 }

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -1988,6 +1988,16 @@
       "apiKeyExpirySection": "API Key Expiry Notifications",
       "warningDays": "Warning days before expiry",
       "checkIntervalHours": "Check interval (hours)",
+      "eventsSection": "Notification Options",
+      "recipients": "Recipients",
+      "recipientsHelp": "Comma-separated email addresses for module published, approval pending, CVE detected, and scanner update notifications. Falls back to the CVE recipients list when left blank.",
+      "event": {
+        "api_key_expiring": "API key expiring",
+        "module_published": "New module version published",
+        "approval_pending": "New approval pending",
+        "cve_detected": "CVE detected",
+        "scanner_update_available": "Scanner update available"
+      },
       "save": "Save",
       "saveSuccess": "Notification settings saved",
       "saveError": "Failed to save notification settings",
@@ -1995,7 +2005,41 @@
       "testRecipients": "Recipients (comma-separated, optional)",
       "testSuccess": "Test email sent successfully",
       "testError": "Failed to send test email",
-      "loadError": "Failed to load notification settings"
+      "loadError": "Failed to load notification settings",
+      "channels": {
+        "title": "Notification Channels",
+        "description": "Send module published, approval pending, CVE detected, and scanner update alerts to a webhook, Slack, Microsoft Teams, or an ad-hoc email recipient list. Destinations are stored encrypted and never shown again.",
+        "add": "Add channel",
+        "edit": "Edit channel",
+        "noChannels": "No notification channels yet. Add one to receive alerts.",
+        "name": "Name",
+        "typeLabel": "Type",
+        "actions": "Actions",
+        "events": "Events",
+        "allEvents": "All events",
+        "target": "Destination URL",
+        "targetHelp": "The webhook, Slack, or Teams incoming-webhook URL to POST to.",
+        "targetKeep": "Leave blank to keep the current URL.",
+        "targetEmail": "Recipient emails",
+        "targetEmailHelp": "Comma-separated email addresses. Sent via the configured SMTP relay.",
+        "targetEmailKeep": "Leave blank to keep the current recipients.",
+        "type": {
+          "webhook": "Webhook (JSON)",
+          "slack": "Slack",
+          "teams": "Microsoft Teams",
+          "email": "Email"
+        },
+        "eventsHelp": "Leave all unchecked to receive every event.",
+        "enabled": "Enabled",
+        "test": "Send test",
+        "testSent": "Test notification sent.",
+        "testError": "Failed to send test notification",
+        "lastDelivery": "Last delivery",
+        "neverSent": "Never sent",
+        "deleteTitle": "Delete channel",
+        "deleteConfirm": "Delete the channel \"{{name}}\"?",
+        "saveError": "Failed to save channel"
+      }
     }
   },
   "scmWizard": {

--- a/frontend/src/pages/admin/NotificationsPage.tsx
+++ b/frontend/src/pages/admin/NotificationsPage.tsx
@@ -12,16 +12,54 @@ import {
   TextField,
   Switch,
   FormControlLabel,
+  FormGroup,
+  Checkbox,
   Button,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  IconButton,
+  Tooltip,
+  Chip,
+  Stack,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  MenuItem,
 } from '@mui/material'
+import AddIcon from '@mui/icons-material/Add'
+import SendIcon from '@mui/icons-material/Send'
+import EditIcon from '@mui/icons-material/Edit'
+import DeleteIcon from '@mui/icons-material/Delete'
 import Page from '../../components/Page'
 import PageHeader from '../../components/PageHeader'
 import PageTitleIcon from '@mui/icons-material/Notifications'
+import ConfirmDialog from '../../components/ConfirmDialog'
 import api from '../../services/api'
 import { queryKeys } from '../../services/queryKeys'
 import { useAuth } from '../../contexts/AuthContext'
 import { getErrorMessage } from '../../utils/errors'
-import type { NotificationsConfigInput } from '../../types'
+import type {
+  NotificationChannel,
+  NotificationChannelEvent,
+  NotificationChannelInput,
+  NotificationEvents,
+  NotificationsConfigInput,
+} from '../../types'
+
+const CHANNEL_EVENT_TYPES: NotificationChannelEvent[] = [
+  'module_published',
+  'approval_pending',
+  'cve_detected',
+  'scanner_update_available',
+]
+
+function apiErr(e: unknown, fallback: string): string {
+  return getErrorMessage(e, fallback)
+}
 
 interface FormState {
   enabled: boolean
@@ -31,9 +69,27 @@ interface FormState {
   password: string
   from: string
   use_tls: boolean
+  recipients: string
+  events: NotificationEvents
   api_key_expiry_warning_days: number
   api_key_expiry_check_interval_hours: number
 }
+
+const defaultEvents: NotificationEvents = {
+  api_key_expiring: true,
+  module_published: true,
+  approval_pending: true,
+  cve_detected: true,
+  scanner_update_available: true,
+}
+
+const EVENT_TYPES: Array<keyof NotificationEvents> = [
+  'api_key_expiring',
+  'module_published',
+  'approval_pending',
+  'cve_detected',
+  'scanner_update_available',
+]
 
 const defaultFormState: FormState = {
   enabled: false,
@@ -43,8 +99,332 @@ const defaultFormState: FormState = {
   password: '',
   from: '',
   use_tls: true,
+  recipients: '',
+  events: defaultEvents,
   api_key_expiry_warning_days: 7,
   api_key_expiry_check_interval_hours: 24,
+}
+
+// ChannelsSection lists admin-configured notification channels (webhook,
+// Slack, Microsoft Teams, or an ad-hoc email recipient list) for the
+// module_published, approval_pending, cve_detected, and
+// scanner_update_available events — additional delivery destinations
+// alongside the shared SMTP recipients list above.
+function ChannelsSection({ isAdmin }: { isAdmin: boolean }) {
+  const { t } = useTranslation()
+  const queryClient = useQueryClient()
+  const [formOpen, setFormOpen] = useState(false)
+  const [editing, setEditing] = useState<NotificationChannel | null>(null)
+  const [deleteTarget, setDeleteTarget] = useState<NotificationChannel | null>(null)
+  const [notice, setNotice] = useState<{ severity: 'success' | 'error'; text: string } | null>(null)
+
+  const q = useQuery({ queryKey: queryKeys.notifications.channels(), queryFn: api.listNotificationChannels })
+  const invalidate = () => queryClient.invalidateQueries({ queryKey: queryKeys.notifications.channels() })
+
+  const deleteMutation = useMutation({ mutationFn: api.deleteNotificationChannel, onSuccess: invalidate })
+  const testMutation = useMutation({
+    mutationFn: api.testNotificationChannel,
+    onSuccess: () => {
+      setNotice({ severity: 'success', text: t('admin.notifications.channels.testSent') })
+      invalidate()
+    },
+    onError: (e) => setNotice({ severity: 'error', text: apiErr(e, t('admin.notifications.channels.testError')) }),
+  })
+  const toggleMutation = useMutation({
+    mutationFn: ({ ch, enabled }: { ch: NotificationChannel; enabled: boolean }) =>
+      api.updateNotificationChannel(ch.id, { name: ch.name, type: ch.type, events: ch.events, enabled }),
+    onSuccess: invalidate,
+    onError: (e) => setNotice({ severity: 'error', text: apiErr(e, t('admin.notifications.channels.saveError')) }),
+  })
+
+  return (
+    <Paper sx={{ p: 3, mb: 3 }}>
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', mb: 2 }}>
+        <Box>
+          <Typography variant="h6" gutterBottom>
+            {t('admin.notifications.channels.title')}
+          </Typography>
+          <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+            {t('admin.notifications.channels.description')}
+          </Typography>
+        </Box>
+        <Button
+          variant="contained"
+          startIcon={<AddIcon />}
+          disabled={!isAdmin}
+          onClick={() => {
+            setEditing(null)
+            setFormOpen(true)
+          }}
+        >
+          {t('admin.notifications.channels.add')}
+        </Button>
+      </Box>
+      <Divider sx={{ mb: 2 }} />
+
+      {notice && (
+        <Alert severity={notice.severity} sx={{ mb: 2 }} onClose={() => setNotice(null)}>
+          {notice.text}
+        </Alert>
+      )}
+
+      {q.isLoading && (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 2 }}>
+          <CircularProgress size={24} />
+        </Box>
+      )}
+      {q.isError && <Alert severity="error">{t('common.error')}</Alert>}
+      {q.data && q.data.length === 0 && (
+        <Alert severity="info">{t('admin.notifications.channels.noChannels')}</Alert>
+      )}
+
+      {q.data && q.data.length > 0 && (
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>{t('admin.notifications.channels.name')}</TableCell>
+              <TableCell>{t('admin.notifications.channels.typeLabel')}</TableCell>
+              <TableCell>{t('admin.notifications.channels.events')}</TableCell>
+              <TableCell>{t('admin.notifications.channels.enabled')}</TableCell>
+              <TableCell>{t('admin.notifications.channels.lastDelivery')}</TableCell>
+              <TableCell align="right">{t('admin.notifications.channels.actions')}</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {q.data.map((ch) => (
+              <TableRow key={ch.id} hover>
+                <TableCell>{ch.name}</TableCell>
+                <TableCell>{t(`admin.notifications.channels.type.${ch.type}`)}</TableCell>
+                <TableCell>
+                  <Stack direction="row" spacing={0.5} useFlexGap sx={{ flexWrap: 'wrap' }}>
+                    {ch.events.length === 0 ? (
+                      <Chip size="small" variant="outlined" label={t('admin.notifications.channels.allEvents')} />
+                    ) : (
+                      ch.events.map((e) => (
+                        <Chip key={e} size="small" variant="outlined" label={t(`admin.notifications.event.${e}`)} />
+                      ))
+                    )}
+                  </Stack>
+                </TableCell>
+                <TableCell>
+                  <Switch
+                    size="small"
+                    checked={ch.enabled}
+                    disabled={!isAdmin}
+                    onChange={(e) => toggleMutation.mutate({ ch, enabled: e.target.checked })}
+                    slotProps={{ input: { 'aria-label': t('admin.notifications.channels.enabled') } }}
+                  />
+                </TableCell>
+                <TableCell>
+                  {ch.last_status ? (
+                    <Chip
+                      size="small"
+                      color={ch.last_status === 'sent' ? 'success' : 'error'}
+                      label={ch.last_status}
+                    />
+                  ) : (
+                    <Box component="span" sx={{ color: 'text.secondary' }}>
+                      {t('admin.notifications.channels.neverSent')}
+                    </Box>
+                  )}
+                </TableCell>
+                <TableCell align="right">
+                  <Tooltip title={t('admin.notifications.channels.test')}>
+                    <span>
+                      <IconButton
+                        size="small"
+                        disabled={!isAdmin || testMutation.isPending}
+                        onClick={() => testMutation.mutate(ch.id)}
+                      >
+                        <SendIcon fontSize="small" />
+                      </IconButton>
+                    </span>
+                  </Tooltip>
+                  <Tooltip title={t('common.edit')}>
+                    <span>
+                      <IconButton
+                        size="small"
+                        disabled={!isAdmin}
+                        onClick={() => {
+                          setEditing(ch)
+                          setFormOpen(true)
+                        }}
+                      >
+                        <EditIcon fontSize="small" />
+                      </IconButton>
+                    </span>
+                  </Tooltip>
+                  <Tooltip title={t('common.delete')}>
+                    <span>
+                      <IconButton size="small" color="error" disabled={!isAdmin} onClick={() => setDeleteTarget(ch)}>
+                        <DeleteIcon fontSize="small" />
+                      </IconButton>
+                    </span>
+                  </Tooltip>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+
+      <ChannelFormDialog
+        open={formOpen}
+        channel={editing}
+        onClose={() => setFormOpen(false)}
+        onSaved={() => {
+          setFormOpen(false)
+          invalidate()
+        }}
+      />
+
+      <ConfirmDialog
+        open={Boolean(deleteTarget)}
+        onClose={() => setDeleteTarget(null)}
+        title={t('admin.notifications.channels.deleteTitle')}
+        severity="error"
+        description={t('admin.notifications.channels.deleteConfirm', { name: deleteTarget?.name ?? '' })}
+        confirmLabel={t('common.delete')}
+        loading={deleteMutation.isPending}
+        onConfirm={async () => {
+          if (!deleteTarget) return
+          await deleteMutation.mutateAsync(deleteTarget.id)
+          setDeleteTarget(null)
+        }}
+      />
+    </Paper>
+  )
+}
+
+function ChannelFormDialog({
+  open,
+  channel,
+  onClose,
+  onSaved,
+}: {
+  open: boolean
+  channel: NotificationChannel | null
+  onClose: () => void
+  onSaved: () => void
+}) {
+  const { t } = useTranslation()
+  const [name, setName] = useState('')
+  const [type, setType] = useState<NotificationChannel['type']>('webhook')
+  const [target, setTarget] = useState('')
+  const [events, setEvents] = useState<NotificationChannelEvent[]>([])
+  const [enabled, setEnabled] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const [seededFor, setSeededFor] = useState<string | null>(null)
+  const seedKey = channel?.id ?? 'new'
+  if (open && seededFor !== seedKey) {
+    setSeededFor(seedKey)
+    setError(null)
+    setName(channel?.name ?? '')
+    setType(channel?.type ?? 'webhook')
+    setTarget('')
+    setEvents(channel?.events ?? [])
+    setEnabled(channel?.enabled ?? true)
+  }
+  if (!open && seededFor !== null) setSeededFor(null)
+
+  const toggleEvent = (e: NotificationChannelEvent) =>
+    setEvents((prev) => (prev.includes(e) ? prev.filter((x) => x !== e) : [...prev, e]))
+
+  const mutation = useMutation({
+    mutationFn: () => {
+      const input: NotificationChannelInput = {
+        name,
+        type,
+        events,
+        enabled,
+        target: target || undefined,
+      }
+      return channel ? api.updateNotificationChannel(channel.id, input) : api.createNotificationChannel(input)
+    },
+    onSuccess: onSaved,
+    onError: (e) => setError(apiErr(e, t('admin.notifications.channels.saveError'))),
+  })
+
+  // On create the target is required; on edit a blank target keeps the existing one.
+  const targetRequired = !channel
+  const canSave = Boolean(name) && (!targetRequired || Boolean(target))
+  const isEmail = type === 'email'
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+      <DialogTitle>
+        {channel ? t('admin.notifications.channels.edit') : t('admin.notifications.channels.add')}
+      </DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} sx={{ mt: 1 }}>
+          {error && <Alert severity="error">{error}</Alert>}
+          <TextField
+            label={t('admin.notifications.channels.name')}
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            required
+            fullWidth
+            size="small"
+          />
+          <TextField
+            label={t('admin.notifications.channels.typeLabel')}
+            value={type}
+            onChange={(e) => setType(e.target.value as NotificationChannel['type'])}
+            select
+            fullWidth
+            size="small"
+          >
+            <MenuItem value="webhook">{t('admin.notifications.channels.type.webhook')}</MenuItem>
+            <MenuItem value="slack">{t('admin.notifications.channels.type.slack')}</MenuItem>
+            <MenuItem value="teams">{t('admin.notifications.channels.type.teams')}</MenuItem>
+            <MenuItem value="email">{t('admin.notifications.channels.type.email')}</MenuItem>
+          </TextField>
+          <TextField
+            label={isEmail ? t('admin.notifications.channels.targetEmail') : t('admin.notifications.channels.target')}
+            value={target}
+            onChange={(e) => setTarget(e.target.value)}
+            required={targetRequired}
+            fullWidth
+            size="small"
+            type={isEmail ? 'text' : 'url'}
+            placeholder={isEmail ? 'ops@example.com, oncall@example.com' : 'https://'}
+            helperText={
+              channel
+                ? isEmail
+                  ? t('admin.notifications.channels.targetEmailKeep')
+                  : t('admin.notifications.channels.targetKeep')
+                : isEmail
+                  ? t('admin.notifications.channels.targetEmailHelp')
+                  : t('admin.notifications.channels.targetHelp')
+            }
+          />
+          <Box>
+            <FormGroup row>
+              {CHANNEL_EVENT_TYPES.map((e) => (
+                <FormControlLabel
+                  key={e}
+                  control={<Checkbox size="small" checked={events.includes(e)} onChange={() => toggleEvent(e)} />}
+                  label={t(`admin.notifications.event.${e}`)}
+                />
+              ))}
+            </FormGroup>
+            <Box sx={{ color: 'text.secondary', fontSize: 12 }}>{t('admin.notifications.channels.eventsHelp')}</Box>
+          </Box>
+          <FormControlLabel
+            control={<Switch checked={enabled} onChange={(e) => setEnabled(e.target.checked)} />}
+            label={t('admin.notifications.channels.enabled')}
+          />
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>{t('common.cancel')}</Button>
+        <Button variant="contained" disabled={mutation.isPending || !canSave} onClick={() => mutation.mutate()}>
+          {t('common.save')}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
 }
 
 const NotificationsPage: React.FC = () => {
@@ -77,6 +457,8 @@ const NotificationsPage: React.FC = () => {
         password: '',
         from: config.smtp.from,
         use_tls: config.smtp.use_tls,
+        recipients: config.recipients.join(', '),
+        events: config.events,
         api_key_expiry_warning_days: config.api_key_expiry_warning_days,
         api_key_expiry_check_interval_hours: config.api_key_expiry_check_interval_hours,
       })
@@ -136,10 +518,18 @@ const NotificationsPage: React.FC = () => {
         from: form.from,
         use_tls: form.use_tls,
       },
+      recipients: form.recipients
+        .split(',')
+        .map((r) => r.trim())
+        .filter(Boolean),
+      events: form.events,
       api_key_expiry_warning_days: form.api_key_expiry_warning_days,
       api_key_expiry_check_interval_hours: form.api_key_expiry_check_interval_hours,
     })
   }
+
+  const toggleEvent = (key: keyof NotificationEvents) =>
+    setForm((f) => ({ ...f, events: { ...f.events, [key]: !f.events[key] } }))
 
   return (
     <Page maxWidth="md">
@@ -286,6 +676,35 @@ const NotificationsPage: React.FC = () => {
               </Grid>
             </Grid>
 
+            <Typography variant="h6" sx={{ mt: 3 }} gutterBottom>
+              {t('admin.notifications.eventsSection')}
+            </Typography>
+            <Divider sx={{ mb: 2 }} />
+            <TextField
+              fullWidth
+              label={t('admin.notifications.recipients')}
+              helperText={t('admin.notifications.recipientsHelp')}
+              value={form.recipients}
+              onChange={(e) => setForm((f) => ({ ...f, recipients: e.target.value }))}
+              disabled={!isAdmin}
+              sx={{ mb: 2 }}
+            />
+            <FormGroup>
+              {EVENT_TYPES.map((key) => (
+                <FormControlLabel
+                  key={key}
+                  control={
+                    <Checkbox
+                      checked={form.events[key]}
+                      onChange={() => toggleEvent(key)}
+                      disabled={!isAdmin}
+                    />
+                  }
+                  label={t(`admin.notifications.event.${key}`)}
+                />
+              ))}
+            </FormGroup>
+
             <Box sx={{ mt: 3 }}>
               <Button
                 variant="contained"
@@ -323,6 +742,8 @@ const NotificationsPage: React.FC = () => {
               </Button>
             </Box>
           </Paper>
+
+          <ChannelsSection isAdmin={isAdmin} />
         </>
       )}
     </Page>

--- a/frontend/src/pages/admin/__tests__/NotificationsPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/NotificationsPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
@@ -6,11 +6,21 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 const getNotificationsConfigMock = vi.fn()
 const saveNotificationsConfigMock = vi.fn()
 const sendTestNotificationMock = vi.fn()
+const listNotificationChannelsMock = vi.fn()
+const createNotificationChannelMock = vi.fn()
+const updateNotificationChannelMock = vi.fn()
+const deleteNotificationChannelMock = vi.fn()
+const testNotificationChannelMock = vi.fn()
 vi.mock('../../../services/api', () => ({
   default: {
     getNotificationsConfig: (...args: unknown[]) => getNotificationsConfigMock(...args),
     saveNotificationsConfig: (...args: unknown[]) => saveNotificationsConfigMock(...args),
     sendTestNotification: (...args: unknown[]) => sendTestNotificationMock(...args),
+    listNotificationChannels: (...args: unknown[]) => listNotificationChannelsMock(...args),
+    createNotificationChannel: (...args: unknown[]) => createNotificationChannelMock(...args),
+    updateNotificationChannel: (...args: unknown[]) => updateNotificationChannelMock(...args),
+    deleteNotificationChannel: (...args: unknown[]) => deleteNotificationChannelMock(...args),
+    testNotificationChannel: (...args: unknown[]) => testNotificationChannelMock(...args),
   },
 }))
 
@@ -45,6 +55,14 @@ const fakeConfig = {
     from: 'notify@example.com',
     use_tls: true,
   },
+  recipients: [] as string[],
+  events: {
+    api_key_expiring: true,
+    module_published: true,
+    approval_pending: true,
+    cve_detected: true,
+    scanner_update_available: true,
+  },
   api_key_expiry_warning_days: 7,
   api_key_expiry_check_interval_hours: 24,
   password_configured: true,
@@ -54,6 +72,7 @@ describe('NotificationsPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockAllowedScopes = ['admin']
+    listNotificationChannelsMock.mockResolvedValue([])
   })
 
   it('renders SMTP fields from mocked config', async () => {
@@ -264,6 +283,103 @@ describe('NotificationsPage', () => {
       expect(screen.getByRole('button', { name: 'Send Test Email' })).toBeDisabled()
       expect(screen.getByRole('switch', { name: 'Enable notifications' })).toBeDisabled()
       expect(screen.getByLabelText('Host')).toBeDisabled()
+    })
+  })
+
+  describe('notification channels', () => {
+    const channel = {
+      id: 'c1',
+      name: 'ops-slack',
+      type: 'slack',
+      has_target: true,
+      events: ['cve_detected'],
+      enabled: true,
+      last_status: 'sent',
+      last_error: null,
+      last_sent_at: '2026-07-01T00:00:00Z',
+      created_at: '2026-06-01',
+      updated_at: '2026-06-10',
+    }
+
+    it('lists channels with event chips and delivery status', async () => {
+      getNotificationsConfigMock.mockResolvedValue(fakeConfig)
+      listNotificationChannelsMock.mockResolvedValue([channel])
+      renderPage()
+
+      const row = await screen.findByRole('row', { name: /ops-slack/ })
+      expect(within(row).getByText('CVE detected')).toBeInTheDocument()
+      expect(within(row).getByText('sent')).toBeInTheDocument()
+    })
+
+    it('shows the empty hint when no channels exist', async () => {
+      getNotificationsConfigMock.mockResolvedValue(fakeConfig)
+      listNotificationChannelsMock.mockResolvedValue([])
+      renderPage()
+
+      expect(
+        await screen.findByText('No notification channels yet. Add one to receive alerts.'),
+      ).toBeInTheDocument()
+    })
+
+    it('creates a webhook channel with selected events', async () => {
+      const user = userEvent.setup()
+      getNotificationsConfigMock.mockResolvedValue(fakeConfig)
+      listNotificationChannelsMock.mockResolvedValue([])
+      createNotificationChannelMock.mockResolvedValue({ ...channel, type: 'webhook' })
+      renderPage()
+
+      await screen.findByText('No notification channels yet. Add one to receive alerts.')
+
+      await user.click(screen.getByRole('button', { name: 'Add channel' }))
+      const dialog = await screen.findByRole('dialog')
+      await user.type(within(dialog).getByLabelText('Name', { exact: false }), 'ops-webhook')
+      await user.type(
+        within(dialog).getByLabelText('Destination URL', { exact: false }),
+        'https://example.com/hook',
+      )
+      await user.click(within(dialog).getByLabelText('CVE detected'))
+      await user.click(within(dialog).getByRole('button', { name: 'Save' }))
+
+      await waitFor(() => {
+        expect(createNotificationChannelMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            name: 'ops-webhook',
+            type: 'webhook',
+            target: 'https://example.com/hook',
+            events: ['cve_detected'],
+          }),
+        )
+      })
+    })
+
+    it('sends a test notification through a channel', async () => {
+      const user = userEvent.setup()
+      getNotificationsConfigMock.mockResolvedValue(fakeConfig)
+      listNotificationChannelsMock.mockResolvedValue([channel])
+      testNotificationChannelMock.mockResolvedValue({ status: 'sent' })
+      renderPage()
+
+      const row = await screen.findByRole('row', { name: /ops-slack/ })
+      const [sendButton] = within(row).getAllByRole('button')
+      await user.click(sendButton)
+
+      await waitFor(() => expect(testNotificationChannelMock).toHaveBeenCalledWith('c1', expect.anything()))
+      expect(await screen.findByText('Test notification sent.')).toBeInTheDocument()
+    })
+
+    it('deletes a channel after confirmation', async () => {
+      const user = userEvent.setup()
+      getNotificationsConfigMock.mockResolvedValue(fakeConfig)
+      listNotificationChannelsMock.mockResolvedValue([channel])
+      deleteNotificationChannelMock.mockResolvedValue(undefined)
+      renderPage()
+
+      const row = await screen.findByRole('row', { name: /ops-slack/ })
+      const rowButtons = within(row).getAllByRole('button')
+      await user.click(rowButtons[rowButtons.length - 1])
+      await user.click(await screen.findByTestId('confirm-dialog-confirm'))
+
+      await waitFor(() => expect(deleteNotificationChannelMock).toHaveBeenCalledWith('c1', expect.anything()))
     })
   })
 })

--- a/frontend/src/services/__tests__/api.test.ts
+++ b/frontend/src/services/__tests__/api.test.ts
@@ -586,6 +586,14 @@ describe('ApiClient', () => {
           use_tls: true,
           password: 'secret',
         },
+        recipients: [] as string[],
+        events: {
+          api_key_expiring: true,
+          module_published: true,
+          approval_pending: true,
+          cve_detected: true,
+          scanner_update_available: true,
+        },
         api_key_expiry_warning_days: 7,
         api_key_expiry_check_interval_hours: 24,
       }
@@ -2647,7 +2655,7 @@ describe('ApiClient', () => {
 
     it('returns null without reporting an error on 404 (endpoint not implemented)', async () => {
       const client = await getApiClient()
-      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => { })
         ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockRejectedValueOnce({
           isAxiosError: true,
           response: { status: 404 },
@@ -2661,7 +2669,7 @@ describe('ApiClient', () => {
 
     it('returns null and reports the error on a non-404 failure', async () => {
       const client = await getApiClient()
-      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => { })
       const serverError = Object.assign(new Error('Internal Server Error'), {
         isAxiosError: true,
         response: { status: 500 },
@@ -2678,7 +2686,7 @@ describe('ApiClient', () => {
 
     it('returns null and reports the error on a network failure with no response', async () => {
       const client = await getApiClient()
-      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => { })
         ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
           new Error('Network Error'),
         )

--- a/frontend/src/services/api/notificationsApi.ts
+++ b/frontend/src/services/api/notificationsApi.ts
@@ -1,5 +1,7 @@
 import { http } from './http'
 import type {
+  NotificationChannel,
+  NotificationChannelInput,
   NotificationsConfig,
   NotificationsConfigInput,
   NotificationsTestRequest,
@@ -26,5 +28,38 @@ export async function sendTestNotification(
   data?: NotificationsTestRequest,
 ): Promise<NotificationsTestResult> {
   const response = await http.post('/api/v1/admin/notifications/test', data ?? {})
+  return response.data
+}
+
+// ============================================================================
+// Notification channels (webhook / Slack / Microsoft Teams / email)
+// ============================================================================
+
+export async function listNotificationChannels(): Promise<NotificationChannel[]> {
+  const response = await http.get('/api/v1/admin/notifications/channels')
+  return response.data.channels
+}
+
+export async function createNotificationChannel(
+  data: NotificationChannelInput,
+): Promise<NotificationChannel> {
+  const response = await http.post('/api/v1/admin/notifications/channels', data)
+  return response.data
+}
+
+export async function updateNotificationChannel(
+  id: string,
+  data: NotificationChannelInput,
+): Promise<NotificationChannel> {
+  const response = await http.put(`/api/v1/admin/notifications/channels/${id}`, data)
+  return response.data
+}
+
+export async function deleteNotificationChannel(id: string): Promise<void> {
+  await http.delete(`/api/v1/admin/notifications/channels/${id}`)
+}
+
+export async function testNotificationChannel(id: string): Promise<{ status: string }> {
+  const response = await http.post(`/api/v1/admin/notifications/channels/${id}/test`)
   return response.data
 }

--- a/frontend/src/services/queryKeys.ts
+++ b/frontend/src/services/queryKeys.ts
@@ -143,5 +143,6 @@ export const queryKeys = {
   notifications: {
     _def: ['notifications'] as const,
     config: () => [...queryKeys.notifications._def, 'config'] as const,
+    channels: () => [...queryKeys.notifications._def, 'channels'] as const,
   },
 } as const

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -363,9 +363,18 @@ export interface ScannerLatestInfo {
 export interface ScannerInstallRequest { tool: string; version?: string; activate?: boolean }
 export interface ScannerInstallResult extends ScanningInstallResult { activated?: boolean }
 export interface NotificationsSmtpConfig { host: string; port: number; username: string; from: string; use_tls: boolean }
+export interface NotificationEvents {
+  api_key_expiring: boolean
+  module_published: boolean
+  approval_pending: boolean
+  cve_detected: boolean
+  scanner_update_available: boolean
+}
 export interface NotificationsConfig {
   enabled: boolean
   smtp: NotificationsSmtpConfig
+  recipients: string[]
+  events: NotificationEvents
   api_key_expiry_warning_days: number
   api_key_expiry_check_interval_hours: number
   password_configured: boolean
@@ -373,11 +382,44 @@ export interface NotificationsConfig {
 export interface NotificationsConfigInput {
   enabled: boolean
   smtp: NotificationsSmtpConfig & { password: string }
+  recipients: string[]
+  events: NotificationEvents
   api_key_expiry_warning_days: number
   api_key_expiry_check_interval_hours: number
 }
 export interface NotificationsTestRequest { recipients?: string[]; subject?: string; smtp?: Partial<NotificationsSmtpConfig & { password: string }> }
 export interface NotificationsTestResult { success: boolean; message: string }
+
+// Notification channels — additional delivery destinations (webhook, Slack,
+// Microsoft Teams, or an ad-hoc email recipient list) for the
+// module_published, approval_pending, cve_detected, and
+// scanner_update_available events, alongside the shared SMTP recipients list.
+export type NotificationChannelType = 'webhook' | 'slack' | 'teams' | 'email'
+export type NotificationChannelEvent =
+  | 'module_published'
+  | 'approval_pending'
+  | 'cve_detected'
+  | 'scanner_update_available'
+export interface NotificationChannel {
+  id: string
+  name: string
+  type: NotificationChannelType
+  has_target: boolean
+  events: NotificationChannelEvent[] // empty = all events
+  enabled: boolean
+  last_status: string | null
+  last_error: string | null
+  last_sent_at: string | null
+  created_at: string
+  updated_at: string
+}
+export interface NotificationChannelInput {
+  name: string
+  type: NotificationChannelType
+  target?: string // destination URL or recipient list; omit on edit to keep existing
+  events: NotificationChannelEvent[]
+  enabled: boolean
+}
 
 // Setup Wizard — LDAP configuration
 export interface LDAPConfigInput {


### PR DESCRIPTION
## Summary

Adds the admin UI for managing **notification delivery channels** (webhook, Slack, Microsoft Teams, or an ad-hoc email recipient list) and per-event controls on the Notifications settings page. Pairs with the channel-delivery API in `sethbacon/terraform-registry-backend`.

## Changes

- New **Notification Channels** section: a table with add/edit dialog, event chips, an enable/disable switch, a per-channel **Send test** action, and last-delivery status.
- **Per-event checkboxes** (module published, approval pending, CVE detected, scanner update available) and a **recipients** field added to the SMTP settings form.
- Channel **targets are write-only** in the UI — never displayed after creation — and the target field is relabelled ("Recipient emails" vs "Destination URL") based on the selected channel type.
- New TypeScript types (`NotificationChannel`, `NotificationChannelInput`, event/type unions), API service functions, and query keys.

## Testing

- `tsc --noEmit` — clean.
- `vitest run` for `NotificationsPage` — 18 tests pass (existing SMTP-config tests plus new channel list/create/test/delete coverage).

## Security review

UI-side review: channel targets are never rendered (write-only); all values are React-escaped (no `dangerouslySetInnerHTML`); the delete flow uses a typed confirm dialog. No findings.

## Related

Backend counterpart: `sethbacon/terraform-registry-backend#625`.
