### PR TITLE
fix(ci): disable SBOM release-asset upload (releases are immutable here)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,11 +83,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [guard, ci]
     permissions:
-      # write (not read): anchore/sbom-action's upload-release-assets default
-      # attaches the generated SBOM to the tag's GitHub Release (already created
-      # by release-please) — that upload 403s ("Resource not accessible by
-      # integration") without contents: write.
-      contents: write
+      contents: read
       packages: write # required to push to ghcr.io
       id-token: write # required for Sigstore OIDC (cosign keyless signing)
       attestations: write # required for SLSA provenance attestation
@@ -162,6 +158,13 @@ jobs:
           image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
           format: spdx-json
           output-file: sbom.spdx.json
+          # The "Protect release tags" ruleset makes the tag's GitHub Release
+          # (already created by release-please by the time this runs) immutable,
+          # so attaching the SBOM as a release asset always 404s/403s with
+          # "Cannot upload assets to an immutable release." The SBOM is still
+          # published as a workflow-run artifact (upload-artifact stays default
+          # true) — just not as a release asset.
+          upload-release-assets: false
 
       - name: Attest SBOM
         uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0


### PR DESCRIPTION
## Summary

Follow-up to #576. That fix added `contents: write` to the `docker` job so the SBOM release-asset upload's *auth* would succeed — it did (confirmed no more `Resource not accessible by integration` on the `v2.19.1` run), but the very next attempt hit a different, structural error:

```
##[error]Cannot upload assets to an immutable release. - https://docs.github.com/rest
```

This repo has an active ruleset **"Protect release tags"** (`deletion`/`update`/`non_fast_forward` on `refs/tags/v*`). Once a tag is covered by such a ruleset, GitHub treats its GitHub Release as **immutable** after creation — and release-please creates the Release *before* this workflow's `docker` job runs, so `anchore/sbom-action`'s default `upload-release-assets: true` can never succeed here, regardless of token permissions.

## Fix

- Set `upload-release-assets: false` on the `Generate SBOM (Syft)` step. The SBOM is still published as a workflow-run artifact (`upload-artifact` stays at its default `true`) — just not attached to the release itself.
- Revert the `docker` job's `permissions` back to `contents: read` (no longer needed by any step now that the release-asset upload is disabled) — restores least-privilege from #576.

## Verification

- Confirmed via `gh run view --log-failed` on the `v2.19.1` release run ([29665675630](https://github.com/sethbacon/terraform-registry-frontend/actions/runs/29665675630)) that this is the exact and only remaining failure — Docker build/push, Trivy scan, and SLSA provenance attestation all succeed.
- Confirmed the ruleset via `gh api repos/sethbacon/terraform-registry-frontend/rulesets` (id 15553493, target `tag`, rules `deletion`/`non_fast_forward`/`update`, `enforcement: active`).
- Will re-verify once merged by re-running the release workflow against `v2.19.1` (`workflow_dispatch`) to confirm the SBOM step now succeeds and the GitHub Release gets published with its notes.
