### PR TITLE
docs: correct stale security, testing and accessibility claims

### DIFF
--- a/ACCESSIBILITY.md
+++ b/ACCESSIBILITY.md
@@ -59,4 +59,4 @@ within 5 business days.
 
 - [axe DevTools](https://www.deque.com/axe/) — browser extension for manual audits
 - [@axe-core/react](https://github.com/dequelabs/axe-core-npm/tree/develop/packages/react) — runtime checks in development
-- [Lighthouse](https://developer.chrome.com/docs/lighthouse/) — CI accessibility scoring (target: ≥90)
+- [Lighthouse](https://developer.chrome.com/docs/lighthouse/) — not wired into CI; a suggested manual/local tool for spot-checking accessibility scores (target: ≥90) before a release

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -132,19 +132,19 @@ The catch-all route (`*`) redirects to `/`.
   queryKeys.ts  (cache key factory)
      |
      v
-  api.ts  (Axios client)
+  services/api  (Axios client)
      |
      v
   Backend API  (/api/v1/...)
 ```
 
-### API Client (`services/api.ts`)
+### API Client (`services/api/`)
 
-A singleton `ApiClient` class wrapping an Axios instance. Key features:
+A composed barrel object (`services/api/index.ts`) that spreads every per-domain module (`modulesApi.ts`, `usersApi.ts`, etc.) into one flat `apiClient`, all sharing the single configured Axios instance in `services/api/http.ts`. The old 1900-line `ApiClient` god object (issue #474) was split into these per-domain modules; existing `import apiClient from '../services/api'` call sites keep working unchanged. Key features (implemented in `http.ts`):
 
 - **Base URL**: Empty in dev (Vite proxy handles `/api/*`), configurable via `VITE_API_URL` in production.
 - **Cookie credentials**: The Axios instance is created with `withCredentials: true`, so the HttpOnly auth cookie and the `tfr_csrf` cookie are sent on every request.
-- **Request interceptor (CSRF)**: On mutating requests (`POST`/`PUT`/`PATCH`/`DELETE`), reads the non-HttpOnly `tfr_csrf` cookie and echoes it in an `X-CSRF-Token` header (double-submit pattern). As a backward-compatible migration fallback, if a legacy `auth_token` is still present in `localStorage` it is attached as `Authorization: Bearer <token>`; this path is slated for removal once all sessions use cookies.
+- **Request interceptor (CSRF)**: On mutating requests (`POST`/`PUT`/`PATCH`/`DELETE`), reads the non-HttpOnly `tfr_csrf` cookie and echoes it in an `X-CSRF-Token` header (double-submit pattern). Auth is cookie-only -- no request ever attaches an `Authorization: Bearer` header sourced from `localStorage` (`authStorage.ts` keeps the legacy key list only to purge leftover values from pre-cookie-migration sessions).
 - **Response interceptor (401)**: On 401, clears auth and redirects to `/login` -- except for SCM OAuth endpoints (`/scm-providers/*/repositories`, `/tags`, `/branches`) where 401 means the SCM token expired, not the user session.
 - **Breadcrumb interceptor**: Records every API call (method, URL, status, duration) for error reporting context.
 - **Setup requests**: The `setupRequest(token)` method creates one-off requests with `Authorization: SetupToken <token>` for the first-run setup wizard.
@@ -215,7 +215,7 @@ sequenceDiagram
     IdP-->>U: 302 Redirect to /auth/callback?code=...
     U->>FE: /auth/callback (CallbackPage)
     Note over FE,BE: Backend set an HttpOnly auth cookie (+ tfr_csrf cookie) on the callback redirect
-    FE->>FE: CallbackPage navigates to the return URL<br/>(legacy: a ?token= query param, if present, is stored in localStorage)
+    FE->>FE: CallbackPage navigates to the return URL<br/>(no token ever transits the URL -- the session lives in the HttpOnly cookie)
     FE->>BE: GET /api/v1/auth/me (HttpOnly cookie sent via withCredentials)
     BE-->>FE: { user, role_template, allowed_scopes }
     FE->>FE: Cache user + scopes in state & localStorage
@@ -234,7 +234,7 @@ sequenceDiagram
 ### Key details
 
 - **AuthContext** (`contexts/AuthContext.tsx`) provides: `user`, `roleTemplate`, `allowedScopes`, `isAuthenticated`, `isLoading`, `login`, `logout`, `refreshToken`, `setToken`.
-- **Session detection**: The session lives in an HttpOnly cookie. On mount, AuthContext calls `/api/v1/auth/me` (cookie sent via `withCredentials`) to detect and validate the session. If a cached user is in `localStorage` it restores UI state immediately (optimistic) and revalidates against `/auth/me` in the background. A legacy `auth_token` in `localStorage` is still honoured as a migration fallback.
+- **Session detection**: The session lives in an HttpOnly cookie. On mount, AuthContext calls `/api/v1/auth/me` (cookie sent via `withCredentials`) to detect and validate the session. If a cached user is in `localStorage` it restores UI state immediately (optimistic) and revalidates against `/auth/me` in the background.
 - **Logout**: Clears local session state and the cached localStorage keys (`auth_token`, `user`, `role_template`, `allowed_scopes`, `authorized`) and redirects to the backend's logout endpoint, which clears the HttpOnly auth cookie and terminates the IdP session.
 - **Dev mode login**: When the backend runs with `DEV_MODE=true`, the login page shows a "Dev Login (Admin)" button that authenticates directly without an IdP redirect.
 - **Token refresh**: `refreshToken()` calls `api.refreshToken()` and updates the stored token. On failure, it calls `logout()`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,7 +122,7 @@ TypeScript strict mode is enforced. `any` types require explicit justification i
 
 ### Conventions
 
-- **All API calls** go through `services/api.ts` (Axios instance with auth interceptors). Never call `fetch` directly.
+- **All API calls** go through `services/api/` (composed barrel over per-domain modules sharing the Axios instance + auth interceptors in `services/api/http.ts`). Never call `fetch` directly.
 - **Global state** uses React Context (`AuthContext`, `ThemeContext`). Redux is not used.
 - **Protected routes** use `components/ProtectedRoute.tsx`.
 - **MUI `TextField` inputs** for non-obvious fields must include a `helperText` prop explaining what value is expected and why.
@@ -255,7 +255,7 @@ frontend/src/
 - **TypeScript strict mode** is enforced. Avoid `any` types; if unavoidable, add a comment explaining why.
 - **ESLint** runs with zero warnings (`npm run lint`). No `// eslint-disable` without a comment justifying it.
 - **No unused variables or imports**. ESLint catches these.
-- **All API calls** go through `services/api.ts`. Never use `fetch` or create separate Axios instances.
+- **All API calls** go through `services/api/`. Never use `fetch` or create separate Axios instances.
 - **MUI TextField inputs** for non-obvious fields must include a `helperText` prop.
 - **Imports**: prefer named imports. Group imports: React/external libraries first, then internal modules.
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -99,7 +99,7 @@ The following are stored in the browser's `localStorage`, not as cookies:
 
 | Key                           | Purpose                                                             | Duration |
 | ------------------------------ | --------------------------------------------------------------------- | -------- |
-| `auth_token`                   | **Sensitive.** Legacy session JWT, used only during the transitional migration away from `localStorage`-based auth (see `SECURITY.md`); new sessions use the HttpOnly cookie above instead. Cleared on logout or session expiry. | Session  |
+| `auth_token`                   | **Sensitive.** Nothing writes this key anymore -- sessions are cookie-only (see `SECURITY.md`). Kept only so a one-time cleanup can purge a stale JWT left behind by a session from before the cookie-only migration. Cleared on logout or session expiry. | Session  |
 | `user`                         | Cached profile info (id, email, name) for the signed-in user. Cleared on logout or session expiry. | Session  |
 | `role_template`                | Cached role template for the signed-in user. Cleared on logout or session expiry. | Session  |
 | `allowed_scopes`                | Cached authorization scopes for the signed-in user. Cleared on logout or session expiry. | Session  |

--- a/README.md
+++ b/README.md
@@ -121,9 +121,9 @@ App
 
 **State management**: React Query (`@tanstack/react-query`) for all server state; React Context for app-level concerns (auth, theme, help panel); local `useState` for UI-only state.
 
-**Data fetching**: API calls go through `services/api.ts` (Axios). Query cache keys are defined in `services/queryKeys.ts` using a factory pattern. Mutations invalidate related queries via `queryClient.invalidateQueries()`.
+**Data fetching**: API calls go through `services/api/` (a composed barrel over per-domain modules sharing one Axios instance in `services/api/http.ts`). Query cache keys are defined in `services/queryKeys.ts` using a factory pattern. Mutations invalidate related queries via `queryClient.invalidateQueries()`.
 
-**Authentication**: Sessions are cookie-only. The backend sets an HttpOnly auth cookie; the Axios client sends it on every request via `withCredentials: true`, and `AuthContext` detects the session by calling `/api/v1/auth/me`. Mutating requests are protected by a CSRF double-submit: the non-HttpOnly `tfr_csrf` cookie is echoed in an `X-CSRF-Token` header. A 401 clears local session state and redirects to `/login`. (A legacy `localStorage` Bearer token is still honoured as a backward-compatible migration fallback and will be removed once all sessions use cookies.)
+**Authentication**: Sessions are cookie-only. The backend sets an HttpOnly auth cookie; the Axios client sends it on every request via `withCredentials: true`, and `AuthContext` detects the session by calling `/api/v1/auth/me`. Mutating requests are protected by a CSRF double-submit: the non-HttpOnly `tfr_csrf` cookie is echoed in an `X-CSRF-Token` header. A 401 clears local session state and redirects to `/login`. (The migration off of `localStorage` Bearer tokens is complete; `authStorage.ts` retains the pre-migration key list solely to purge leftover values from sessions predating the cookie-only auth model.)
 
 **Security posture (CSP nonce)**: When served through nginx, a per-request CSP nonce is derived from `$request_id` and injected into `index.html` (the `__CSP_NONCE__` placeholder), so the `Content-Security-Policy` `style-src` can use `'nonce-…'` instead of `'unsafe-inline'`. The Emotion cache reads the same nonce so MUI styles are allowed. See [`frontend/nginx.conf`](frontend/nginx.conf).
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -57,13 +57,13 @@ We will credit reporters in the release notes unless anonymity is requested.
 ## Security Practices
 
 - All releases are signed with [cosign](https://github.com/sigstore/cosign) (keyless, Sigstore) and include SLSA build provenance attestations
-- Dependencies are monitored by Dependabot (npm — frontend + e2e — and GitHub Actions)
+- Dependencies are monitored by Dependabot, weekly (npm — frontend + e2e —, Docker, and GitHub Actions)
 - `npm audit --audit-level=high` runs in the Docker build and the scheduled security workflow
 - Markdown rendering is sanitised with `rehype-sanitize` (XSS mitigation)
 - `ApiDocumentation.tsx` renders the same-origin `/swagger.json` spec via `swagger-ui-react`, relying on that dependency's bundled DOMPurify-based sanitizer rather than app-side sanitization. This is a tracked residual-trust item, not an active vuln: the spec is server-controlled, and the mitigation is keeping `swagger-ui-react` patched (covered by the weekly `npm audit`/Dependabot workflow) plus ensuring the backend never reflects user-controlled strings into spec description/example fields
 - The frontend follows OWASP Top 10 mitigations applicable to SPAs (output encoding, strict CSP via nginx, no `dangerouslySetInnerHTML` outside the sanitised renderer)
 - HSTS (`Strict-Transport-Security`) is sent by `nginx.conf`, which terminates TLS directly. `nginx-ecs.conf.template` (ECS/Cloud Run/ACA) and any deployment that fronts the container with an external reverse proxy/ALB (see `deployments/docker-compose.prod.yml`) deliberately do **not** set it themselves -- HSTS only has effect on the hop that actually terminates TLS, so it must be configured at that edge/ALB, not on the origin container behind it
-- Authentication uses an HttpOnly session cookie set by the backend (no JWT persisted in `localStorage` outside a transitional migration path); mutating requests are protected by a double-submit CSRF token (the `tfr_csrf` cookie echoed in an `X-CSRF-Token` header)
+- Authentication uses an HttpOnly session cookie set by the backend (no JWT is ever persisted in `localStorage`); mutating requests are protected by a double-submit CSRF token (the `tfr_csrf` cookie echoed in an `X-CSRF-Token` header)
 
 ## Repository Hardening
 
@@ -106,7 +106,8 @@ matching `v*.*.*` with a "Restrict deletions" rule.
 - Dependabot vulnerability alerts: enabled
 - Dependabot automated security fixes: enabled
 - Dependabot version updates configured via `.github/dependabot.yml` for npm
-  (frontend + e2e) and GitHub Actions (biweekly)
+  (frontend + e2e), Docker (frontend), and GitHub Actions -- all weekly
+  (Mondays)
 
 ### Code Ownership
 
@@ -149,7 +150,10 @@ controls:
   methodology as this repo on 2026-07-10 (26 findings: 2 high, 16 medium,
   remainder low/info). All findings were remediated in
   [v0.5.3](https://github.com/sethbacon/terraform-suite-ui/releases/tag/v0.5.3)
-  (2026-07-11), which is the version pinned here. The package repo now
+  (2026-07-11). The pin has moved past v0.5.3 since then via the manual,
+  reviewed update process below -- see `frontend/package.json` for the
+  exact version currently pinned, rather than relying on a version number
+  in this doc that would go stale on the next bump. The package repo now
   carries its own `SECURITY.md` and a security-model section in its README.
 - **Upstream supply-chain gates** — the package's own CI runs typecheck,
   tests, build, and CodeQL; its publish workflow verifies the tarball

--- a/TESTING.md
+++ b/TESTING.md
@@ -59,7 +59,7 @@ Setup file: `frontend/src/setupTests.ts`
 
 ### Mocking the API client with `vi.mock`
 
-The API client (`services/api.ts`) is a class-based singleton. Tests mock it at the module level using `vi.mock` and `vi.hoisted`:
+The API client (`services/api/`) is a composed barrel object over per-domain modules that share one Axios instance (`services/api/http.ts`). Tests mock it at the module level using `vi.mock` and `vi.hoisted`:
 
 ```ts
 // vi.hoisted runs BEFORE imports, so mock variables are available in vi.mock
@@ -82,7 +82,7 @@ This pattern is used consistently across:
 
 ### Mocking Axios for interceptor tests
 
-The API test file uses a more advanced pattern that captures the interceptor callbacks registered during `ApiClient` construction. This allows testing auth header injection and 401 handling directly:
+The API test file uses a more advanced pattern that captures the interceptor callbacks registered when `services/api/http.ts` creates its Axios instance. This allows testing CSRF header injection and 401 handling directly:
 
 ```ts
 vi.mock('axios', () => {
@@ -98,7 +98,7 @@ vi.mock('axios', () => {
 });
 ```
 
-Each test calls `getApiClient()` which resets modules (`vi.resetModules()`) and re-imports `api.ts` to get a fresh instance with fresh interceptors.
+Each test calls `getApiClient()` which resets modules (`vi.resetModules()`) and re-imports `services/api` to get a fresh instance with fresh interceptors.
 
 ### Testing hooks with `renderHook`
 
@@ -265,10 +265,12 @@ e2e/tests/
   oidc-settings.spec.ts        # OIDC configuration page
   policies.spec.ts             # Mirror policies
   providers.spec.ts            # Provider browsing
+  security.spec.ts             # Security-abuse scenarios (#489)
   setup-wizard.spec.ts         # First-run setup wizard
   terraform-binaries.spec.ts   # Terraform binary mirror browsing
   terraform-mirror-admin.spec.ts # Terraform mirror admin
   upload.spec.ts               # Module/provider upload
+  version-approvals.spec.ts    # Version approval flows
   visual-regression.spec.ts    # Pixel-diff snapshots (excluded from CI gate; run on demand)
 ```
 

--- a/frontend/nginx-ecs.conf.template
+++ b/frontend/nginx-ecs.conf.template
@@ -18,6 +18,16 @@
 #      ALB default rule; in practice those paths should be intercepted by the
 #      higher-priority ALB listener rules and never reach nginx.
 
+# Derive the per-request CSP nonce ONCE. A map variable is evaluated lazily and
+# cached for the whole request — surviving the internal redirect to /index.html —
+# so the CSP header and the sub_filter body rewrite see the SAME value. A plain
+# `set $csp_nonce $request_id` re-runs after that redirect and yields a SECOND,
+# different id, so the header nonce and the <meta>/emotion nonce disagree and the
+# browser blocks every injected style. See frontend/nginx.conf for the same fix.
+map $request_id $csp_nonce {
+    default $request_id;
+}
+
 server {
     listen 80;
     server_name _;
@@ -31,12 +41,12 @@ server {
     add_header X-Frame-Options "DENY" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-    set $csp_nonce $request_id;
     add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'nonce-$csp_nonce'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none';" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
 
-    # Inject CSP nonce into index.html
-    sub_filter_once on;
+    # Inject CSP nonce into index.html. once off = replace EVERY __CSP_NONCE__
+    # so the <meta> is covered even if another occurrence precedes it in the document.
+    sub_filter_once off;
     sub_filter '__CSP_NONCE__' '$csp_nonce';
 
     # Upload size limit (matches backend: 100MB modules, 500MB providers)


### PR DESCRIPTION
Closes #607
Closes #625
Closes #627
Closes #628
Closes #629
Part of #472 (SECURITY.md no longer cites a stale audited version for the suite-ui pin)

Batch `g-docs` from the 2026-07-22 blind security audit:

- **#607** — README/ARCHITECTURE/SECURITY/PRIVACY no longer describe the removed legacy localStorage Bearer-token fallback.
- **#625** — TESTING.md's removed "ApiClient class" description and missing e2e inventory corrected. Sibling scouting found the same false claim in ARCHITECTURE.md and stale `services/api.ts` paths in CONTRIBUTING.md and README.
- **#627** — ACCESSIBILITY.md's claimed Lighthouse CI gate (which does not exist) removed.
- **#628** — SECURITY.md's Dependabot cadence corrected to match dependabot.yml, including the omitted Docker ecosystem.
- **#629** — `nginx-ecs.conf.template`'s CSP-nonce anti-pattern fixed to mirror the proven `nginx.conf` pattern (map + `sub_filter_once off`).
- **#472 regression** — the pin claim now points at package.json rather than a version string that drifts.

Two matches were deliberately left alone with rationale: `docs/roadmap-version-approval.md` (explicitly a historical design record) and CHANGELOG.md (generated history accurately describing a past commit).

Verification: 3-reviewer adversarial panel consensus (3/3); lint, full unit suite and build green. No test was added for the nginx change — the repo has no nginx-config test harness, and building one was out of scope for a docs batch (flagged rather than faked).