### PR TITLE
fix(security): URL encoding, safe-URL validation and error-telemetry wiring in the API layer

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -58,8 +58,9 @@ server {
     }
 
     # Proxy API requests to backend (plain HTTP — backend has no TLS)
-    # Mirror sync operations can take several minutes to download provider binaries.
-    location ~* ^/api/v1/admin/mirrors/[^/]+/sync$ {
+    # Mirror sync operations (provider and Terraform binary) can take several
+    # minutes to download; both sync endpoints need the same carve-out (#599).
+    location ~* ^/api/v1/admin/(mirrors|terraform-mirrors)/[^/]+/sync$ {
         proxy_pass http://backend:8080;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;

--- a/frontend/scripts/contract-check.allowlist.json
+++ b/frontend/scripts/contract-check.allowlist.json
@@ -20,6 +20,11 @@
       "method": "POST",
       "path": "/api/v1/dev/impersonate/{}",
       "reason": "Backend route is registered conditionally under DEV_MODE=true and is intentionally undocumented in production swagger. Permanent allowlist entry."
+    },
+    {
+      "method": "GET",
+      "path": "/api/v1/ui/config",
+      "reason": "Backend handler uiConfigHandler (terraform-registry-backend/backend/internal/api/suite.go) has no swag annotations and the route is absent from backend/docs/swagger.json -- unlike the sibling /api/v1/ui/theme route, which is documented. Tracked in #600; remove this entry once the backend adds @Router/@Summary annotations for uiConfigHandler and regenerates swagger.json."
     }
   ]
 }

--- a/frontend/src/components/DevUserSwitcher.tsx
+++ b/frontend/src/components/DevUserSwitcher.tsx
@@ -14,6 +14,7 @@ import {
 import SyncAlt from '@mui/icons-material/SyncAlt'
 import { useAuth } from '../contexts/AuthContext'
 import apiClient from '../services/api'
+import { captureError } from '../services/errorReporting'
 
 interface DevUser {
   id: string
@@ -64,6 +65,12 @@ const DevUserSwitcher = () => {
       window.location.reload()
     } catch (error) {
       console.error('Failed to impersonate user:', error)
+      // This catch has no getErrorMessage() call to piggyback telemetry on, so
+      // report it directly -- otherwise a real impersonation failure is only
+      // visible in the console, never in the error-reporting pipeline (#623).
+      captureError(error instanceof Error ? error : new Error(String(error)), {
+        context: 'Failed to impersonate user',
+      })
     } finally {
       setSwitching(false)
     }

--- a/frontend/src/components/PublishFromSCMWizard.tsx
+++ b/frontend/src/components/PublishFromSCMWizard.tsx
@@ -25,6 +25,7 @@ import {
 } from '@mui/material'
 import api from '../services/api'
 import { getErrorMessage } from '../utils/errors'
+import { captureError } from '../services/errorReporting'
 import RepositoryBrowser from './RepositoryBrowser'
 import type { SCMProvider, SCMRepository, SCMTag } from '../types/scm'
 
@@ -78,6 +79,11 @@ const PublishFromSCMWizard: React.FC<PublishFromSCMWizardProps> = ({
     } catch (err: unknown) {
       setError(t('scmWizard.loadProvidersError'))
       console.error('Error loading providers:', err)
+      // setError() here uses a plain i18n string, not getErrorMessage(), so it
+      // doesn't get telemetry reporting for free -- report explicitly (#623).
+      captureError(err instanceof Error ? err : new Error(String(err)), {
+        context: 'Error loading providers',
+      })
     } finally {
       setLoading(false)
     }

--- a/frontend/src/components/SuiteSwitcher.test.tsx
+++ b/frontend/src/components/SuiteSwitcher.test.tsx
@@ -1,11 +1,18 @@
 import { afterEach, expect, it, vi } from 'vitest'
 import { fireEvent, render, screen } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { AxiosResponse } from 'axios'
+import { http } from '../services/api/http'
 import { SuiteSwitcher } from './SuiteSwitcher'
 
 function withQuery(ui: React.ReactNode) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return <QueryClientProvider client={qc}>{ui}</QueryClientProvider>
+}
+
+// Minimal AxiosResponse stub — useSuite only reads `.data`.
+function axiosResponse<T>(data: T): AxiosResponse<T> {
+  return { data } as AxiosResponse<T>
 }
 
 afterEach(() => {
@@ -14,25 +21,20 @@ afterEach(() => {
 })
 
 it('renders nothing when no sibling', async () => {
-  vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-    new Response(JSON.stringify({ sibling: null }), { status: 200 }),
-  )
+  vi.spyOn(http, 'get').mockResolvedValue(axiosResponse({ sibling: null }))
   render(withQuery(<SuiteSwitcher />))
   expect(screen.queryByRole('button')).toBeNull()
 })
 
 it('renders a link when a sibling is active', async () => {
-  vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-    new Response(
-      JSON.stringify({
-        sibling: {
-          app: 'terraform-state-manager',
-          state: 'active',
-          publicUrl: 'https://tfstate.example.com',
-        },
-      }),
-      { status: 200 },
-    ),
+  vi.spyOn(http, 'get').mockResolvedValue(
+    axiosResponse({
+      sibling: {
+        app: 'terraform-state-manager',
+        state: 'active',
+        publicUrl: 'https://tfstate.example.com',
+      },
+    }),
   )
   render(withQuery(<SuiteSwitcher />))
   expect(
@@ -41,17 +43,14 @@ it('renders a link when a sibling is active', async () => {
 })
 
 it('warns the sibling opens in a new tab until a shared store is confirmed', async () => {
-  vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-    new Response(
-      JSON.stringify({
-        sibling: {
-          app: 'terraform-state-manager',
-          state: 'active',
-          publicUrl: 'https://tfstate.example.com',
-        },
-      }),
-      { status: 200 },
-    ),
+  vi.spyOn(http, 'get').mockResolvedValue(
+    axiosResponse({
+      sibling: {
+        app: 'terraform-state-manager',
+        state: 'active',
+        publicUrl: 'https://tfstate.example.com',
+      },
+    }),
   )
   render(withQuery(<SuiteSwitcher />))
   // No sharedStore flag → set expectations that a separate sign-in may be needed.
@@ -61,18 +60,15 @@ it('warns the sibling opens in a new tab until a shared store is confirmed', asy
 })
 
 it('drops the sign-in hint when the sibling reports a shared store', async () => {
-  vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-    new Response(
-      JSON.stringify({
-        sibling: {
-          app: 'terraform-state-manager',
-          state: 'active',
-          publicUrl: 'https://tfstate.example.com',
-          sharedStore: true,
-        },
-      }),
-      { status: 200 },
-    ),
+  vi.spyOn(http, 'get').mockResolvedValue(
+    axiosResponse({
+      sibling: {
+        app: 'terraform-state-manager',
+        state: 'active',
+        publicUrl: 'https://tfstate.example.com',
+        sharedStore: true,
+      },
+    }),
   )
   render(withQuery(<SuiteSwitcher />))
   expect(
@@ -86,17 +82,14 @@ it('reuses one sibling tab via a stable window name instead of opening a new one
   // sibling resolves to this app's own origin (SuiteSwitcher's isSameOrigin gate) —
   // cross-origin siblings always open via '_blank' + noopener,noreferrer instead.
   const siblingUrl = `${window.location.origin}/state-manager`
-  vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-    new Response(
-      JSON.stringify({
-        sibling: {
-          app: 'terraform-state-manager',
-          state: 'active',
-          publicUrl: siblingUrl,
-        },
-      }),
-      { status: 200 },
-    ),
+  vi.spyOn(http, 'get').mockResolvedValue(
+    axiosResponse({
+      sibling: {
+        app: 'terraform-state-manager',
+        state: 'active',
+        publicUrl: siblingUrl,
+      },
+    }),
   )
   const focus = vi.fn()
   const openSpy = vi.spyOn(window, 'open').mockReturnValue({ focus } as unknown as Window)
@@ -112,17 +105,14 @@ it('reuses one sibling tab via a stable window name instead of opening a new one
 
 it('claims this tab under its own app id so the sibling reuses the original tab', async () => {
   // Same-origin sibling URL — see the previous test for why this matters.
-  vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-    new Response(
-      JSON.stringify({
-        sibling: {
-          app: 'terraform-state-manager',
-          state: 'active',
-          publicUrl: `${window.location.origin}/state-manager`,
-        },
-      }),
-      { status: 200 },
-    ),
+  vi.spyOn(http, 'get').mockResolvedValue(
+    axiosResponse({
+      sibling: {
+        app: 'terraform-state-manager',
+        state: 'active',
+        publicUrl: `${window.location.origin}/state-manager`,
+      },
+    }),
   )
   vi.spyOn(window, 'open').mockReturnValue({ focus: vi.fn() } as unknown as Window)
   render(withQuery(<SuiteSwitcher />))
@@ -133,25 +123,24 @@ it('claims this tab under its own app id so the sibling reuses the original tab'
 })
 
 it('renders nothing when sibling is degraded', async () => {
-  vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-    new Response(
-      JSON.stringify({
-        sibling: {
-          app: 'terraform-registry',
-          state: 'degraded',
-          publicUrl: 'https://registry.example.com',
-        },
-      }),
-      { status: 200 },
-    ),
+  vi.spyOn(http, 'get').mockResolvedValue(
+    axiosResponse({
+      sibling: {
+        app: 'terraform-registry',
+        state: 'degraded',
+        publicUrl: 'https://registry.example.com',
+      },
+    }),
   )
   render(withQuery(<SuiteSwitcher />))
   await new Promise((r) => setTimeout(r, 50))
   expect(screen.queryByRole('button')).toBeNull()
 })
 
-it('renders nothing when fetch fails', async () => {
-  vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('', { status: 500 }))
+it('renders nothing when the config request fails', async () => {
+  // With the shared http client, a non-2xx/3xx response (validateStatus in
+  // http.ts) rejects rather than resolving with an !ok Response.
+  vi.spyOn(http, 'get').mockRejectedValue(new Error('Request failed with status code 500'))
   render(withQuery(<SuiteSwitcher />))
   await new Promise((r) => setTimeout(r, 50))
   expect(screen.queryByRole('button')).toBeNull()

--- a/frontend/src/components/__tests__/DevUserSwitcher.test.tsx
+++ b/frontend/src/components/__tests__/DevUserSwitcher.test.tsx
@@ -27,7 +27,12 @@ vi.mock('../../contexts/AuthContext', () => ({
   useAuth: () => mockAuth,
 }))
 
+vi.mock('../../services/errorReporting', () => ({
+  captureError: vi.fn(),
+}))
+
 import DevUserSwitcher from '../DevUserSwitcher'
+import { captureError } from '../../services/errorReporting'
 
 describe('DevUserSwitcher', () => {
   beforeEach(() => {
@@ -134,5 +139,32 @@ describe('DevUserSwitcher', () => {
       expect(screen.getByText(/DEV/)).toBeInTheDocument()
     })
     expect(screen.getByText('Select user')).toBeInTheDocument()
+  })
+
+  // Regression guard (#623): a failed impersonation only logged via console.error
+  // before this fix -- it must also reach the app's telemetry pipeline.
+  it('reports a failed impersonation to telemetry', async () => {
+    const impersonateError = new Error('impersonation failed')
+    getDevStatusMock.mockResolvedValue({ dev_mode: true })
+    listUsersForImpersonationMock.mockResolvedValue({
+      users: [
+        { id: 'u1', email: 'admin@example.com', name: 'Admin', primary_role: 'admin' },
+        { id: 'u2', email: 'user@example.com', name: 'Regular User', primary_role: 'viewer' },
+      ],
+    })
+    impersonateUserMock.mockRejectedValue(impersonateError)
+
+    render(<DevUserSwitcher />)
+    await waitFor(() => expect(screen.getByText(/DEV/)).toBeInTheDocument())
+
+    fireEvent.mouseDown(screen.getByRole('combobox'))
+    const listbox = await screen.findByRole('listbox')
+    fireEvent.click(within(listbox).getByText('Regular User'))
+
+    await waitFor(() =>
+      expect(captureError).toHaveBeenCalledWith(impersonateError, {
+        context: 'Failed to impersonate user',
+      }),
+    )
   })
 })

--- a/frontend/src/components/__tests__/PublishFromSCMWizard.test.tsx
+++ b/frontend/src/components/__tests__/PublishFromSCMWizard.test.tsx
@@ -5,6 +5,9 @@ import api from '../../services/api'
 import type { SCMProvider, SCMRepository, SCMTag } from '../../types/scm'
 
 vi.mock('../../services/api')
+vi.mock('../../services/errorReporting', () => ({
+  captureError: vi.fn(),
+}))
 vi.mock('../RepositoryBrowser', () => ({
   default: ({
     onRepositorySelect,
@@ -102,6 +105,7 @@ function renderWizard(
 }
 
 import PublishFromSCMWizard from '../PublishFromSCMWizard'
+import { captureError } from '../../services/errorReporting'
 
 describe('PublishFromSCMWizard', () => {
   // ── Step 0: Select Provider ──────────────────────────────────
@@ -132,6 +136,19 @@ describe('PublishFromSCMWizard', () => {
     renderWizard()
     await waitFor(() =>
       expect(screen.getByText('Failed to load SCM providers')).toBeInTheDocument(),
+    )
+  })
+
+  // Regression guard (#623): a failed provider load only logged via console.error
+  // before this fix -- it must also reach the app's telemetry pipeline.
+  it('reports a failed provider load to telemetry', async () => {
+    const loadError = new Error('net')
+    ;(api.listSCMProviders as Mock).mockRejectedValue(loadError)
+    renderWizard()
+    await waitFor(() =>
+      expect(captureError).toHaveBeenCalledWith(loadError, {
+        context: 'Error loading providers',
+      }),
     )
   })
 

--- a/frontend/src/hooks/__tests__/useModuleDetail.test.ts
+++ b/frontend/src/hooks/__tests__/useModuleDetail.test.ts
@@ -43,6 +43,18 @@ vi.mock('../../config', () => ({
   REGISTRY_HOST: 'registry.example.com',
 }))
 
+const mockUseSuite = vi.hoisted(() =>
+  vi.fn(
+    (): {
+      sibling: { app: string; state: string; publicUrl: string } | null
+      active: boolean
+    } => ({ sibling: null, active: false }),
+  ),
+)
+vi.mock('../useSuite', () => ({
+  useSuite: mockUseSuite,
+}))
+
 import { useModuleDetail } from '../useModuleDetail'
 import { useParams } from 'react-router-dom'
 import { useAuth } from '../../contexts/AuthContext'
@@ -89,6 +101,7 @@ describe('useModuleDetail', () => {
       allowedScopes: ['admin'],
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any)
+    mockUseSuite.mockReturnValue({ sibling: null, active: false })
     mockApi.getModule.mockResolvedValue(moduleData)
     mockApi.getModuleVersions.mockResolvedValue(versionsData)
     mockApi.getModuleSCMInfo.mockRejectedValue(new Error('404'))
@@ -592,5 +605,31 @@ describe('useModuleDetail', () => {
     await waitFor(() => expect(result.current.loading).toBe(false))
 
     expect(result.current.getTerraformExample()).toBe('')
+  })
+
+  // Regression guards (#559): suiteSiblingUrl comes from the backend
+  // /api/v1/ui/config and flows into ConsumedByPanel's window.open() navigation
+  // sink -- it must be validated at this app boundary before ConsumedByPanel
+  // ever sees it, instead of trusting the backend value verbatim.
+  it('passes through a safe suite sibling URL', async () => {
+    mockUseSuite.mockReturnValue({
+      sibling: { app: 'terraform-state-manager', state: 'active', publicUrl: 'https://tsm.example.com' },
+      active: true,
+    })
+    const { result } = renderHook(() => useModuleDetail(), { wrapper: createWrapper() })
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    expect(result.current.suiteSiblingUrl).toBe('https://tsm.example.com')
+  })
+
+  it('drops an unsafe suite sibling URL instead of handing it to the navigation sink', async () => {
+    mockUseSuite.mockReturnValue({
+      sibling: { app: 'terraform-state-manager', state: 'active', publicUrl: '//evil.com' },
+      active: true,
+    })
+    const { result } = renderHook(() => useModuleDetail(), { wrapper: createWrapper() })
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    expect(result.current.suiteSiblingUrl).toBeUndefined()
   })
 })

--- a/frontend/src/hooks/__tests__/useSuite.test.tsx
+++ b/frontend/src/hooks/__tests__/useSuite.test.tsx
@@ -1,0 +1,52 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import type { AxiosResponse } from 'axios'
+import { http } from '../../services/api/http'
+import { useSuite } from '../useSuite'
+
+function axiosResponse<T>(data: T): AxiosResponse<T> {
+  return { data } as AxiosResponse<T>
+}
+
+function withQuery() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  )
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('useSuite', () => {
+  // Regression guard (#600): fetchUIConfig must go through the shared http
+  // client -- not a hardcoded relative fetch() -- so it inherits API_BASE_URL
+  // resolution in the split-origin deployment mode, CSRF/401 handling, and
+  // scripts/contract-check.ts coverage like every other backend call.
+  it('resolves the sibling config via the shared http client, not a bare fetch()', async () => {
+    const getSpy = vi
+      .spyOn(http, 'get')
+      .mockResolvedValue(axiosResponse({ sibling: { app: 'terraform-state-manager', state: 'active', publicUrl: 'https://tsm.example.com' } }))
+    const fetchSpy = vi.spyOn(globalThis, 'fetch')
+
+    const { result } = renderHook(() => useSuite(), { wrapper: withQuery() })
+
+    await waitFor(() => expect(result.current.active).toBe(true))
+
+    expect(getSpy).toHaveBeenCalledWith('/api/v1/ui/config')
+    // A raw, hardcoded-relative fetch() would bypass API_BASE_URL resolution in
+    // the split-origin deployment mode -- assert it is never used for this call.
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('degrades to no sibling when the request fails', async () => {
+    vi.spyOn(http, 'get').mockRejectedValue(new Error('network error'))
+
+    const { result } = renderHook(() => useSuite(), { wrapper: withQuery() })
+
+    await waitFor(() => expect(result.current.sibling).toBeNull())
+    expect(result.current.active).toBe(false)
+  })
+})

--- a/frontend/src/hooks/useModuleDetail.ts
+++ b/frontend/src/hooks/useModuleDetail.ts
@@ -10,6 +10,7 @@ import { useSuite } from './useSuite'
 import { REGISTRY_HOST } from '../config'
 import { getErrorMessage, getErrorStatus } from '../utils/errors'
 import { queryKeys } from '../services/queryKeys'
+import { isSafeExternalUrl } from '../utils/externalUrl'
 
 // ---------------------------------------------------------------------------
 // Semver sort helper (shared by query & version selection)
@@ -644,7 +645,10 @@ export function useModuleDetail() {
     // Suite "Consumed by"
     moduleConsumers,
     suiteActive,
-    suiteSiblingUrl: suiteSibling?.publicUrl,
+    // Defense-in-depth: sibling.publicUrl comes from the backend /api/v1/ui/config;
+    // validate it at the app boundary before ConsumedByPanel hands it to its
+    // window.open() navigation sink (#559).
+    suiteSiblingUrl: isSafeExternalUrl(suiteSibling?.publicUrl) ? suiteSibling?.publicUrl : undefined,
     // Security scan
     moduleScan,
     scanLoading,

--- a/frontend/src/hooks/useSuite.ts
+++ b/frontend/src/hooks/useSuite.ts
@@ -1,28 +1,23 @@
 import { useQuery } from '@tanstack/react-query'
+import api from '../services/api'
+import type { SuiteSibling } from '../services/api'
 
-export interface SuiteSibling {
-  app: string
-  state: 'active' | 'degraded' | 'unreachable' | 'unknown'
-  publicUrl?: string
-  links?: Record<string, string>
-  // Identity provenance from the sibling's manifest. issuer identifies which app
-  // minted its tokens; sharedStore is true only when an operator has confirmed
-  // both apps use one identity store + IdP (single sign-on). Absent/false ⇒ the
-  // switcher warns that opening the sibling may require a separate sign-in.
-  issuer?: string
-  sharedStore?: boolean
-}
+export type { SuiteSibling }
 
 async function fetchUIConfig(): Promise<{ sibling: SuiteSibling | null }> {
   // Swallow any network/parse failure (endpoint absent pre-Phase-0, sibling
   // unreachable, or no backend in tests) and degrade to "no sibling". This keeps
   // the switcher inert instead of surfacing an unhandled rejection — notably,
-  // every test that renders <Layout> mounts useSuite, and an un-stubbed fetch
+  // every test that renders <Layout> mounts useSuite, and an un-stubbed request
   // would otherwise throw ECONNREFUSED.
+  //
+  // api.getUIConfig() (services/api/suiteApi.ts) routes through the shared http
+  // client (not a bare fetch()) so this call inherits API_BASE_URL resolution
+  // for the split-origin deployment mode, CSRF/401 handling, and
+  // scripts/contract-check.ts coverage like every other backend call in the
+  // app (#600).
   try {
-    const res = await fetch('/api/v1/ui/config', { credentials: 'include' })
-    if (!res.ok) return { sibling: null }
-    return await res.json()
+    return await api.getUIConfig()
   } catch {
     return { sibling: null }
   }

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -1504,6 +1504,7 @@
       "errUpdate": "Failed to update provider",
       "errDelete": "Failed to delete provider",
       "errOAuth": "Failed to initiate OAuth",
+      "errOAuthInvalidUrl": "The OAuth provider returned an invalid authorization URL",
       "errSaveToken": "Failed to save access token",
       "errDisconnect": "Failed to disconnect",
       "labelClientId": "Client ID",

--- a/frontend/src/pages/ProviderDetailPage.tsx
+++ b/frontend/src/pages/ProviderDetailPage.tsx
@@ -42,6 +42,7 @@ import Add from '@mui/icons-material/Add'
 import GitHub from '@mui/icons-material/GitHub'
 import api from '../services/api'
 import { getErrorMessage } from '../utils/errors'
+import { captureError } from '../services/errorReporting'
 import { Provider, ProviderVersion, ProviderDocEntry } from '../types'
 import { useAuth } from '../contexts/AuthContext'
 import { REGISTRY_HOST } from '../config'
@@ -140,6 +141,11 @@ const ProviderDetailPage: React.FC = () => {
       }
     } catch (err) {
       console.error('Failed to load provider details:', err)
+      // setError() here uses a plain hardcoded string, not getErrorMessage(), so
+      // it doesn't get telemetry reporting for free -- report explicitly (#623).
+      captureError(err instanceof Error ? err : new Error(String(err)), {
+        context: 'Failed to load provider details',
+      })
       setError('Failed to load provider details. Please try again.')
     } finally {
       setLoading(false)

--- a/frontend/src/pages/__tests__/ProviderDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/ProviderDetailPage.test.tsx
@@ -43,7 +43,12 @@ vi.mock('../../components/ProviderDocContent', () => ({
   default: () => <div data-testid="provider-doc-content" />,
 }))
 
+vi.mock('../../services/errorReporting', () => ({
+  captureError: vi.fn(),
+}))
+
 import ProviderDetailPage from '../ProviderDetailPage'
+import { captureError } from '../../services/errorReporting'
 
 function renderPage(path = '/providers/hashicorp/aws') {
   return render(
@@ -112,6 +117,20 @@ describe('ProviderDetailPage', () => {
     await waitFor(() => {
       expect(screen.getByText(/failed to load provider details/i)).toBeInTheDocument()
     })
+  })
+
+  // Regression guard (#623): setError() here uses a plain hardcoded string, not
+  // getErrorMessage(), so a failed load only logged via console.error before this
+  // fix -- it must also reach the app's telemetry pipeline.
+  it('reports a failed provider details load to telemetry', async () => {
+    const loadError = new Error('Network error')
+    searchProvidersMock.mockRejectedValue(loadError)
+    renderPage()
+    await waitFor(() =>
+      expect(captureError).toHaveBeenCalledWith(loadError, {
+        context: 'Failed to load provider details',
+      }),
+    )
   })
 
   it('renders provider details after loading', async () => {

--- a/frontend/src/pages/admin/OrganizationsPage.tsx
+++ b/frontend/src/pages/admin/OrganizationsPage.tsx
@@ -45,6 +45,7 @@ import { Organization, OrganizationMemberWithUser, User } from '../../types'
 import { RoleTemplate } from '../../types/rbac'
 import { useAuth } from '../../contexts/AuthContext'
 import { getErrorMessage } from '../../utils/errors'
+import { captureError } from '../../services/errorReporting'
 import { queryKeys } from '../../services/queryKeys'
 
 const OrganizationsPage: React.FC = () => {
@@ -194,6 +195,11 @@ const OrganizationsPage: React.FC = () => {
       setMembers(membersData)
     } catch (err) {
       console.error('Failed to load members:', err)
+      // No getErrorMessage() call here (list load just resets local state), so
+      // report explicitly to keep this failure visible in telemetry too (#623).
+      captureError(err instanceof Error ? err : new Error(String(err)), {
+        context: 'Failed to load members',
+      })
       setMembers([])
     } finally {
       setMembersLoading(false)
@@ -206,6 +212,9 @@ const OrganizationsPage: React.FC = () => {
       setAllUsers(response.users || [])
     } catch (err) {
       console.error('Failed to load users:', err)
+      captureError(err instanceof Error ? err : new Error(String(err)), {
+        context: 'Failed to load users',
+      })
       setAllUsers([])
     }
   }
@@ -216,6 +225,9 @@ const OrganizationsPage: React.FC = () => {
       setRoleTemplates(templates || [])
     } catch (err) {
       console.error('Failed to load role templates:', err)
+      captureError(err instanceof Error ? err : new Error(String(err)), {
+        context: 'Failed to load role templates',
+      })
       setRoleTemplates([])
     }
   }

--- a/frontend/src/pages/admin/SCMProvidersPage.tsx
+++ b/frontend/src/pages/admin/SCMProvidersPage.tsx
@@ -41,6 +41,7 @@ import PageHeader from '../../components/PageHeader'
 import PageTitleIcon from '@mui/icons-material/GitHub'
 import api from '../../services/api'
 import { getErrorMessage } from '../../utils/errors'
+import { isSafeExternalUrl } from '../../utils/externalUrl'
 import { useAuth } from '../../contexts/AuthContext'
 import type {
   SCMProvider,
@@ -227,6 +228,13 @@ const SCMProvidersPage: React.FC = () => {
     } else {
       try {
         const response = await api.initiateSCMOAuth(provider.id)
+        // Defense-in-depth: authorization_url comes from the backend (ultimately the
+        // SCM provider's own OAuth config); validate it at the app boundary before
+        // this full-page redirect navigation sink, instead of trusting it verbatim (#559).
+        if (!isSafeExternalUrl(response.authorization_url)) {
+          setError(t('admin.scmProviders.errOAuthInvalidUrl'))
+          return
+        }
         window.location.href = response.authorization_url
       } catch (err: unknown) {
         setError(getErrorMessage(err, t('admin.scmProviders.errOAuth')))

--- a/frontend/src/pages/admin/UsersPage.tsx
+++ b/frontend/src/pages/admin/UsersPage.tsx
@@ -49,6 +49,7 @@ import { useAuth } from '../../contexts/AuthContext'
 import { User, UserMembership, Organization } from '../../types'
 import { RoleTemplate } from '../../types/rbac'
 import { getErrorMessage } from '../../utils/errors'
+import { captureError } from '../../services/errorReporting'
 import { queryKeys } from '../../services/queryKeys'
 
 interface UserWithMemberships extends User {
@@ -174,6 +175,11 @@ const UsersPage: React.FC = () => {
       setOrganizations(orgs || [])
     } catch (err) {
       console.error('Failed to load organizations:', err)
+      // No getErrorMessage() call here (list load just resets local state), so
+      // report explicitly to keep this failure visible in telemetry too (#623).
+      captureError(err instanceof Error ? err : new Error(String(err)), {
+        context: 'Failed to load organizations',
+      })
       setOrganizations([])
     } finally {
       setOrgsLoading(false)
@@ -187,6 +193,9 @@ const UsersPage: React.FC = () => {
       setRoleTemplates(templates || [])
     } catch (err) {
       console.error('Failed to load role templates:', err)
+      captureError(err instanceof Error ? err : new Error(String(err)), {
+        context: 'Failed to load role templates',
+      })
       setRoleTemplates([])
     } finally {
       setRoleTemplatesLoading(false)
@@ -243,6 +252,9 @@ const UsersPage: React.FC = () => {
           })
         } catch (err) {
           console.error('Failed to add user to organization:', err)
+          captureError(err instanceof Error ? err : new Error(String(err)), {
+            context: 'Failed to add user to organization',
+          })
         }
       }
     },

--- a/frontend/src/pages/admin/__tests__/OrganizationsPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/OrganizationsPage.test.tsx
@@ -36,7 +36,12 @@ vi.mock('../../../contexts/AuthContext', () => ({
   useAuth: () => ({ allowedScopes: mockAllowedScopes, user: { id: 'u1' } }),
 }))
 
+vi.mock('../../../services/errorReporting', () => ({
+  captureError: vi.fn(),
+}))
+
 import OrganizationsPage from '../OrganizationsPage'
+import { captureError } from '../../../services/errorReporting'
 
 function createQueryClient() {
   return new QueryClient({
@@ -534,5 +539,21 @@ describe('OrganizationsPage', () => {
     )
     expect(updateOrganizationMock).not.toHaveBeenCalled()
     expect(createOrganizationMock).not.toHaveBeenCalled()
+  })
+
+  // Regression guard (#623): a failed members load only reset local state via
+  // console.error before this fix -- it must also reach the app's telemetry pipeline.
+  it('reports a failed members load to telemetry', async () => {
+    listOrganizationsMock.mockResolvedValue(fakeOrgs)
+    const loadError = new Error('members load failed')
+    listOrganizationMembersMock.mockRejectedValue(loadError)
+    listRoleTemplatesMock.mockResolvedValue([])
+    renderPage()
+    await waitFor(() => expect(screen.getByText('acme-corp')).toBeInTheDocument())
+    const membersBtns = screen.getAllByRole('button', { name: /view members/i })
+    await userEvent.click(membersBtns[0])
+    await waitFor(() =>
+      expect(captureError).toHaveBeenCalledWith(loadError, { context: 'Failed to load members' }),
+    )
   })
 })

--- a/frontend/src/pages/admin/__tests__/SCMProvidersPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/SCMProvidersPage.test.tsx
@@ -215,6 +215,28 @@ describe('SCMProvidersPage', () => {
     await waitFor(() => expect(initiateSCMOAuthMock).toHaveBeenCalledWith('scm-1'))
   })
 
+  // Regression guard (#559): authorization_url comes from the backend; it must be
+  // validated at the app boundary before this full-page redirect navigation sink,
+  // instead of trusting it verbatim (unvalidated redirect).
+  it('refuses to redirect when the OAuth authorization URL is unsafe', async () => {
+    listSCMProvidersMock.mockResolvedValue(fakeProviders)
+    initiateSCMOAuthMock.mockResolvedValue({ authorization_url: '//evil.com/steal-session' })
+    const originalLocation = window.location
+    Object.defineProperty(window, 'location', {
+      value: { ...originalLocation, href: '' },
+      writable: true,
+      configurable: true,
+    })
+    renderPage()
+    await waitFor(() => expect(screen.getByText('GitHub Enterprise')).toBeInTheDocument())
+    await userEvent.click(screen.getByRole('button', { name: /connect scm provider/i }))
+    await waitFor(() => expect(initiateSCMOAuthMock).toHaveBeenCalledWith('scm-1'))
+    expect(window.location.href).toBe('')
+    expect(
+      screen.getByText('The OAuth provider returned an invalid authorization URL'),
+    ).toBeInTheDocument()
+  })
+
   it('opens PAT dialog for Bitbucket Data Center provider', async () => {
     const bbProvider = [
       { ...fakeProviders[0], provider_type: 'bitbucket_dc' as const, name: 'BB DC' },

--- a/frontend/src/pages/admin/__tests__/UsersPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/UsersPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { render, screen, waitFor, fireEvent, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { MemoryRouter } from 'react-router-dom'
@@ -49,7 +49,12 @@ vi.mock('../../../contexts/AuthContext', () => ({
   useAuth: () => useAuthMock(),
 }))
 
+vi.mock('../../../services/errorReporting', () => ({
+  captureError: vi.fn(),
+}))
+
 import UsersPage from '../../admin/UsersPage'
+import { captureError } from '../../../services/errorReporting'
 
 // ---- Helpers ----
 
@@ -348,6 +353,72 @@ describe('UsersPage', () => {
     fireEvent.change(nameInputs[0], { target: { value: 'X' } })
     await userEvent.click(screen.getByRole('button', { name: /^create$/i }))
     await waitFor(() => expect(screen.getByText(/boom/)).toBeInTheDocument())
+  })
+
+  // Regression guards (#623): these catch blocks only logged via console.error
+  // before this fix -- they must also reach the app's telemetry pipeline.
+  it('reports a failed organizations load to telemetry', async () => {
+    listUsersMock.mockResolvedValue(fakeUsersResponse)
+    getUserMembershipsMock.mockResolvedValue([])
+    const loadError = new Error('organizations load failed')
+    listOrganizationsMock.mockRejectedValue(loadError)
+    listRoleTemplatesMock.mockResolvedValue(fakeRoleTemplates)
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Alice Smith')).toBeInTheDocument())
+    await userEvent.click(screen.getByRole('button', { name: /add user/i }))
+    await waitFor(() =>
+      expect(captureError).toHaveBeenCalledWith(loadError, {
+        context: 'Failed to load organizations',
+      }),
+    )
+  })
+
+  it('reports a failed role templates load to telemetry', async () => {
+    listUsersMock.mockResolvedValue(fakeUsersResponse)
+    getUserMembershipsMock.mockResolvedValue([])
+    listOrganizationsMock.mockResolvedValue(fakeOrganizations)
+    const loadError = new Error('role templates load failed')
+    listRoleTemplatesMock.mockRejectedValue(loadError)
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Alice Smith')).toBeInTheDocument())
+    await userEvent.click(screen.getByRole('button', { name: /add user/i }))
+    await waitFor(() =>
+      expect(captureError).toHaveBeenCalledWith(loadError, {
+        context: 'Failed to load role templates',
+      }),
+    )
+  })
+
+  it('reports a failed "add user to organization" to telemetry', async () => {
+    listUsersMock.mockResolvedValue(fakeUsersResponse)
+    getUserMembershipsMock.mockResolvedValue([])
+    listOrganizationsMock.mockResolvedValue(fakeOrganizations)
+    listRoleTemplatesMock.mockResolvedValue(fakeRoleTemplates)
+    createUserMock.mockResolvedValue({ id: 'u-new', email: 'c@example.com', name: 'Carol' })
+    const addMemberError = new Error('add member failed')
+    addOrganizationMemberMock.mockRejectedValue(addMemberError)
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Alice Smith')).toBeInTheDocument())
+    await userEvent.click(screen.getByRole('button', { name: /add user/i }))
+    await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument())
+    const dialog = screen.getByRole('dialog')
+    const emailInput = dialog.querySelector('input[type="email"]') as HTMLInputElement
+    const nameInputs = dialog.querySelectorAll('input[type="text"]')
+    fireEvent.change(emailInput, { target: { value: 'c@example.com' } })
+    fireEvent.change(nameInputs[0], { target: { value: 'Carol' } })
+
+    // Select an organization so the create mutation also calls addOrganizationMember.
+    const orgCombobox = within(dialog).getAllByRole('combobox')[0]
+    fireEvent.mouseDown(orgCombobox)
+    const listbox = await screen.findByRole('listbox')
+    fireEvent.click(within(listbox).getByText('Acme'))
+
+    await userEvent.click(screen.getByRole('button', { name: /^create$/i }))
+    await waitFor(() =>
+      expect(captureError).toHaveBeenCalledWith(addMemberError, {
+        context: 'Failed to add user to organization',
+      }),
+    )
   })
 
   it('changes rows per page in pagination', async () => {

--- a/frontend/src/services/__tests__/api.test.ts
+++ b/frontend/src/services/__tests__/api.test.ts
@@ -1294,6 +1294,51 @@ describe('ApiClient', () => {
     })
   })
 
+  // ─── Path-segment encoding at call sites (#614, CWE-116) ───────────────────
+  // encodeSegment() itself is unit-tested in api/__tests__/http.test.ts. These
+  // guard the call sites: a future edit that dropped encodeSegment() from a
+  // domain function's URL-building would not be caught by benign alphanumeric
+  // ids elsewhere in this file, since those are encoding-invariant.
+  describe('path-segment encoding at call sites', () => {
+    it('getModule encodes a fragment character in a route param so the request is not truncated', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { id: 'm1' },
+        })
+      await client.getModule('ns', 'mod#evil', 'aws')
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/modules/ns/mod%23evil/aws')
+    })
+
+    it('deleteModuleVersion encodes a path separator in the version so the target resource cannot shift', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.delete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
+      await client.deleteModuleVersion('ns', 'mod', 'aws', '../other')
+      expect(mockAxiosInstance.delete).toHaveBeenCalledWith(
+        '/api/v1/modules/ns/mod/aws/versions/..%2Fother',
+      )
+    })
+
+    it('getProvider encodes a query-string character in a route param so it cannot inject query params', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { id: 'p1' },
+        })
+      await client.getProvider('hashicorp', 'aws?admin=true')
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith(
+        '/api/v1/providers/hashicorp/aws%3Fadmin%3Dtrue',
+      )
+    })
+
+    it('getSCMProvider encodes a fragment character in the id so the request is not truncated', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { id: 'scm-1' },
+        })
+      await client.getSCMProvider('scm-1#evil')
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/scm-providers/scm-1%23evil')
+    })
+  })
+
   // ─── Users ────────────────────────────────────────────────────────────────
   describe('user methods', () => {
     it('searchUsers', async () => {
@@ -2023,9 +2068,14 @@ describe('ApiClient', () => {
       const client = await getApiClient()
         ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: {} })
       await client.triggerMirrorSync('mir-1', { namespace: 'hashicorp' })
-      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/admin/mirrors/mir-1/sync', {
-        namespace: 'hashicorp',
-      })
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith(
+        '/api/v1/admin/mirrors/mir-1/sync',
+        { namespace: 'hashicorp' },
+        // Regression guard (#599): nginx grants this endpoint a 600s
+        // proxy_read_timeout/proxy_send_timeout because syncs can take several
+        // minutes -- the client must not abort at the shared 30s default.
+        { timeout: 600_000 },
+      )
     })
 
     it('getMirrorStatus', async () => {
@@ -2572,6 +2622,10 @@ describe('ApiClient', () => {
       expect(mockAxiosInstance.post).toHaveBeenCalledWith(
         '/api/v1/admin/terraform-mirrors/tc-1/sync',
         {},
+        // Regression guard (#599): this endpoint didn't even match nginx's
+        // long-timeout regex before the fix, so it needs the same client-side
+        // override as triggerMirrorSync once nginx.conf covers both paths.
+        { timeout: 600_000 },
       )
     })
 

--- a/frontend/src/services/api/__tests__/http.test.ts
+++ b/frontend/src/services/api/__tests__/http.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest'
+import { encodeSegment } from '../http'
+
+describe('encodeSegment', () => {
+  // Regression guard (#614, CWE-116): axios does not URL-encode manually-built
+  // path strings, so an unescaped identifier containing '#', '?', or '/' can
+  // truncate the request at a fragment, inject a bogus query string, or shift
+  // the path to a different resource than intended.
+  it('encodes a fragment character so it cannot truncate the path', () => {
+    expect(encodeSegment('1.0.0#evil')).toBe('1.0.0%23evil')
+  })
+
+  it('encodes a query-string character so it cannot inject query params', () => {
+    expect(encodeSegment('name?admin=true')).toBe('name%3Fadmin%3Dtrue')
+  })
+
+  it('encodes a path separator so it cannot shift the target resource', () => {
+    expect(encodeSegment('../other-namespace')).toBe('..%2Fother-namespace')
+  })
+
+  it('leaves a normal alphanumeric identifier unchanged', () => {
+    expect(encodeSegment('hashicorp')).toBe('hashicorp')
+  })
+})

--- a/frontend/src/services/api/__tests__/suiteApi.test.ts
+++ b/frontend/src/services/api/__tests__/suiteApi.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import type { AxiosResponse } from 'axios'
+import { http } from '../http'
+import { getUIConfig } from '../suiteApi'
+
+function axiosResponse<T>(data: T): AxiosResponse<T> {
+  return { data } as AxiosResponse<T>
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('getUIConfig', () => {
+  // Regression guard (#600): this call must go through the shared http client
+  // (not a hardcoded relative fetch()) -- and live under services/api/ -- so it
+  // inherits API_BASE_URL resolution, CSRF/401 handling, and is visible to
+  // scripts/contract-check.ts, which only walks domain modules in this directory.
+  it('requests the sibling config via the shared http client', async () => {
+    const getSpy = vi
+      .spyOn(http, 'get')
+      .mockResolvedValue(axiosResponse({ sibling: null }))
+
+    const result = await getUIConfig()
+
+    expect(getSpy).toHaveBeenCalledWith('/api/v1/ui/config')
+    expect(result).toEqual({ sibling: null })
+  })
+
+  it('propagates a request failure to the caller (no swallowing here)', async () => {
+    vi.spyOn(http, 'get').mockRejectedValue(new Error('network error'))
+
+    await expect(getUIConfig()).rejects.toThrow('network error')
+  })
+})

--- a/frontend/src/services/api/apiKeysApi.ts
+++ b/frontend/src/services/api/apiKeysApi.ts
@@ -1,7 +1,7 @@
 /**
  * API Keys domain API — key listing, CRUD, and rotation.
  */
-import { http } from './http'
+import { http, encodeSegment } from './http'
 import type { APIKey, RotateAPIKeyResponse } from '../../types'
 
 /**
@@ -58,7 +58,7 @@ export async function createAPIKey(data: {
 }
 
 export async function getAPIKey(id: string) {
-  const response = await http.get(`/api/v1/apikeys/${id}`)
+  const response = await http.get(`/api/v1/apikeys/${encodeSegment(id)}`)
   return response.data
 }
 
@@ -66,12 +66,12 @@ export async function updateAPIKey(
   id: string,
   data: { name?: string; scopes?: string[]; expires_at?: string },
 ) {
-  const response = await http.put(`/api/v1/apikeys/${id}`, data)
+  const response = await http.put(`/api/v1/apikeys/${encodeSegment(id)}`, data)
   return response.data
 }
 
 export async function deleteAPIKey(id: string): Promise<{ message: string }> {
-  const response = await http.delete<{ message: string }>(`/api/v1/apikeys/${id}`)
+  const response = await http.delete<{ message: string }>(`/api/v1/apikeys/${encodeSegment(id)}`)
   return response.data
 }
 
@@ -79,7 +79,7 @@ export async function rotateAPIKey(
   id: string,
   gracePeriodHours: number = 0,
 ): Promise<RotateAPIKeyResponse> {
-  const response = await http.post<RotateAPIKeyResponse>(`/api/v1/apikeys/${id}/rotate`, {
+  const response = await http.post<RotateAPIKeyResponse>(`/api/v1/apikeys/${encodeSegment(id)}/rotate`, {
     grace_period_hours: gracePeriodHours,
   })
   return response.data

--- a/frontend/src/services/api/auditApi.ts
+++ b/frontend/src/services/api/auditApi.ts
@@ -1,4 +1,4 @@
-import { http } from './http'
+import { http, encodeSegment } from './http'
 import type { AuditLog, AuditLogListResponse } from '../../types'
 
 // ============================================================================
@@ -22,7 +22,7 @@ export async function listAuditLogs(opts?: {
 }
 
 export async function getAuditLog(id: string): Promise<AuditLog> {
-  const response = await http.get<AuditLog>(`/api/v1/admin/audit-logs/${id}`)
+  const response = await http.get<AuditLog>(`/api/v1/admin/audit-logs/${encodeSegment(id)}`)
   return response.data
 }
 

--- a/frontend/src/services/api/authApi.ts
+++ b/frontend/src/services/api/authApi.ts
@@ -1,4 +1,4 @@
-import { http, API_BASE_URL } from './http'
+import { http, API_BASE_URL, encodeSegment } from './http'
 import type { User, RoleTemplateInfo } from '../../types'
 
 // Authentication
@@ -15,7 +15,7 @@ export async function getAuthProviders(): Promise<{
 }
 
 export async function login(provider: string) {
-  window.location.href = `${API_BASE_URL}/api/v1/auth/login?provider=${provider}`
+  window.location.href = `${API_BASE_URL}/api/v1/auth/login?provider=${encodeSegment(provider)}`
 }
 
 /**

--- a/frontend/src/services/api/devApi.ts
+++ b/frontend/src/services/api/devApi.ts
@@ -1,4 +1,4 @@
-import { http } from './http'
+import { http, encodeSegment } from './http'
 
 // ============================================================================
 // Development-Only Endpoints (disabled in production)
@@ -40,6 +40,6 @@ export async function impersonateUser(userId: string): Promise<{
   }
   message: string
 }> {
-  const response = await http.post(`/api/v1/dev/impersonate/${userId}`)
+  const response = await http.post(`/api/v1/dev/impersonate/${encodeSegment(userId)}`)
   return response.data
 }

--- a/frontend/src/services/api/http.ts
+++ b/frontend/src/services/api/http.ts
@@ -26,6 +26,20 @@ export function getCookie(name: string): string {
   return match ? decodeURIComponent(match[1]) : ''
 }
 
+/**
+ * URL-encode a single path segment before interpolating it into a
+ * template-literal request URL. Axios does not encode manually-built path
+ * strings, so an unescaped identifier containing '#', '?', or '/' can
+ * truncate the request at a fragment (silently dropping later path
+ * segments), inject a bogus query string, or shift the path to a different
+ * resource than intended (CWE-116). Domain API modules should wrap every
+ * interpolated namespace/name/id/version/etc. segment with this before
+ * building a URL (#614).
+ */
+export function encodeSegment(value: string): string {
+  return encodeURIComponent(value)
+}
+
 function getMockResponse(url: string): { data: unknown; status: number } {
   // Mock responses for development when backend is not available
   let mockData: { data: unknown } = { data: [] }

--- a/frontend/src/services/api/index.ts
+++ b/frontend/src/services/api/index.ts
@@ -32,6 +32,7 @@ import * as scanningApi from './scanningApi'
 import * as scmApi from './scmApi'
 import * as setupApi from './setupApi'
 import * as storageApi from './storageApi'
+import * as suiteApi from './suiteApi'
 import * as terraformMirrorApi from './terraformMirrorApi'
 import * as themeApi from './themeApi'
 import * as usersApi from './usersApi'
@@ -57,6 +58,7 @@ export const apiDomains = {
   scmApi,
   setupApi,
   storageApi,
+  suiteApi,
   terraformMirrorApi,
   themeApi,
   usersApi,
@@ -82,6 +84,7 @@ const apiClient = {
   ...scmApi,
   ...setupApi,
   ...storageApi,
+  ...suiteApi,
   ...terraformMirrorApi,
   ...themeApi,
   ...usersApi,
@@ -90,5 +93,6 @@ const apiClient = {
 }
 
 export type { ModuleConsumer } from './modulesApi'
+export type { SuiteSibling } from './suiteApi'
 
 export default apiClient

--- a/frontend/src/services/api/mirrorsApi.ts
+++ b/frontend/src/services/api/mirrorsApi.ts
@@ -1,4 +1,4 @@
-import { http } from './http'
+import { http, encodeSegment } from './http'
 import type {
   CreateMirrorConfigRequest,
   MirrorConfiguration,
@@ -18,7 +18,7 @@ export async function listMirrors(enabledOnly = false): Promise<MirrorConfigurat
 }
 
 export async function getMirror(id: string): Promise<MirrorConfiguration> {
-  const response = await http.get<MirrorConfiguration>(`/api/v1/admin/mirrors/${id}`)
+  const response = await http.get<MirrorConfiguration>(`/api/v1/admin/mirrors/${encodeSegment(id)}`)
   return response.data
 }
 
@@ -31,12 +31,12 @@ export async function updateMirror(
   id: string,
   data: UpdateMirrorConfigRequest,
 ): Promise<MirrorConfiguration> {
-  const response = await http.put<MirrorConfiguration>(`/api/v1/admin/mirrors/${id}`, data)
+  const response = await http.put<MirrorConfiguration>(`/api/v1/admin/mirrors/${encodeSegment(id)}`, data)
   return response.data
 }
 
 export async function deleteMirror(id: string): Promise<{ message: string }> {
-  const response = await http.delete<{ message: string }>(`/api/v1/admin/mirrors/${id}`)
+  const response = await http.delete<{ message: string }>(`/api/v1/admin/mirrors/${encodeSegment(id)}`)
   return response.data
 }
 
@@ -45,20 +45,25 @@ export async function triggerMirrorSync(
   data?: { namespace?: string; provider_name?: string },
 ): Promise<{ message: string }> {
   const response = await http.post<{ message: string }>(
-    `/api/v1/admin/mirrors/${id}/sync`,
+    `/api/v1/admin/mirrors/${encodeSegment(id)}/sync`,
     data || {},
+    // Mirror sync can take several minutes to download provider binaries;
+    // nginx grants this endpoint a matching 600s proxy_read_timeout/
+    // proxy_send_timeout (nginx.conf) so the client must not abort at the
+    // shared 30s default (http.ts) while the backend job is still running (#599).
+    { timeout: 600_000 },
   )
   return response.data
 }
 
 export async function getMirrorStatus(id: string): Promise<MirrorSyncStatus> {
-  const response = await http.get<MirrorSyncStatus>(`/api/v1/admin/mirrors/${id}/status`)
+  const response = await http.get<MirrorSyncStatus>(`/api/v1/admin/mirrors/${encodeSegment(id)}/status`)
   return response.data
 }
 
 export async function getMirrorProviders(id: string): Promise<MirroredProvider[]> {
   const response = await http.get<{ providers?: MirroredProvider[] }>(
-    `/api/v1/admin/mirrors/${id}/providers`,
+    `/api/v1/admin/mirrors/${encodeSegment(id)}/providers`,
   )
   return response.data.providers ?? []
 }
@@ -79,7 +84,7 @@ export async function listApprovalRequests(options?: {
 }
 
 export async function getApprovalRequest(id: string): Promise<MirrorApprovalRequest> {
-  const response = await http.get<MirrorApprovalRequest>(`/api/v1/admin/approvals/${id}`)
+  const response = await http.get<MirrorApprovalRequest>(`/api/v1/admin/approvals/${encodeSegment(id)}`)
   return response.data
 }
 
@@ -98,7 +103,7 @@ export async function reviewApproval(
   data: { status: 'approved' | 'rejected'; notes?: string },
 ): Promise<MirrorApprovalRequest> {
   const response = await http.put<MirrorApprovalRequest>(
-    `/api/v1/admin/approvals/${id}/review`,
+    `/api/v1/admin/approvals/${encodeSegment(id)}/review`,
     data,
   )
   return response.data
@@ -115,7 +120,7 @@ export async function listMirrorPolicies(organizationId?: string): Promise<Mirro
 }
 
 export async function getMirrorPolicy(id: string): Promise<MirrorPolicy> {
-  const response = await http.get<MirrorPolicy>(`/api/v1/admin/policies/${id}`)
+  const response = await http.get<MirrorPolicy>(`/api/v1/admin/policies/${encodeSegment(id)}`)
   return response.data
 }
 
@@ -149,12 +154,12 @@ export async function updateMirrorPolicy(
     requires_approval?: boolean
   },
 ): Promise<MirrorPolicy> {
-  const response = await http.put<MirrorPolicy>(`/api/v1/admin/policies/${id}`, data)
+  const response = await http.put<MirrorPolicy>(`/api/v1/admin/policies/${encodeSegment(id)}`, data)
   return response.data
 }
 
 export async function deleteMirrorPolicy(id: string): Promise<{ message: string }> {
-  const response = await http.delete<{ message: string }>(`/api/v1/admin/policies/${id}`)
+  const response = await http.delete<{ message: string }>(`/api/v1/admin/policies/${encodeSegment(id)}`)
   return response.data
 }
 

--- a/frontend/src/services/api/modulesApi.ts
+++ b/frontend/src/services/api/modulesApi.ts
@@ -1,4 +1,4 @@
-import { http } from './http'
+import { http, encodeSegment } from './http'
 import type { Module, ModuleVersion, ModuleDoc } from '../../types'
 
 /**
@@ -64,7 +64,7 @@ export async function getModuleVersions(
   system: string,
 ): Promise<ModuleVersionsResponse> {
   const response = await http.get<ModuleVersionsResponse>(
-    `/v1/modules/${namespace}/${name}/${system}/versions`,
+    `/v1/modules/${encodeSegment(namespace)}/${encodeSegment(name)}/${encodeSegment(system)}/versions`,
   )
   return response.data
 }
@@ -107,7 +107,7 @@ export async function uploadModule(
 }
 
 export async function getModule(namespace: string, name: string, system: string): Promise<Module> {
-  const response = await http.get<Module>(`/api/v1/modules/${namespace}/${name}/${system}`)
+  const response = await http.get<Module>(`/api/v1/modules/${encodeSegment(namespace)}/${encodeSegment(name)}/${encodeSegment(system)}`)
   return response.data
 }
 
@@ -117,7 +117,7 @@ export async function deleteModule(
   system: string,
 ): Promise<{ message: string }> {
   const response = await http.delete<{ message: string }>(
-    `/api/v1/modules/${namespace}/${name}/${system}`,
+    `/api/v1/modules/${encodeSegment(namespace)}/${encodeSegment(name)}/${encodeSegment(system)}`,
   )
   return response.data
 }
@@ -129,7 +129,7 @@ export async function deleteModuleVersion(
   version: string,
 ): Promise<{ message: string }> {
   const response = await http.delete<{ message: string }>(
-    `/api/v1/modules/${namespace}/${name}/${system}/versions/${version}`,
+    `/api/v1/modules/${encodeSegment(namespace)}/${encodeSegment(name)}/${encodeSegment(system)}/versions/${encodeSegment(version)}`,
   )
   return response.data
 }
@@ -141,7 +141,7 @@ export async function reanalyzeModuleVersion(
   version: string,
 ): Promise<{ message: string; docs?: string; scan?: string }> {
   const response = await http.post<{ message: string; docs?: string; scan?: string }>(
-    `/api/v1/modules/${namespace}/${name}/${system}/versions/${version}/reanalyze`,
+    `/api/v1/modules/${encodeSegment(namespace)}/${encodeSegment(name)}/${encodeSegment(system)}/versions/${encodeSegment(version)}/reanalyze`,
   )
   return response.data
 }
@@ -158,7 +158,7 @@ export async function deprecateModuleVersion(
   if (message) body.message = message
   if (replacementSource) body.replacement_source = replacementSource
   const response = await http.post<{ message: string }>(
-    `/api/v1/modules/${namespace}/${name}/${system}/versions/${version}/deprecate`,
+    `/api/v1/modules/${encodeSegment(namespace)}/${encodeSegment(name)}/${encodeSegment(system)}/versions/${encodeSegment(version)}/deprecate`,
     body,
   )
   return response.data
@@ -171,7 +171,7 @@ export async function undeprecateModuleVersion(
   version: string,
 ): Promise<{ message: string }> {
   const response = await http.delete<{ message: string }>(
-    `/api/v1/modules/${namespace}/${name}/${system}/versions/${version}/deprecate`,
+    `/api/v1/modules/${encodeSegment(namespace)}/${encodeSegment(name)}/${encodeSegment(system)}/versions/${encodeSegment(version)}/deprecate`,
   )
   return response.data
 }
@@ -183,7 +183,7 @@ export async function deprecateModule(
   data: { message: string; successor_module_id?: string },
 ): Promise<{ message: string }> {
   const response = await http.post<{ message: string }>(
-    `/api/v1/modules/${namespace}/${name}/${system}/deprecate`,
+    `/api/v1/modules/${encodeSegment(namespace)}/${encodeSegment(name)}/${encodeSegment(system)}/deprecate`,
     data,
   )
   return response.data
@@ -195,7 +195,7 @@ export async function undeprecateModule(
   system: string,
 ): Promise<{ message: string }> {
   const response = await http.delete<{ message: string }>(
-    `/api/v1/modules/${namespace}/${name}/${system}/deprecate`,
+    `/api/v1/modules/${encodeSegment(namespace)}/${encodeSegment(name)}/${encodeSegment(system)}/deprecate`,
   )
   return response.data
 }
@@ -209,7 +209,7 @@ export async function getModuleConsumers(
   // token is configured, else returns an empty list. Backend wraps the list
   // as { consumers: [...] }; callers expect a bare array.
   const response = await http.get<{ consumers?: ModuleConsumer[] }>(
-    `/api/v1/suite/modules/${namespace}/${name}/${system}/consumers`,
+    `/api/v1/suite/modules/${encodeSegment(namespace)}/${encodeSegment(name)}/${encodeSegment(system)}/consumers`,
   )
   return response.data?.consumers ?? []
 }
@@ -218,7 +218,7 @@ export async function updateModule(
   id: string,
   data: { description?: string; source?: string; namespace?: string },
 ): Promise<Module> {
-  const response = await http.put<Module>(`/api/v1/admin/modules/${id}`, data)
+  const response = await http.put<Module>(`/api/v1/admin/modules/${encodeSegment(id)}`, data)
   return response.data
 }
 
@@ -229,7 +229,7 @@ export async function getModuleDocs(
   version: string,
 ): Promise<ModuleDoc> {
   const response = await http.get<ModuleDoc>(
-    `/api/v1/modules/${namespace}/${name}/${system}/versions/${version}/docs`,
+    `/api/v1/modules/${encodeSegment(namespace)}/${encodeSegment(name)}/${encodeSegment(system)}/versions/${encodeSegment(version)}/docs`,
   )
   return response.data
 }

--- a/frontend/src/services/api/notificationsApi.ts
+++ b/frontend/src/services/api/notificationsApi.ts
@@ -1,4 +1,4 @@
-import { http } from './http'
+import { http, encodeSegment } from './http'
 import type {
   NotificationChannel,
   NotificationChannelInput,
@@ -51,15 +51,15 @@ export async function updateNotificationChannel(
   id: string,
   data: NotificationChannelInput,
 ): Promise<NotificationChannel> {
-  const response = await http.put(`/api/v1/admin/notifications/channels/${id}`, data)
+  const response = await http.put(`/api/v1/admin/notifications/channels/${encodeSegment(id)}`, data)
   return response.data
 }
 
 export async function deleteNotificationChannel(id: string): Promise<void> {
-  await http.delete(`/api/v1/admin/notifications/channels/${id}`)
+  await http.delete(`/api/v1/admin/notifications/channels/${encodeSegment(id)}`)
 }
 
 export async function testNotificationChannel(id: string): Promise<{ status: string }> {
-  const response = await http.post(`/api/v1/admin/notifications/channels/${id}/test`)
+  const response = await http.post(`/api/v1/admin/notifications/channels/${encodeSegment(id)}/test`)
   return response.data
 }

--- a/frontend/src/services/api/organizationsApi.ts
+++ b/frontend/src/services/api/organizationsApi.ts
@@ -1,7 +1,7 @@
 /**
  * Organizations domain API — organization CRUD, search, and member management.
  */
-import { http } from './http'
+import { http, encodeSegment } from './http'
 import { sanitizeServerErrorMessage } from '../../utils/errors'
 import type { Organization, OrganizationMemberWithUser } from '../../types'
 
@@ -51,7 +51,7 @@ export async function searchOrganizations(
 
 export async function getOrganization(id: string): Promise<Organization> {
   const response = await http.get<{ organization: Record<string, unknown> }>(
-    `/api/v1/organizations/${id}`,
+    `/api/v1/organizations/${encodeSegment(id)}`,
   )
   return transformOrganization(response.data.organization)
 }
@@ -91,14 +91,14 @@ export async function updateOrganization(
   },
 ): Promise<Organization> {
   const response = await http.put<{ organization: Record<string, unknown> }>(
-    `/api/v1/organizations/${id}`,
+    `/api/v1/organizations/${encodeSegment(id)}`,
     data,
   )
   return transformOrganization(response.data.organization)
 }
 
 export async function deleteOrganization(id: string): Promise<{ message: string }> {
-  const response = await http.delete<{ message: string }>(`/api/v1/organizations/${id}`)
+  const response = await http.delete<{ message: string }>(`/api/v1/organizations/${encodeSegment(id)}`)
   return response.data
 }
 
@@ -106,7 +106,7 @@ export async function addOrganizationMember(
   orgId: string,
   data: { user_id: string; role_template_id?: string },
 ) {
-  const response = await http.post(`/api/v1/organizations/${orgId}/members`, data)
+  const response = await http.post(`/api/v1/organizations/${encodeSegment(orgId)}/members`, data)
   return response.data
 }
 
@@ -115,7 +115,7 @@ export async function updateOrganizationMember(
   userId: string,
   data: { role_template_id?: string },
 ) {
-  const response = await http.put(`/api/v1/organizations/${orgId}/members/${userId}`, data)
+  const response = await http.put(`/api/v1/organizations/${encodeSegment(orgId)}/members/${encodeSegment(userId)}`, data)
   return response.data
 }
 
@@ -124,7 +124,7 @@ export async function removeOrganizationMember(
   userId: string,
 ): Promise<{ message: string }> {
   const response = await http.delete<{ message: string }>(
-    `/api/v1/organizations/${orgId}/members/${userId}`,
+    `/api/v1/organizations/${encodeSegment(orgId)}/members/${encodeSegment(userId)}`,
   )
   return response.data
 }
@@ -133,7 +133,7 @@ export async function listOrganizationMembers(
   orgId: string,
 ): Promise<OrganizationMemberWithUser[]> {
   const response = await http.get<{ members?: OrganizationMemberWithUser[] }>(
-    `/api/v1/organizations/${orgId}/members`,
+    `/api/v1/organizations/${encodeSegment(orgId)}/members`,
   )
   return response.data.members || []
 }

--- a/frontend/src/services/api/providersApi.ts
+++ b/frontend/src/services/api/providersApi.ts
@@ -1,4 +1,4 @@
-import { http } from './http'
+import { http, encodeSegment } from './http'
 import type {
   Provider,
   ProviderVersion,
@@ -55,7 +55,7 @@ export async function getProviderVersions(
   type: string,
 ): Promise<ProviderVersionsResponse> {
   const response = await http.get<ProviderVersionsResponse>(
-    `/v1/providers/${namespace}/${type}/versions`,
+    `/v1/providers/${encodeSegment(namespace)}/${encodeSegment(type)}/versions`,
   )
   return response.data
 }
@@ -87,7 +87,7 @@ export async function uploadProvider(
 }
 
 export async function getProvider(namespace: string, type: string) {
-  const response = await http.get(`/api/v1/providers/${namespace}/${type}`)
+  const response = await http.get(`/api/v1/providers/${encodeSegment(namespace)}/${encodeSegment(type)}`)
   return response.data
 }
 
@@ -95,7 +95,7 @@ export async function deleteProvider(
   namespace: string,
   type: string,
 ): Promise<{ message: string }> {
-  const response = await http.delete<{ message: string }>(`/api/v1/providers/${namespace}/${type}`)
+  const response = await http.delete<{ message: string }>(`/api/v1/providers/${encodeSegment(namespace)}/${encodeSegment(type)}`)
   return response.data
 }
 
@@ -105,7 +105,7 @@ export async function deleteProviderVersion(
   version: string,
 ): Promise<{ message: string }> {
   const response = await http.delete<{ message: string }>(
-    `/api/v1/providers/${namespace}/${type}/versions/${version}`,
+    `/api/v1/providers/${encodeSegment(namespace)}/${encodeSegment(type)}/versions/${encodeSegment(version)}`,
   )
   return response.data
 }
@@ -117,7 +117,7 @@ export async function deprecateProviderVersion(
   message?: string,
 ): Promise<{ message: string }> {
   const response = await http.post<{ message: string }>(
-    `/api/v1/providers/${namespace}/${type}/versions/${version}/deprecate`,
+    `/api/v1/providers/${encodeSegment(namespace)}/${encodeSegment(type)}/versions/${encodeSegment(version)}/deprecate`,
     message ? { message } : {},
   )
   return response.data
@@ -129,7 +129,7 @@ export async function undeprecateProviderVersion(
   version: string,
 ): Promise<{ message: string }> {
   const response = await http.delete<{ message: string }>(
-    `/api/v1/providers/${namespace}/${type}/versions/${version}/deprecate`,
+    `/api/v1/providers/${encodeSegment(namespace)}/${encodeSegment(type)}/versions/${encodeSegment(version)}/deprecate`,
   )
   return response.data
 }
@@ -149,7 +149,7 @@ export async function getProviderDocs(
   if (limit !== undefined) params.limit = limit
   if (offset !== undefined) params.offset = offset
   const response = await http.get<ProviderDocsResponse>(
-    `/api/v1/providers/${namespace}/${type}/versions/${version}/docs`,
+    `/api/v1/providers/${encodeSegment(namespace)}/${encodeSegment(type)}/versions/${encodeSegment(version)}/docs`,
     { params },
   )
   return response.data
@@ -163,7 +163,7 @@ export async function getProviderDocContent(
   slug: string,
 ): Promise<ProviderDocContent> {
   const response = await http.get<ProviderDocContent>(
-    `/api/v1/providers/${namespace}/${type}/versions/${version}/docs/${category}/${slug}`,
+    `/api/v1/providers/${encodeSegment(namespace)}/${encodeSegment(type)}/versions/${encodeSegment(version)}/docs/${encodeSegment(category)}/${encodeSegment(slug)}`,
   )
   return response.data
 }

--- a/frontend/src/services/api/rolesApi.ts
+++ b/frontend/src/services/api/rolesApi.ts
@@ -1,4 +1,4 @@
-import { http } from './http'
+import { http, encodeSegment } from './http'
 import type { RoleTemplate } from '../../types/rbac'
 
 // ============================================================================
@@ -11,7 +11,7 @@ export async function listRoleTemplates(): Promise<RoleTemplate[]> {
 }
 
 export async function getRoleTemplate(id: string): Promise<RoleTemplate> {
-  const response = await http.get<RoleTemplate>(`/api/v1/admin/role-templates/${id}`)
+  const response = await http.get<RoleTemplate>(`/api/v1/admin/role-templates/${encodeSegment(id)}`)
   return response.data
 }
 
@@ -34,11 +34,11 @@ export async function updateRoleTemplate(
     scopes?: string[]
   },
 ): Promise<RoleTemplate> {
-  const response = await http.put<RoleTemplate>(`/api/v1/admin/role-templates/${id}`, data)
+  const response = await http.put<RoleTemplate>(`/api/v1/admin/role-templates/${encodeSegment(id)}`, data)
   return response.data
 }
 
 export async function deleteRoleTemplate(id: string): Promise<{ message: string }> {
-  const response = await http.delete<{ message: string }>(`/api/v1/admin/role-templates/${id}`)
+  const response = await http.delete<{ message: string }>(`/api/v1/admin/role-templates/${encodeSegment(id)}`)
   return response.data
 }

--- a/frontend/src/services/api/scanningApi.ts
+++ b/frontend/src/services/api/scanningApi.ts
@@ -1,4 +1,4 @@
-import { http } from './http'
+import { http, encodeSegment } from './http'
 import type {
   ModuleScan,
   ScannerAutoUpdateInput,
@@ -17,7 +17,7 @@ export async function getModuleScan(
   version: string,
 ): Promise<ModuleScan> {
   const response = await http.get(
-    `/api/v1/modules/${namespace}/${name}/${system}/versions/${version}/scan`,
+    `/api/v1/modules/${encodeSegment(namespace)}/${encodeSegment(name)}/${encodeSegment(system)}/versions/${encodeSegment(version)}/scan`,
   )
   return response.data
 }
@@ -37,7 +37,7 @@ export async function getScanningStats(params?: {
 }
 
 export async function getScanByID(scanID: string): Promise<ModuleScan> {
-  const response = await http.get(`/api/v1/admin/scanning/scans/${scanID}`)
+  const response = await http.get(`/api/v1/admin/scanning/scans/${encodeSegment(scanID)}`)
   return response.data
 }
 

--- a/frontend/src/services/api/scmApi.ts
+++ b/frontend/src/services/api/scmApi.ts
@@ -1,4 +1,4 @@
-import { http } from './http'
+import { http, encodeSegment } from './http'
 import type {
   ModuleSCMLink,
   SCMBranch,
@@ -34,7 +34,7 @@ export async function createSCMProvider(data: {
 }
 
 export async function getSCMProvider(id: string): Promise<SCMProvider> {
-  const response = await http.get(`/api/v1/scm-providers/${id}`)
+  const response = await http.get(`/api/v1/scm-providers/${encodeSegment(id)}`)
   return response.data
 }
 
@@ -54,12 +54,12 @@ export async function updateSCMProvider(
     app_private_key?: string
   },
 ): Promise<SCMProvider> {
-  const response = await http.put(`/api/v1/scm-providers/${id}`, data)
+  const response = await http.put(`/api/v1/scm-providers/${encodeSegment(id)}`, data)
   return response.data
 }
 
 export async function deleteSCMProvider(id: string): Promise<{ message: string }> {
-  const response = await http.delete(`/api/v1/scm-providers/${id}`)
+  const response = await http.delete(`/api/v1/scm-providers/${encodeSegment(id)}`)
   return response.data
 }
 
@@ -67,20 +67,20 @@ export async function deleteSCMProvider(id: string): Promise<{ message: string }
 export async function verifySCMProvider(
   providerId: string,
 ): Promise<{ ok: boolean; expires_at?: string | null }> {
-  const response = await http.post(`/api/v1/scm-providers/${providerId}/verify`)
+  const response = await http.post(`/api/v1/scm-providers/${encodeSegment(providerId)}/verify`)
   return response.data
 }
 
 // SCM OAuth
 export async function initiateSCMOAuth(providerId: string) {
-  const response = await http.get(`/api/v1/scm-providers/${providerId}/oauth/authorize`)
+  const response = await http.get(`/api/v1/scm-providers/${encodeSegment(providerId)}/oauth/authorize`)
   return response.data
 }
 
 export async function refreshSCMToken(
   providerId: string,
 ): Promise<{ message: string; expires_at?: string }> {
-  const response = await http.post(`/api/v1/scm-providers/${providerId}/oauth/refresh`)
+  const response = await http.post(`/api/v1/scm-providers/${encodeSegment(providerId)}/oauth/refresh`)
   return response.data
 }
 
@@ -90,7 +90,7 @@ export async function getSCMTokenStatus(providerId: string): Promise<{
   expires_at?: string | null
   token_type?: string
 }> {
-  const response = await http.get(`/api/v1/scm-providers/${providerId}/oauth/token`)
+  const response = await http.get(`/api/v1/scm-providers/${encodeSegment(providerId)}/oauth/token`)
   return response.data
 }
 
@@ -99,7 +99,7 @@ export async function listSCMRepositories(
   search?: string,
 ): Promise<{ repositories: SCMRepository[] | null }> {
   const params = search ? { search } : {}
-  const response = await http.get(`/api/v1/scm-providers/${providerId}/repositories`, {
+  const response = await http.get(`/api/v1/scm-providers/${encodeSegment(providerId)}/repositories`, {
     params,
   })
   return response.data
@@ -111,7 +111,7 @@ export async function listSCMRepositoryTags(
   repo: string,
 ): Promise<{ tags: SCMTag[] | null }> {
   const response = await http.get<{ tags: SCMTag[] | null }>(
-    `/api/v1/scm-providers/${providerId}/repositories/${owner}/${repo}/tags`,
+    `/api/v1/scm-providers/${encodeSegment(providerId)}/repositories/${encodeSegment(owner)}/${encodeSegment(repo)}/tags`,
   )
   return response.data
 }
@@ -122,13 +122,13 @@ export async function listSCMRepositoryBranches(
   repo: string,
 ): Promise<{ branches: SCMBranch[] | null }> {
   const response = await http.get<{ branches: SCMBranch[] | null }>(
-    `/api/v1/scm-providers/${providerId}/repositories/${owner}/${repo}/branches`,
+    `/api/v1/scm-providers/${encodeSegment(providerId)}/repositories/${encodeSegment(owner)}/${encodeSegment(repo)}/branches`,
   )
   return response.data
 }
 
 export async function revokeSCMToken(providerId: string): Promise<{ message: string }> {
-  const response = await http.delete(`/api/v1/scm-providers/${providerId}/oauth/token`)
+  const response = await http.delete(`/api/v1/scm-providers/${encodeSegment(providerId)}/oauth/token`)
   return response.data
 }
 
@@ -136,7 +136,7 @@ export async function saveSCMToken(
   providerId: string,
   accessToken: string,
 ): Promise<{ message: string }> {
-  const response = await http.post(`/api/v1/scm-providers/${providerId}/token`, {
+  const response = await http.post(`/api/v1/scm-providers/${encodeSegment(providerId)}/token`, {
     access_token: accessToken,
   })
   return response.data
@@ -161,12 +161,12 @@ export async function linkModuleToSCM(
   webhook_registered: boolean
   note: string
 }> {
-  const response = await http.post(`/api/v1/admin/modules/${moduleId}/scm`, data)
+  const response = await http.post(`/api/v1/admin/modules/${encodeSegment(moduleId)}/scm`, data)
   return response.data
 }
 
 export async function getModuleSCMInfo(moduleId: string): Promise<ModuleSCMLink> {
-  const response = await http.get<ModuleSCMLink>(`/api/v1/admin/modules/${moduleId}/scm`)
+  const response = await http.get<ModuleSCMLink>(`/api/v1/admin/modules/${encodeSegment(moduleId)}/scm`)
   return response.data
 }
 
@@ -179,12 +179,12 @@ export async function updateModuleSCMLink(
     tag_pattern?: string
   },
 ): Promise<{ message: string }> {
-  const response = await http.put(`/api/v1/admin/modules/${moduleId}/scm`, data)
+  const response = await http.put(`/api/v1/admin/modules/${encodeSegment(moduleId)}/scm`, data)
   return response.data
 }
 
 export async function unlinkModuleFromSCM(moduleId: string): Promise<{ message: string }> {
-  const response = await http.delete(`/api/v1/admin/modules/${moduleId}/scm`)
+  const response = await http.delete(`/api/v1/admin/modules/${encodeSegment(moduleId)}/scm`)
   return response.data
 }
 
@@ -192,13 +192,13 @@ export async function triggerManualSync(
   moduleId: string,
   data?: { tag_name?: string; commit_sha?: string },
 ): Promise<{ message: string }> {
-  const response = await http.post(`/api/v1/admin/modules/${moduleId}/scm/sync`, data || {})
+  const response = await http.post(`/api/v1/admin/modules/${encodeSegment(moduleId)}/scm/sync`, data || {})
   return response.data
 }
 
 export async function getWebhookEvents(moduleId: string): Promise<SCMWebhookEvent[]> {
   const response = await http.get<{ events?: SCMWebhookEvent[] }>(
-    `/api/v1/admin/modules/${moduleId}/scm/events`,
+    `/api/v1/admin/modules/${encodeSegment(moduleId)}/scm/events`,
   )
   // Backend wraps the list as { events: [...] }; callers expect a bare array.
   return response.data?.events ?? []

--- a/frontend/src/services/api/storageApi.ts
+++ b/frontend/src/services/api/storageApi.ts
@@ -1,4 +1,4 @@
-import { http } from './http'
+import { http, encodeSegment } from './http'
 import type {
   MigrationPlan,
   StorageConfigInput,
@@ -21,7 +21,7 @@ export async function listStorageConfigs(): Promise<StorageConfigResponse[]> {
 }
 
 export async function getStorageConfig(id: string): Promise<StorageConfigResponse> {
-  const response = await http.get(`/api/v1/storage/configs/${id}`)
+  const response = await http.get(`/api/v1/storage/configs/${encodeSegment(id)}`)
   return response.data
 }
 
@@ -36,18 +36,18 @@ export async function updateStorageConfig(
   id: string,
   data: StorageConfigInput,
 ): Promise<StorageConfigResponse> {
-  const response = await http.put(`/api/v1/storage/configs/${id}`, data)
+  const response = await http.put(`/api/v1/storage/configs/${encodeSegment(id)}`, data)
   return response.data
 }
 
 export async function deleteStorageConfig(id: string): Promise<void> {
-  await http.delete(`/api/v1/storage/configs/${id}`)
+  await http.delete(`/api/v1/storage/configs/${encodeSegment(id)}`)
 }
 
 export async function activateStorageConfig(
   id: string,
 ): Promise<{ message: string; config: StorageConfigResponse }> {
-  const response = await http.post(`/api/v1/storage/configs/${id}/activate`)
+  const response = await http.post(`/api/v1/storage/configs/${encodeSegment(id)}/activate`)
   return response.data
 }
 
@@ -85,12 +85,12 @@ export async function startStorageMigration(
 }
 
 export async function getStorageMigration(id: string): Promise<StorageMigration> {
-  const response = await http.get(`/api/v1/admin/storage/migrations/${id}`)
+  const response = await http.get(`/api/v1/admin/storage/migrations/${encodeSegment(id)}`)
   return response.data
 }
 
 export async function cancelStorageMigration(id: string): Promise<StorageMigration> {
-  const response = await http.post(`/api/v1/admin/storage/migrations/${id}/cancel`)
+  const response = await http.post(`/api/v1/admin/storage/migrations/${encodeSegment(id)}/cancel`)
   return response.data
 }
 

--- a/frontend/src/services/api/suiteApi.ts
+++ b/frontend/src/services/api/suiteApi.ts
@@ -1,0 +1,27 @@
+/**
+ * Suite sibling-discovery domain API — reports whether a paired suite app
+ * (e.g. terraform-state-manager) is reachable and how to link to it.
+ */
+import { http } from './http'
+
+export interface SuiteSibling {
+  app: string
+  state: 'active' | 'degraded' | 'unreachable' | 'unknown'
+  publicUrl?: string
+  links?: Record<string, string>
+  // Identity provenance from the sibling's manifest. issuer identifies which app
+  // minted its tokens; sharedStore is true only when an operator has confirmed
+  // both apps use one identity store + IdP (single sign-on). Absent/false ⇒ the
+  // switcher warns that opening the sibling may require a separate sign-in.
+  issuer?: string
+  sharedStore?: boolean
+}
+
+// Lives here (not in useSuite.ts) so this call goes through the shared http
+// client -- inheriting API_BASE_URL resolution for the split-origin deployment
+// mode and CSRF/401 handling -- and is covered by scripts/contract-check.ts,
+// which only walks domain modules under services/api/ (#600).
+export async function getUIConfig(): Promise<{ sibling: SuiteSibling | null }> {
+  const response = await http.get<{ sibling: SuiteSibling | null }>('/api/v1/ui/config')
+  return response.data
+}

--- a/frontend/src/services/api/terraformMirrorApi.ts
+++ b/frontend/src/services/api/terraformMirrorApi.ts
@@ -1,4 +1,4 @@
-import { http } from './http'
+import { http, encodeSegment } from './http'
 import type {
   CreateTerraformMirrorConfigRequest,
   TerraformBinaryDownloadResponse,
@@ -48,7 +48,7 @@ export async function createTerraformMirrorConfig(
 
 export async function getTerraformMirrorConfig(configId: string): Promise<TerraformMirrorConfig> {
   const response = await http.get<TerraformMirrorConfig>(
-    `/api/v1/admin/terraform-mirrors/${configId}`,
+    `/api/v1/admin/terraform-mirrors/${encodeSegment(configId)}`,
   )
   return response.data
 }
@@ -57,7 +57,7 @@ export async function getTerraformMirrorStatus(
   configId: string,
 ): Promise<TerraformMirrorStatusResponse> {
   const response = await http.get<TerraformMirrorStatusResponse>(
-    `/api/v1/admin/terraform-mirrors/${configId}/status`,
+    `/api/v1/admin/terraform-mirrors/${encodeSegment(configId)}/status`,
   )
   return response.data
 }
@@ -67,20 +67,25 @@ export async function updateTerraformMirrorConfig(
   data: UpdateTerraformMirrorConfigRequest,
 ): Promise<TerraformMirrorConfig> {
   const response = await http.put<TerraformMirrorConfig>(
-    `/api/v1/admin/terraform-mirrors/${configId}`,
+    `/api/v1/admin/terraform-mirrors/${encodeSegment(configId)}`,
     data,
   )
   return response.data
 }
 
 export async function deleteTerraformMirrorConfig(configId: string): Promise<void> {
-  await http.delete(`/api/v1/admin/terraform-mirrors/${configId}`)
+  await http.delete(`/api/v1/admin/terraform-mirrors/${encodeSegment(configId)}`)
 }
 
 export async function triggerTerraformMirrorSync(configId: string): Promise<{ message: string }> {
   const response = await http.post<{ message: string }>(
-    `/api/v1/admin/terraform-mirrors/${configId}/sync`,
+    `/api/v1/admin/terraform-mirrors/${encodeSegment(configId)}/sync`,
     {},
+    // Mirror sync can take several minutes to download binaries; nginx grants
+    // this endpoint a matching 600s proxy_read_timeout/proxy_send_timeout
+    // (nginx.conf) so the client must not abort at the shared 30s default
+    // (http.ts) while the backend job is still running (#599).
+    { timeout: 600_000 },
   )
   return response.data
 }
@@ -92,7 +97,7 @@ export async function listTerraformVersions(
   const params: Record<string, string> = {}
   if (options?.synced !== undefined) params.synced = String(options.synced)
   const response = await http.get<TerraformVersionListResponse>(
-    `/api/v1/admin/terraform-mirrors/${configId}/versions`,
+    `/api/v1/admin/terraform-mirrors/${encodeSegment(configId)}/versions`,
     {
       params,
     },
@@ -105,24 +110,24 @@ export async function getTerraformVersion(
   version: string,
 ): Promise<TerraformVersion> {
   const response = await http.get<TerraformVersion>(
-    `/api/v1/admin/terraform-mirrors/${configId}/versions/${version}`,
+    `/api/v1/admin/terraform-mirrors/${encodeSegment(configId)}/versions/${encodeSegment(version)}`,
   )
   return response.data
 }
 
 export async function deleteTerraformVersion(configId: string, version: string): Promise<void> {
-  await http.delete(`/api/v1/admin/terraform-mirrors/${configId}/versions/${version}`)
+  await http.delete(`/api/v1/admin/terraform-mirrors/${encodeSegment(configId)}/versions/${encodeSegment(version)}`)
 }
 
 export async function deprecateTerraformVersion(configId: string, version: string): Promise<void> {
-  await http.post(`/api/v1/admin/terraform-mirrors/${configId}/versions/${version}/deprecate`, {})
+  await http.post(`/api/v1/admin/terraform-mirrors/${encodeSegment(configId)}/versions/${encodeSegment(version)}/deprecate`, {})
 }
 
 export async function undeprecateTerraformVersion(
   configId: string,
   version: string,
 ): Promise<void> {
-  await http.delete(`/api/v1/admin/terraform-mirrors/${configId}/versions/${version}/deprecate`)
+  await http.delete(`/api/v1/admin/terraform-mirrors/${encodeSegment(configId)}/versions/${encodeSegment(version)}/deprecate`)
 }
 
 export async function listTerraformVersionPlatforms(
@@ -131,7 +136,7 @@ export async function listTerraformVersionPlatforms(
 ): Promise<TerraformVersionPlatform[]> {
   const response = await http.get<
     TerraformVersionPlatform[] | { platforms?: TerraformVersionPlatform[] }
-  >(`/api/v1/admin/terraform-mirrors/${configId}/versions/${version}/platforms`)
+  >(`/api/v1/admin/terraform-mirrors/${encodeSegment(configId)}/versions/${encodeSegment(version)}/platforms`)
   return Array.isArray(response.data) ? response.data : (response.data.platforms ?? [])
 }
 
@@ -140,7 +145,7 @@ export async function getTerraformMirrorHistory(
   limit = 20,
 ): Promise<TerraformSyncHistoryListResponse> {
   const response = await http.get<TerraformSyncHistoryListResponse>(
-    `/api/v1/admin/terraform-mirrors/${configId}/history`,
+    `/api/v1/admin/terraform-mirrors/${encodeSegment(configId)}/history`,
     {
       params: { limit },
     },
@@ -164,13 +169,13 @@ export async function listPublicTerraformVersions(
   name: string,
 ): Promise<TerraformVersionListResponse> {
   const response = await http.get<TerraformVersionListResponse>(
-    `/terraform/binaries/${name}/versions`,
+    `/terraform/binaries/${encodeSegment(name)}/versions`,
   )
   return response.data
 }
 
 export async function getPublicLatestTerraformVersion(name: string): Promise<TerraformVersion> {
-  const response = await http.get<TerraformVersion>(`/terraform/binaries/${name}/versions/latest`)
+  const response = await http.get<TerraformVersion>(`/terraform/binaries/${encodeSegment(name)}/versions/latest`)
   return response.data
 }
 
@@ -179,7 +184,7 @@ export async function getPublicTerraformVersion(
   version: string,
 ): Promise<TerraformVersion> {
   const response = await http.get<TerraformVersion>(
-    `/terraform/binaries/${name}/versions/${version}`,
+    `/terraform/binaries/${encodeSegment(name)}/versions/${encodeSegment(version)}`,
   )
   return response.data
 }
@@ -191,7 +196,7 @@ export async function getTerraformBinaryDownload(
   arch: string,
 ): Promise<TerraformBinaryDownloadResponse> {
   const response = await http.get<TerraformBinaryDownloadResponse>(
-    `/terraform/binaries/${name}/versions/${version}/${os}/${arch}`,
+    `/terraform/binaries/${encodeSegment(name)}/versions/${encodeSegment(version)}/${encodeSegment(os)}/${encodeSegment(arch)}`,
   )
   return response.data
 }

--- a/frontend/src/services/api/usersApi.ts
+++ b/frontend/src/services/api/usersApi.ts
@@ -1,7 +1,7 @@
 /**
  * Users domain API — user CRUD, search, GDPR export/erasure, and membership lookups.
  */
-import { http } from './http'
+import { http, encodeSegment } from './http'
 import type { PaginationMeta, User, UserMembership } from '../../types'
 
 /**
@@ -68,7 +68,7 @@ export async function searchUsers(
 }
 
 export async function getUser(id: string) {
-  const response = await http.get<{ user: Record<string, unknown> }>(`/api/v1/users/${id}`)
+  const response = await http.get<{ user: Record<string, unknown> }>(`/api/v1/users/${encodeSegment(id)}`)
   return transformUser(response.data.user)
 }
 
@@ -78,12 +78,12 @@ export async function createUser(data: { email: string; name: string }) {
 }
 
 export async function updateUser(id: string, data: { name?: string; email?: string }) {
-  const response = await http.put<{ user: Record<string, unknown> }>(`/api/v1/users/${id}`, data)
+  const response = await http.put<{ user: Record<string, unknown> }>(`/api/v1/users/${encodeSegment(id)}`, data)
   return transformUser(response.data.user)
 }
 
 export async function deleteUser(id: string): Promise<{ message: string }> {
-  const response = await http.delete<{ message: string }>(`/api/v1/users/${id}`)
+  const response = await http.delete<{ message: string }>(`/api/v1/users/${encodeSegment(id)}`)
   return response.data
 }
 
@@ -93,7 +93,7 @@ export async function deleteUser(id: string): Promise<{ message: string }> {
 // sets `Content-Disposition: attachment; filename=user-data-{id}.json`
 // and we want that filename hint to flow to the browser.
 export async function exportUserData(id: string): Promise<{ blob: Blob; filename: string }> {
-  const response = await http.get(`/api/v1/admin/users/${id}/export`, {
+  const response = await http.get(`/api/v1/admin/users/${encodeSegment(id)}/export`, {
     responseType: 'blob',
   })
   // Default to user-data-{id}.json; override if the server provided a Content-Disposition.
@@ -110,13 +110,13 @@ export async function exportUserData(id: string): Promise<{ blob: Blob; filename
 
 // GDPR Article 17 — anonymize user PII while preserving audit trail.
 export async function eraseUser(id: string): Promise<{ message: string; user_id: string }> {
-  const response = await http.post(`/api/v1/admin/users/${id}/erase`)
+  const response = await http.post(`/api/v1/admin/users/${encodeSegment(id)}/erase`)
   return response.data as { message: string; user_id: string }
 }
 
 export async function getUserMemberships(userId: string): Promise<UserMembership[]> {
   const response = await http.get<{ memberships?: UserMembership[] }>(
-    `/api/v1/users/${userId}/memberships`,
+    `/api/v1/users/${encodeSegment(userId)}/memberships`,
   )
   return response.data.memberships || []
 }

--- a/frontend/src/services/api/versionApprovalsApi.ts
+++ b/frontend/src/services/api/versionApprovalsApi.ts
@@ -1,4 +1,4 @@
-import { http } from './http'
+import { http, encodeSegment } from './http'
 import type {
   VersionApprovalBulkResponse,
   VersionApprovalEvent,
@@ -29,11 +29,11 @@ export async function listVersionApprovals(params?: {
 }
 
 export async function approveVersion(id: string, data?: { notes?: string }): Promise<void> {
-  await http.put(`/api/v1/admin/version-approvals/${id}/approve`, data ?? {})
+  await http.put(`/api/v1/admin/version-approvals/${encodeSegment(id)}/approve`, data ?? {})
 }
 
 export async function rejectVersion(id: string, data?: { notes?: string }): Promise<void> {
-  await http.put(`/api/v1/admin/version-approvals/${id}/reject`, data ?? {})
+  await http.put(`/api/v1/admin/version-approvals/${encodeSegment(id)}/reject`, data ?? {})
 }
 
 export async function bulkApproveVersions(
@@ -60,7 +60,7 @@ export async function bulkRejectVersions(
 
 export async function getVersionApprovalEvents(id: string): Promise<VersionApprovalEvent[]> {
   const response = await http.get<VersionApprovalEvent[]>(
-    `/api/v1/admin/version-approvals/${id}/events`,
+    `/api/v1/admin/version-approvals/${encodeSegment(id)}/events`,
   )
   return Array.isArray(response.data) ? response.data : []
 }

--- a/frontend/src/utils/__tests__/errors.test.ts
+++ b/frontend/src/utils/__tests__/errors.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { AxiosError, AxiosHeaders, CanceledError } from 'axios'
 import {
   getErrorMessage,
@@ -19,7 +19,48 @@ function axiosErrorWith(dataError: unknown, status = 500, message = 'Request fai
   return error
 }
 
+vi.mock('../../services/errorReporting', () => ({
+  captureError: vi.fn(),
+}))
+
+import { captureError } from '../../services/errorReporting'
+
 describe('getErrorMessage', () => {
+  beforeEach(() => {
+    vi.mocked(captureError).mockClear()
+  })
+
+  // Regression guard (#619): getErrorMessage is the one call every caught-API-error
+  // handler already goes through -- wiring telemetry reporting here, instead of at
+  // each of the ~90 call sites, is what gets handled failures into the same
+  // error-reporting pipeline as uncaught ones.
+  it('reports the caught error to telemetry, tagged with the fallback as context', () => {
+    const error = new Error('boom')
+    getErrorMessage(error, 'Failed to do the thing')
+    expect(captureError).toHaveBeenCalledWith(error, { context: 'Failed to do the thing' })
+  })
+
+  it('reports an AxiosError to telemetry as-is (not re-wrapped)', () => {
+    const error = new AxiosError('Network Error')
+    getErrorMessage(error, 'Failed to load')
+    expect(captureError).toHaveBeenCalledWith(error, { context: 'Failed to load' })
+  })
+
+  it('wraps a non-Error thrown value in an Error before reporting to telemetry', () => {
+    getErrorMessage('a string error', 'Failed fallback')
+    expect(captureError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'a string error' }),
+      { context: 'Failed fallback' },
+    )
+  })
+
+  it('wraps a non-Error, non-string thrown value using the fallback as the message', () => {
+    getErrorMessage({ code: 123 }, 'Failed fallback')
+    expect(captureError).toHaveBeenCalledWith(expect.objectContaining({ message: 'Failed fallback' }), {
+      context: 'Failed fallback',
+    })
+  })
+
   it('extracts error message from AxiosError with response.data.error', () => {
     const error = new AxiosError('Request failed')
     error.response = {

--- a/frontend/src/utils/errors.ts
+++ b/frontend/src/utils/errors.ts
@@ -1,5 +1,6 @@
 import axios, { AxiosError } from 'axios'
 import i18n from '../i18n'
+import { captureError } from '../services/errorReporting'
 
 /** Longest backend-supplied error string we are willing to render verbatim. */
 const MAX_SERVER_MESSAGE_LENGTH = 300
@@ -55,8 +56,16 @@ export function isCanceledError(err: unknown): boolean {
  * Extracts a human-readable error message from an unknown catch-block value.
  * Handles Axios errors (with nested response.data.error), native Errors, and
  * arbitrary thrown values.
+ *
+ * As a side effect, reports the caught error to the app's error-telemetry
+ * pipeline (captureError), tagged with the caller-supplied fallback message
+ * as context, so handled API/UI failures get the same production visibility
+ * as uncaught errors instead of only setting local component state (#619).
  */
 export function getErrorMessage(err: unknown, fallback = 'An unexpected error occurred'): string {
+  captureError(err instanceof Error ? err : new Error(typeof err === 'string' ? err : fallback), {
+    context: fallback,
+  })
   if (err instanceof AxiosError) {
     // A request that hit the client-side timeout has no response either, but is a
     // distinct, more actionable condition than "can't reach the server at all" --


### PR DESCRIPTION
Closes #599
Closes #600
Closes #614
Closes #619
Closes #623
Part of #559 (backend-sourced URLs now pass isSafeExternalUrl at the app boundary)

Batch `b-api-url-telemetry` from the 2026-07-22 blind security audit:

- **#614** — path-segment identifiers are `encodeURIComponent`-encoded across `api/*.ts` (representative call-site tests with special-character identifiers).
- **#619/#623** — `captureError()` wired into the API-error catch sites so handled failures reach telemetry instead of console-only.
- **#600** — `useSuite.ts` routed through the shared client/API_BASE_URL resolution and contract-check.
- **#599** — mirror-sync endpoints get timeouts matched to their nginx grants.
- **#559 regression** — backend-provided URLs pass the `isSafeExternalUrl` guard before reaching navigation sinks.

Verification: 3-reviewer adversarial panel consensus; lint, vitest and build green. Two reviewer follow-ups deliberately rebutted with rationale (double-logging claim; exhaustive-encoding-test scope) — recorded in the run report.

Merge order: after `a-http-client-core` (overlap in `organizationsApi.ts` and error-utils tests); this branch will be rebased once that lands.