### PR TITLE
fix(notifications): guard against a null recipients array from the API

### DIFF
--- a/frontend/src/pages/admin/NotificationsPage.tsx
+++ b/frontend/src/pages/admin/NotificationsPage.tsx
@@ -457,7 +457,7 @@ const NotificationsPage: React.FC = () => {
         password: '',
         from: config.smtp.from,
         use_tls: config.smtp.use_tls,
-        recipients: config.recipients.join(', '),
+        recipients: (config.recipients ?? []).join(', '),
         events: config.events,
         api_key_expiry_warning_days: config.api_key_expiry_warning_days,
         api_key_expiry_check_interval_hours: config.api_key_expiry_check_interval_hours,

--- a/frontend/src/pages/admin/__tests__/NotificationsPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/NotificationsPage.test.tsx
@@ -86,6 +86,18 @@ describe('NotificationsPage', () => {
     expect(screen.getByDisplayValue('notify@example.com')).toBeInTheDocument()
   })
 
+  // Regression test: a never-configured backend can return recipients: null
+  // (a nil Go slice marshals to JSON null). config.recipients.join(', ') on a
+  // null value threw "Cannot read properties of null (reading 'join')" and
+  // crashed the whole page. Guard: (config.recipients ?? []).join(', ').
+  it('renders without crashing when recipients is null', async () => {
+    getNotificationsConfigMock.mockResolvedValue({ ...fakeConfig, recipients: null })
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('smtp.example.com')).toBeInTheDocument()
+    })
+  })
+
   it('shows "configured" helper when password_configured is true', async () => {
     getNotificationsConfigMock.mockResolvedValue(fakeConfig)
     renderPage()


### PR DESCRIPTION
<!-- markdownlint-disable MD013 MD041 -->
## Summary

`GET /api/v1/admin/notifications/config` could return
`"recipients":null` on a never-configured backend (a nil Go slice
marshals to JSON `null`, not `[]`). `config.recipients.join(', ')`
then threw `TypeError: Cannot read properties of null (reading
'join')`, crashing the entire admin Notifications page ("Something
went wrong").

Confirmed live on the UAT registry. Backend fix (normalize the field
to an empty array server-side) lands separately in
`terraform-registry-backend` (sethbacon/terraform-registry-backend#633);
this is the client-side defense-in-depth half so the page never
crashes regardless of what the API returns.

## Changelog

- fix: guard against a null `recipients` array from `/api/v1/admin/notifications/config` crashing the Notifications page

## Checklist

- [x] `npm run lint` passes
- [x] `npx tsc --noEmit` (typecheck) passes
- [x] `npm test` (unit tests) passes
- [ ] `npm run build` succeeds
- [x] PR targets `main`
- [x] Remote branch will be deleted after merge

Added a regression test rendering the page with `recipients: null`;
full suite (19 tests) passes.
