### PR TITLE
feat(help): add context help for the admin Notifications page

### DIFF
--- a/frontend/src/components/HelpPanel.tsx
+++ b/frontend/src/components/HelpPanel.tsx
@@ -89,6 +89,7 @@ const HELP_ACTION_KEYS: Record<string, string[]> = {
   securityScanning: ['viewConfiguration', 'summaryStatistics', 'reviewScanResults'],
   mtls: ['viewStatus', 'certificateMappings', 'configurationSource'],
   scim: ['endpointUrls', 'authentication', 'supportedOperations'],
+  notifications: ['smtpConfig', 'testEmail', 'notificationChannels', 'recipientsEvents', 'apiKeyExpiry'],
 }
 
 function makeContent(key: string, t: TStr): HelpContent {
@@ -158,6 +159,8 @@ function getHelpContent(pathname: string, t: TStr): HelpContent {
       return makeContent('mtls', t)
     case '/admin/scim':
       return makeContent('scim', t)
+    case '/admin/notifications':
+      return makeContent('notifications', t)
     default:
       return makeContent('default', t)
   }

--- a/frontend/src/components/__tests__/HelpPanel.test.tsx
+++ b/frontend/src/components/__tests__/HelpPanel.test.tsx
@@ -150,6 +150,13 @@ describe('HelpPanel', () => {
     expect(screen.getByText('Auto-Approval')).toBeInTheDocument()
   })
 
+  it('renders notifications help', () => {
+    renderAtPath('/admin/notifications')
+    expect(screen.getByText('Notifications')).toBeInTheDocument()
+    expect(screen.getByText(/shared outbound SMTP relay/)).toBeInTheDocument()
+    expect(screen.getByText('Notification Channels')).toBeInTheDocument()
+  })
+
   it('renders default help for unknown paths', () => {
     renderAtPath('/some/unknown/path')
     expect(screen.getByText('Help')).toBeInTheDocument()

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -883,6 +883,32 @@
           "text": "Users support full CRUD and soft-delete. Groups are read-only and map to registry organizations. Filtering and pagination are supported."
         }
       }
+    },
+    "notifications": {
+      "title": "Notifications",
+      "overview": "Configure the shared outbound SMTP relay and add notification channels (webhook, Slack, Microsoft Teams, or email) that deliver alerts for module publishing, approval requests, CVE detections, and scanner updates.",
+      "actions": {
+        "smtpConfig": {
+          "heading": "SMTP Configuration",
+          "text": "Set the relay host, port, credentials, and From address used by every email-based notification. Toggle \"Use TLS\" to require an encrypted connection (implicit TLS or STARTTLS) — a relay that can't satisfy it will fail rather than silently send in the clear."
+        },
+        "testEmail": {
+          "heading": "Send Test Email",
+          "text": "After saving SMTP settings, send a test message to one or more comma-separated addresses to confirm the relay accepts your configuration before relying on it for real alerts."
+        },
+        "notificationChannels": {
+          "heading": "Notification Channels",
+          "text": "Add a channel to deliver alerts to a webhook, Slack, Microsoft Teams, or an ad-hoc email recipient list. Each channel can subscribe to specific events or all of them, and can be tested, toggled, or deleted independently. Destination targets are stored encrypted and never shown again after creation."
+        },
+        "recipientsEvents": {
+          "heading": "Recipients & Event Toggles",
+          "text": "The Recipients field and event checkboxes control the shared SMTP fallback used by module published, approval pending, CVE detected, and scanner update alerts when no dedicated channel is configured for that event."
+        },
+        "apiKeyExpiry": {
+          "heading": "API Key Expiry Notifications",
+          "text": "Set how many days before expiry a warning email is sent, and how often (in hours) the background job checks for keys nearing expiration."
+        }
+      }
     }
   },
   "admin": {


### PR DESCRIPTION
<!-- markdownlint-disable MD013 MD041 -->
## Summary

`/admin/notifications` had no entry in `HelpPanel`'s route map, so
clicking "Context Help" there fell through to the generic default
content instead of anything specific to SMTP settings, test emails,
notification channels, recipients/event toggles, or API key expiry
settings.

Adds a `notifications` help content section (matching the existing
`oidcGroups`/`apiKeys`/`scim` style) covering all five areas of the
page:
- SMTP configuration
- Send Test Email
- Notification Channels (webhook/Slack/Teams/email)
- Recipients & event toggles
- API Key Expiry Notifications

## Changelog

- feat: add context help content for the admin Notifications page

## Checklist

- [x] `npm run lint` passes
- [x] `npx tsc --noEmit` (typecheck) passes
- [x] `npm test` (unit tests) passes
- [ ] `npm run build` succeeds
- [x] PR targets `main`
- [x] Remote branch will be deleted after merge

Added a regression test asserting the Notifications help content
renders; full `HelpPanel.test.tsx` suite (31 tests) passes.
