### PR TITLE
fix(e2e): replace Dashboard spinner-check dance with settled-content wait

### DIFF
--- a/e2e/tests/admin.spec.ts
+++ b/e2e/tests/admin.spec.ts
@@ -262,16 +262,14 @@ test.describe('Admin: Dashboard', () => {
   test('dashboard page loads with stat cards', async ({ loggedInPage: page }) => {
     await page.goto('/admin');
 
-    // Wait for loading to finish
-    await page.waitForSelector(
-      '[class*="MuiPaper"], [class*="MuiCard"], [class*="MuiCircularProgress"]',
-      { timeout: 10_000 }
-    );
-
-    const loadingSpinner = page.locator('[class*="MuiCircularProgress"]').first();
-    if (await loadingSpinner.isVisible()) {
-      await expect(loadingSpinner).toBeHidden({ timeout: 15_000 });
-    }
+    // Wait directly for settled content -- either stat-card/health-pill Paper
+    // elements (success) or the error Alert -- instead of a spinner-check
+    // dance, which races a fast backend (MuiPaper/MuiContainer can appear
+    // while the stats call is still in-flight; see dcf87d6/7c1646c for the
+    // same fix applied to the API Keys/Storage E2E tests).
+    const paper = page.locator('[class*="MuiPaper"]');
+    const alert = page.locator('[class*="MuiAlert"]');
+    await expect(paper.or(alert).first()).toBeVisible({ timeout: 15_000 });
 
     // Stat cards or content should be present
     const content = await page.locator('main, [class*="MuiContainer"]').first().textContent();
@@ -282,31 +280,18 @@ test.describe('Admin: Dashboard', () => {
   test('dashboard page shows at least one stat card', async ({ loggedInPage: page }) => {
     await page.goto('/admin');
 
-    // Wait for loading to finish
-    const loadingSpinner = page.locator('[class*="MuiCircularProgress"]').first();
-    if (await loadingSpinner.isVisible()) {
-      await expect(loadingSpinner).toBeHidden({ timeout: 15_000 });
-    }
-
-    await page.waitForSelector('[class*="MuiPaper"], [class*="MuiCard"]', { timeout: 10_000 });
-
     const cards = page.locator('[class*="MuiPaper"], [class*="MuiCard"]');
+    await expect(cards.first()).toBeVisible({ timeout: 15_000 });
+
     expect(await cards.count()).toBeGreaterThan(0);
   });
 
   test('dashboard quick action buttons are present', async ({ loggedInPage: page }) => {
     await page.goto('/admin');
 
-    const loadingSpinner = page.locator('[class*="MuiCircularProgress"]').first();
-    if (await loadingSpinner.isVisible()) {
-      await expect(loadingSpinner).toBeHidden({ timeout: 15_000 });
-    }
-
-    await page.waitForSelector('[class*="MuiButton"], [class*="MuiIconButton"]', {
-      timeout: 10_000,
-    });
-
     const actionBtns = page.locator('[class*="MuiButton"]');
+    await expect(actionBtns.first()).toBeVisible({ timeout: 15_000 });
+
     expect(await actionBtns.count()).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
Closes #<!-- no direct issue; fixes the E2E failure behind sethbacon/terraform-registry-frontend#580 -->

## Summary
The 3 `Admin: Dashboard` E2E tests used the same "spinner-check dance" pattern already identified and fixed for Storage/API Keys in this file (`dcf87d6`, `6177d4a`, `7c1646c`): `waitForSelector` on a generic Paper/Card/CircularProgress selector list, then a one-shot `loadingSpinner.isVisible()` check before reading page content.

On a fast backend response, `MuiCircularProgress` can be removed and replaced by real content in the gap between the initial `waitForSelector` resolving and the one-shot `isVisible()` check running -- so the spinner is never observed as visible (skipping the wait-for-hidden step) while the new content `Paper` hasn't committed yet, producing a brief window where the page's content is genuinely empty.

This is the actual root cause of #580 in this repo: `dashboard page loads with stat cards` failed on webkit with `content.length === 0` in both the original attempt and the retry (run [29729765119](https://github.com/sethbacon/terraform-registry-frontend/actions/runs/29729765119)).

**Fix:** use the same `.or()` / `toBeVisible()` auto-retrying pattern already proven for Storage/API Keys -- wait directly for a settled end state (stat-card `Paper` or the error `Alert`) instead of racing a one-shot spinner check. Applied to all 3 Dashboard tests since they shared the identical anti-pattern (only one had actually been observed failing, but `maxFailures: 1` meant the suite bailed before the other two even ran on webkit that day).

Also relates to sethbacon/terraform-registry-backend#642, which fixes a real backend bug (GDPR export querying a nonexistent `created_by` column) surfaced by recurring Postgres errors in the same failing run's logs -- unrelated to this specific test failure, but from the same investigation.

## Changelog
- fix: replace flaky spinner-check-dance wait with settled-content wait in Dashboard E2E tests

## Checklist

- [x] `npm run lint` passes (unaffected -- e2e/ isn't linted by CI, but `get_errors` reports no issues)
- [x] `npx tsc --noEmit` (typecheck) passes (`get_errors` clean; no standalone tsc in e2e/ package)
- [ ] `npm test` (unit tests) -- N/A, this PR only touches e2e/, not frontend/
- [ ] `npm run build` -- N/A, this PR only touches e2e/, not frontend/
- [x] PR targets `main`
- [x] Remote branch will be deleted after merge

**Note:** I was not able to run the actual Playwright webkit test locally in this session (would require a full docker-compose stack + webkit browser install). The fix applies an established, already-shipped pattern from this exact file rather than a novel guess -- recommend watching the `E2E (gated/manual)` check on this PR (or the next scheduled run) to confirm.
