### PR TITLE
fix(ci): grant contents:write to the docker job for SBOM release-asset upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: [guard, ci]
     permissions:
-      contents: read
+      # write (not read): anchore/sbom-action's upload-release-assets default
+      # attaches the generated SBOM to the tag's GitHub Release (already created
+      # by release-please) — that upload 403s ("Resource not accessible by
+      # integration") without contents: write.
+      contents: write
       packages: write # required to push to ghcr.io
       id-token: write # required for Sigstore OIDC (cosign keyless signing)
       attestations: write # required for SLSA provenance attestation


### PR DESCRIPTION
## Summary

`release.yml`'s `docker` job's SBOM step (`anchore/sbom-action`, default `upload-release-assets: true`) tries to attach the generated SBOM to the tag's GitHub Release (already created by release-please by the time this workflow runs). The job only granted `contents: read`, so that upload has been silently failing with `Resource not accessible by integration` (a 403) on both the `v2.18.0` and `v2.19.0` releases.

**Impact of the bug**: the Docker image push, Trivy scan, SLSA provenance attestation, and cosign signature all still succeed — only the SBOM-as-release-asset upload fails, which in turn fails the whole `docker` job, which skips the downstream `release` job (`Publish GitHub Release`, which appends the "docker pull" instructions + generated release notes to the release body).

## Fix

Add `contents: write` to the `docker` job's `permissions` block (alongside the existing `packages: write`, `id-token: write`, `attestations: write`).

## Verification

- YAML change only, no application code touched.
- Confirmed the exact failure via `gh run view --log-failed` on both the `v2.18.0` run ([29643967406](https://github.com/sethbacon/terraform-registry-frontend/actions/runs/29643967406)) and the `v2.19.0` run ([29662812147](https://github.com/sethbacon/terraform-registry-frontend/actions/runs/29662812147)) — same step (`Generate SBOM (Syft)`), same error, right after `Attaching SBOMs to release: '<tag>'`.
- Will re-verify once this merges by re-running the `v2.19.0` release workflow (`gh workflow run release.yml -f tag=v2.19.0` or a `workflow_dispatch`) to confirm the SBOM attaches and the GitHub Release gets published.
