### PR TITLE
fix(security): consistent client scope gating, dev-login bundle stripping, scope typing

### DIFF
--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -6,12 +6,13 @@ import { Box, Dialog, Typography, useTheme } from '@mui/material'
 import { useAuth } from '../contexts/AuthContext'
 import api from '../services/api'
 import type { Module, Provider } from '../types'
+import type { ScopeValue } from '../types/rbac'
 
 export interface CommandPaletteNavItem {
   label: string
   path: string
   /** If set, the entry is hidden unless the user has the scope (or 'admin'). */
-  scope?: string | null
+  scope?: ScopeValue | null
   group: 'Navigation' | 'Admin'
   keywords?: string[]
 }
@@ -55,14 +56,14 @@ export const defaultCommands: CommandPaletteNavItem[] = [
   {
     label: 'Publish Module',
     path: '/admin/upload/module',
-    scope: 'modules:publish',
+    scope: 'modules:write',
     group: 'Admin',
     keywords: ['upload'],
   },
   {
     label: 'Upload Provider',
     path: '/admin/upload/provider',
-    scope: 'providers:publish',
+    scope: 'providers:write',
     group: 'Admin',
     keywords: ['publish'],
   },

--- a/frontend/src/components/DevUserSwitcher.tsx
+++ b/frontend/src/components/DevUserSwitcher.tsx
@@ -13,8 +13,12 @@ import {
 } from '@mui/material'
 import SyncAlt from '@mui/icons-material/SyncAlt'
 import { useAuth } from '../contexts/AuthContext'
-import apiClient from '../services/api'
 import { captureError } from '../services/errorReporting'
+// Imported directly from the domain module rather than the shared `../services/api`
+// barrel: the barrel is spread into every eagerly-loaded page's `apiClient`, so
+// pulling devApi through it would drag dev/impersonate endpoints back into the
+// production bundle despite this component's own lazy import in Layout.tsx (#608).
+import * as devApi from '../services/api/devApi'
 
 interface DevUser {
   id: string
@@ -35,11 +39,11 @@ const DevUserSwitcher = () => {
   useEffect(() => {
     const checkDevMode = async () => {
       try {
-        const status = await apiClient.getDevStatus()
+        const status = await devApi.getDevStatus()
         setDevMode(status.dev_mode)
         if (status.dev_mode) {
           // Load users for impersonation
-          const usersData = await apiClient.listUsersForImpersonation()
+          const usersData = await devApi.listUsersForImpersonation()
           setUsers(usersData.users || [])
         }
       } catch {
@@ -59,7 +63,7 @@ const DevUserSwitcher = () => {
 
     setSwitching(true)
     try {
-      await apiClient.impersonateUser(targetUserId)
+      await devApi.impersonateUser(targetUserId)
       // The backend swapped the HttpOnly auth cookie to the impersonated user;
       // reload the page so the auth context picks up the new session via /auth/me.
       window.location.reload()

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react'
+import { useState, useCallback, lazy, Suspense } from 'react'
 import { useTranslation } from 'react-i18next'
 import { IconButton, ListItemIcon, Menu, MenuItem, Tooltip } from '@mui/material'
 import SearchIcon from '@mui/icons-material/Search'
@@ -14,7 +14,6 @@ import {
   componentShowcaseItem,
   adminNavGroups,
 } from '../navigation'
-import DevUserSwitcher from './DevUserSwitcher'
 import { SuiteSwitcher } from './SuiteSwitcher'
 import HelpPanel, { HELP_PANEL_WIDTH } from './HelpPanel'
 import AboutModal from './AboutModal'
@@ -39,6 +38,13 @@ const LANGUAGE_NATIVE_NAMES = {
 } as const
 
 const LANGUAGES = Object.entries(LANGUAGE_NATIVE_NAMES).map(([code, label]) => ({ code, label }))
+
+// Dev-only "switch to any user" impersonation UI (#608). Loaded via a dynamic
+// import (rather than a static one) so that, combined with the
+// import.meta.env.DEV guard below, bundlers dead-code-eliminate it and its
+// devApi impersonation calls out of the production bundle instead of merely
+// relying on the runtime dev_mode probe + server-side DEV_MODE gate.
+const DevUserSwitcher = lazy(() => import('./DevUserSwitcher'))
 
 /**
  * Application shell. A thin wrapper over the shared SuiteLayout that injects the
@@ -87,7 +93,11 @@ const Layout = () => {
         contentInsetRight={helpOpen ? HELP_PANEL_WIDTH : 0}
         appBarActions={
           <>
-            {isAuthenticated && <DevUserSwitcher />}
+            {isAuthenticated && import.meta.env.DEV && (
+              <Suspense fallback={null}>
+                <DevUserSwitcher />
+              </Suspense>
+            )}
             <Tooltip title={t('header.quickNav')}>
               <IconButton
                 color="inherit"

--- a/frontend/src/components/LazyRoute.tsx
+++ b/frontend/src/components/LazyRoute.tsx
@@ -2,6 +2,7 @@ import { Suspense } from 'react'
 import type { ComponentType } from 'react'
 import ErrorBoundary from './ErrorBoundary'
 import ProtectedRoute from './ProtectedRoute'
+import type { ScopeValue } from '../types/rbac'
 
 const loader = <div>Loading...</div>
 
@@ -12,7 +13,7 @@ interface LazyRouteProps {
    * requires an authenticated user but no specific scope. Pass a scope
    * string for a route gated on that scope (via ProtectedRoute).
    */
-  requiredScope?: string | null
+  requiredScope?: ScopeValue | null
 }
 
 /**

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -1,10 +1,11 @@
 import { Navigate } from 'react-router-dom'
 import { useAuth } from '../contexts/AuthContext'
 import { CircularProgress, Box, Container, Typography, Alert, Button } from '@mui/material'
+import type { ScopeValue } from '../types/rbac'
 
 interface ProtectedRouteProps {
   children: React.ReactNode
-  requiredScope?: string // Optional scope required to access this route
+  requiredScope?: ScopeValue // Optional scope required to access this route
 }
 
 const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children, requiredScope }) => {

--- a/frontend/src/components/__tests__/CommandPalette.test.tsx
+++ b/frontend/src/components/__tests__/CommandPalette.test.tsx
@@ -63,6 +63,24 @@ describe('filterByScope', () => {
     expect(entry?.label).toBe('Hosted Binaries')
     expect(entry?.path).toBe('/terraform-binaries')
   })
+
+  // #633 — the Publish/Upload commands must reference the real modules:write /
+  // providers:write scopes (not the nonexistent modules:publish /
+  // providers:publish), or a non-admin holder of the real write scope never
+  // sees these commands (fails closed, but silently).
+  it('reveals Publish Module / Upload Provider to holders of the real write scopes', () => {
+    const withModulesWrite = filterByScope(defaultCommands, ['modules:write'])
+    expect(withModulesWrite.find((i) => i.path === '/admin/upload/module')).toBeDefined()
+
+    const withProvidersWrite = filterByScope(defaultCommands, ['providers:write'])
+    expect(withProvidersWrite.find((i) => i.path === '/admin/upload/provider')).toBeDefined()
+  })
+
+  it('hides Publish Module / Upload Provider without the write scopes', () => {
+    const result = filterByScope(defaultCommands, [])
+    expect(result.find((i) => i.path === '/admin/upload/module')).toBeUndefined()
+    expect(result.find((i) => i.path === '/admin/upload/provider')).toBeUndefined()
+  })
 })
 
 describe('CommandPalette', () => {

--- a/frontend/src/components/__tests__/DevUserSwitcher.test.tsx
+++ b/frontend/src/components/__tests__/DevUserSwitcher.test.tsx
@@ -5,12 +5,13 @@ const getDevStatusMock = vi.fn()
 const listUsersForImpersonationMock = vi.fn()
 const impersonateUserMock = vi.fn()
 
-vi.mock('../../services/api', () => ({
-  default: {
-    getDevStatus: (...args: unknown[]) => getDevStatusMock(...args),
-    listUsersForImpersonation: (...args: unknown[]) => listUsersForImpersonationMock(...args),
-    impersonateUser: (...args: unknown[]) => impersonateUserMock(...args),
-  },
+// DevUserSwitcher imports devApi directly (not the shared `../../services/api`
+// barrel, which deliberately excludes it — see services/api/index.ts) so the
+// dev-only endpoints stay out of the production bundle (#608).
+vi.mock('../../services/api/devApi', () => ({
+  getDevStatus: (...args: unknown[]) => getDevStatusMock(...args),
+  listUsersForImpersonation: (...args: unknown[]) => listUsersForImpersonationMock(...args),
+  impersonateUser: (...args: unknown[]) => impersonateUserMock(...args),
 }))
 
 const mockAuth = {

--- a/frontend/src/components/__tests__/Layout.test.tsx
+++ b/frontend/src/components/__tests__/Layout.test.tsx
@@ -217,6 +217,17 @@ describe('Layout', () => {
     expect(screen.queryByTestId('dev-user-switcher')).not.toBeInTheDocument()
   })
 
+  it('does not render DevUserSwitcher outside dev builds, even when authenticated (#608)', async () => {
+    vi.stubEnv('DEV', false)
+    try {
+      renderLayout({ scopes: ['admin'] })
+      await screen.findByLabelText('Account') // wait for the authenticated shell to settle
+      expect(screen.queryByTestId('dev-user-switcher')).not.toBeInTheDocument()
+    } finally {
+      vi.unstubAllEnvs()
+    }
+  })
+
   it('renders a skip-to-content link', async () => {
     renderLayout()
     const skipLink = await screen.findByText('Skip to content')

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -14,6 +14,36 @@ import {
 import api from '../services/api'
 import { clearAuthStorage } from '../utils/authStorage'
 import { queryClient } from '../queryClient'
+import type { RoleTemplateInfo } from '../types'
+
+// Membership.organization_id/organization_name are required, non-optional
+// strings in the shared package's contract, so the synthetic membership below
+// can't simply omit them. This obviously-fake sentinel (rather than '') is
+// used for both fields so that if a future suite-ui feature (an org switcher,
+// breadcrumbs, etc.) ever renders them, it fails visibly instead of silently
+// showing a blank organization (#622).
+const NO_ORGANIZATION_SENTINEL = '(no organization — registry has a single role_template)'
+
+/**
+ * Builds the synthetic single-membership array the shared package's
+ * MeResponse contract expects, from this app's single role_template (the
+ * registry backend has no real multi-org membership concept). Exported for
+ * unit testing.
+ */
+export function toSyntheticMemberships(
+  roleTemplate: RoleTemplateInfo | null,
+): MeResponse['memberships'] {
+  return roleTemplate
+    ? [
+      {
+        organization_id: NO_ORGANIZATION_SENTINEL,
+        organization_name: NO_ORGANIZATION_SENTINEL,
+        role_template_name: roleTemplate.name,
+        role_template_scopes: roleTemplate.scopes,
+      },
+    ]
+    : []
+}
 
 // On sign-out, also drop the react-query cache so prior-user admin/query data does not
 // linger in memory until a full page reload (a retention gap on shared/kiosk machines).
@@ -29,23 +59,20 @@ const authApi: AuthApi = {
       user: r.user,
       allowed_scopes: r.allowed_scopes,
       session_expires_at: r.session_expires_at ?? undefined,
-      memberships: r.role_template
-        ? [
-          {
-            organization_id: '',
-            organization_name: '',
-            role_template_name: r.role_template.name,
-            role_template_scopes: r.role_template.scopes,
-          },
-        ]
-        : [],
+      memberships: toSyntheticMemberships(r.role_template),
     }
   },
   login: (provider) => api.login(provider),
   // Registry dev/LDAP logins set the HttpOnly auth cookie (plus tfr_csrf) via
   // Set-Cookie on the response — no token in the body, nothing to persist. The
   // suite AuthProvider resolves the session via the subsequent /auth/me probe.
-  devLogin: () => api.devLogin(),
+  //
+  // devLogin is dynamically imported (rather than going through the eager `api`
+  // barrel, which deliberately excludes devApi) so this dev-only endpoint stays
+  // out of the production bundle even though AuthContext itself is always
+  // eagerly loaded (#608). LoginPage only calls this from its own
+  // import.meta.env-gated "Dev Login" button.
+  devLogin: () => import('../services/api/devApi').then((devApi) => devApi.devLogin()),
   ldapLogin: (username, password) => api.ldapLogin(username, password),
   logout: () => api.logout(),
   refreshToken: async () => {

--- a/frontend/src/contexts/__tests__/AuthContext.test.tsx
+++ b/frontend/src/contexts/__tests__/AuthContext.test.tsx
@@ -1,5 +1,5 @@
 import { render, act, waitFor } from '@testing-library/react'
-import { AuthProvider, useAuth } from '../AuthContext'
+import { AuthProvider, useAuth, toSyntheticMemberships } from '../AuthContext'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { AUTH_STORAGE_KEYS } from '../../utils/authStorage'
 
@@ -14,6 +14,10 @@ const mockApi = vi.hoisted(() => ({
 }))
 
 vi.mock('../../services/api', () => ({ default: mockApi }))
+// devLogin is dynamically imported from devApi directly (not the barrel above,
+// which deliberately excludes it) so the dev-only endpoint is dead-code-eliminated
+// from the production bundle (#608) — mock that import target too.
+vi.mock('../../services/api/devApi', () => ({ devLogin: () => mockApi.devLogin() }))
 
 const me = {
   user: { id: 'u1', email: 'a@b.c', name: 'Alice' },
@@ -136,5 +140,26 @@ describe('AuthProvider', () => {
     await act(() => latest.refreshSession())
     expect(latest.isAuthenticated).toBe(true)
     expect(mockApi.logout).not.toHaveBeenCalled()
+  })
+})
+
+describe('toSyntheticMemberships (#622)', () => {
+  it('returns an empty array when there is no role template', () => {
+    expect(toSyntheticMemberships(null)).toEqual([])
+  })
+
+  it('fills organization_id/organization_name with an obviously-fake sentinel, not blank strings', () => {
+    const [membership] = toSyntheticMemberships({
+      name: 'admin',
+      display_name: 'Administrator',
+      scopes: ['admin'],
+    })
+    expect(membership.role_template_name).toBe('admin')
+    expect(membership.role_template_scopes).toEqual(['admin'])
+    // Must not silently render blank — a future consumer should notice these
+    // are placeholders, not real organization data.
+    expect(membership.organization_id).not.toBe('')
+    expect(membership.organization_name).not.toBe('')
+    expect(membership.organization_id).toBe(membership.organization_name)
   })
 })

--- a/frontend/src/navigation.tsx
+++ b/frontend/src/navigation.tsx
@@ -22,11 +22,16 @@ import History from '@mui/icons-material/History'
 import Notifications from '@mui/icons-material/Notifications'
 import type { NavItem, NavGroup } from '@sethbacon/terraform-suite-ui'
 import { ADMIN_ROUTE_SCOPES } from './routeScopes'
+import type { ScopeValue } from './types/rbac'
 
 // Reads the scope for an admin nav item from the shared route-scope map
 // (routeScopes.ts) so App.tsx's route guards and this sidebar's item
-// filtering can't drift apart.
-function adminScope(path: string): string | null {
+// filtering can't drift apart. Returns the canonical ScopeValue union (#633)
+// rather than widening back to `string | null` -- NavItem.scope itself stays
+// `string | null` (defined by the out-of-tree @sethbacon/terraform-suite-ui
+// package), but this keeps ADMIN_ROUTE_SCOPES's compile-time protection
+// intact through this call site instead of discarding it here.
+function adminScope(path: string): ScopeValue | null {
   return ADMIN_ROUTE_SCOPES[path] ?? null
 }
 

--- a/frontend/src/pages/admin/APIKeysPage.tsx
+++ b/frontend/src/pages/admin/APIKeysPage.tsx
@@ -85,6 +85,15 @@ const APIKeysPage: React.FC = () => {
   const queryClient = useQueryClient()
   const { allowedScopes, roleTemplate } = useAuth()
   const isAdmin = allowedScopes.includes('admin')
+  // The route itself is gated at no scope at all (routeScopes.ts: null) so any
+  // authenticated user can reach this page. listAPIKeys returns keys across the
+  // caller's organization (each key carries its own user_id/user_name), so
+  // Create/Edit/Rotate/Delete act on OTHER users' keys too -- separately from
+  // page visibility, only show those controls to callers who hold the scope
+  // the mutating endpoints actually need (#609): an unscoped viewer would
+  // otherwise see fully actionable buttons that only fail once clicked,
+  // relying entirely on the server to say no.
+  const canManage = isAdmin || allowedScopes.includes('api_keys:manage')
   const [error, setError] = useState<string | null>(null)
 
   // API-key-expiry notification settings (admin-only). Shares the notifications
@@ -496,9 +505,11 @@ const APIKeysPage: React.FC = () => {
         title={t('admin.apiKeys.pageTitle')}
         description={t('admin.apiKeys.pageSubtitle')}
         actions={
-          <Button variant="contained" startIcon={<AddIcon />} onClick={handleOpenDialog}>
-            {t('admin.apiKeys.createApiKey')}
-          </Button>
+          canManage ? (
+            <Button variant="contained" startIcon={<AddIcon />} onClick={handleOpenDialog}>
+              {t('admin.apiKeys.createApiKey')}
+            </Button>
+          ) : undefined
         }
       />
       {error && (
@@ -536,11 +547,15 @@ const APIKeysPage: React.FC = () => {
             title={t('admin.apiKeys.emptyTitle')}
             description={t('admin.apiKeys.emptyDescription')}
             icon={<KeyIcon />}
-            primaryAction={{
-              label: t('admin.apiKeys.emptyAction'),
-              icon: <AddIcon />,
-              onClick: handleOpenDialog,
-            }}
+            primaryAction={
+              canManage
+                ? {
+                  label: t('admin.apiKeys.emptyAction'),
+                  icon: <AddIcon />,
+                  onClick: handleOpenDialog,
+                }
+                : undefined
+            }
             data-testid="apikeys-empty-state"
           />
         ) : (
@@ -607,34 +622,38 @@ const APIKeysPage: React.FC = () => {
                       </TableCell>
                       <TableCell align="right">
                         <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 0.5 }}>
-                          <Tooltip title={t('admin.apiKeys.tooltipEdit')}>
-                            <IconButton
-                              size="small"
-                              aria-label={t('admin.apiKeys.ariaEdit')}
-                              onClick={() => handleEditClick(apiKey)}
-                            >
-                              <EditIcon fontSize="small" />
-                            </IconButton>
-                          </Tooltip>
-                          <Tooltip title={t('admin.apiKeys.tooltipRotate')}>
-                            <IconButton
-                              size="small"
-                              aria-label={t('admin.apiKeys.ariaRotate')}
-                              onClick={() => handleRotateClick(apiKey)}
-                            >
-                              <AutorenewIcon fontSize="small" />
-                            </IconButton>
-                          </Tooltip>
-                          <Tooltip title={t('admin.apiKeys.tooltipDelete')}>
-                            <IconButton
-                              size="small"
-                              aria-label={t('admin.apiKeys.ariaDelete')}
-                              onClick={() => handleDeleteClick(apiKey)}
-                              color="error"
-                            >
-                              <DeleteIcon fontSize="small" />
-                            </IconButton>
-                          </Tooltip>
+                          {canManage && (
+                            <>
+                              <Tooltip title={t('admin.apiKeys.tooltipEdit')}>
+                                <IconButton
+                                  size="small"
+                                  aria-label={t('admin.apiKeys.ariaEdit')}
+                                  onClick={() => handleEditClick(apiKey)}
+                                >
+                                  <EditIcon fontSize="small" />
+                                </IconButton>
+                              </Tooltip>
+                              <Tooltip title={t('admin.apiKeys.tooltipRotate')}>
+                                <IconButton
+                                  size="small"
+                                  aria-label={t('admin.apiKeys.ariaRotate')}
+                                  onClick={() => handleRotateClick(apiKey)}
+                                >
+                                  <AutorenewIcon fontSize="small" />
+                                </IconButton>
+                              </Tooltip>
+                              <Tooltip title={t('admin.apiKeys.tooltipDelete')}>
+                                <IconButton
+                                  size="small"
+                                  aria-label={t('admin.apiKeys.ariaDelete')}
+                                  onClick={() => handleDeleteClick(apiKey)}
+                                  color="error"
+                                >
+                                  <DeleteIcon fontSize="small" />
+                                </IconButton>
+                              </Tooltip>
+                            </>
+                          )}
                         </Box>
                       </TableCell>
                     </TableRow>

--- a/frontend/src/pages/admin/ApprovalsPage.tsx
+++ b/frontend/src/pages/admin/ApprovalsPage.tsx
@@ -34,11 +34,20 @@ import api from '../../services/api'
 import { formatDate } from '../../utils'
 import { MirrorApprovalRequest } from '../../types/rbac'
 import { getErrorMessage } from '../../utils/errors'
+import { useAuth } from '../../contexts/AuthContext'
 import { queryKeys } from '../../services/queryKeys'
 
 const ApprovalsPage: React.FC = () => {
   const { t } = useTranslation()
   const queryClient = useQueryClient()
+  const { allowedScopes } = useAuth()
+  // The route itself is gated at mirrors:read (view-only) so auditors/viewers
+  // can browse approval requests (routeScopes.ts). Create-request and
+  // Approve/Reject mutate approval state though, so canManage additionally
+  // gates those controls on mirrors:manage/admin — a mirrors:read-only
+  // viewer would otherwise see fully actionable controls that only fail once
+  // clicked (#609).
+  const canManage = allowedScopes.includes('admin') || allowedScopes.includes('mirrors:manage')
   const [error, setError] = useState<string | null>(null)
   const [success, setSuccess] = useState<string | null>(null)
 
@@ -224,13 +233,15 @@ const ApprovalsPage: React.FC = () => {
                 >
                   {t('admin.approvals.refresh')}
                 </Button>
-                <Button
-                  variant="contained"
-                  startIcon={<AddIcon />}
-                  onClick={() => setCreateDialogOpen(true)}
-                >
-                  {t('admin.approvals.createRequest')}
-                </Button>
+                {canManage && (
+                  <Button
+                    variant="contained"
+                    startIcon={<AddIcon />}
+                    onClick={() => setCreateDialogOpen(true)}
+                  >
+                    {t('admin.approvals.createRequest')}
+                  </Button>
+                )}
               </Box>
             }
           />
@@ -328,7 +339,7 @@ const ApprovalsPage: React.FC = () => {
                     )}
                   </CardContent>
 
-                  {approval.status === 'pending' && (
+                  {approval.status === 'pending' && canManage && (
                     <CardActions>
                       <Button
                         size="small"

--- a/frontend/src/pages/admin/DashboardPage.tsx
+++ b/frontend/src/pages/admin/DashboardPage.tsx
@@ -41,6 +41,7 @@ import Security from '@mui/icons-material/Security'
 import VpnKey from '@mui/icons-material/VpnKey'
 import api from '../../services/api'
 import { useAuth } from '../../contexts/AuthContext'
+import type { ScopeValue } from '../../types/rbac'
 import Page from '../../components/Page'
 import PageHeader from '../../components/PageHeader'
 import PageTitleIcon from '@mui/icons-material/Dashboard'
@@ -703,7 +704,7 @@ const DashboardPage: React.FC = () => {
     : false
 
   // ---- Zone 2: stat cards --------------------------------------------------
-  const statCards: (StatCardProps & { scope: string | null; gridMd: number })[] = !data
+  const statCards = (!data
     ? []
     : [
       // Row 1 — content cards (each md=6)
@@ -776,13 +777,14 @@ const DashboardPage: React.FC = () => {
           />
         ),
       },
-    ].filter((c) => c.scope === null || hasScope(c.scope))
+    ] satisfies (StatCardProps & { scope: ScopeValue | null; gridMd: number })[]
+  ).filter((c) => c.scope === null || hasScope(c.scope))
 
   // ---- Zone 3 left: recent syncs -------------------------------------------
   const recentSyncs = data ? data.recent_syncs.slice(0, 8) : []
 
   // ---- Zone 3 right: quick links -------------------------------------------
-  const quickLinks: (QuickLinkProps & { scope: string | null })[] = [
+  const quickLinks = ([
     {
       label: t('admin.dashboard.qlUploadModule'),
       icon: <CloudUpload fontSize="small" />,
@@ -839,7 +841,8 @@ const DashboardPage: React.FC = () => {
       color: '#78909C',
       scope: 'admin',
     },
-  ].filter((l) => l.scope === null || hasScope(l.scope))
+  ] satisfies (QuickLinkProps & { scope: ScopeValue | null })[]
+  ).filter((l) => l.scope === null || hasScope(l.scope))
 
   return (
     <Page maxWidth="lg" aria-busy={loading} aria-live="polite">

--- a/frontend/src/pages/admin/MirrorsPage.tsx
+++ b/frontend/src/pages/admin/MirrorsPage.tsx
@@ -65,6 +65,7 @@ import Page from '../../components/Page'
 import PageHeader from '../../components/PageHeader'
 import PageTitleIcon from '@mui/icons-material/CloudDownload'
 import api from '../../services/api'
+import { useAuth } from '../../contexts/AuthContext'
 import {
   type MirrorConfiguration,
   type MirrorSyncHistory,
@@ -286,6 +287,14 @@ const ProviderRow: React.FC<{ provider: MirroredProvider }> = ({ provider }) => 
 const MirrorsPage: React.FC = () => {
   const { t } = useTranslation()
   const queryClient = useQueryClient()
+  const { allowedScopes } = useAuth()
+  // The route itself is gated at mirrors:read (view-only) so auditors/viewers
+  // can browse mirror configurations (routeScopes.ts). Add/Edit/Delete/
+  // Trigger-Sync mutate mirror config or kick off syncs against the upstream
+  // registry though, so canManage additionally gates those controls on
+  // mirrors:manage/admin — a mirrors:read-only viewer would otherwise see
+  // fully actionable controls that only fail once clicked (#609).
+  const canManage = allowedScopes.includes('admin') || allowedScopes.includes('mirrors:manage')
   const [error, setError] = useState<string | null>(null)
   const [success, setSuccess] = useState<string | null>(null)
   const [createDialogOpen, setCreateDialogOpen] = useState(false)
@@ -350,12 +359,15 @@ const MirrorsPage: React.FC = () => {
     setError(getErrorMessage(queryError, t('admin.mirrors.errLoadMirrors')))
   }
 
-  // Auto-open the Add Mirror dialog when navigated here with ?action=add
+  // Auto-open the Add Mirror dialog when navigated here with ?action=add.
+  // Gated on canManage too, so a mirrors:read-only viewer can't reach the
+  // create form via a deep link that bypasses the (also gated) Add Mirror
+  // button (#609).
   useEffect(() => {
-    if (searchParams.get('action') === 'add') {
+    if (canManage && searchParams.get('action') === 'add') {
       setCreateDialogOpen(true)
     }
-  }, [searchParams])
+  }, [searchParams, canManage])
 
   const createMutation = useMutation({
     mutationFn: (data: CreateMirrorConfigRequest) => api.createMirror(data),
@@ -616,16 +628,18 @@ const MirrorsPage: React.FC = () => {
                 >
                   {t('admin.mirrors.refresh')}
                 </Button>
-                <Button
-                  variant="contained"
-                  startIcon={<AddIcon />}
-                  onClick={() => {
-                    resetForm()
-                    setCreateDialogOpen(true)
-                  }}
-                >
-                  {t('admin.mirrors.addMirror')}
-                </Button>
+                {canManage && (
+                  <Button
+                    variant="contained"
+                    startIcon={<AddIcon />}
+                    onClick={() => {
+                      resetForm()
+                      setCreateDialogOpen(true)
+                    }}
+                  >
+                    {t('admin.mirrors.addMirror')}
+                  </Button>
+                )}
               </Box>
             }
           />
@@ -809,43 +823,45 @@ const MirrorsPage: React.FC = () => {
                             </IconButton>
                           </Tooltip>
                         </Box>
-                        <Box>
-                          <Tooltip title={t('admin.mirrors.tooltipTriggerSync')}>
-                            <span>
+                        {canManage && (
+                          <Box>
+                            <Tooltip title={t('admin.mirrors.tooltipTriggerSync')}>
+                              <span>
+                                <IconButton
+                                  size="small"
+                                  aria-label={t('admin.mirrors.ariaSyncMirror')}
+                                  color="primary"
+                                  onClick={() => handleTriggerSync(mirror)}
+                                  disabled={mirror.last_sync_status === 'in_progress'}
+                                >
+                                  <SyncIcon fontSize="small" />
+                                </IconButton>
+                              </span>
+                            </Tooltip>
+                            <Tooltip title={t('admin.mirrors.tooltipEdit')}>
                               <IconButton
                                 size="small"
-                                aria-label={t('admin.mirrors.ariaSyncMirror')}
-                                color="primary"
-                                onClick={() => handleTriggerSync(mirror)}
-                                disabled={mirror.last_sync_status === 'in_progress'}
+                                aria-label={t('admin.mirrors.ariaEditMirror')}
+                                onClick={() => openEditDialog(mirror)}
                               >
-                                <SyncIcon fontSize="small" />
+                                <EditIcon fontSize="small" />
                               </IconButton>
-                            </span>
-                          </Tooltip>
-                          <Tooltip title={t('admin.mirrors.tooltipEdit')}>
-                            <IconButton
-                              size="small"
-                              aria-label={t('admin.mirrors.ariaEditMirror')}
-                              onClick={() => openEditDialog(mirror)}
-                            >
-                              <EditIcon fontSize="small" />
-                            </IconButton>
-                          </Tooltip>
-                          <Tooltip title={t('admin.mirrors.tooltipDelete')}>
-                            <IconButton
-                              size="small"
-                              aria-label={t('admin.mirrors.ariaDeleteMirror')}
-                              color="error"
-                              onClick={() => {
-                                setMirrorToDelete(mirror)
-                                setDeleteConfirmOpen(true)
-                              }}
-                            >
-                              <DeleteIcon fontSize="small" />
-                            </IconButton>
-                          </Tooltip>
-                        </Box>
+                            </Tooltip>
+                            <Tooltip title={t('admin.mirrors.tooltipDelete')}>
+                              <IconButton
+                                size="small"
+                                aria-label={t('admin.mirrors.ariaDeleteMirror')}
+                                color="error"
+                                onClick={() => {
+                                  setMirrorToDelete(mirror)
+                                  setDeleteConfirmOpen(true)
+                                }}
+                              >
+                                <DeleteIcon fontSize="small" />
+                              </IconButton>
+                            </Tooltip>
+                          </Box>
+                        )}
                       </CardActions>
                     </Card>
                   </Grid>

--- a/frontend/src/pages/admin/OrganizationsPage.tsx
+++ b/frontend/src/pages/admin/OrganizationsPage.tsx
@@ -52,6 +52,12 @@ const OrganizationsPage: React.FC = () => {
   const { t } = useTranslation()
   const queryClient = useQueryClient()
   const { allowedScopes } = useAuth()
+  // The route itself is gated at organizations:read (view-only) so auditors/
+  // viewers can browse the org list (routeScopes.ts). Add/Edit/Delete mutate
+  // organizations though, so canManage additionally gates those controls (and
+  // the membership-management controls below) on organizations:write/admin —
+  // a read-only viewer would otherwise see actionable buttons that only fail
+  // once clicked, relying entirely on the server to say no (#609).
   const canManage =
     allowedScopes.includes('admin') || allowedScopes.includes('organizations:write')
   const [error, setError] = useState<string | null>(null)
@@ -291,9 +297,11 @@ const OrganizationsPage: React.FC = () => {
         title={t('admin.organizations.pageTitle')}
         description={t('admin.organizations.pageSubtitle')}
         actions={
-          <Button variant="contained" startIcon={<AddIcon />} onClick={() => handleOpenDialog()}>
-            {t('admin.organizations.addOrganization')}
-          </Button>
+          canManage ? (
+            <Button variant="contained" startIcon={<AddIcon />} onClick={() => handleOpenDialog()}>
+              {t('admin.organizations.addOrganization')}
+            </Button>
+          ) : undefined
         }
       />
       {error && !import.meta.env.DEV && (
@@ -316,14 +324,16 @@ const OrganizationsPage: React.FC = () => {
             >
               {t('admin.organizations.emptyState')}
             </Typography>
-            <Button
-              variant="outlined"
-              startIcon={<AddIcon />}
-              onClick={() => handleOpenDialog()}
-              sx={{ mt: 2 }}
-            >
-              {t('admin.organizations.createFirst')}
-            </Button>
+            {canManage && (
+              <Button
+                variant="outlined"
+                startIcon={<AddIcon />}
+                onClick={() => handleOpenDialog()}
+                sx={{ mt: 2 }}
+              >
+                {t('admin.organizations.createFirst')}
+              </Button>
+            )}
           </Box>
         ) : (
           <TableContainer>
@@ -380,26 +390,30 @@ const OrganizationsPage: React.FC = () => {
                     </TableCell>
                     <TableCell>{new Date(org.created_at).toLocaleDateString()}</TableCell>
                     <TableCell align="right">
-                      <Tooltip title={t('admin.organizations.tooltipEditOrg')}>
-                        <IconButton
-                          size="small"
-                          aria-label={t('admin.organizations.ariaEditOrg')}
-                          onClick={() => handleOpenDialog(org)}
-                          color="primary"
-                        >
-                          <EditIcon />
-                        </IconButton>
-                      </Tooltip>
-                      <Tooltip title={t('admin.organizations.tooltipDeleteOrg')}>
-                        <IconButton
-                          size="small"
-                          aria-label={t('admin.organizations.ariaDeleteOrg')}
-                          onClick={() => handleDeleteClick(org)}
-                          color="error"
-                        >
-                          <DeleteIcon />
-                        </IconButton>
-                      </Tooltip>
+                      {canManage && (
+                        <>
+                          <Tooltip title={t('admin.organizations.tooltipEditOrg')}>
+                            <IconButton
+                              size="small"
+                              aria-label={t('admin.organizations.ariaEditOrg')}
+                              onClick={() => handleOpenDialog(org)}
+                              color="primary"
+                            >
+                              <EditIcon />
+                            </IconButton>
+                          </Tooltip>
+                          <Tooltip title={t('admin.organizations.tooltipDeleteOrg')}>
+                            <IconButton
+                              size="small"
+                              aria-label={t('admin.organizations.ariaDeleteOrg')}
+                              onClick={() => handleDeleteClick(org)}
+                              color="error"
+                            >
+                              <DeleteIcon />
+                            </IconButton>
+                          </Tooltip>
+                        </>
+                      )}
                     </TableCell>
                   </TableRow>
                 ))}

--- a/frontend/src/pages/admin/SCMProvidersPage.tsx
+++ b/frontend/src/pages/admin/SCMProvidersPage.tsx
@@ -42,6 +42,7 @@ import PageTitleIcon from '@mui/icons-material/GitHub'
 import api from '../../services/api'
 import { getErrorMessage } from '../../utils/errors'
 import { isSafeExternalUrl } from '../../utils/externalUrl'
+import { useAuth } from '../../contexts/AuthContext'
 import type {
   SCMProvider,
   SCMProviderType,
@@ -61,6 +62,15 @@ interface TokenStatus {
 const SCMProvidersPage: React.FC = () => {
   const { t } = useTranslation()
   const queryClient = useQueryClient()
+  const { allowedScopes } = useAuth()
+  // The route itself is gated at scm:read (view-only) so auditors/viewers can
+  // browse configured providers (routeScopes.ts). Add/Edit/Delete/Connect/
+  // Disconnect/Verify/Save-PAT all mutate or exercise live credentials
+  // (OAuth client secrets, GitHub App private keys, webhook secrets, PATs)
+  // though, so canManage additionally gates those controls on scm:manage/
+  // admin — a scm:read-only viewer would otherwise see fully actionable
+  // credential controls that only fail once clicked (#609).
+  const canManage = allowedScopes.includes('admin') || allowedScopes.includes('scm:manage')
   const [error, setError] = useState<string | null>(null)
   const [createDialogOpen, setCreateDialogOpen] = useState(false)
   const [editingProvider, setEditingProvider] = useState<SCMProvider | null>(null)
@@ -413,16 +423,18 @@ const SCMProvidersPage: React.FC = () => {
                 >
                   {t('admin.scmProviders.refresh')}
                 </Button>
-                <Button
-                  variant="contained"
-                  startIcon={<AddIcon />}
-                  onClick={() => {
-                    resetForm()
-                    setCreateDialogOpen(true)
-                  }}
-                >
-                  {t('admin.scmProviders.addProvider')}
-                </Button>
+                {canManage && (
+                  <Button
+                    variant="contained"
+                    startIcon={<AddIcon />}
+                    onClick={() => {
+                      resetForm()
+                      setCreateDialogOpen(true)
+                    }}
+                  >
+                    {t('admin.scmProviders.addProvider')}
+                  </Button>
+                )}
               </Box>
             }
           />
@@ -663,7 +675,7 @@ const SCMProvidersPage: React.FC = () => {
                   </CardContent>
 
                   <CardActions>
-                    {!isAppModeProvider(provider) && (
+                    {!isAppModeProvider(provider) && canManage && (
                       <>
                         <Tooltip
                           title={
@@ -710,7 +722,7 @@ const SCMProvidersPage: React.FC = () => {
                         )}
                       </>
                     )}
-                    {isAppModeProvider(provider) && (
+                    {isAppModeProvider(provider) && canManage && (
                       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mr: 'auto' }}>
                         <Button
                           size="small"
@@ -731,28 +743,32 @@ const SCMProvidersPage: React.FC = () => {
                         )}
                       </Box>
                     )}
-                    <Tooltip title={t('admin.scmProviders.tooltipEdit')}>
-                      <IconButton
-                        size="small"
-                        aria-label={t('admin.scmProviders.ariaEdit')}
-                        onClick={() => openEditDialog(provider)}
-                      >
-                        <EditIcon />
-                      </IconButton>
-                    </Tooltip>
-                    <Tooltip title={t('admin.scmProviders.tooltipDelete')}>
-                      <IconButton
-                        size="small"
-                        aria-label={t('admin.scmProviders.ariaDelete')}
-                        color="error"
-                        onClick={() => {
-                          setProviderToDelete(provider)
-                          setDeleteConfirmOpen(true)
-                        }}
-                      >
-                        <DeleteIcon />
-                      </IconButton>
-                    </Tooltip>
+                    {canManage && (
+                      <>
+                        <Tooltip title={t('admin.scmProviders.tooltipEdit')}>
+                          <IconButton
+                            size="small"
+                            aria-label={t('admin.scmProviders.ariaEdit')}
+                            onClick={() => openEditDialog(provider)}
+                          >
+                            <EditIcon />
+                          </IconButton>
+                        </Tooltip>
+                        <Tooltip title={t('admin.scmProviders.tooltipDelete')}>
+                          <IconButton
+                            size="small"
+                            aria-label={t('admin.scmProviders.ariaDelete')}
+                            color="error"
+                            onClick={() => {
+                              setProviderToDelete(provider)
+                              setDeleteConfirmOpen(true)
+                            }}
+                          >
+                            <DeleteIcon />
+                          </IconButton>
+                        </Tooltip>
+                      </>
+                    )}
                   </CardActions>
                 </Card>
               </Grid>

--- a/frontend/src/pages/admin/TerraformMirrorPage.tsx
+++ b/frontend/src/pages/admin/TerraformMirrorPage.tsx
@@ -65,6 +65,7 @@ import SyncIcon from '@mui/icons-material/Sync'
 
 import api from '../../services/api'
 import { getErrorMessage } from '../../utils/errors'
+import { useAuth } from '../../contexts/AuthContext'
 import ReleasesGPGKeyStatus from '../../components/ReleasesGPGKeyStatus'
 import {
   type TerraformMirrorConfig,
@@ -113,7 +114,8 @@ const VersionRow: React.FC<{
   version: TerraformVersion
   configId: string
   onDelete: (v: TerraformVersion) => void
-}> = ({ version, configId, onDelete }) => {
+  canManage: boolean
+}> = ({ version, configId, onDelete, canManage }) => {
   const { t } = useTranslation()
   const [open, setOpen] = useState(false)
   const [platforms, setPlatforms] = useState<TerraformVersionPlatform[] | null>(null)
@@ -190,19 +192,21 @@ const VersionRow: React.FC<{
           {version.synced_at ? new Date(version.synced_at).toLocaleString() : '—'}
         </TableCell>
         <TableCell align="right">
-          <Tooltip title={t('admin.terraformMirror.tooltipDeleteVersion')}>
-            <span>
-              <IconButton
-                size="small"
-                aria-label={t('admin.terraformMirror.ariaDeleteVersion')}
-                color="error"
-                onClick={() => onDelete(version)}
-                disabled={version.sync_status === 'syncing'}
-              >
-                <DeleteIcon fontSize="small" />
-              </IconButton>
-            </span>
-          </Tooltip>
+          {canManage && (
+            <Tooltip title={t('admin.terraformMirror.tooltipDeleteVersion')}>
+              <span>
+                <IconButton
+                  size="small"
+                  aria-label={t('admin.terraformMirror.ariaDeleteVersion')}
+                  color="error"
+                  onClick={() => onDelete(version)}
+                  disabled={version.sync_status === 'syncing'}
+                >
+                  <DeleteIcon fontSize="small" />
+                </IconButton>
+              </span>
+            </Tooltip>
+          )}
         </TableCell>
       </TableRow>
       <TableRow>
@@ -291,7 +295,18 @@ const ConfigCard: React.FC<{
   onViewVersions: (c: TerraformMirrorConfig) => void
   onViewHistory: (c: TerraformMirrorConfig) => void
   syncing: boolean
-}> = ({ config, status, onEdit, onDelete, onSync, onViewVersions, onViewHistory, syncing }) => {
+  canManage: boolean
+}> = ({
+  config,
+  status,
+  onEdit,
+  onDelete,
+  onSync,
+  onViewVersions,
+  onViewHistory,
+  syncing,
+  canManage,
+}) => {
   const { t } = useTranslation()
   return (
     <Card variant="outlined">
@@ -413,39 +428,41 @@ const ConfigCard: React.FC<{
             </IconButton>
           </Tooltip>
         </Box>
-        <Box>
-          <Tooltip title={t('admin.terraformMirror.tooltipTriggerSync')}>
-            <span>
+        {canManage && (
+          <Box>
+            <Tooltip title={t('admin.terraformMirror.tooltipTriggerSync')}>
+              <span>
+                <IconButton
+                  size="small"
+                  aria-label={t('admin.terraformMirror.ariaSyncMirror')}
+                  onClick={() => onSync(config)}
+                  disabled={syncing || !config.enabled}
+                >
+                  <SyncIcon fontSize="small" />
+                </IconButton>
+              </span>
+            </Tooltip>
+            <Tooltip title={t('admin.terraformMirror.tooltipEditConfig')}>
               <IconButton
                 size="small"
-                aria-label={t('admin.terraformMirror.ariaSyncMirror')}
-                onClick={() => onSync(config)}
-                disabled={syncing || !config.enabled}
+                aria-label={t('admin.terraformMirror.ariaEditMirror')}
+                onClick={() => onEdit(config)}
               >
-                <SyncIcon fontSize="small" />
+                <EditIcon fontSize="small" />
               </IconButton>
-            </span>
-          </Tooltip>
-          <Tooltip title={t('admin.terraformMirror.tooltipEditConfig')}>
-            <IconButton
-              size="small"
-              aria-label={t('admin.terraformMirror.ariaEditMirror')}
-              onClick={() => onEdit(config)}
-            >
-              <EditIcon fontSize="small" />
-            </IconButton>
-          </Tooltip>
-          <Tooltip title={t('admin.terraformMirror.tooltipDeleteMirror')}>
-            <IconButton
-              size="small"
-              aria-label={t('admin.terraformMirror.ariaDeleteMirror')}
-              color="error"
-              onClick={() => onDelete(config)}
-            >
-              <DeleteIcon fontSize="small" />
-            </IconButton>
-          </Tooltip>
-        </Box>
+            </Tooltip>
+            <Tooltip title={t('admin.terraformMirror.tooltipDeleteMirror')}>
+              <IconButton
+                size="small"
+                aria-label={t('admin.terraformMirror.ariaDeleteMirror')}
+                color="error"
+                onClick={() => onDelete(config)}
+              >
+                <DeleteIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
+          </Box>
+        )}
       </CardActions>
     </Card>
   )
@@ -506,6 +523,14 @@ const emptyCreate = (): CreateTerraformMirrorConfigRequest => ({
 const TerraformMirrorPage: React.FC = () => {
   const { t } = useTranslation()
   const queryClient = useQueryClient()
+  const { allowedScopes } = useAuth()
+  // The route itself is gated at mirrors:read (view-only) so auditors/viewers
+  // can browse mirror configurations (routeScopes.ts). Add/Edit/Delete config
+  // and Delete-version, plus Trigger-Sync, mutate mirror state though, so
+  // canManage additionally gates those controls on mirrors:manage/admin — a
+  // mirrors:read-only viewer would otherwise see fully actionable controls
+  // that only fail once clicked (#609).
+  const canManage = allowedScopes.includes('admin') || allowedScopes.includes('mirrors:manage')
   const [error, setError] = useState<string | null>(null)
   const [success, setSuccess] = useState<string | null>(null)
 
@@ -776,18 +801,20 @@ const TerraformMirrorPage: React.FC = () => {
                 >
                   {t('admin.terraformMirror.refresh')}
                 </Button>
-                <Button
-                  variant="contained"
-                  startIcon={<AddIcon />}
-                  onClick={() => {
-                    setCreateForm(emptyCreate())
-                    setCreateVersionFilter('')
-                    setCreatePlatformFilter([])
-                    setCreateOpen(true)
-                  }}
-                >
-                  {t('admin.terraformMirror.addMirror')}
-                </Button>
+                {canManage && (
+                  <Button
+                    variant="contained"
+                    startIcon={<AddIcon />}
+                    onClick={() => {
+                      setCreateForm(emptyCreate())
+                      setCreateVersionFilter('')
+                      setCreatePlatformFilter([])
+                      setCreateOpen(true)
+                    }}
+                  >
+                    {t('admin.terraformMirror.addMirror')}
+                  </Button>
+                )}
               </Box>
             }
           />
@@ -835,6 +862,7 @@ const TerraformMirrorPage: React.FC = () => {
                       onViewVersions={openVersions}
                       onViewHistory={openHistory}
                       syncing={syncingIds.has(cfg.id)}
+                      canManage={canManage}
                     />
                   </Grid>
                 )
@@ -1265,6 +1293,7 @@ const TerraformMirrorPage: React.FC = () => {
                             version={v}
                             configId={versionsConfig.id}
                             onDelete={setDeleteVersion}
+                            canManage={canManage}
                           />
                         ))}
                       </TableBody>

--- a/frontend/src/pages/admin/UsersPage.tsx
+++ b/frontend/src/pages/admin/UsersPage.tsx
@@ -63,6 +63,13 @@ const UsersPage: React.FC = () => {
   const queryClient = useQueryClient()
   const { allowedScopes } = useAuth()
   const isAdmin = allowedScopes.includes('admin')
+  // The route itself is gated at users:read (view-only) so auditors/viewers can
+  // browse the directory (routeScopes.ts). Add/Edit/Delete mutate OTHER users'
+  // accounts though, so — separately from that view gate — only show those
+  // controls to callers who actually hold the write scope the mutations need
+  // (#609): a users:read-only viewer would otherwise see actionable buttons
+  // that only fail once clicked, relying entirely on the server to say no.
+  const canManageUsers = isAdmin || allowedScopes.includes('users:write')
   const [error, setError] = useState<string | null>(null)
   const [info, setInfo] = useState<string | null>(null)
   const [searchQuery, setSearchQuery] = useState('')
@@ -439,9 +446,11 @@ const UsersPage: React.FC = () => {
         title={t('admin.users.pageTitle')}
         description={t('admin.users.pageSubtitle')}
         actions={
-          <Button variant="contained" startIcon={<AddIcon />} onClick={() => handleOpenDialog()}>
-            {t('admin.users.addUser')}
-          </Button>
+          canManageUsers ? (
+            <Button variant="contained" startIcon={<AddIcon />} onClick={() => handleOpenDialog()}>
+              {t('admin.users.addUser')}
+            </Button>
+          ) : undefined
         }
       />
       {error && (
@@ -559,16 +568,18 @@ const UsersPage: React.FC = () => {
                     </TableCell>
                     <TableCell>{new Date(user.created_at).toLocaleDateString()}</TableCell>
                     <TableCell align="right" sx={{ whiteSpace: 'nowrap' }}>
-                      <Tooltip title={t('admin.users.tooltipEdit')}>
-                        <IconButton
-                          size="small"
-                          aria-label={t('admin.users.ariaEdit')}
-                          onClick={() => handleOpenDialog(user)}
-                          color="primary"
-                        >
-                          <EditIcon />
-                        </IconButton>
-                      </Tooltip>
+                      {canManageUsers && (
+                        <Tooltip title={t('admin.users.tooltipEdit')}>
+                          <IconButton
+                            size="small"
+                            aria-label={t('admin.users.ariaEdit')}
+                            onClick={() => handleOpenDialog(user)}
+                            color="primary"
+                          >
+                            <EditIcon />
+                          </IconButton>
+                        </Tooltip>
+                      )}
                       {isAdmin && (
                         <>
                           <Tooltip title={t('admin.users.tooltipExport')}>
@@ -599,16 +610,18 @@ const UsersPage: React.FC = () => {
                           </Tooltip>
                         </>
                       )}
-                      <Tooltip title={t('admin.users.tooltipDelete')}>
-                        <IconButton
-                          size="small"
-                          aria-label={t('admin.users.ariaDelete')}
-                          onClick={() => handleDeleteClick(user)}
-                          color="error"
-                        >
-                          <DeleteIcon />
-                        </IconButton>
-                      </Tooltip>
+                      {canManageUsers && (
+                        <Tooltip title={t('admin.users.tooltipDelete')}>
+                          <IconButton
+                            size="small"
+                            aria-label={t('admin.users.ariaDelete')}
+                            onClick={() => handleDeleteClick(user)}
+                            color="error"
+                          >
+                            <DeleteIcon />
+                          </IconButton>
+                        </Tooltip>
+                      )}
                     </TableCell>
                   </TableRow>
                 ))

--- a/frontend/src/pages/admin/VersionApprovalsPage.tsx
+++ b/frontend/src/pages/admin/VersionApprovalsPage.tsx
@@ -41,6 +41,7 @@ import api from '../../services/api'
 import { queryKeys } from '../../services/queryKeys'
 import { getErrorMessage } from '../../utils/errors'
 import { formatDate } from '../../utils'
+import { useAuth } from '../../contexts/AuthContext'
 import type {
   VersionApproval,
   VersionApprovalStatus,
@@ -145,12 +146,14 @@ function VersionRow({
   onToggleSelect,
   onApprove,
   onReject,
+  canManage,
 }: {
   item: VersionApproval
   selected: boolean
   onToggleSelect: () => void
   onApprove: (item: VersionApproval) => void
   onReject: (item: VersionApproval) => void
+  canManage: boolean
 }) {
   const { t } = useTranslation()
   const [open, setOpen] = useState(false)
@@ -211,7 +214,7 @@ function VersionRow({
         <TableCell>
           <Box sx={{ display: 'flex', gap: 0.5, alignItems: 'center' }}>
             <ApprovalStatusChip status={item.approval_status} />
-            {item.approval_status === 'pending_approval' && (
+            {item.approval_status === 'pending_approval' && canManage && (
               <>
                 <Button
                   size="small"
@@ -252,6 +255,14 @@ const STATUS_TABS: Array<{ label: string; value: VersionApprovalStatus | '' }> =
 const VersionApprovalsPage: React.FC = () => {
   const { t } = useTranslation()
   const queryClient = useQueryClient()
+  const { allowedScopes } = useAuth()
+  // The route itself is gated at mirrors:read (view-only) so auditors/viewers
+  // can browse pending versions (routeScopes.ts). Approve/Reject and the bulk
+  // equivalents mutate approval state though, so canManage additionally
+  // gates those controls on mirrors:manage/admin — a mirrors:read-only
+  // viewer would otherwise see fully actionable controls that only fail once
+  // clicked (#609).
+  const canManage = allowedScopes.includes('admin') || allowedScopes.includes('mirrors:manage')
 
   const [statusTab, setStatusTab] = useState<VersionApprovalStatus | ''>('pending_approval')
   const [typeFilter, setTypeFilter] = useState<'provider' | 'terraform' | 'scanner' | ''>('')
@@ -451,7 +462,7 @@ const VersionApprovalsPage: React.FC = () => {
         </ToggleButtonGroup>
       </Box>
 
-      {selected.size > 0 && (
+      {selected.size > 0 && canManage && (
         <Box sx={{ display: 'flex', gap: 1, mb: 1 }}>
           <Button
             variant="contained"
@@ -518,6 +529,7 @@ const VersionApprovalsPage: React.FC = () => {
                     onToggleSelect={() => toggleOne(item.id)}
                     onApprove={(i) => openActionDialog('approve', i)}
                     onReject={(i) => openActionDialog('reject', i)}
+                    canManage={canManage}
                   />
                 ))
               )}

--- a/frontend/src/pages/admin/__tests__/APIKeysPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/APIKeysPage.test.tsx
@@ -27,12 +27,15 @@ vi.mock('../../../services/api', () => ({
   },
 }))
 
+// Default to admin scope so existing tests pass; individual tests can override.
+const useAuthMock = vi.fn(() => ({
+  allowedScopes: ['admin'],
+  roleTemplate: { display_name: 'Administrator' },
+  user: { id: 'user-1' },
+}))
+
 vi.mock('../../../contexts/AuthContext', () => ({
-  useAuth: () => ({
-    allowedScopes: ['admin'],
-    roleTemplate: { display_name: 'Administrator' },
-    user: { id: 'user-1' },
-  }),
+  useAuth: () => useAuthMock(),
 }))
 
 import APIKeysPage from '../APIKeysPage'
@@ -426,5 +429,58 @@ describe('APIKeysPage', () => {
     // "Never" appears both for expiration and last used; check multiple
     const neverTexts = screen.getAllByText('Never')
     expect(neverTexts.length).toBeGreaterThanOrEqual(2)
+  })
+
+  // ---- Mutation controls require api_keys:manage/admin, not just an
+  // authenticated session (#609 -- route is gated at null scope) ----
+
+  describe('mutation control gating', () => {
+    it('hides Create/Edit/Rotate/Delete for a caller with no manage scope', async () => {
+      useAuthMock.mockReturnValue({
+        allowedScopes: ['modules:read'],
+        roleTemplate: { display_name: 'Viewer' },
+        user: { id: 'user-1' },
+      })
+      listAPIKeysMock.mockResolvedValue(fakeKeys)
+      renderPage()
+      await waitFor(() => screen.getByText('CI Pipeline Key'))
+
+      // View access is unaffected -- the viewer still sees the key list.
+      expect(screen.getByText('Expired Key')).toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: /Create API Key/i })).not.toBeInTheDocument()
+      expect(screen.queryByLabelText('Edit API key')).not.toBeInTheDocument()
+      expect(screen.queryByLabelText('Rotate API key')).not.toBeInTheDocument()
+      expect(screen.queryByLabelText('Delete API key')).not.toBeInTheDocument()
+    })
+
+    it('hides the empty-state Create action for a caller with no manage scope', async () => {
+      useAuthMock.mockReturnValue({
+        allowedScopes: ['modules:read'],
+        roleTemplate: { display_name: 'Viewer' },
+        user: { id: 'user-1' },
+      })
+      listAPIKeysMock.mockResolvedValue([])
+      renderPage()
+      await waitFor(() => {
+        expect(screen.getByText('No API keys yet')).toBeInTheDocument()
+      })
+      expect(screen.queryByTestId('apikeys-empty-state-primary')).not.toBeInTheDocument()
+    })
+
+    it('shows Create/Edit/Rotate/Delete once api_keys:manage is granted (non-admin)', async () => {
+      useAuthMock.mockReturnValue({
+        allowedScopes: ['modules:read', 'api_keys:manage'],
+        roleTemplate: { display_name: 'API Key Manager' },
+        user: { id: 'user-1' },
+      })
+      listAPIKeysMock.mockResolvedValue(fakeKeys)
+      renderPage()
+      await waitFor(() => screen.getByText('CI Pipeline Key'))
+
+      expect(screen.getByRole('button', { name: /Create API Key/i })).toBeInTheDocument()
+      expect(screen.getAllByLabelText('Edit API key').length).toBeGreaterThan(0)
+      expect(screen.getAllByLabelText('Rotate API key').length).toBeGreaterThan(0)
+      expect(screen.getAllByLabelText('Delete API key').length).toBeGreaterThan(0)
+    })
   })
 })

--- a/frontend/src/pages/admin/__tests__/ApprovalsPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/ApprovalsPage.test.tsx
@@ -14,6 +14,12 @@ vi.mock('../../../services/api', () => ({
   },
 }))
 
+let mockAllowedScopes: string[] = ['admin']
+
+vi.mock('../../../contexts/AuthContext', () => ({
+  useAuth: () => ({ allowedScopes: mockAllowedScopes, user: { id: 'u1' } }),
+}))
+
 import ApprovalsPage from '../ApprovalsPage'
 
 function renderWithProviders(ui: React.ReactElement) {
@@ -63,6 +69,7 @@ const fakeApprovals = [
 describe('ApprovalsPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockAllowedScopes = ['admin']
   })
 
   it('shows loading spinner while fetching', () => {
@@ -276,5 +283,31 @@ describe('ApprovalsPage', () => {
     listApprovalRequestsMock.mockResolvedValue(fakeApprovals)
     renderWithProviders(<ApprovalsPage />)
     await waitFor(() => expect(screen.getByText(/auto[\s-]*approved/i)).toBeInTheDocument())
+  })
+
+  // ── canManage gates create/approve/reject controls (#609) ──────────────────
+
+  it('hides Create Request and Approve/Reject controls for the mirrors:read scope', async () => {
+    mockAllowedScopes = ['mirrors:read']
+    listApprovalRequestsMock.mockResolvedValue(fakeApprovals)
+    renderWithProviders(<ApprovalsPage />)
+    await waitFor(() => expect(screen.getByText('hashicorp/aws')).toBeInTheDocument())
+
+    // View access is unaffected — the viewer still sees the approval cards.
+    expect(screen.getByText('datadog/datadog')).toBeInTheDocument()
+    expect(screen.queryByText('Create Request')).not.toBeInTheDocument()
+    expect(screen.queryByText('Approve')).not.toBeInTheDocument()
+    expect(screen.queryByText('Reject')).not.toBeInTheDocument()
+  })
+
+  it('shows Create Request and Approve/Reject controls for the canonical mirrors:manage scope', async () => {
+    mockAllowedScopes = ['mirrors:manage']
+    listApprovalRequestsMock.mockResolvedValue(fakeApprovals)
+    renderWithProviders(<ApprovalsPage />)
+    await waitFor(() => expect(screen.getByText('hashicorp/aws')).toBeInTheDocument())
+
+    expect(screen.getByText('Create Request')).toBeInTheDocument()
+    expect(screen.getByText('Approve')).toBeInTheDocument()
+    expect(screen.getByText('Reject')).toBeInTheDocument()
   })
 })

--- a/frontend/src/pages/admin/__tests__/MirrorsPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/MirrorsPage.test.tsx
@@ -24,6 +24,12 @@ vi.mock('../../../services/api', () => ({
   },
 }))
 
+let mockAllowedScopes: string[] = ['admin']
+
+vi.mock('../../../contexts/AuthContext', () => ({
+  useAuth: () => ({ allowedScopes: mockAllowedScopes, user: { id: 'u1' } }),
+}))
+
 import MirrorsPage from '../MirrorsPage'
 
 function renderWithProviders(
@@ -95,6 +101,7 @@ const neverSyncedMirror = {
 describe('MirrorsPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockAllowedScopes = ['admin']
   })
 
   it('shows loading spinner while fetching', () => {
@@ -467,6 +474,45 @@ describe('MirrorsPage', () => {
     await waitFor(() => {
       expect(screen.getByText('Add Provider Mirror')).toBeInTheDocument()
     })
+  })
+
+  // ── canManage gates mirror CRUD/sync controls (#609) ───────────────────────
+
+  it('hides Add/Edit/Delete/Sync mirror controls for the mirrors:read scope', async () => {
+    mockAllowedScopes = ['mirrors:read']
+    listMirrorsMock.mockResolvedValue([baseMirror])
+    renderWithProviders(<MirrorsPage />)
+    await waitFor(() => expect(screen.getByText('Upstream Public')).toBeInTheDocument())
+
+    // View access is unaffected — the viewer still sees the mirror list.
+    expect(screen.queryByText('Add Mirror')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Edit mirror')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Delete mirror')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Sync mirror')).not.toBeInTheDocument()
+  })
+
+  it('shows Add/Edit/Delete/Sync mirror controls for the canonical mirrors:manage scope', async () => {
+    mockAllowedScopes = ['mirrors:manage']
+    listMirrorsMock.mockResolvedValue([baseMirror])
+    renderWithProviders(<MirrorsPage />)
+    await waitFor(() => expect(screen.getByText('Upstream Public')).toBeInTheDocument())
+
+    expect(screen.getByText('Add Mirror')).toBeInTheDocument()
+    expect(screen.getByLabelText('Edit mirror')).toBeInTheDocument()
+    expect(screen.getByLabelText('Delete mirror')).toBeInTheDocument()
+    expect(screen.getByLabelText('Sync mirror')).toBeInTheDocument()
+  })
+
+  it('ignores the ?action=add deep link for the mirrors:read scope', async () => {
+    mockAllowedScopes = ['mirrors:read']
+    listMirrorsMock.mockResolvedValue([])
+    renderWithProviders(<MirrorsPage />, {
+      initialEntries: ['/admin/mirrors?action=add'],
+    })
+    await waitFor(() => {
+      expect(screen.getByText('Mirroring — Provider Config')).toBeInTheDocument()
+    })
+    expect(screen.queryByText('Add Provider Mirror')).not.toBeInTheDocument()
   })
 
   it('shows error alert when create mutation fails', async () => {

--- a/frontend/src/pages/admin/__tests__/OrganizationsPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/OrganizationsPage.test.tsx
@@ -518,6 +518,32 @@ describe('OrganizationsPage', () => {
     expect(screen.queryByRole('button', { name: /remove member/i })).not.toBeInTheDocument()
   })
 
+  // ── canManage also gates org CRUD itself, not just membership (#609) ──────
+
+  it('hides Add/Edit/Delete organization controls for the organizations:read scope', async () => {
+    mockAllowedScopes = ['organizations:read']
+    listOrganizationsMock.mockResolvedValue(fakeOrgs)
+    renderPage()
+    await waitFor(() => expect(screen.getByText('acme-corp')).toBeInTheDocument())
+
+    // View access is unaffected — the viewer still sees the org directory.
+    expect(screen.getByText('globex')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /add organization/i })).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Edit organization')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Delete organization')).not.toBeInTheDocument()
+  })
+
+  it('shows Add/Edit/Delete organization controls for the canonical organizations:write scope', async () => {
+    mockAllowedScopes = ['organizations:write']
+    listOrganizationsMock.mockResolvedValue(fakeOrgs)
+    renderPage()
+    await waitFor(() => expect(screen.getByText('acme-corp')).toBeInTheDocument())
+
+    expect(screen.getByRole('button', { name: /add organization/i })).toBeInTheDocument()
+    expect(screen.getAllByLabelText('Edit organization').length).toBeGreaterThan(0)
+    expect(screen.getAllByLabelText('Delete organization').length).toBeGreaterThan(0)
+  })
+
   it('blocks save and shows field error when name format is invalid', async () => {
     listOrganizationsMock.mockResolvedValue(fakeOrgs)
     renderPage()

--- a/frontend/src/pages/admin/__tests__/SCMProvidersPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/SCMProvidersPage.test.tsx
@@ -30,10 +30,12 @@ vi.mock('../../../services/api', () => ({
   },
 }))
 
+let mockAllowedScopes: string[] = ['admin']
+
 vi.mock('../../../contexts/AuthContext', () => ({
   useAuth: () => ({
     isAuthenticated: true,
-    allowedScopes: ['admin'],
+    allowedScopes: mockAllowedScopes,
     user: { id: 'u1', email: 'admin@example.com', name: 'Admin', role_template_name: 'admin' },
   }),
 }))
@@ -85,8 +87,53 @@ const fakeMemberships = [
 describe('SCMProvidersPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockAllowedScopes = ['admin']
     getCurrentUserMembershipsMock.mockResolvedValue([])
     getSCMTokenStatusMock.mockResolvedValue({ connected: false })
+  })
+
+  // ── canManage gates credential-mutation controls (#609) ────────────────────
+
+  it('hides Add/Edit/Delete/Connect provider controls for the scm:read scope', async () => {
+    mockAllowedScopes = ['scm:read']
+    listSCMProvidersMock.mockResolvedValue(fakeProviders)
+    renderPage()
+    await waitFor(() => expect(screen.getByText('GitHub Enterprise')).toBeInTheDocument())
+
+    // View access is unaffected — the viewer still sees the provider list.
+    expect(screen.queryByRole('button', { name: /add.*provider/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /edit scm provider/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /delete scm provider/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /connect scm provider/i })).not.toBeInTheDocument()
+  })
+
+  it('hides Test connection for app-mode providers under the scm:read scope', async () => {
+    mockAllowedScopes = ['scm:read']
+    const appProvider = [
+      {
+        ...fakeProviders[0],
+        id: 'scm-app',
+        name: 'ADO App',
+        provider_type: 'azuredevops' as const,
+        auth_mode: 'entra_app' as const,
+      },
+    ]
+    listSCMProvidersMock.mockResolvedValue(appProvider)
+    renderPage()
+    await waitFor(() => expect(screen.getByText('ADO App')).toBeInTheDocument())
+    expect(screen.queryByRole('button', { name: /test connection/i })).not.toBeInTheDocument()
+  })
+
+  it('shows Add/Edit/Delete/Connect provider controls for the canonical scm:manage scope', async () => {
+    mockAllowedScopes = ['scm:manage']
+    listSCMProvidersMock.mockResolvedValue(fakeProviders)
+    renderPage()
+    await waitFor(() => expect(screen.getByText('GitHub Enterprise')).toBeInTheDocument())
+
+    expect(screen.getByRole('button', { name: /add.*provider/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /edit scm provider/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /delete scm provider/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /connect scm provider/i })).toBeInTheDocument()
   })
 
   it('shows loading spinner initially', () => {

--- a/frontend/src/pages/admin/__tests__/TerraformMirrorPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/TerraformMirrorPage.test.tsx
@@ -30,6 +30,12 @@ vi.mock('../../../services/api', () => ({
   },
 }))
 
+let mockAllowedScopes: string[] = ['admin']
+
+vi.mock('../../../contexts/AuthContext', () => ({
+  useAuth: () => ({ allowedScopes: mockAllowedScopes, user: { id: 'u1' } }),
+}))
+
 import TerraformMirrorPage from '../../admin/TerraformMirrorPage'
 
 function createQueryClient() {
@@ -67,6 +73,7 @@ const fakeConfigs = [
 describe('TerraformMirrorPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockAllowedScopes = ['admin']
     getTerraformMirrorStatusMock.mockResolvedValue({
       status: 'idle',
       version_count: 3,
@@ -686,5 +693,64 @@ describe('TerraformMirrorPage', () => {
     await userEvent.click(screen.getByRole('button', { name: /view details/i }))
     await waitFor(() => expect(screen.getByText('1.5.0')).toBeInTheDocument())
     expect(screen.getByText('Pending Approval')).toBeInTheDocument()
+  })
+
+  // ── canManage gates mirror-config CRUD/sync + delete-version (#609) ────────
+
+  it('hides Add/Edit/Delete/Sync mirror and Delete version controls for the mirrors:read scope', async () => {
+    mockAllowedScopes = ['mirrors:read']
+    listTerraformMirrorConfigsMock.mockResolvedValue({ configs: fakeConfigs })
+    listVersionsMock.mockResolvedValue({
+      versions: [
+        {
+          id: 'v1',
+          version: '1.5.0',
+          sync_status: 'synced',
+          is_latest: true,
+          is_deprecated: false,
+          synced_at: '2025-06-01T00:00:00Z',
+        },
+      ],
+    })
+    renderPage()
+    await waitFor(() => expect(screen.getAllByText('terraform').length).toBeGreaterThan(0))
+
+    // View access is unaffected — the viewer still sees the config card.
+    expect(screen.queryByRole('button', { name: /add mirror/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /edit mirror/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /delete mirror/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /^sync mirror$/i })).not.toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('button', { name: /view details/i }))
+    await waitFor(() => expect(screen.getByText('1.5.0')).toBeInTheDocument())
+    expect(screen.queryByRole('button', { name: /delete version/i })).not.toBeInTheDocument()
+  })
+
+  it('shows Add/Edit/Delete/Sync mirror and Delete version controls for the canonical mirrors:manage scope', async () => {
+    mockAllowedScopes = ['mirrors:manage']
+    listTerraformMirrorConfigsMock.mockResolvedValue({ configs: fakeConfigs })
+    listVersionsMock.mockResolvedValue({
+      versions: [
+        {
+          id: 'v1',
+          version: '1.5.0',
+          sync_status: 'synced',
+          is_latest: true,
+          is_deprecated: false,
+          synced_at: '2025-06-01T00:00:00Z',
+        },
+      ],
+    })
+    renderPage()
+    await waitFor(() => expect(screen.getAllByText('terraform').length).toBeGreaterThan(0))
+
+    expect(screen.getByRole('button', { name: /add mirror/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /edit mirror/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /delete mirror/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^sync mirror$/i })).toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('button', { name: /view details/i }))
+    await waitFor(() => expect(screen.getByText('1.5.0')).toBeInTheDocument())
+    expect(screen.getByRole('button', { name: /delete version/i })).toBeInTheDocument()
   })
 })

--- a/frontend/src/pages/admin/__tests__/UsersPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/UsersPage.test.tsx
@@ -457,6 +457,44 @@ describe('UsersPage', () => {
     expect(getUserMembershipsMock).not.toHaveBeenCalled()
   })
 
+  // ---- Mutation controls require users:write, not just users:read (#609) ----
+
+  describe('mutation control gating', () => {
+    it('hides Add/Edit/Delete for a users:read-only viewer', async () => {
+      useAuthMock.mockReturnValue({
+        allowedScopes: ['users:read'],
+        roleTemplate: { display_name: 'Auditor' },
+        user: { id: 'user-1' },
+      })
+      listUsersMock.mockResolvedValue(fakeUsersResponse)
+      getUserMembershipsMock.mockResolvedValue([])
+      renderPage()
+      await waitFor(() => screen.getByText('alice@example.com'))
+
+      // View access is unaffected — the viewer still sees the user directory.
+      expect(screen.getByText('bob@example.com')).toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: /add user/i })).not.toBeInTheDocument()
+      expect(screen.queryByLabelText('Edit user')).not.toBeInTheDocument()
+      expect(screen.queryByLabelText('Delete user')).not.toBeInTheDocument()
+    })
+
+    it('shows Add/Edit/Delete once users:write is granted (non-admin)', async () => {
+      useAuthMock.mockReturnValue({
+        allowedScopes: ['users:read', 'users:write'],
+        roleTemplate: { display_name: 'User Manager' },
+        user: { id: 'user-1' },
+      })
+      listUsersMock.mockResolvedValue(fakeUsersResponse)
+      getUserMembershipsMock.mockResolvedValue([])
+      renderPage()
+      await waitFor(() => screen.getByText('alice@example.com'))
+
+      expect(screen.getByRole('button', { name: /add user/i })).toBeInTheDocument()
+      expect(screen.getAllByLabelText('Edit user').length).toBeGreaterThan(0)
+      expect(screen.getAllByLabelText('Delete user').length).toBeGreaterThan(0)
+    })
+  })
+
   // ---- GDPR actions (admin-scoped) ----
 
   describe('GDPR actions', () => {

--- a/frontend/src/pages/admin/__tests__/VersionApprovalsPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/VersionApprovalsPage.test.tsx
@@ -21,6 +21,12 @@ vi.mock('../../../services/api', () => ({
   },
 }))
 
+let mockAllowedScopes: string[] = ['admin']
+
+vi.mock('../../../contexts/AuthContext', () => ({
+  useAuth: () => ({ allowedScopes: mockAllowedScopes, user: { id: 'u1' } }),
+}))
+
 import VersionApprovalsPage from '../VersionApprovalsPage'
 
 function renderWithProviders(ui: React.ReactElement) {
@@ -67,6 +73,7 @@ const emptyResponse = { items: [], total: 0 }
 
 beforeEach(() => {
   vi.clearAllMocks()
+  mockAllowedScopes = ['admin']
   listVersionApprovalsMock.mockResolvedValue({
     items: [fakePendingProvider, fakePendingTerraform],
     total: 2,
@@ -322,5 +329,35 @@ describe('VersionApprovalsPage', () => {
     listVersionApprovalsMock.mockRejectedValue(new Error('boom'))
     renderWithProviders(<VersionApprovalsPage />)
     await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument())
+  })
+
+  // ── canManage gates approve/reject controls (#609) ──────────────────────────
+
+  it('hides per-row and bulk Approve/Reject controls for the mirrors:read scope', async () => {
+    mockAllowedScopes = ['mirrors:read']
+    const user = userEvent.setup()
+    renderWithProviders(<VersionApprovalsPage />)
+    await waitFor(() => expect(screen.getByText('5.90.0')).toBeInTheDocument())
+
+    expect(screen.queryByRole('button', { name: 'Approve' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Reject' })).not.toBeInTheDocument()
+
+    // Selecting a row still doesn't reveal the bulk action bar for a
+    // read-only viewer.
+    await user.click(screen.getAllByRole('checkbox')[1])
+    expect(screen.queryByRole('button', { name: /Approve Selected/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Reject Selected/ })).not.toBeInTheDocument()
+  })
+
+  it('shows per-row and bulk Approve/Reject controls for the canonical mirrors:manage scope', async () => {
+    mockAllowedScopes = ['mirrors:manage']
+    const user = userEvent.setup()
+    renderWithProviders(<VersionApprovalsPage />)
+    await waitFor(() => expect(screen.getAllByRole('button', { name: 'Approve' })).toHaveLength(2))
+    expect(screen.getAllByRole('button', { name: 'Reject' })).toHaveLength(2)
+
+    await user.click(screen.getAllByRole('checkbox')[1])
+    expect(screen.getByRole('button', { name: /Approve Selected/ })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Reject Selected/ })).toBeInTheDocument()
   })
 })

--- a/frontend/src/routeScopes.ts
+++ b/frontend/src/routeScopes.ts
@@ -1,3 +1,5 @@
+import type { ScopeValue } from './types/rbac'
+
 // Single source of truth for which scope (if any) each /admin/* route
 // requires. App.tsx (route guards, via LazyRoute) and navigation.tsx
 // (sidebar item filtering) both read from this map instead of each
@@ -6,8 +8,10 @@
 //
 // A value of `null` means the route requires an authenticated user but no
 // specific scope (matches NavItem['scope']'s "always visible to
-// authenticated users" convention).
-export const ADMIN_ROUTE_SCOPES: Record<string, string | null> = {
+// authenticated users" convention). Values are typed as the canonical
+// ScopeValue union (#633) so a typo'd/retired scope is a compile error
+// instead of silently drifting from types/rbac.ts's AVAILABLE_SCOPES.
+export const ADMIN_ROUTE_SCOPES: Record<string, ScopeValue | null> = {
   '/admin': null,
   '/admin/users': 'users:read',
   '/admin/organizations': 'organizations:read',

--- a/frontend/src/services/__tests__/api.test.ts
+++ b/frontend/src/services/__tests__/api.test.ts
@@ -828,6 +828,16 @@ describe('ApiClient', () => {
       )
       expect([...composedFnNames].sort()).toEqual([...domainFnNames].sort())
     })
+
+    it('excludes devApi (dev-only endpoints stay out of the eager production bundle, #608)', async () => {
+      const mod = await import('../api')
+      const composed = mod.default as Record<string, unknown>
+      expect(composed.devLogin).toBeUndefined()
+      expect(composed.getDevStatus).toBeUndefined()
+      expect(composed.listUsersForImpersonation).toBeUndefined()
+      expect(composed.impersonateUser).toBeUndefined()
+      expect(mod.apiDomains).not.toHaveProperty('devApi')
+    })
   })
 
   // ─── CVE Advisories ───────────────────────────────────────────────────────
@@ -957,45 +967,10 @@ describe('ApiClient', () => {
       expect(result.allowed_scopes).toEqual([])
     })
 
-    it('devLogin calls POST /api/v1/dev/login (cookie is set server-side, token-less body)', async () => {
-      const client = await getApiClient()
-        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-          data: { user: { id: 'u1' }, expires_in: 3600 },
-        })
-      const result = await client.devLogin()
-      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/dev/login')
-      expect(result.expires_in).toBe(3600)
-    })
-
-    it('getDevStatus calls GET /api/v1/dev/status', async () => {
-      const client = await getApiClient()
-        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-          data: { dev_mode: true },
-        })
-      const result = await client.getDevStatus()
-      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/dev/status')
-      expect(result.dev_mode).toBe(true)
-    })
-
-    it('listUsersForImpersonation calls GET /api/v1/dev/users', async () => {
-      const client = await getApiClient()
-        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-          data: { users: [], dev_mode: true },
-        })
-      const result = await client.listUsersForImpersonation()
-      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/dev/users')
-      expect(result.dev_mode).toBe(true)
-    })
-
-    it('impersonateUser calls POST /api/v1/dev/impersonate/:id (cookie swap, token-less body)', async () => {
-      const client = await getApiClient()
-        ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-          data: { user: { id: 'u1', email: 'a@b.com', name: 'A' }, message: 'ok' },
-        })
-      const result = await client.impersonateUser('u1')
-      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/dev/impersonate/u1')
-      expect(result.message).toBe('ok')
-    })
+    // devLogin/getDevStatus/listUsersForImpersonation/impersonateUser are covered
+    // in services/api/__tests__/devApi.test.ts, not here: devApi is deliberately
+    // excluded from this composed client so it can be dead-code-eliminated from
+    // the production bundle (#608) — see the "excludes devApi" test below.
   })
 
   // ─── Modules ──────────────────────────────────────────────────────────────

--- a/frontend/src/services/api/__tests__/devApi.test.ts
+++ b/frontend/src/services/api/__tests__/devApi.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi } from 'vitest'
+import type { AxiosInstance, InternalAxiosRequestConfig, AxiosResponse, AxiosError } from 'axios'
+
+// devApi.ts is deliberately excluded from the composed `services/api` barrel
+// (see services/api/index.ts) so its dev-only endpoints can be dead-code-
+// eliminated from the production bundle instead of riding along in every
+// page's eager `import api from '../services/api'` (#608). It is tested here,
+// against its own module boundary, mirroring the axios-mock pattern used for
+// the composed client in services/__tests__/api.test.ts.
+
+type ReqFulfilled = (config: InternalAxiosRequestConfig) => InternalAxiosRequestConfig
+type ResFulfilled = (response: AxiosResponse) => AxiosResponse
+type ResRejected = (error: AxiosError) => unknown
+
+let mockAxiosInstance: AxiosInstance
+
+function getDevApi() {
+  vi.resetModules()
+  vi.doMock('axios', () => {
+    const mockInstance = {
+      get: vi.fn(),
+      post: vi.fn(),
+      put: vi.fn(),
+      delete: vi.fn(),
+      interceptors: {
+        request: {
+          use: vi.fn((_fulfilled: ReqFulfilled) => {}),
+        },
+        response: {
+          use: vi.fn((_fulfilled: ResFulfilled, _rejected: ResRejected) => {}),
+        },
+      },
+    }
+    return {
+      default: {
+        create: vi.fn(() => {
+          mockAxiosInstance = mockInstance as unknown as AxiosInstance
+          return mockInstance
+        }),
+      },
+    }
+  })
+
+  return import('../devApi')
+}
+
+describe('devApi', () => {
+  it('devLogin calls POST /api/v1/dev/login (cookie is set server-side, token-less body)', async () => {
+    const devApi = await getDevApi()
+      ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        data: { user: { id: 'u1' }, expires_in: 3600 },
+      })
+    const result = await devApi.devLogin()
+    expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/dev/login')
+    expect(result.expires_in).toBe(3600)
+  })
+
+  it('getDevStatus calls GET /api/v1/dev/status', async () => {
+    const devApi = await getDevApi()
+      ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        data: { dev_mode: true },
+      })
+    const result = await devApi.getDevStatus()
+    expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/dev/status')
+    expect(result.dev_mode).toBe(true)
+  })
+
+  it('listUsersForImpersonation calls GET /api/v1/dev/users', async () => {
+    const devApi = await getDevApi()
+      ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        data: { users: [], dev_mode: true },
+      })
+    const result = await devApi.listUsersForImpersonation()
+    expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/dev/users')
+    expect(result.dev_mode).toBe(true)
+  })
+
+  it('impersonateUser calls POST /api/v1/dev/impersonate/:id (cookie swap, token-less body)', async () => {
+    const devApi = await getDevApi()
+      ; (mockAxiosInstance.post as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        data: { user: { id: 'u1', email: 'a@b.com', name: 'A' }, message: 'ok' },
+      })
+    const result = await devApi.impersonateUser('u1')
+    expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v1/dev/impersonate/u1')
+    expect(result.message).toBe('ok')
+  })
+})

--- a/frontend/src/services/api/index.ts
+++ b/frontend/src/services/api/index.ts
@@ -20,7 +20,6 @@ import * as advisoriesApi from './advisoriesApi'
 import * as apiKeysApi from './apiKeysApi'
 import * as auditApi from './auditApi'
 import * as authApi from './authApi'
-import * as devApi from './devApi'
 import * as identityApi from './identityApi'
 import * as mirrorsApi from './mirrorsApi'
 import * as modulesApi from './modulesApi'
@@ -39,6 +38,15 @@ import * as usersApi from './usersApi'
 import * as versionApi from './versionApi'
 import * as versionApprovalsApi from './versionApprovalsApi'
 
+// devApi (dev/status, dev/login, dev/users, dev/impersonate/:id) is deliberately
+// NOT part of this barrel. Every other domain module here is spread into the
+// eagerly-imported `apiClient` object below, which pulls its code into the main
+// bundle regardless of any import.meta.env.DEV guard at the *call site* --
+// spreading devApi in too would defeat DevUserSwitcher's lazy import and undo
+// the dead-code elimination it exists for (#608). Import
+// '../services/api/devApi' directly (statically only from code that is itself
+// dev-only/lazy-loaded, or via a dynamic import()) instead.
+
 /** Domain modules composed into the flat client, exported for the parity test. */
 export const apiDomains = {
   adminStatsApi,
@@ -46,7 +54,6 @@ export const apiDomains = {
   apiKeysApi,
   auditApi,
   authApi,
-  devApi,
   identityApi,
   mirrorsApi,
   modulesApi,
@@ -72,7 +79,6 @@ const apiClient = {
   ...apiKeysApi,
   ...auditApi,
   ...authApi,
-  ...devApi,
   ...identityApi,
   ...mirrorsApi,
   ...modulesApi,

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -214,22 +214,6 @@ export interface PaginationMeta {
   total: number
 }
 
-export interface AuthContextType {
-  user: User | null
-  roleTemplate: RoleTemplateInfo | null // Primary role template (backward compat)
-  allowedScopes: string[] // Combined scopes across all org memberships
-  isAuthenticated: boolean
-  isLoading: boolean
-  sessionExpiresAt: Date | null
-  sessionExpiresSoon: boolean
-  login: (provider?: string) => void
-  devLogin: () => Promise<void>
-  ldapLogin: (username: string, password: string) => Promise<void>
-  logout: () => void
-  refreshSession: () => Promise<void>
-  hasScope: (scope: string) => boolean
-}
-
 // Storage Configuration Types
 export type StorageBackendType = 'local' | 'azure' | 's3' | 'gcs'
 


### PR DESCRIPTION
Closes #608
Closes #609
Closes #622
Closes #633
Closes #636

Batch `d-auth-scope-gating` from the 2026-07-22 blind security audit:

- **#609** — mutation controls on read-gated admin routes are now gated on the corresponding manage scope. Beyond the pages named in the issue, the adversarial panel forced coverage of every sibling: OrganizationsPage, UsersPage, SCMProvidersPage, MirrorsPage, TerraformMirrorPage, ApprovalsPage, VersionApprovalsPage, and APIKeysPage (whose route is scoped `null` — weaker than the `:read` routes). Client gating remains UX-only; the server stays authoritative (#499 accepted risk).
- **#608** — dev-login/impersonation code is code-split out of the production bundle (`devApi` imported directly rather than through the shared barrel, which is spread into every eagerly-loaded page).
- **#622** — the fabricated placeholder multi-org membership shape is replaced with an explicit sentinel.
- **#633** — scope strings are typed (`ScopeValue`) and the non-existent `*:publish` scopes referenced by CommandPalette are corrected.
- **#636** — the dead pre-suite-ui `AuthContextType` interface is removed.

Verification: 3-reviewer adversarial panel; this batch took **two unanimous 0/3 rejections** for incomplete sibling scouting before reaching consensus on the third round. Post-rebase: lint clean, build green, and the three touched admin-page suites pass in isolation (125/125). Note: two `SetupWizardPage.test.tsx` tests fail on a loaded machine, but they fail identically on a branch with zero source changes — pre-existing on main, not from this PR.