### PR TITLE
chore(deps): bump @sethbacon/terraform-suite-ui to 0.6.1

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,7 +19,7 @@
         "@mui/icons-material": "^9.2.0",
         "@mui/material": "^9.2.0",
         "@mui/material-pigment-css": "^9.2.0",
-        "@sethbacon/terraform-suite-ui": "0.6.0",
+        "@sethbacon/terraform-suite-ui": "0.6.1",
         "@tanstack/react-query": "^5.101.2",
         "@tanstack/react-query-devtools": "^5.101.2",
         "@testing-library/dom": "^10.4.1",
@@ -2504,9 +2504,9 @@
       }
     },
     "node_modules/@sethbacon/terraform-suite-ui": {
-      "version": "0.6.0",
-      "resolved": "https://npm.pkg.github.com/download/@sethbacon/terraform-suite-ui/0.6.0/98b89afc1408565a272d3176cab9e3941fc147bb",
-      "integrity": "sha512-3A+O9buFkkN6HVnv0raQvGMlEflXDqx6iwjdpuHDWiWsmZmVELuIKDZg+pTTjE5Suzki3V42Wv9IZH2IPJPqVA==",
+      "version": "0.6.1",
+      "resolved": "https://npm.pkg.github.com/download/@sethbacon/terraform-suite-ui/0.6.1/668b7cfad38f786e633ed7e969d3a6aa9b3328ed",
+      "integrity": "sha512-H8M8QT5NjrVGINM6DOWwDINYrlEGEqjtAZplvP9uHvAd8U1V6f4nNFP2ySRWQtocBZMajmxsFMn2n2210rpVvQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=24.0.0 <25"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,7 +31,7 @@
     "@mui/icons-material": "^9.2.0",
     "@mui/material": "^9.2.0",
     "@mui/material-pigment-css": "^9.2.0",
-    "@sethbacon/terraform-suite-ui": "0.6.0",
+    "@sethbacon/terraform-suite-ui": "0.6.1",
     "@tanstack/react-query": "^5.101.2",
     "@tanstack/react-query-devtools": "^5.101.2",
     "@testing-library/dom": "^10.4.1",


### PR DESCRIPTION
## Summary

Manual, reviewed pin bump for `@sethbacon/terraform-suite-ui` (0.6.0 -> 0.6.1), per the exact-pin supply-chain policy documented for this package (load-bearing shared auth/session/shell code -- see SECURITY.md in `terraform-state-manager-frontend` for the shared policy text; this repo enforces the same convention).

Upstream CHANGELOG entry reviewed for this release:

> fix(shell): make SuiteSwitcher reuse one tab per sibling regardless of origin ([sethbacon/terraform-suite-ui#77](https://github.com/sethbacon/terraform-suite-ui/pull/77))

No auth/consent-relevant changes in this release -- the fix is scoped entirely to `SuiteSwitcher`'s tab-open/reuse behavior (no prop/API changes). `package.json` and `package-lock.json` (integrity hash + resolved tarball URL) updated together via `npm install`.

**Note on local test run:** a full local `npm test` run showed 17 failures across 5 unrelated files (Storage/Mirror/SCM Providers/Setup Wizard admin pages -- all `waitFor()` dialog-close timeouts). Re-running just those 5 files in isolation produced a *different* set of 7 failures, confirming this is pre-existing environmental flakiness (not deterministic, not related to this change -- none of the affected pages touch `SuiteSwitcher`) rather than a regression from the bump. Lint, typecheck, and build are all clean.

## Changelog

- chore(deps): bump `@sethbacon/terraform-suite-ui` to 0.6.1 (SuiteSwitcher tab-reuse fix)

## Checklist

- [x] `npm run lint` passes
- [x] `npx tsc --noEmit` (typecheck) passes
- [ ] `npm test` (unit tests) -- clean except pre-existing flaky tests unrelated to this change (see note above); CI is the authoritative check
- [x] `npm run build` succeeds
- [x] PR targets `main`
- [x] Remote branch will be deleted after merge
