### PR TITLE
feat(modules): add organization picker to module publish flow

### DIFF
--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -1777,6 +1777,8 @@
       "formUploadTitle": "Terraform-Modul hochladen",
       "formScmTitle": "Modul mit dem SCM-Repository verknüpfen",
       "scmSubtitle": "Legen Sie zunächst die Modulidentität fest. Anschließend wählen Sie ein Repository aus und nehmen die Veröffentlichungseinstellungen vor.",
+      "labelOrganization": "Organisation",
+      "helpOrganization": "Die Organisation, die diesen Namespace besitzen wird. Erforderlich, wenn Sie mehreren Organisationen angehören.",
       "labelNamespace": "Namensraum",
       "helpNamespace": "Ihre Organisationskennung",
       "labelModuleName": "Modulname",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -1779,6 +1779,8 @@
       "formUploadTitle": "Upload Terraform Module",
       "formScmTitle": "Link Module to SCM Repository",
       "scmSubtitle": "First, define the module identity. Then you'll choose a repository and configure publishing settings.",
+      "labelOrganization": "Organization",
+      "helpOrganization": "The organization that will own this namespace. Required when you belong to more than one organization.",
       "labelNamespace": "Namespace",
       "helpNamespace": "Your organization identifier",
       "labelModuleName": "Module Name",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -1777,6 +1777,8 @@
       "formUploadTitle": "Subir un módulo de Terraform",
       "formScmTitle": "Conectar el módulo al repositorio SCM",
       "scmSubtitle": "En primer lugar, define la identidad del módulo. A continuación, elige un repositorio y configura los ajustes de publicación.",
+      "labelOrganization": "Organización",
+      "helpOrganization": "La organización que será propietaria de este namespace. Requerido cuando perteneces a más de una organización.",
       "labelNamespace": "Espacio de nombres",
       "helpNamespace": "El identificador de su organización",
       "labelModuleName": "Nombre del módulo",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -1777,6 +1777,8 @@
       "formUploadTitle": "Télécharger un module Terraform",
       "formScmTitle": "Lier le module au référentiel SCM",
       "scmSubtitle": "Commencez par définir l'identité du module. Vous devrez ensuite choisir un référentiel et configurer les paramètres de publication.",
+      "labelOrganization": "Organisation",
+      "helpOrganization": "L'organisation qui possédera ce namespace. Requis lorsque vous appartenez à plusieurs organisations.",
       "labelNamespace": "Espace de noms",
       "helpNamespace": "L'identifiant de votre organisation",
       "labelModuleName": "Nom du module",

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -1777,6 +1777,8 @@
       "formUploadTitle": "Carica il modulo Terraform",
       "formScmTitle": "Collegare il modulo al repository SCM",
       "scmSubtitle": "Per prima cosa, definisci l'identità del modulo. Successivamente, sceglierai un repository e configurerai le impostazioni di pubblicazione.",
+      "labelOrganization": "Organizzazione",
+      "helpOrganization": "L'organizzazione che possiederà questo namespace. Richiesto quando appartieni a più di un'organizzazione.",
       "labelNamespace": "Spazio dei nomi",
       "helpNamespace": "Il codice identificativo della tua organizzazione",
       "labelModuleName": "Nome del modulo",

--- a/frontend/src/locales/ja/translation.json
+++ b/frontend/src/locales/ja/translation.json
@@ -1777,6 +1777,8 @@
       "formUploadTitle": "Terraformモジュールをアップロードする",
       "formScmTitle": "モジュールをSCMリポジトリにリンクする",
       "scmSubtitle": "まず、モジュールの識別子を定義します。次に、リポジトリを選択し、公開設定を行います。",
+      "labelOrganization": "組織",
+      "helpOrganization": "この名前空間を所有する組織。複数の組織に所属している場合は必須です。",
       "labelNamespace": "名前空間",
       "helpNamespace": "組織識別子",
       "labelModuleName": "モジュール名",

--- a/frontend/src/locales/nb/translation.json
+++ b/frontend/src/locales/nb/translation.json
@@ -1777,6 +1777,8 @@
       "formUploadTitle": "Last opp Terraform-modul",
       "formScmTitle": "Koble modulen til SCM-lageret",
       "scmSubtitle": "Først må du definere modulidentiteten. Deretter velger du et arkiv og konfigurerer publiseringsinnstillingene.",
+      "labelOrganization": "Organisasjon",
+      "helpOrganization": "Organisasjonen som vil eie dette navneområdet. Obligatorisk når du tilhører mer enn én organisasjon.",
       "labelNamespace": "Navneområde",
       "helpNamespace": "Organisasjonsidentifikatoren din",
       "labelModuleName": "Modulnavn",

--- a/frontend/src/locales/nl/translation.json
+++ b/frontend/src/locales/nl/translation.json
@@ -1777,6 +1777,8 @@
       "formUploadTitle": "Terraform-module uploaden",
       "formScmTitle": "Module koppelen aan SCM-repository",
       "scmSubtitle": "Bepaal eerst de module-identiteit. Vervolgens kies je een repository en stel je de publicatie-instellingen in.",
+      "labelOrganization": "Organisatie",
+      "helpOrganization": "De organisatie die eigenaar wordt van deze namespace. Verplicht wanneer u tot meer dan één organisatie behoort.",
       "labelNamespace": "Naamruimte",
       "helpNamespace": "Uw organisatie-ID",
       "labelModuleName": "Naam van de module",

--- a/frontend/src/locales/pt/translation.json
+++ b/frontend/src/locales/pt/translation.json
@@ -1777,6 +1777,8 @@
       "formUploadTitle": "Carregar módulo Terraform",
       "formScmTitle": "Ligar o módulo ao repositório SCM",
       "scmSubtitle": "Primeiro, defina a identidade do módulo. Em seguida, escolha um repositório e configure as definições de publicação.",
+      "labelOrganization": "Organização",
+      "helpOrganization": "A organização que será proprietária deste namespace. Obrigatório quando você pertence a mais de uma organização.",
       "labelNamespace": "Espaço de nomes",
       "helpNamespace": "O identificador da sua organização",
       "labelModuleName": "Nome do módulo",

--- a/frontend/src/locales/zh/translation.json
+++ b/frontend/src/locales/zh/translation.json
@@ -1777,6 +1777,8 @@
       "formUploadTitle": "上传 Terraform 模块",
       "formScmTitle": "将模块链接到 SCM 存储库",
       "scmSubtitle": "首先，定义模块标识。然后，您需要选择一个仓库并配置发布设置。",
+      "labelOrganization": "组织",
+      "helpOrganization": "将拥有此命名空间的组织。当您属于多个组织时必填。",
       "labelNamespace": "命名空间",
       "helpNamespace": "您的组织标识符",
       "labelModuleName": "模块名称",

--- a/frontend/src/pages/admin/ModuleUploadPage.tsx
+++ b/frontend/src/pages/admin/ModuleUploadPage.tsx
@@ -1,6 +1,7 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useLocation, useNavigate } from 'react-router-dom'
+import { useQuery } from '@tanstack/react-query'
 import {
   Typography,
   Box,
@@ -14,6 +15,11 @@ import {
   CardActionArea,
   CardContent,
   LinearProgress,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  FormHelperText,
 } from '@mui/material'
 import CloudUpload from '@mui/icons-material/CloudUpload'
 import SCMIcon from '@mui/icons-material/AccountTree'
@@ -27,7 +33,9 @@ import PageTitleIcon from '@mui/icons-material/ViewModule'
 import PublishFromSCMWizard from '../../components/PublishFromSCMWizard'
 import FileDropZone from '../../components/FileDropZone'
 import PolicyResultsPanel from '../../components/PolicyResultsPanel'
-import { PolicyResult } from '../../types'
+import { PolicyResult, UserMembership } from '../../types'
+import { useAuth } from '../../contexts/AuthContext'
+import { queryKeys } from '../../services/queryKeys'
 
 type ModuleMethod = 'choose' | 'upload' | 'scm'
 
@@ -35,6 +43,7 @@ const ModuleUploadPage: React.FC = () => {
   const { t } = useTranslation()
   const location = useLocation()
   const navigate = useNavigate()
+  const { user } = useAuth()
   const state = location.state as {
     moduleData?: { namespace: string; name: string; provider: string }
     method?: ModuleMethod
@@ -42,6 +51,24 @@ const ModuleUploadPage: React.FC = () => {
   const prefilledModule = state?.moduleData
 
   const [moduleMethod, setModuleMethod] = useState<ModuleMethod>(state?.method ?? 'choose')
+  const [selectedOrgId, setSelectedOrgId] = useState<string | undefined>(undefined)
+
+  // Memberships query
+  const { data: memberships = [] } = useQuery<UserMembership[]>({
+    queryKey: queryKeys.users.memberships(user?.id ?? ''),
+    queryFn: async () => {
+      const data = await api.getCurrentUserMemberships()
+      return data || []
+    },
+    enabled: !!user?.id,
+  })
+
+  // Set default org when memberships load
+  useEffect(() => {
+    if (memberships.length > 0 && !selectedOrgId) {
+      setSelectedOrgId(memberships[0].organization_id)
+    }
+  }, [memberships]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // SCM new-module metadata (before wizard)
   const [scmNamespace, setScmNamespace] = useState(prefilledModule?.namespace || '')
@@ -100,6 +127,7 @@ const ModuleUploadPage: React.FC = () => {
       formData.append('system', moduleProvider)
       formData.append('version', moduleVersion)
       if (moduleDescription) formData.append('description', moduleDescription)
+      if (selectedOrgId) formData.append('organization_id', selectedOrgId)
       formData.append('file', moduleFile)
 
       const result = await api.uploadModule(formData, {
@@ -147,6 +175,7 @@ const ModuleUploadPage: React.FC = () => {
         name: scmName,
         system: scmSystem,
         description: scmDescription || undefined,
+        organization_id: selectedOrgId,
       })
       setScmModuleId(module.id)
     } catch (err: unknown) {
@@ -259,6 +288,26 @@ const ModuleUploadPage: React.FC = () => {
             {t('admin.moduleUpload.scmSubtitle')}
           </Typography>
           <Stack spacing={3} sx={{ maxWidth: 500 }}>
+            {memberships.length > 1 && (
+              <FormControl fullWidth>
+                <InputLabel id="scm-org-label">
+                  {t('admin.moduleUpload.labelOrganization')}
+                </InputLabel>
+                <Select
+                  labelId="scm-org-label"
+                  value={selectedOrgId || ''}
+                  onChange={(e) => setSelectedOrgId(e.target.value)}
+                  label={t('admin.moduleUpload.labelOrganization')}
+                >
+                  {memberships.map((membership) => (
+                    <MenuItem key={membership.organization_id} value={membership.organization_id}>
+                      {membership.organization_name}
+                    </MenuItem>
+                  ))}
+                </Select>
+                <FormHelperText>{t('admin.moduleUpload.helpOrganization')}</FormHelperText>
+              </FormControl>
+            )}
             <TextField
               label={t('admin.moduleUpload.labelNamespace')}
               value={scmNamespace}
@@ -385,6 +434,26 @@ const ModuleUploadPage: React.FC = () => {
       </Box>
 
       <Stack spacing={3}>
+        {memberships.length > 1 && (
+          <FormControl fullWidth disabled={uploading}>
+            <InputLabel id="upload-org-label">
+              {t('admin.moduleUpload.labelOrganization')}
+            </InputLabel>
+            <Select
+              labelId="upload-org-label"
+              value={selectedOrgId || ''}
+              onChange={(e) => setSelectedOrgId(e.target.value)}
+              label={t('admin.moduleUpload.labelOrganization')}
+            >
+              {memberships.map((membership) => (
+                <MenuItem key={membership.organization_id} value={membership.organization_id}>
+                  {membership.organization_name}
+                </MenuItem>
+              ))}
+            </Select>
+            <FormHelperText>{t('admin.moduleUpload.helpOrganization')}</FormHelperText>
+          </FormControl>
+        )}
         <Stack
           direction={{ xs: 'column', md: 'row' }}
           spacing={2}

--- a/frontend/src/pages/admin/__tests__/ModuleUploadPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/ModuleUploadPage.test.tsx
@@ -17,6 +17,7 @@ vi.mock('../../../services/api', () => ({
   default: {
     uploadModule: vi.fn(),
     createModuleRecord: vi.fn(),
+    getCurrentUserMemberships: vi.fn(),
   },
 }))
 
@@ -24,18 +25,30 @@ vi.mock('../../../components/PublishFromSCMWizard', () => ({
   default: () => <div data-testid="scm-wizard">SCM Wizard</div>,
 }))
 
+vi.mock('../../../contexts/AuthContext', () => ({
+  useAuth: () => ({ user: { id: 'test-user-id', username: 'testuser' } }),
+}))
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import ModuleUploadPage from '../../admin/ModuleUploadPage'
 import apiDefault from '../../../services/api'
 const api = apiDefault as unknown as {
   uploadModule: ReturnType<typeof vi.fn>
   createModuleRecord: ReturnType<typeof vi.fn>
+  getCurrentUserMemberships: ReturnType<typeof vi.fn>
 }
+
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } },
+})
 
 function renderPage() {
   return render(
-    <MemoryRouter>
-      <ModuleUploadPage />
-    </MemoryRouter>,
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <ModuleUploadPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
   )
 }
 
@@ -47,6 +60,8 @@ async function openUploadForm(user: ReturnType<typeof userEvent.setup>) {
 describe('ModuleUploadPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    queryClient.clear()
+    api.getCurrentUserMemberships.mockResolvedValue([])
   })
 
   it('renders the page heading', () => {
@@ -121,6 +136,8 @@ describe('ModuleUploadPage', () => {
 describe('ModuleUploadPage — upload form (roadmap 2.5)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    queryClient.clear()
+    api.getCurrentUserMemberships.mockResolvedValue([])
   })
 
   it('renders identity fields in namespace/name/provider order', async () => {
@@ -214,5 +231,113 @@ describe('ModuleUploadPage — upload form (roadmap 2.5)', () => {
     expect(byLabel(/^Provider/).value).toBe('aws')
     expect(byLabel(/Version/).value).toBe('1.0.0')
     expect(inputs.length).toBeGreaterThan(0)
+  })
+})
+
+describe('ModuleUploadPage — organization picker', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    queryClient.clear()
+  })
+
+  it('renders org picker when user has multiple memberships (SCM flow)', async () => {
+    api.getCurrentUserMemberships.mockResolvedValue([
+      { organization_id: 'org1', organization_name: 'Org One', created_at: '2024-01-01' },
+      { organization_id: 'org2', organization_name: 'Org Two', created_at: '2024-01-02' },
+    ])
+
+    const user = userEvent.setup()
+    renderPage()
+    await user.click(screen.getByText('Link from SCM Repository'))
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/Organization/i)).toBeInTheDocument()
+    })
+
+    // Default to first org - check displayed text
+    await waitFor(() => {
+      expect(screen.getByText('Org One')).toBeInTheDocument()
+    })
+
+    // Can select a different org
+    const orgSelect = screen.getByLabelText(/Organization/i)
+    await user.click(orgSelect)
+    const org2Option = await screen.findByRole('option', { name: 'Org Two' })
+    await user.click(org2Option)
+
+    await waitFor(() => {
+      expect(screen.getByText('Org Two')).toBeInTheDocument()
+    })
+  })
+
+  it('does not render org picker when user has single membership (SCM flow)', async () => {
+    api.getCurrentUserMemberships.mockResolvedValue([
+      { organization_id: 'org1', organization_name: 'Org One', created_at: '2024-01-01' },
+    ])
+
+    const user = userEvent.setup()
+    renderPage()
+    await user.click(screen.getByText('Link from SCM Repository'))
+
+    await waitFor(() => {
+      expect(screen.queryByLabelText(/Organization/i)).not.toBeInTheDocument()
+    })
+  })
+
+  it('includes organization_id in createModuleRecord when org is selected', async () => {
+    api.getCurrentUserMemberships.mockResolvedValue([
+      { organization_id: 'org1', organization_name: 'Org One', created_at: '2024-01-01' },
+      { organization_id: 'org2', organization_name: 'Org Two', created_at: '2024-01-02' },
+    ])
+    api.createModuleRecord.mockResolvedValue({
+      id: 'mod123',
+      namespace: 'ns',
+      name: 'vpc',
+      system: 'aws',
+    })
+
+    const user = userEvent.setup()
+    renderPage()
+    await user.click(screen.getByText('Link from SCM Repository'))
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/Organization/i)).toBeInTheDocument()
+    })
+
+    const byLabel = (t: RegExp) => screen.getByLabelText(t) as HTMLInputElement
+    await user.type(byLabel(/Namespace/), 'myns')
+    await user.type(byLabel(/Module Name/), 'vpc')
+    await user.type(byLabel(/^Provider/), 'aws')
+
+    const orgSelect = screen.getByLabelText(/Organization/i) as HTMLSelectElement
+    await user.click(orgSelect)
+    const org2Option = await screen.findByRole('option', { name: 'Org Two' })
+    await user.click(org2Option)
+
+    await user.click(screen.getByRole('button', { name: /Continue to Repository Selection/i }))
+
+    await waitFor(() => {
+      expect(api.createModuleRecord).toHaveBeenCalledWith({
+        namespace: 'myns',
+        name: 'vpc',
+        system: 'aws',
+        organization_id: 'org2',
+      })
+    })
+  })
+
+  it('renders org picker in upload flow when user has multiple memberships', async () => {
+    api.getCurrentUserMemberships.mockResolvedValue([
+      { organization_id: 'org1', organization_name: 'Org One', created_at: '2024-01-01' },
+      { organization_id: 'org2', organization_name: 'Org Two', created_at: '2024-01-02' },
+    ])
+
+    const user = userEvent.setup()
+    renderPage()
+    await user.click(screen.getByText('Upload from File'))
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/Organization/i)).toBeInTheDocument()
+    })
   })
 })

--- a/frontend/src/services/__tests__/api.test.ts
+++ b/frontend/src/services/__tests__/api.test.ts
@@ -860,11 +860,13 @@ describe('ApiClient', () => {
         namespace: 'ns',
         name: 'mod',
         system: 'aws',
+        organization_id: 'org123',
       })
       expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/admin/modules/create', {
         namespace: 'ns',
         name: 'mod',
         system: 'aws',
+        organization_id: 'org123',
       })
       expect(result.id).toBe('m1')
     })

--- a/frontend/src/services/api/modulesApi.ts
+++ b/frontend/src/services/api/modulesApi.ts
@@ -74,6 +74,7 @@ export async function createModuleRecord(data: {
   name: string
   system: string
   description?: string
+  organization_id?: string
 }): Promise<{ id: string; namespace: string; name: string; system: string }> {
   const response = await http.post('/api/v1/admin/modules/create', data)
   return response.data
@@ -92,11 +93,11 @@ export async function uploadModule(
     },
     onUploadProgress: options?.onUploadProgress
       ? (event) => {
-          if (event.total && event.total > 0) {
-            const percent = Math.round((event.loaded / event.total) * 100)
-            options.onUploadProgress?.(percent)
-          }
+        if (event.total && event.total > 0) {
+          const percent = Math.round((event.loaded / event.total) * 100)
+          options.onUploadProgress?.(percent)
         }
+      }
       : undefined,
   })
   return response.data


### PR DESCRIPTION
## Summary

Adds an organization picker to the module publish UI so a user who belongs to **multiple** organizations can choose which organization owns the namespace when creating or uploading a module. Single-org users see no change.

## Changes

- **`ModuleUploadPage.tsx`** — a memberships-driven organization `Select` (via `getCurrentUserMemberships()`) rendered in both the SCM-link and file-upload flows, shown only when the user has more than one membership, defaulting to the first. The selected org is passed to `createModuleRecord` (SCM flow) and appended to the multipart `FormData` (upload flow).
- **`modulesApi.ts`** — `createModuleRecord` accepts an optional `organization_id`.
- **i18n** — `admin.moduleUpload.labelOrganization` / `helpOrganization` added to all 10 locales.
- Tests for picker rendering (multi- vs single-org) and `organization_id` propagation.

## Why

Pairs with terraform-registry-backend #645, which derives namespace ownership from the authenticated publisher and now requires a multi-org caller to specify the target organization on first publish into a new namespace (instead of silently defaulting to the operator org). This gives those users a way to choose in the UI.

## Verification

- `npm run build` (tsc + vite) — passes
- `npm test` (affected files) — 237/237 pass
