### PR TITLE
fix(admin): align Notifications page UX with State Manager's cleaner layout

### DIFF
--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -2001,8 +2001,8 @@
     "notifications": {
       "pageTitle": "Notifications",
       "pageSubtitle": "Configure email notifications and SMTP settings",
-      "enabled": "Enable notifications",
-      "smtpSection": "SMTP Configuration",
+      "smtpSection": "SMTP Relay Settings",
+      "smtpSectionDescription": "The shared outbound mail server used for notification-channel emails, CVE alerts, and scanner update alerts.",
       "host": "Host",
       "port": "Port",
       "username": "Username",
@@ -2014,11 +2014,7 @@
       "apiKeyExpirySection": "API Key Expiry Notifications",
       "warningDays": "Warning days before expiry",
       "checkIntervalHours": "Check interval (hours)",
-      "eventsSection": "Notification Options",
-      "recipients": "Recipients",
-      "recipientsHelp": "Comma-separated email addresses for module published, approval pending, CVE detected, and scanner update notifications. Falls back to the CVE recipients list when left blank.",
       "event": {
-        "api_key_expiring": "API key expiring",
         "module_published": "New module version published",
         "approval_pending": "New approval pending",
         "cve_detected": "CVE detected",

--- a/frontend/src/pages/admin/NotificationsPage.tsx
+++ b/frontend/src/pages/admin/NotificationsPage.tsx
@@ -12,8 +12,6 @@ import {
   TextField,
   Switch,
   FormControlLabel,
-  FormGroup,
-  Checkbox,
   Button,
 } from '@mui/material'
 import { NotificationChannelsSection, type NotificationChannelTypeOption } from '@sethbacon/terraform-suite-ui'
@@ -28,7 +26,6 @@ import type {
   NotificationChannelEvent,
   NotificationChannelInput,
   NotificationChannelType,
-  NotificationEvents,
   NotificationsConfigInput,
 } from '../../types'
 
@@ -40,47 +37,21 @@ const CHANNEL_EVENT_TYPES: NotificationChannelEvent[] = [
 ]
 
 interface FormState {
-  enabled: boolean
   host: string
   port: number
   username: string
   password: string
   from: string
   use_tls: boolean
-  recipients: string
-  events: NotificationEvents
-  api_key_expiry_warning_days: number
-  api_key_expiry_check_interval_hours: number
 }
-
-const defaultEvents: NotificationEvents = {
-  api_key_expiring: true,
-  module_published: true,
-  approval_pending: true,
-  cve_detected: true,
-  scanner_update_available: true,
-}
-
-const EVENT_TYPES: Array<keyof NotificationEvents> = [
-  'api_key_expiring',
-  'module_published',
-  'approval_pending',
-  'cve_detected',
-  'scanner_update_available',
-]
 
 const defaultFormState: FormState = {
-  enabled: false,
   host: '',
   port: 587,
   username: '',
   password: '',
   from: '',
   use_tls: true,
-  recipients: '',
-  events: defaultEvents,
-  api_key_expiry_warning_days: 7,
-  api_key_expiry_check_interval_hours: 24,
 }
 
 // ChannelsSection lists admin-configured notification channels (webhook,
@@ -119,17 +90,12 @@ const NotificationsPage: React.FC = () => {
   useEffect(() => {
     if (config) {
       setForm({
-        enabled: config.enabled,
         host: config.smtp.host,
         port: config.smtp.port,
         username: config.smtp.username,
         password: '',
         from: config.smtp.from,
         use_tls: config.smtp.use_tls,
-        recipients: (config.recipients ?? []).join(', '),
-        events: config.events,
-        api_key_expiry_warning_days: config.api_key_expiry_warning_days,
-        api_key_expiry_check_interval_hours: config.api_key_expiry_check_interval_hours,
       })
     }
   }, [config])
@@ -176,9 +142,10 @@ const NotificationsPage: React.FC = () => {
   })
 
   const handleSave = () => {
+    if (!config) return
     setError(null)
     saveMutation.mutate({
-      enabled: form.enabled,
+      enabled: config.enabled,
       smtp: {
         host: form.host,
         port: form.port,
@@ -187,18 +154,12 @@ const NotificationsPage: React.FC = () => {
         from: form.from,
         use_tls: form.use_tls,
       },
-      recipients: form.recipients
-        .split(',')
-        .map((r) => r.trim())
-        .filter(Boolean),
-      events: form.events,
-      api_key_expiry_warning_days: form.api_key_expiry_warning_days,
-      api_key_expiry_check_interval_hours: form.api_key_expiry_check_interval_hours,
+      recipients: config.recipients ?? [],
+      events: config.events,
+      api_key_expiry_warning_days: config.api_key_expiry_warning_days,
+      api_key_expiry_check_interval_hours: config.api_key_expiry_check_interval_hours,
     })
   }
-
-  const toggleEvent = (key: keyof NotificationEvents) =>
-    setForm((f) => ({ ...f, events: { ...f.events, [key]: !f.events[key] } }))
 
   const channelsQuery = useQuery({
     queryKey: queryKeys.notifications.channels(),
@@ -234,19 +195,11 @@ const NotificationsPage: React.FC = () => {
           )}
 
           <Paper sx={{ p: 3, mb: 3 }}>
-            <FormControlLabel
-              control={
-                <Switch
-                  checked={form.enabled}
-                  onChange={(e) => setForm((f) => ({ ...f, enabled: e.target.checked }))}
-                  disabled={!isAdmin}
-                />
-              }
-              label={t('admin.notifications.enabled')}
-            />
-
             <Typography variant="h6" sx={{ mt: 2 }} gutterBottom>
               {t('admin.notifications.smtpSection')}
+            </Typography>
+            <Typography variant="body2" sx={{ color: 'text.secondary', mb: 2 }}>
+              {t('admin.notifications.smtpSectionDescription')}
             </Typography>
             <Divider sx={{ mb: 2 }} />
             <Grid container spacing={2}>
@@ -315,35 +268,6 @@ const NotificationsPage: React.FC = () => {
               </Grid>
             </Grid>
 
-            <Typography variant="h6" sx={{ mt: 3 }} gutterBottom>
-              {t('admin.notifications.eventsSection')}
-            </Typography>
-            <Divider sx={{ mb: 2 }} />
-            <TextField
-              fullWidth
-              label={t('admin.notifications.recipients')}
-              helperText={t('admin.notifications.recipientsHelp')}
-              value={form.recipients}
-              onChange={(e) => setForm((f) => ({ ...f, recipients: e.target.value }))}
-              disabled={!isAdmin}
-              sx={{ mb: 2 }}
-            />
-            <FormGroup>
-              {EVENT_TYPES.map((key) => (
-                <FormControlLabel
-                  key={key}
-                  control={
-                    <Checkbox
-                      checked={form.events[key]}
-                      onChange={() => toggleEvent(key)}
-                      disabled={!isAdmin}
-                    />
-                  }
-                  label={t(`admin.notifications.event.${key}`)}
-                />
-              ))}
-            </FormGroup>
-
             <Box sx={{ mt: 3 }}>
               <Button
                 variant="contained"
@@ -353,13 +277,12 @@ const NotificationsPage: React.FC = () => {
                 {saveMutation.isPending ? <CircularProgress size={20} /> : t('admin.notifications.save')}
               </Button>
             </Box>
-          </Paper>
 
-          <Paper sx={{ p: 3 }}>
+            <Divider sx={{ my: 3 }} />
+
             <Typography variant="h6" gutterBottom>
               {t('admin.notifications.test')}
             </Typography>
-            <Divider sx={{ mb: 2 }} />
             <Box sx={{ display: 'flex', gap: 2, alignItems: 'center', flexWrap: 'wrap' }}>
               <TextField
                 label={t('admin.notifications.testRecipients')}

--- a/frontend/src/pages/admin/__tests__/NotificationsPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/NotificationsPage.test.tsx
@@ -137,7 +137,7 @@ describe('NotificationsPage', () => {
     })
   })
 
-  it('toggles the enabled and use_tls switches and edits SMTP fields', async () => {
+  it('toggles the use_tls switch and edits SMTP fields', async () => {
     const user = userEvent.setup()
     getNotificationsConfigMock.mockResolvedValue(fakeConfig)
     renderPage()
@@ -145,11 +145,6 @@ describe('NotificationsPage', () => {
     await waitFor(() => {
       expect(screen.getByDisplayValue('smtp.example.com')).toBeInTheDocument()
     })
-
-    const enabledSwitch = screen.getByRole('switch', { name: 'Enable notifications' })
-    expect(enabledSwitch).toBeChecked()
-    await user.click(enabledSwitch)
-    expect(enabledSwitch).not.toBeChecked()
 
     const useTlsSwitch = screen.getByRole('switch', { name: 'Use TLS' })
     expect(useTlsSwitch).toBeChecked()
@@ -165,6 +160,49 @@ describe('NotificationsPage', () => {
     await user.clear(portField)
     await user.type(portField, '2525')
     expect(screen.getByDisplayValue('2525')).toBeInTheDocument()
+  })
+
+  it('does not render the legacy Enable Notifications toggle or Notification Options section (config now lives per-channel or on the API Keys page)', async () => {
+    getNotificationsConfigMock.mockResolvedValue(fakeConfig)
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('smtp.example.com')).toBeInTheDocument()
+    })
+
+    expect(screen.queryByRole('switch', { name: 'Enable notifications' })).not.toBeInTheDocument()
+    expect(screen.queryByText('Notification Options')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Recipients')).not.toBeInTheDocument()
+    expect(screen.queryByText('API key expiring')).not.toBeInTheDocument()
+  })
+
+  it('preserves the existing enabled/recipients/events/api-key-expiry settings when saving SMTP changes (this page no longer edits them)', async () => {
+    const user = userEvent.setup()
+    getNotificationsConfigMock.mockResolvedValue({
+      ...fakeConfig,
+      enabled: true,
+      recipients: ['ops@example.com'],
+    })
+    saveNotificationsConfigMock.mockResolvedValue(fakeConfig)
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('smtp.example.com')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => {
+      expect(saveNotificationsConfigMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          enabled: true,
+          recipients: ['ops@example.com'],
+          events: fakeConfig.events,
+          api_key_expiry_warning_days: fakeConfig.api_key_expiry_warning_days,
+          api_key_expiry_check_interval_hours: fakeConfig.api_key_expiry_check_interval_hours,
+        }),
+      )
+    })
   })
 
   it('saves with an empty password when the password field is left blank', async () => {
@@ -293,7 +331,7 @@ describe('NotificationsPage', () => {
 
       expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
       expect(screen.getByRole('button', { name: 'Send Test Email' })).toBeDisabled()
-      expect(screen.getByRole('switch', { name: 'Enable notifications' })).toBeDisabled()
+      expect(screen.getByRole('switch', { name: 'Use TLS' })).toBeDisabled()
       expect(screen.getByLabelText('Host')).toBeDisabled()
     })
   })


### PR DESCRIPTION
## Summary

Registry's admin Notifications page had drifted from State Manager's cleaner layout: an extra "Enable notifications" toggle + "Notification Options" section (recipients box + 5 event checkboxes) that duplicated the per-channel event config already available in the "Add channel" dialog, plus an "API key expiring" checkbox that duplicated the dedicated control already on the API Keys page. This reworks the page to match State Manager's structure (SMTP Relay Settings + Send Test Email in one card, then Notification channels) and removes the duplication.

Before/after was reviewed live against a local Docker Compose stack (registry.local:3000, Dev Login) before opening this PR.

## Changelog

- fix: align Registry admin Notifications page UX with State Manager (remove duplicated Enable-notifications/Notification-Options controls; API key expiry now lives only on the API Keys page)

## Checklist

- [x] `npm run lint` passes
- [x] `npx tsc --noEmit` (typecheck) passes
- [x] `npm test` (unit tests) passes
- [x] `npm run build` succeeds
- [x] PR targets `main`
- [x] Remote branch will be deleted after merge
