### PR TITLE
chore: bump terraform-suite-ui to 0.7.0

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,7 +19,7 @@
         "@mui/icons-material": "^9.2.0",
         "@mui/material": "^9.2.0",
         "@mui/material-pigment-css": "^9.2.0",
-        "@sethbacon/terraform-suite-ui": "0.6.1",
+        "@sethbacon/terraform-suite-ui": "0.7.0",
         "@tanstack/react-query": "^5.101.2",
         "@tanstack/react-query-devtools": "^5.101.2",
         "@testing-library/dom": "^10.4.1",
@@ -2508,12 +2508,12 @@
       }
     },
     "node_modules/@sethbacon/terraform-suite-ui": {
-      "version": "0.6.1",
-      "resolved": "https://npm.pkg.github.com/download/@sethbacon/terraform-suite-ui/0.6.1/668b7cfad38f786e633ed7e969d3a6aa9b3328ed",
-      "integrity": "sha512-H8M8QT5NjrVGINM6DOWwDINYrlEGEqjtAZplvP9uHvAd8U1V6f4nNFP2ySRWQtocBZMajmxsFMn2n2210rpVvQ==",
+      "version": "0.7.0",
+      "resolved": "https://npm.pkg.github.com/download/@sethbacon/terraform-suite-ui/0.7.0/fd8a9701e480ee4e509fa80b777974728ae7da75",
+      "integrity": "sha512-tLSskv/KmTKwXZmfKb1zRZG7BjAFlT+xGaJFgRypG3xBNuCjBdx+2Hno588XRD+tuNbkWARbIUya99f0UubHLQ==",
       "license": "Apache-2.0",
       "engines": {
-        "node": ">=24.0.0 <25"
+        "node": ">=22.0.0 <25"
       },
       "peerDependencies": {
         "@emotion/react": "^11.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,7 +31,7 @@
     "@mui/icons-material": "^9.2.0",
     "@mui/material": "^9.2.0",
     "@mui/material-pigment-css": "^9.2.0",
-    "@sethbacon/terraform-suite-ui": "0.6.1",
+    "@sethbacon/terraform-suite-ui": "0.7.0",
     "@tanstack/react-query": "^5.101.2",
     "@tanstack/react-query-devtools": "^5.101.2",
     "@testing-library/dom": "^10.4.1",


### PR DESCRIPTION
Bumps `@sethbacon/terraform-suite-ui` 0.6.1 → [0.7.0](https://github.com/sethbacon/terraform-suite-ui/releases/tag/v0.7.0).

The release's breaking change (`authError: unknown` → `string | null`) does not affect this app — it never reads `authError`. `scope: null` nav literals remain valid with the now-optional `NavItem.scope`. Also picks up the supply-chain-hardened, minified dist.

Local suite: 1770/1771 passed; the one failure (TerraformMirrorPage error-state) passes in isolation — a local Windows parallel-run flake unrelated to this bump. CI is authoritative.