### PR TITLE
fix(docker): match /run/nginx.pid in newer nginx base images

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -84,7 +84,7 @@ RUN mkdir -p /var/cache/nginx/client_temp \
     /var/cache/nginx/scgi_temp && \
     chown -R 101:101 /var/cache/nginx && \
     chown -R 101:101 /var/log/nginx && \
-    sed -i 's|pid\s*/var/run/nginx.pid;|pid /tmp/nginx.pid;|' /etc/nginx/nginx.conf
+    sed -i -E 's#pid[[:space:]]+/(var/run|run)/nginx\.pid;#pid /tmp/nginx.pid;#' /etc/nginx/nginx.conf
 
 # Expose ports
 EXPOSE 80 443


### PR DESCRIPTION
<!-- markdownlint-disable MD013 MD041 -->
## Summary

The `nginx:1.31-alpine` base image bump changed its default `nginx.conf` pid
directive from `pid /var/run/nginx.pid;` to `pid /run/nginx.pid;`. The
Dockerfile's `sed` patch (which redirects the pid file to `/tmp` so nginx can
run as non-root uid 101 under the Helm chart's `podSecurityContext`) only
matched the old `/var/run` path, so it silently no-op'd.

Confirmed live on AKS (registry.brunswick.com): the new frontend pod
crash-looped with:

```text
nginx: [emerg] open() "/run/nginx.pid" failed (13: Permission denied)
```

This blocked the backend deploy pipeline's `helm upgrade --wait` from
completing (`UPGRADE FAILED: context deadline exceeded`) while the previous
pod kept serving traffic.

Fix: update the `sed` pattern to match both `/run` and `/var/run`, with
flexible whitespace, so it survives future base image bumps.

## Changelog

- fix: match `/run/nginx.pid` (not just `/var/run/nginx.pid`) when patching the nginx pid path for non-root uid 101

## Checklist

Docker-only change (no TS/app source touched), so lint/typecheck/unit tests
are unaffected. CI's image build will validate the Dockerfile.

- [ ] `npm run lint` passes
- [ ] `npx tsc --noEmit` (typecheck) passes
- [ ] `npm test` (unit tests) passes
- [ ] `npm run build` succeeds
- [x] PR targets `main`
- [x] Remote branch will be deleted after merge
