### PR TITLE
ci(contract-check): bump backend pin to 3.2.0 for notification channel routes

### DIFF
--- a/deployments/docker-compose.contract-check.yml
+++ b/deployments/docker-compose.contract-check.yml
@@ -20,7 +20,9 @@ services:
     # Pinned backend image. Bump this tag in lockstep with backend releases
     # whose API surface the frontend wants to depend on. The contract check
     # validates that every route api.ts calls exists on this exact backend.
-    image: ${BACKEND_IMAGE:-ghcr.io/sethbacon/terraform-registry-backend:2.7.2}
+    # 3.2.0 is the first release with the admin notification-channel routes
+    # (/api/v1/admin/notifications/channels[/{id}][/test]) the UI now calls.
+    image: ${BACKEND_IMAGE:-ghcr.io/sethbacon/terraform-registry-backend:3.2.0}
     environment:
       - TFR_DATABASE_HOST=postgres
       - TFR_DATABASE_PORT=5432


### PR DESCRIPTION
## What

Fixes the failing **Contract Check** on `main`. Root cause is a static image pin — **not** runner container caching.

## Why it was failing

The contract check stands up the backend from `deployments/docker-compose.contract-check.yml`, which hard-pins:

```
ghcr.io/sethbacon/terraform-registry-backend:2.7.2
```

2.7.2 predates the admin notification-channel routes the UI began calling in #563 (`/api/v1/admin/notifications/channels`, `.../{id}`, `.../{id}/test`). Those allowlist entries were intentionally removed pending the backend release, so once #563 merged the check failed on `main`. The job never sets `BACKEND_IMAGE`, so it always pulls exactly 2.7.2 — nothing is cached by the runner.

## Fix

Bump the pin to `3.2.0` — the first backend release that ships those routes, now published to ghcr (`:3.2.0`, `:3.2`, `:latest`).

## Verification

Ran the real `contract-check.ts` against 3.2.0's `swagger.json` locally:

```
Backend has 220 (method, path) tuples
Skipped (allowlist): 4
OK: every frontend route exists on backend (or is on the allowlist).
```

All 187 frontend call sites resolve against 3.2.0 — the 2.x → 3.x jump introduced no other route mismatches. The PR's own contract-check job (real Docker stack) will re-confirm.
