### PR TITLE
fix(security): resolve high-severity vulns and CodeQL Python gap

### DIFF
--- a/.github/workflows/weekly-security.yml
+++ b/.github/workflows/weekly-security.yml
@@ -62,11 +62,14 @@ jobs:
             --lockfile=e2e/package-lock.json
 
   # ── CodeQL ────────────────────────────────────────────
-  # Scans both the application source (javascript-typescript) and the repo's
-  # GitHub Actions workflows (actions). The `actions` leg is required to keep the
-  # code-scanning tool-status configuration for this workflow current: a
-  # previously-registered `actions` configuration reports a stale "configuration
-  # error" on the Code scanning status page when no analysis refreshes it.
+  # Scans the application source (javascript-typescript), the repo's GitHub
+  # Actions workflows (actions), and the wiki-sync helper script (python).
+  # The `actions` leg is required to keep the code-scanning tool-status
+  # configuration for this workflow current: a previously-registered `actions`
+  # configuration reports a stale "configuration error" on the Code scanning
+  # status page when no analysis refreshes it. `python` was added to close a
+  # coverage gap flagged on the Code scanning overview page (scripts/sync-wiki.py
+  # was auto-detected as an analyzable language but never actually scanned).
   codeql:
     name: CodeQL (${{ matrix.language }})
     runs-on: ubuntu-latest
@@ -77,7 +80,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [javascript-typescript, actions]
+        language: [javascript-typescript, actions, python]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -361,7 +361,9 @@
       }
     },
     "node_modules/@babel/runtime-corejs3": {
-      "version": "7.29.2",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.29.7.tgz",
+      "integrity": "sha512-ppj9ouYku+RX0ljtgZd+KMO5mkM2bCqg8H2PYAFWnLsHEIKIdRojqbJ2i3eVHrisuxy7nOFCmngTDdWtUCdXUQ==",
       "license": "MIT",
       "dependencies": {
         "core-js-pure": "^3.48.0"
@@ -2386,6 +2388,8 @@
     },
     "node_modules/@scarf/scarf": {
       "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0"
     },
@@ -2531,11 +2535,13 @@
       "license": "MIT"
     },
     "node_modules/@swagger-api/apidom-ast": {
-      "version": "1.11.1",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ast/-/apidom-ast-1.11.3.tgz",
+      "integrity": "sha512-Nfi/0vy+cIHClX7raXamtHnCMBbwI1PEg+yroIzyy8LcCH7zcS0Xi4ARG3CkDQswOnWO2gLDAUAFjDvkQWdZ+A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-error": "^1.11.1",
+        "@swagger-api/apidom-error": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -2543,12 +2549,14 @@
       }
     },
     "node_modules/@swagger-api/apidom-core": {
-      "version": "1.11.1",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-core/-/apidom-core-1.11.3.tgz",
+      "integrity": "sha512-21/PXEqCzsWkiwKWHt0TPJE7GUtog3BhMlvYLUEPbteXOrk+PNazbjYDPl4zfZGRLaoGhTqpFBY5pXafdzaHWQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-ast": "^1.11.1",
-        "@swagger-api/apidom-error": "^1.11.1",
+        "@swagger-api/apidom-ast": "^1.11.3",
+        "@swagger-api/apidom-error": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "minim": "~0.23.8",
         "ramda": "~0.30.0",
@@ -2558,31 +2566,37 @@
       }
     },
     "node_modules/@swagger-api/apidom-error": {
-      "version": "1.11.1",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-error/-/apidom-error-1.11.3.tgz",
+      "integrity": "sha512-Z4mIDyZUF2kDFHBzKsxkYSaHpGSvGDc7gAkdzLKxcQk4849iCUXxs0PpQLxZxfYcmUSwkw7AZmIP/OKGpsR8JA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7"
       }
     },
     "node_modules/@swagger-api/apidom-json-pointer": {
-      "version": "1.11.1",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-json-pointer/-/apidom-json-pointer-1.11.3.tgz",
+      "integrity": "sha512-z6eEvJ5HIb0aFqVldHyU5Guut+bv/opu28i+rrfDb1LEG3IWk5T3DbW9d/nWpAfNze/bjwiZvPphmkuycijb2w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.1",
-        "@swagger-api/apidom-error": "^1.11.1",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-error": "^1.11.3",
         "@swaggerexpert/json-pointer": "^2.10.1"
       }
     },
     "node_modules/@swagger-api/apidom-ns-api-design-systems": {
-      "version": "1.11.1",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-api-design-systems/-/apidom-ns-api-design-systems-1.11.3.tgz",
+      "integrity": "sha512-HTISScqScdnUc2BKqMaWM+ISU79AlHlr+XHUR9g0R8QiO4KzCkWUi6TncP0gvGoEY+BvfR0OkztfxYrelkksmg==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.1",
-        "@swagger-api/apidom-error": "^1.11.1",
-        "@swagger-api/apidom-ns-openapi-3-1": "^1.11.1",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-error": "^1.11.3",
+        "@swagger-api/apidom-ns-openapi-3-1": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -2590,13 +2604,15 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-arazzo-1": {
-      "version": "1.11.1",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-arazzo-1/-/apidom-ns-arazzo-1-1.11.3.tgz",
+      "integrity": "sha512-AHRSbuYy5oA8c/7j7nahxMASjt0cuOWyUk4yu+cKG+KS85ho2f2NiFThqQjtIJLisvrp+qNniJ1EwTfcCTivTQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.1",
-        "@swagger-api/apidom-ns-json-schema-2020-12": "^1.11.1",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-ns-json-schema-2020-12": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -2604,13 +2620,15 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-asyncapi-2": {
-      "version": "1.11.1",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-asyncapi-2/-/apidom-ns-asyncapi-2-1.11.3.tgz",
+      "integrity": "sha512-bn/Pf52SCsSGcw7qO3gAje+KjhhpWJxWjjWQe5Jv9oPoXCnvGoSspSXMY3zIrhz9XfrP94AdWBUpOlWBoaaDBQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.1",
-        "@swagger-api/apidom-ns-json-schema-draft-7": "^1.11.1",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-ns-json-schema-draft-7": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -2618,13 +2636,15 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-asyncapi-3": {
-      "version": "1.11.1",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-asyncapi-3/-/apidom-ns-asyncapi-3-1.11.3.tgz",
+      "integrity": "sha512-QhZtf8YeMRVtgVioJj0qKdNG0LEzi9RPSrC9KWfCdwEBlkhNDhHFh6FIJWayYAwR6DPlOXjTYQf97V9QwIuRmQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.1",
-        "@swagger-api/apidom-ns-asyncapi-2": "^1.11.1",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-ns-asyncapi-2": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -2632,13 +2652,15 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-json-schema-2019-09": {
-      "version": "1.11.1",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-2019-09/-/apidom-ns-json-schema-2019-09-1.11.3.tgz",
+      "integrity": "sha512-zHA4/oin6Fg6VN0bWmMRu1nt4Xnd05mF5T+Od6vEmid1bxDXpfSSMaPpdu+WCBJ5dDX19EeBVTJoAI0U4psxBg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.1",
-        "@swagger-api/apidom-error": "^1.11.1",
-        "@swagger-api/apidom-ns-json-schema-draft-7": "^1.11.1",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-error": "^1.11.3",
+        "@swagger-api/apidom-ns-json-schema-draft-7": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -2646,13 +2668,15 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-json-schema-2020-12": {
-      "version": "1.11.1",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-2020-12/-/apidom-ns-json-schema-2020-12-1.11.3.tgz",
+      "integrity": "sha512-zUWRb5DlvlZXtf2JmiNqUwwgGc4eUAsUQPU59kP140vkPT98HDhNJx9UXoHLgP5F/Zk8f2rzeG237u+JnCT9/g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.1",
-        "@swagger-api/apidom-error": "^1.11.1",
-        "@swagger-api/apidom-ns-json-schema-2019-09": "^1.11.1",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-error": "^1.11.3",
+        "@swagger-api/apidom-ns-json-schema-2019-09": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -2660,12 +2684,14 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-json-schema-draft-4": {
-      "version": "1.11.1",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-4/-/apidom-ns-json-schema-draft-4-1.11.3.tgz",
+      "integrity": "sha512-udOM8ZQT7BzsyT9012R7/VjeazjOlyLwKpmpbgHZDG6uGHqsnWn9lN+F8/5Eox9qqBnQNqDNtDhBEMYjE6RYNQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-ast": "^1.11.1",
-        "@swagger-api/apidom-core": "^1.11.1",
+        "@swagger-api/apidom-ast": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -2673,13 +2699,15 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-json-schema-draft-6": {
-      "version": "1.11.1",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-6/-/apidom-ns-json-schema-draft-6-1.11.3.tgz",
+      "integrity": "sha512-ZOgo5OtpQ6e5XQ5R1H8CYTYXEtnD0l+FyN065A6c2O1NxJXFKS2a5SZTvx+udA4mugtkTSmr7hAQe2ae+KAXQw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.1",
-        "@swagger-api/apidom-error": "^1.11.1",
-        "@swagger-api/apidom-ns-json-schema-draft-4": "^1.11.1",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-error": "^1.11.3",
+        "@swagger-api/apidom-ns-json-schema-draft-4": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -2687,13 +2715,15 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-json-schema-draft-7": {
-      "version": "1.11.1",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-7/-/apidom-ns-json-schema-draft-7-1.11.3.tgz",
+      "integrity": "sha512-L5Sc0qMUrUbgVex3fN+tnNHjed/JCAwpwyzdHY8KgUfXHkfM5aLUyyAGirm+ObwZvGDEejsTT2Otp6B5S29eqw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.1",
-        "@swagger-api/apidom-error": "^1.11.1",
-        "@swagger-api/apidom-ns-json-schema-draft-6": "^1.11.1",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-error": "^1.11.3",
+        "@swagger-api/apidom-ns-json-schema-draft-6": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -2701,14 +2731,16 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-openapi-2": {
-      "version": "1.11.1",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-2/-/apidom-ns-openapi-2-1.11.3.tgz",
+      "integrity": "sha512-T241UD+1My1hVJHayTCz9f7rznmeM8rxQW4NtUnD8k677SShpnNkrfeoc1elrpJXdTsnEPIOLCK0EEIyEplHgA==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.1",
-        "@swagger-api/apidom-error": "^1.11.1",
-        "@swagger-api/apidom-ns-json-schema-draft-4": "^1.11.1",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-error": "^1.11.3",
+        "@swagger-api/apidom-ns-json-schema-draft-4": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -2716,13 +2748,15 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-openapi-3-0": {
-      "version": "1.11.1",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-0/-/apidom-ns-openapi-3-0-1.11.3.tgz",
+      "integrity": "sha512-FZvBqWpZFciemMgWBGY89RIH5uLl6ZYtmMAhWzDcmEi1JSjmWKkoqZno//KlqSgbI09gbkzipdMjGK825givPA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.1",
-        "@swagger-api/apidom-error": "^1.11.1",
-        "@swagger-api/apidom-ns-json-schema-draft-4": "^1.11.1",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-error": "^1.11.3",
+        "@swagger-api/apidom-ns-json-schema-draft-4": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -2730,15 +2764,17 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-openapi-3-1": {
-      "version": "1.11.1",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-1/-/apidom-ns-openapi-3-1-1.11.3.tgz",
+      "integrity": "sha512-ObCP+l3/ZhuPaSqXqmSnCpEOIMalQns0c4IZgX6h3o7Jc6K6BcqDMeq4s17dwcQja9fFUtkoIIFuquJBKvK86Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-ast": "^1.11.1",
-        "@swagger-api/apidom-core": "^1.11.1",
-        "@swagger-api/apidom-json-pointer": "^1.11.1",
-        "@swagger-api/apidom-ns-json-schema-2020-12": "^1.11.1",
-        "@swagger-api/apidom-ns-openapi-3-0": "^1.11.1",
+        "@swagger-api/apidom-ast": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-json-pointer": "^1.11.3",
+        "@swagger-api/apidom-ns-json-schema-2020-12": "^1.11.3",
+        "@swagger-api/apidom-ns-openapi-3-0": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -2746,16 +2782,18 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-openapi-3-2": {
-      "version": "1.11.1",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-2/-/apidom-ns-openapi-3-2-1.11.3.tgz",
+      "integrity": "sha512-Ri7KLrfrpJeteghUdzbozxKve2NG5Z1aPWX91DI14j75+v/xBAu91AIZt7K+LV8JWUNk+VbhUlhgSH1JAIVa0g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-ast": "^1.11.1",
-        "@swagger-api/apidom-core": "^1.11.1",
-        "@swagger-api/apidom-json-pointer": "^1.11.1",
-        "@swagger-api/apidom-ns-json-schema-2020-12": "^1.11.1",
-        "@swagger-api/apidom-ns-openapi-3-0": "^1.11.1",
-        "@swagger-api/apidom-ns-openapi-3-1": "^1.11.1",
+        "@swagger-api/apidom-ast": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-json-pointer": "^1.11.3",
+        "@swagger-api/apidom-ns-json-schema-2020-12": "^1.11.3",
+        "@swagger-api/apidom-ns-openapi-3-0": "^1.11.3",
+        "@swagger-api/apidom-ns-openapi-3-1": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -2763,126 +2801,144 @@
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-api-design-systems-json": {
-      "version": "1.11.1",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-json/-/apidom-parser-adapter-api-design-systems-json-1.11.3.tgz",
+      "integrity": "sha512-6LcwiY2Ce1qmsq8CSxCoRMJ3q2quFnEsNgI48LpM9/PYK/idjsB/WrnU9xSl9fXm/aTo/bOO0ckc8KadxVykfA==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.1",
-        "@swagger-api/apidom-ns-api-design-systems": "^1.11.1",
-        "@swagger-api/apidom-parser-adapter-json": "^1.11.1",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-ns-api-design-systems": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-json": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-api-design-systems-yaml": {
-      "version": "1.11.1",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-yaml/-/apidom-parser-adapter-api-design-systems-yaml-1.11.3.tgz",
+      "integrity": "sha512-zk2NuWAOvjEHYQ3lZ43VhAqJk+9KK452HeFfZFne4a4iALhCQ/wceK7tCG81jBMMoWnR0f1JS/vxz7/Y2CNwLA==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.1",
-        "@swagger-api/apidom-ns-api-design-systems": "^1.11.1",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.1",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-ns-api-design-systems": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-arazzo-json-1": {
-      "version": "1.11.1",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-arazzo-json-1/-/apidom-parser-adapter-arazzo-json-1-1.11.3.tgz",
+      "integrity": "sha512-vXP6lYp6Q5/5nLkMJyBRTWYIZYxL6GnOsJsdnN0KdTHuoPXNZWsv5p2oPYlVE/W7gRAZDylUmYZQ1L9rr7BGRw==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.1",
-        "@swagger-api/apidom-ns-arazzo-1": "^1.11.1",
-        "@swagger-api/apidom-parser-adapter-json": "^1.11.1",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-ns-arazzo-1": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-json": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-arazzo-yaml-1": {
-      "version": "1.11.1",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-arazzo-yaml-1/-/apidom-parser-adapter-arazzo-yaml-1-1.11.3.tgz",
+      "integrity": "sha512-zI57Q5DIf7TGv1A2gIk3umbPWMEFWYO3tEmfP0xJGDBn6gZRHgJvvVjn0wQrljigEEw1V3hRDUXk6Zzg3oVNvA==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.1",
-        "@swagger-api/apidom-ns-arazzo-1": "^1.11.1",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.1",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-ns-arazzo-1": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-json-2": {
-      "version": "1.11.1",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-json-2/-/apidom-parser-adapter-asyncapi-json-2-1.11.3.tgz",
+      "integrity": "sha512-VGl15mpHaL+SlsXaRvcVaWXir+pCLrj99QN//Kuir3cpPW6P9IdBztj11bjoIG3aX1bOIrU16/uOhV4G5J4Kag==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.1",
-        "@swagger-api/apidom-ns-asyncapi-2": "^1.11.1",
-        "@swagger-api/apidom-parser-adapter-json": "^1.11.1",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-ns-asyncapi-2": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-json": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-json-3": {
-      "version": "1.11.1",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-json-3/-/apidom-parser-adapter-asyncapi-json-3-1.11.3.tgz",
+      "integrity": "sha512-37dNwdLAcAd7TZW8YqSbpuBoujfoM2AvXBoT1BUxzbYetwNkxP19Q1VtCEAzMxUEQ/9niBANSzuo0zClUEc2kw==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.1",
-        "@swagger-api/apidom-ns-asyncapi-3": "^1.11.1",
-        "@swagger-api/apidom-parser-adapter-json": "^1.11.1",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-ns-asyncapi-3": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-json": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": {
-      "version": "1.11.1",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2/-/apidom-parser-adapter-asyncapi-yaml-2-1.11.3.tgz",
+      "integrity": "sha512-MEZHn+qROKehrXLhDhl7kSQADXjwU2NGSeNuBTr1/nINShpu4Tkxrk7xT0LY8GauKrZR9MyAnueATDQgK8NWhQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.1",
-        "@swagger-api/apidom-ns-asyncapi-2": "^1.11.1",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.1",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-ns-asyncapi-2": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-yaml-3": {
-      "version": "1.11.1",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-yaml-3/-/apidom-parser-adapter-asyncapi-yaml-3-1.11.3.tgz",
+      "integrity": "sha512-qHOK0NXnG7t5Gx0xCIbyfrM5FXLgK6krlZRPlrlT6K853MWWWWmjAieuayPtu72Ak1hd/8U2/oWgbONnPqj76w==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.1",
-        "@swagger-api/apidom-ns-asyncapi-3": "^1.11.1",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.1",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-ns-asyncapi-3": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-json": {
-      "version": "1.11.1",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-json/-/apidom-parser-adapter-json-1.11.3.tgz",
+      "integrity": "sha512-Wj/DTb6mblsaxKfye9kXLwS+KmWWLAM2M2oSs4muOclhAOtcffr2H+STtiT3Hwrzb+cW8RpX6Htvey4rvbj/Jg==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-ast": "^1.11.1",
-        "@swagger-api/apidom-core": "^1.11.1",
-        "@swagger-api/apidom-error": "^1.11.1",
+        "@swagger-api/apidom-ast": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-error": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -2892,126 +2948,144 @@
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-2": {
-      "version": "1.11.1",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-2/-/apidom-parser-adapter-openapi-json-2-1.11.3.tgz",
+      "integrity": "sha512-aDR5vKSApqQgDkvJNJZqvp8slEWHGByz5bzDbw6ZHRPSIZcA2IEHdJPgWJVS5gNtJ+YAnA7veM39oqeoF2yy8w==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.1",
-        "@swagger-api/apidom-ns-openapi-2": "^1.11.1",
-        "@swagger-api/apidom-parser-adapter-json": "^1.11.1",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-ns-openapi-2": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-json": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-0": {
-      "version": "1.11.1",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-0/-/apidom-parser-adapter-openapi-json-3-0-1.11.3.tgz",
+      "integrity": "sha512-hpSBiaVG7qbyJy25/Pl48NCT9uvvsOPAAj+xCAb9TwmIPBcFkVYvj6ZWJbYZsOmzUzcNLOZEOBjRNPN3G31zmQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.1",
-        "@swagger-api/apidom-ns-openapi-3-0": "^1.11.1",
-        "@swagger-api/apidom-parser-adapter-json": "^1.11.1",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-ns-openapi-3-0": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-json": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-1": {
-      "version": "1.11.1",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-1/-/apidom-parser-adapter-openapi-json-3-1-1.11.3.tgz",
+      "integrity": "sha512-EP7U25s5We8Q/2olymVrJL2nKT+skTea6SnR8F3OETsBoef3i1XgQx7AHqUc9S83hp+bOxZ+oPyI6dNwO+J+MA==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.1",
-        "@swagger-api/apidom-ns-openapi-3-1": "^1.11.1",
-        "@swagger-api/apidom-parser-adapter-json": "^1.11.1",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-ns-openapi-3-1": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-json": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-2": {
-      "version": "1.11.1",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-2/-/apidom-parser-adapter-openapi-json-3-2-1.11.3.tgz",
+      "integrity": "sha512-WLuMb0pwH+5hjosRHGvUFLm9iWP0/XNnEdrwdUio4y0eodjDwrPGb2LSdH3zaR8p7mKrqe007jqpjaLLsStzrQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.1",
-        "@swagger-api/apidom-ns-openapi-3-2": "^1.11.1",
-        "@swagger-api/apidom-parser-adapter-json": "^1.11.1",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-ns-openapi-3-2": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-json": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-2": {
-      "version": "1.11.1",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-2/-/apidom-parser-adapter-openapi-yaml-2-1.11.3.tgz",
+      "integrity": "sha512-PyD0E4fwOhOCcP/Aqa9HlvZYuw825E6N0IRC69dxxt6Fy6w6Fv2KYRnRw8OINoog8I6/8uSZOLdeDla3FCqhFA==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.1",
-        "@swagger-api/apidom-ns-openapi-2": "^1.11.1",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.1",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-ns-openapi-2": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": {
-      "version": "1.11.1",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0/-/apidom-parser-adapter-openapi-yaml-3-0-1.11.3.tgz",
+      "integrity": "sha512-7ULkLaEAAVKRNWT525PdKOaUjrZ7G2ulH9VBsMJ9niaZN/n6hnSW8IR4Iaf0cLZ1MjsZsdWovq5slPz2hpqR4A==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.1",
-        "@swagger-api/apidom-ns-openapi-3-0": "^1.11.1",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.1",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-ns-openapi-3-0": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": {
-      "version": "1.11.1",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1/-/apidom-parser-adapter-openapi-yaml-3-1-1.11.3.tgz",
+      "integrity": "sha512-2VqxGS0PaNrYeLgGyOl9m4m6EbJjrtxOswzWK2Rk3/M3gEDfnFdyOVffKWlcdEv6XFJ+wgLy5MPlODrzyOOKCA==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.1",
-        "@swagger-api/apidom-ns-openapi-3-1": "^1.11.1",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.1",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-ns-openapi-3-1": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-2": {
-      "version": "1.11.1",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-2/-/apidom-parser-adapter-openapi-yaml-3-2-1.11.3.tgz",
+      "integrity": "sha512-fRJYMozAyIJP46kKbUPQX2wIzfX9FSC7ZxUn+VWOa587f3zZC3XmydGO46GA/TGuc8cWs7AFD/EfSKWDbsB3Tg==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.1",
-        "@swagger-api/apidom-ns-openapi-3-2": "^1.11.1",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.1",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-ns-openapi-3-2": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-yaml-1-2": {
-      "version": "1.11.1",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-yaml-1-2/-/apidom-parser-adapter-yaml-1-2-1.11.3.tgz",
+      "integrity": "sha512-mSPMfVzDkLC+HPDI/6ho8TxI1PEcDJl/Y53gZdmfCU1xYzUdOF4s0iHalHHt0ipxYpt0EQXD+oGBnpp/TTx4IQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-ast": "^1.11.1",
-        "@swagger-api/apidom-core": "^1.11.1",
-        "@swagger-api/apidom-error": "^1.11.1",
+        "@swagger-api/apidom-ast": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-error": "^1.11.3",
         "@tree-sitter-grammars/tree-sitter-yaml": "=0.7.1",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
@@ -3020,26 +3094,10 @@
         "web-tree-sitter": "=0.24.5"
       }
     },
-    "node_modules/@swagger-api/apidom-parser-adapter-yaml-1-2/node_modules/@tree-sitter-grammars/tree-sitter-yaml": {
-      "version": "0.7.1",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "node-addon-api": "^8.3.1",
-        "node-gyp-build": "^4.8.4"
-      },
-      "peerDependencies": {
-        "tree-sitter": "^0.22.4"
-      },
-      "peerDependenciesMeta": {
-        "tree-sitter": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@swagger-api/apidom-parser-adapter-yaml-1-2/node_modules/tree-sitter": {
       "version": "0.22.4",
+      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.22.4.tgz",
+      "integrity": "sha512-usbHZP9/oxNsUY65MQUsduGRqDHQOou1cagUSwjhoSYAmSahjQDAVsh9s+SlZkn8X8+O1FULRGwHu7AFP3kjzg==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -3049,12 +3107,14 @@
       }
     },
     "node_modules/@swagger-api/apidom-reference": {
-      "version": "1.11.1",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-reference/-/apidom-reference-1.11.3.tgz",
+      "integrity": "sha512-Y0J+pAru/Est0wQJlFeQq2AsWyboOJP456Zv2wV4m0Ib1QY6N2wWiL6clkHpHA0pughemN6gcjBeNlMeRGqXuw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.1",
-        "@swagger-api/apidom-error": "^1.11.1",
+        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-error": "^1.11.3",
         "@types/ramda": "~0.30.0",
         "axios": "^1.16.0",
         "minimatch": "^10.2.1",
@@ -3062,35 +3122,37 @@
         "ramda-adjunct": "^5.0.0"
       },
       "optionalDependencies": {
-        "@swagger-api/apidom-json-pointer": "^1.11.1",
-        "@swagger-api/apidom-ns-arazzo-1": "^1.11.1",
-        "@swagger-api/apidom-ns-asyncapi-2": "^1.11.1",
-        "@swagger-api/apidom-ns-openapi-2": "^1.11.1",
-        "@swagger-api/apidom-ns-openapi-3-0": "^1.11.1",
-        "@swagger-api/apidom-ns-openapi-3-1": "^1.11.1",
-        "@swagger-api/apidom-ns-openapi-3-2": "^1.11.1",
-        "@swagger-api/apidom-parser-adapter-api-design-systems-json": "^1.11.1",
-        "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "^1.11.1",
-        "@swagger-api/apidom-parser-adapter-arazzo-json-1": "^1.11.1",
-        "@swagger-api/apidom-parser-adapter-arazzo-yaml-1": "^1.11.1",
-        "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "^1.11.1",
-        "@swagger-api/apidom-parser-adapter-asyncapi-json-3": "^1.11.1",
-        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "^1.11.1",
-        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-3": "^1.11.1",
-        "@swagger-api/apidom-parser-adapter-json": "^1.11.1",
-        "@swagger-api/apidom-parser-adapter-openapi-json-2": "^1.11.1",
-        "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "^1.11.1",
-        "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "^1.11.1",
-        "@swagger-api/apidom-parser-adapter-openapi-json-3-2": "^1.11.1",
-        "@swagger-api/apidom-parser-adapter-openapi-yaml-2": "^1.11.1",
-        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "^1.11.1",
-        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "^1.11.1",
-        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-2": "^1.11.1",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.1"
+        "@swagger-api/apidom-json-pointer": "^1.11.3",
+        "@swagger-api/apidom-ns-arazzo-1": "^1.11.3",
+        "@swagger-api/apidom-ns-asyncapi-2": "^1.11.3",
+        "@swagger-api/apidom-ns-openapi-2": "^1.11.3",
+        "@swagger-api/apidom-ns-openapi-3-0": "^1.11.3",
+        "@swagger-api/apidom-ns-openapi-3-1": "^1.11.3",
+        "@swagger-api/apidom-ns-openapi-3-2": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-api-design-systems-json": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-arazzo-json-1": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-arazzo-yaml-1": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-asyncapi-json-3": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-3": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-json": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-openapi-json-2": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-openapi-json-3-2": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-2": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-2": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.3"
       }
     },
     "node_modules/@swaggerexpert/cookie": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@swaggerexpert/cookie/-/cookie-2.0.2.tgz",
+      "integrity": "sha512-DPI8YJ0Vznk4CT+ekn3rcFNq1uQwvUHZhH6WvTSPD0YKBIlMS9ur2RYKghXuxxOiqOam/i4lHJH4xTIiTgs3Mg==",
       "license": "Apache-2.0",
       "dependencies": {
         "apg-lite": "^1.0.3"
@@ -3101,6 +3163,8 @@
     },
     "node_modules/@swaggerexpert/json-pointer": {
       "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@swaggerexpert/json-pointer/-/json-pointer-2.10.2.tgz",
+      "integrity": "sha512-qMx1nOrzoB+PF+pzb26Q4Tc2sOlrx9Ba2UBNX9hB31Omrq+QoZ2Gly0KLrQWw4Of1AQ4J9lnD+XOdwOdcdXqqw==",
       "license": "Apache-2.0",
       "dependencies": {
         "apg-lite": "^1.0.4"
@@ -3241,6 +3305,26 @@
         "@testing-library/dom": ">=7.21.4"
       }
     },
+    "node_modules/@tree-sitter-grammars/tree-sitter-yaml": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@tree-sitter-grammars/tree-sitter-yaml/-/tree-sitter-yaml-0.7.1.tgz",
+      "integrity": "sha512-AynBwkIoQCTgjDR33bDUp9Mqq+YTco0is3n5hRApMqG9of/6A4eQsfC1/uSEeHSUyMQSYawcAWamsexnVpIP4Q==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^8.3.1",
+        "node-gyp-build": "^4.8.4"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.22.4"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
@@ -3351,6 +3435,8 @@
     },
     "node_modules/@types/ramda": {
       "version": "0.30.2",
+      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.30.2.tgz",
+      "integrity": "sha512-PyzHvjCalm2BRYjAU6nIB3TprYwMNOUY/7P/N8bSzp9W/yM2YrtGtAnnVtaCNSeOZ8DzKyFDvaqQs7LnWwwmBA==",
       "license": "MIT",
       "dependencies": {
         "types-ramda": "^0.30.1"
@@ -3910,10 +3996,14 @@
     },
     "node_modules/apg-lite": {
       "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/apg-lite/-/apg-lite-1.0.5.tgz",
+      "integrity": "sha512-SlI+nLMQDzCZfS39ihzjGp3JNBQfJXyMi6cg9tkLOCPVErgFsUIAEdO9IezR7kbP5Xd0ozcPNQBkf9TO5cHgWw==",
       "license": "BSD-2-Clause"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
     },
     "node_modules/aria-hidden": {
@@ -4184,7 +4274,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -4484,6 +4576,8 @@
     },
     "node_modules/core-js-pure": {
       "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.49.0.tgz",
+      "integrity": "sha512-XM4RFka59xATyJv/cS3O3Kml72hQXUeGRuuTmMYFxwzc9/7C8OYTaIR/Ji+Yt8DXzsFLNhat15cE/JP15HrCgw==",
       "hasInstallScript": true,
       "license": "MIT",
       "funding": {
@@ -4663,6 +4757,8 @@
     },
     "node_modules/deepmerge": {
       "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5160,7 +5256,9 @@
       }
     },
     "node_modules/eslint-plugin-jsx-a11y/node_modules/brace-expansion": {
-      "version": "1.1.14",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5365,6 +5463,8 @@
     },
     "node_modules/fast-json-patch": {
       "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.1.1.tgz",
+      "integrity": "sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ==",
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -6581,9 +6681,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "funding": [
         {
           "type": "github",
@@ -7036,6 +7136,8 @@
     },
     "node_modules/lodash": {
       "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.debounce": {
@@ -7928,6 +8030,8 @@
     },
     "node_modules/minim": {
       "version": "0.23.8",
+      "resolved": "https://registry.npmjs.org/minim/-/minim-0.23.8.tgz",
+      "integrity": "sha512-bjdr2xW1dBCMsMGGsUeqM4eFI60m94+szhxWys+B1ztIt6gWSfeGBdSVCIawezeHYLYn0j6zrsXdQS/JllBzww==",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.15.0"
@@ -7979,6 +8083,8 @@
     },
     "node_modules/neotraverse": {
       "version": "0.6.18",
+      "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-0.6.18.tgz",
+      "integrity": "sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==",
       "license": "MIT",
       "engines": {
         "node": ">= 10"
@@ -7986,10 +8092,14 @@
     },
     "node_modules/node-abort-controller": {
       "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
+      "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==",
       "license": "MIT"
     },
     "node_modules/node-addon-api": {
-      "version": "8.8.0",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.0.tgz",
+      "integrity": "sha512-ekZMeaaIzSQTSpr7X2X3iJM7lTzgnx8ahAG9pJfT/7+14mlEM8ZYQ9cgCDvSSRbReFK0oHli3WrZdCiRsgAT9Q==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -7998,6 +8108,8 @@
     },
     "node_modules/node-gyp-build": {
       "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
       "license": "MIT",
       "optional": true,
       "bin": {
@@ -8127,6 +8239,8 @@
     },
     "node_modules/openapi-path-templating": {
       "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/openapi-path-templating/-/openapi-path-templating-2.2.1.tgz",
+      "integrity": "sha512-eN14VrDvl/YyGxxrkGOHkVkWEoPyhyeydOUrbvjoz8K5eIGgELASwN1eqFOJ2CTQMGCy2EntOK1KdtJ8ZMekcg==",
       "license": "Apache-2.0",
       "dependencies": {
         "apg-lite": "^1.0.4"
@@ -8137,6 +8251,8 @@
     },
     "node_modules/openapi-server-url-templating": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/openapi-server-url-templating/-/openapi-server-url-templating-1.3.0.tgz",
+      "integrity": "sha512-DPlCms3KKEbjVQb0spV6Awfn6UWNheuG/+folQPzh/wUaKwuqvj8zt5gagD7qoyxtE03cIiKPgLFS3Q8Bz00uQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "apg-lite": "^1.0.4"
@@ -8480,6 +8596,8 @@
     },
     "node_modules/ramda": {
       "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.30.1.tgz",
+      "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -8488,6 +8606,8 @@
     },
     "node_modules/ramda-adjunct": {
       "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-5.1.0.tgz",
+      "integrity": "sha512-8qCpl2vZBXEJyNbi4zqcgdfHtcdsWjOGbiNSEnEBrM6Y0OKOT8UxJbIVGm1TIcjaSu2MxaWcgtsNlKlCk7o7qg==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.3"
@@ -9294,6 +9414,8 @@
     },
     "node_modules/short-unique-id": {
       "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/short-unique-id/-/short-unique-id-5.3.2.tgz",
+      "integrity": "sha512-KRT/hufMSxXKEDSQujfVE0Faa/kZ51ihUcZQAcmP04t00DvPj7Ox5anHke1sJYUtzSuiT/Y5uyzg/W7bBEGhCg==",
       "license": "Apache-2.0",
       "bin": {
         "short-unique-id": "bin/short-unique-id",
@@ -9617,7 +9739,9 @@
       }
     },
     "node_modules/swagger-client": {
-      "version": "3.37.4",
+      "version": "3.37.7",
+      "resolved": "https://registry.npmjs.org/swagger-client/-/swagger-client-3.37.7.tgz",
+      "integrity": "sha512-AzmF/FDSPYBcoxXarHPnqK3lSXoKH9Fh0EjLHAlP0h/D7EG1Fofl/wEuGqhYT+IBpriu3mSgWCh2xAftsYdL8w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.22.15",
@@ -9631,7 +9755,7 @@
         "@swaggerexpert/cookie": "^2.0.2",
         "deepmerge": "~4.3.0",
         "fast-json-patch": "^3.0.0-1",
-        "js-yaml": "^4.1.0",
+        "js-yaml": "^4.2.0",
         "neotraverse": "=0.6.18",
         "node-abort-controller": "^3.1.1",
         "openapi-path-templating": "^2.2.1",
@@ -9641,12 +9765,35 @@
       },
       "engines": {
         "node": ">=22"
+      },
+      "optionalDependencies": {
+        "@swagger-api/apidom-ns-asyncapi-2": "^1.11.3",
+        "@swagger-api/apidom-ns-asyncapi-3": "^1.11.3",
+        "@swagger-api/apidom-ns-openapi-2": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-api-design-systems-json": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-arazzo-json-1": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-arazzo-yaml-1": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-asyncapi-json-3": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-3": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-json": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-openapi-json-2": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-openapi-json-3-2": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-2": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-2": "^1.11.3",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.3"
       }
     },
     "node_modules/swagger-ui-react": {
-      "version": "5.32.9",
-      "resolved": "https://registry.npmjs.org/swagger-ui-react/-/swagger-ui-react-5.32.9.tgz",
-      "integrity": "sha512-zs6PG4G6XEWG2evKHSwx32nWXIlk48a9Hw9YS9hlt55O5W0FM1cpltMrM/AnU+mohdnV7oEx0ap2TaG3fbfLIA==",
+      "version": "5.32.10",
+      "resolved": "https://registry.npmjs.org/swagger-ui-react/-/swagger-ui-react-5.32.10.tgz",
+      "integrity": "sha512-MKzbDXXT4P7KFItdNGvhrUkGUfXKW4vYCyNJntuIHdQbDjoxZHFd7gcZsT5GRyjmYS+K/yuhsSGvWapJev+efw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.27.1",
@@ -9660,7 +9807,7 @@
         "ieee754": "^1.2.1",
         "immutable": "^3.x.x",
         "js-file-download": "^0.4.12",
-        "js-yaml": "=4.2.0",
+        "js-yaml": "=4.3.0",
         "lodash": "^4.18.1",
         "prop-types": "^15.8.1",
         "randexp": "^0.5.3",
@@ -9678,7 +9825,7 @@
         "reselect": "^5.1.1",
         "serialize-error": "^8.1.0",
         "sha.js": "^2.4.12",
-        "swagger-client": "^3.37.4",
+        "swagger-client": "^3.37.7",
         "url-parse": "^1.5.10",
         "xml": "=1.0.1",
         "xml-but-prettier": "^1.0.1",
@@ -9808,6 +9955,8 @@
     },
     "node_modules/tree-sitter": {
       "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.21.1.tgz",
+      "integrity": "sha512-7dxoA6kYvtgWw80265MyqJlkRl4yawIjO7S5MigytjELkX43fV2WsAXzsNfO7sBpPPCF5Gp0+XzHk0DwLCq3xQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -9818,6 +9967,8 @@
     },
     "node_modules/tree-sitter-json": {
       "version": "0.24.8",
+      "resolved": "https://registry.npmjs.org/tree-sitter-json/-/tree-sitter-json-0.24.8.tgz",
+      "integrity": "sha512-Tc9ZZYwHyWZ3Tt1VEw7Pa2scu1YO7/d2BCBbKTx5hXwig3UfdQjsOPkPyLpDJOn/m1UBEWYAtSdGAwCSyagBqQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -9863,10 +10014,14 @@
     },
     "node_modules/ts-mixer": {
       "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
+      "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==",
       "license": "MIT"
     },
     "node_modules/ts-toolbelt": {
       "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz",
+      "integrity": "sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==",
       "license": "Apache-2.0"
     },
     "node_modules/tslib": {
@@ -9984,6 +10139,8 @@
     },
     "node_modules/types-ramda": {
       "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/types-ramda/-/types-ramda-0.30.1.tgz",
+      "integrity": "sha512-1HTsf5/QVRmLzcGfldPFvkVsAdi1db1BBKzi7iW3KBUlOICg/nKnFS+jGqDJS3YD8VsWbAh7JiHeBvbsw8RPxA==",
       "license": "MIT",
       "dependencies": {
         "ts-toolbelt": "^9.6.0"
@@ -10114,6 +10271,8 @@
     },
     "node_modules/unraw": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unraw/-/unraw-3.0.0.tgz",
+      "integrity": "sha512-08/DA66UF65OlpUDIQtbJyrqTR0jTAlJ+jsnkQ4jxR7+K5g5YG1APZKQSMCE1vqqmD+2pv6+IdEjmopFatacvg==",
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
@@ -10423,6 +10582,8 @@
     },
     "node_modules/web-tree-sitter": {
       "version": "0.24.5",
+      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.24.5.tgz",
+      "integrity": "sha512-+J/2VSHN8J47gQUAvF8KDadrfz6uFYVjxoxbKWDoXVsH2u7yLdarCnIURnrMA6uSRkgX3SdmqM5BOoQjPdSh5w==",
       "license": "MIT",
       "optional": true
     },


### PR DESCRIPTION
Relates to #580 (partially addresses it - see note below)

## Summary
Resolves the 3 open Dependabot vulnerability alerts and closes a CodeQL language-coverage gap flagged on the Code scanning overview page.

**Vulnerabilities (all via `npm audit fix`, no `--force`, no `package.json` changes):**
| Package | Before | After | Advisory |
|---|---|---|---|
| brace-expansion | <5.0.7 | 5.0.7 | GHSA-3jxr-9vmj-r5cp (2 alerts, different paths) |
| js-yaml | 4.0.0-4.2.0 | 4.3.0 | GHSA-52cp-r559-cp3m |

js-yaml is a transitive dep of `swagger-ui-react`, which had already published a patch (5.32.9 -> 5.32.10) pulling in the fixed js-yaml. Existing `^5.32.9` range in package.json already covers it, so only package-lock.json changed. `npm audit` now reports 0 vulnerabilities in both frontend/ and e2e/.

**CodeQL:** added `python` to the weekly-security.yml codeql job matrix. `scripts/sync-wiki.py` was auto-detected as an analyzable language (confirmed via the code-scanning default-setup API) but excluded from the matrix, so it was never actually scanned.

Note: this does NOT address the E2E/Playwright job failure that also triggered issue #580 - that is a separate, not-yet-investigated failure and needs its own fix before #580 can be closed.

## Changelog
- fix: resolve 3 high-severity npm vulnerabilities (brace-expansion, js-yaml via swagger-ui-react) and add python to CodeQL scan matrix

## Checklist

- [x] `npm run lint` passes
- [x] `npx tsc --noEmit` (typecheck) passes
- [x] `npm test` (unit tests) passes (15/1767 pre-existing timing-flaky failures, same files/pattern as prior flakiness investigation this session - unrelated to this change)
- [x] `npm run build` succeeds
- [x] PR targets `main`
- [x] Remote branch will be deleted after merge