### PR TITLE
fix(docker): patch OS CVEs, stop baking the dev TLS key, ignore unfixed CVEs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,6 +139,9 @@ jobs:
           scan-type: image
           image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
           severity: HIGH,CRITICAL
+          # Only fail on vulnerabilities that have a fix available; un-actionable
+          # (no-fix-yet) CVEs shouldn't block a release.
+          ignore-unfixed: true
           exit-code: 1
           format: table
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -57,17 +57,22 @@ COPY nginx-ecs.conf.template /etc/nginx/nginx-ecs.conf.template
 COPY docker-entrypoint.sh /docker-entrypoint-custom.sh
 RUN chmod +x /docker-entrypoint-custom.sh
 
-# Generate a self-signed TLS certificate for local Docker Compose use.
-# In ECS the ALB handles TLS; the container only listens on port 80.
-RUN apk add --no-cache openssl && \
+# Apply the latest Alpine security patches on top of the digest-pinned base
+# image. The digest pin freezes the base package set, so without this a rebuild
+# keeps shipping whatever OS CVEs the base layer was built with (e.g. c-ares,
+# curl, libexpat). This is an OS security-patch step and is deliberately
+# distinct from application dependencies, which stay lockfile-pinned (npm ci).
+#
+# openssl is kept for the entrypoint's runtime cert generation (see
+# docker-entrypoint.sh): the throwaway self-signed localhost cert used for local
+# Docker Compose HTTPS is created at container startup and is never baked into
+# the published image. A private key in an image trips Trivy's secret scanner
+# and is a supply-chain smell; production terminates TLS at the ALB/ingress and
+# never uses this cert.
+RUN apk upgrade --no-cache && \
+    apk add --no-cache openssl && \
     mkdir -p /etc/nginx/certs && \
-    openssl req -x509 -newkey rsa:2048 \
-    -keyout /etc/nginx/certs/server.key \
-    -out /etc/nginx/certs/server.crt \
-    -days 365 -nodes \
-    -subj '/CN=localhost' \
-    -addext 'subjectAltName=DNS:localhost,DNS:registry.local,IP:127.0.0.1' && \
-    chmod 600 /etc/nginx/certs/server.key
+    chown 101:101 /etc/nginx/certs
 
 # Pre-create nginx temp dirs owned by the nginx user (uid 101) so the
 # container can run without the CHOWN capability (dropped by the Helm chart

--- a/frontend/docker-entrypoint.sh
+++ b/frontend/docker-entrypoint.sh
@@ -11,6 +11,22 @@ if [ -n "$BACKEND_URL" ]; then
     envsubst '${BACKEND_URL}' \
         < /etc/nginx/nginx-ecs.conf.template \
         > /etc/nginx/conf.d/default.conf
+else
+    # Local Docker Compose / E2E: nginx.conf serves HTTPS on 443 with a
+    # throwaway self-signed localhost cert. Generate it here at startup rather
+    # than at image-build time, so the private key is never baked into -- or
+    # published with -- the image (Trivy's secret scanner flags a baked-in key).
+    # Production sets BACKEND_URL, terminates TLS at the ALB/ingress, and never
+    # reaches this branch.
+    if [ ! -f /etc/nginx/certs/server.key ]; then
+        openssl req -x509 -newkey rsa:2048 \
+            -keyout /etc/nginx/certs/server.key \
+            -out /etc/nginx/certs/server.crt \
+            -days 365 -nodes \
+            -subj '/CN=localhost' \
+            -addext 'subjectAltName=DNS:localhost,DNS:registry.local,IP:127.0.0.1'
+        chmod 600 /etc/nginx/certs/server.key
+    fi
 fi
 
 exec nginx -g 'daemon off;'


### PR DESCRIPTION
## What

Fixes the v2.17.0 release Trivy scan failure and hardens the image against recurrence.

## The two failures

The release Trivy scan (`severity: HIGH,CRITICAL`, `exit-code: 1`) failed on 8 HIGH findings in the published nginx image:

1. **8 HIGH OS-package CVEs** (all with fixes available): `c-ares` (CVE-2026-33630), `curl`/`libcurl` (CVE-2026-5773, CVE-2026-6276), `libexpat` (CVE-2026-56131/56407/56408). The base is pinned by digest (`nginx:1.31-alpine`), which freezes the Alpine package set, so a rebuild kept shipping the stale, vulnerable packages.
2. **1 HIGH secret** — a private key baked into the image at `/etc/nginx/certs/server.key` by the build-time self-signed-cert step.

## Fixes

- **`apk upgrade --no-cache`** in the final stage so each rebuild pulls Alpine's patched packages on top of the digest-pinned base (OS security patching, distinct from the lockfile-pinned npm deps).
- **Moved self-signed cert generation from build time into `docker-entrypoint.sh`'s local branch** (`BACKEND_URL` unset). The dev-only localhost cert is now created at container startup, so no private key is baked into or published with the image. Production sets `BACKEND_URL`, terminates TLS at the ALB/ingress, and never uses this cert.
- **`ignore-unfixed: true`** on the Trivy step so future un-actionable (no-fix-yet) CVEs don't block a release.

Companion PRs harden the sibling images the same way (state-manager frontend/backend, registry backend).

## Recovery note

v2.17.0's release build failed at the scan (post-push), so the image is on ghcr but unattested and the release didn't finalize. After this merges, cut a new patch release (e.g. v2.17.1) — re-running v2.17.0's build would use the old Dockerfile and fail again.
