### PR TITLE
fix(security): error-reporting infra — Sentry dependency, ErrorBoundary leak, CSP, bounded buffer

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -311,9 +311,47 @@ Enhanced error reporter with:
 
 - **Batching**: Queues errors and flushes every 5 seconds or when 10 errors accumulate.
 - **Retry**: Exponential backoff (up to 3 retries) on send failure.
-- **Breadcrumbs**: Records the last 20 events (navigation, API calls, console errors) for debugging context.
+- **Breadcrumbs**: Records the last 20 events (navigation — via `NavigationBreadcrumbTracker`/`useNavigationBreadcrumbs` on every route change, API calls, console errors) for debugging context.
 - **Session tracking**: Random `sessionId` generated per page load, included with all reports.
-- **Error reporting**: If `VITE_ERROR_REPORTING_DSN` is set (e.g. a Sentry DSN or custom HTTP endpoint), batched error reports are POSTed to that URL. Otherwise errors are logged to the console only.
+- **Configuration** (three mutually exclusive outcomes, checked in order):
+  1. `VITE_SENTRY_DSN` set — the Sentry SDK (`@sentry/react`) is lazy-loaded and initialized (preferred for production); `beforeSend`/`beforeBreadcrumb` hooks strip session tokens from URLs before they leave the browser.
+  2. `VITE_ERROR_REPORTING_DSN` set (and no Sentry DSN) — the built-in batched custom reporter POSTs to that URL.
+  3. Neither set — errors are logged to the console only.
+
+### Performance Reporting (`services/performanceReporting.ts`)
+
+Reports Core Web Vitals (CLS, FCP, LCP, INP, TTFB) and route-level navigation
+timing — `reportNavigation()`, called from the same `NavigationBreadcrumbTracker`/
+`useNavigationBreadcrumbs` hook that records navigation breadcrumbs above, so
+every SPA route change reports both. Batches and flushes to `VITE_PERFORMANCE_DSN`
+(falling back to `VITE_ERROR_REPORTING_DSN`) every 10 seconds or 25 entries,
+via `sendBeacon` where available. In development, metrics are also logged to
+the console. `reportNavigation()` is called unconditionally on every route
+change regardless of consent, so it only buffers an entry once the service is
+active (a DSN has been resolved by `init()`); dev-mode console logging stays
+unconditional since it never leaves the browser. This prevents pre-consent
+navigation history from being buffered and then flushed once the user later
+opts in. Same DSN/`connect-src` constraints as error reporting apply (see
+below).
+
+### Telemetry Consent Gating (`components/TelemetryGate.tsx`)
+
+Both error and performance reporting are opt-in: `TelemetryGate` starts/stops
+each service in lockstep with the user's live consent preferences
+(`useConsent()`), calling `init()` when a preference turns on and `destroy()`
+on withdrawal or unmount — no page reload required. See PRIVACY.md section 3.3
+for the consent lifecycle and legal basis.
+
+### CSP and Telemetry Endpoints
+
+The shipped Content-Security-Policy's `connect-src 'self'` (`nginx.conf`,
+`nginx-ecs.conf.template`) means a DSN pointing at a genuinely cross-origin
+endpoint (e.g. a Sentry SaaS `*.ingest.sentry.io` DSN) will have its
+`fetch`/`sendBeacon` calls blocked by the browser — both send paths swallow
+that failure silently by design, so telemetry would appear configured but
+never actually leave the browser. Route third-party DSNs through this app's
+own reverse proxy (same pattern as `nginx-ecs.conf.template`'s `BACKEND_URL`),
+or add the destination origin to `connect-src` in both nginx configs.
 
 ### API Error Utilities (`utils/errors.ts`)
 

--- a/README.md
+++ b/README.md
@@ -85,10 +85,14 @@ Frontend configuration is provided via Vite environment variables. All variables
 | `VITE_API_URL`             | (proxied by Vite in dev) | Backend API **origin** for production builds, e.g. `https://registry.example.com`. Must not include a path: every API call already hardcodes its own `/api/v1/...` prefix, so a path here (e.g. `.../api/v1`) would double it. |
 | `VITE_PROXY_TARGET`        | `http://localhost:8080`  | Backend URL the Vite dev server proxies `/api/*` to. Override for TLS or non-local backend during development.                                                       |
 | `VITE_USE_MOCK_DATA`       | `false`                  | When `true`, the API client returns static mock data instead of calling the backend (offline development).                                                           |
-| `VITE_ERROR_REPORTING_DSN` | _(unset)_                | URL for batched browser error reports (Sentry-compatible DSN or any HTTP endpoint). When unset, errors log to console only.                                          |
+| `VITE_ERROR_REPORTING_DSN` | _(unset)_                | URL for batched browser error reports (Sentry-compatible DSN or any HTTP endpoint). When unset, errors log to console only. Compiled into the public bundle -- see note below. |
+| `VITE_SENTRY_DSN`          | _(unset)_                | Sentry DSN for error reporting via the Sentry SDK (preferred over `VITE_ERROR_REPORTING_DSN` when both are set). Compiled into the public bundle -- see note below.  |
+| `VITE_PERFORMANCE_DSN`     | _(unset)_                | DSN for performance/Web Vitals reporting (`services/performanceReporting.ts`). Falls back to `VITE_ERROR_REPORTING_DSN` when unset. Compiled into the public bundle -- see note below. |
 
 In development the Vite proxy handles `/api/*` routing, so no env var is needed locally.
 For Docker / production builds served through nginx, the bundled nginx config already proxies `/api/*` to the backend, so `VITE_API_URL` is normally left unset. Only set it if the frontend is genuinely served from a different origin than the backend -- and note the shipped Content-Security-Policy's `connect-src 'self'` will block that origin's requests unless you also route both through the same reverse proxy (see `nginx-ecs.conf.template`'s `BACKEND_URL` pattern) instead of calling the other origin directly from the browser. This value is compiled into the public JS bundle, so it must stay public-facing -- never an internal-only hostname.
+
+Like `VITE_API_URL`, the three DSN variables above are compiled into the public JS bundle and ship in cleartext to every visitor. Never embed an auth token or API key in one of these URLs (e.g. as a query-string parameter) for a custom collector -- Sentry's own DSN scheme is write-only-by-design, but a bespoke endpoint that authenticates via an embedded credential would leak it to anyone viewing the bundle. See [`frontend/.env.example`](frontend/.env.example) for the full annotated guidance, which is authoritative for these vars.
 
 ## Tech Stack
 

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -40,10 +40,17 @@
 # Error reporting DSN endpoint.
 # Accepts a Sentry DSN or any URL that accepts POST requests with error payloads.
 # When not set, errors are logged to the browser console only.
+# This value is compiled into the public JS bundle -- like VITE_API_URL above,
+# it ships in cleartext to every visitor. Never embed an auth token or API key
+# in this URL (e.g. as a query-string parameter) for a custom collector --
+# Sentry's own DSN scheme is write-only-by-design, but a bespoke endpoint that
+# authenticates via an embedded credential would leak it to anyone viewing the bundle.
 # VITE_ERROR_REPORTING_DSN=https://your-sentry-dsn-or-endpoint
 
 # Sentry DSN for error reporting (preferred over VITE_ERROR_REPORTING_DSN when set).
+# Same public-bundle exposure as VITE_ERROR_REPORTING_DSN above applies here too.
 # VITE_SENTRY_DSN=https://your-sentry-dsn
 
 # DSN for performance/RUM reporting. Falls back to VITE_ERROR_REPORTING_DSN when not set.
+# Same public-bundle exposure as VITE_ERROR_REPORTING_DSN above applies here too.
 # VITE_PERFORMANCE_DSN=https://your-performance-dsn-or-endpoint

--- a/frontend/nginx-ecs.conf.template
+++ b/frontend/nginx-ecs.conf.template
@@ -41,6 +41,11 @@ server {
     add_header X-Frame-Options "DENY" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    # connect-src 'self' also constrains VITE_SENTRY_DSN / VITE_ERROR_REPORTING_DSN /
+    # VITE_PERFORMANCE_DSN (services/errorReporting.ts, performanceReporting.ts): a
+    # genuinely cross-origin DSN (e.g. a Sentry SaaS *.ingest.sentry.io endpoint) will
+    # have its fetch/sendBeacon calls silently blocked by the browser. Route such DSNs
+    # through this reverse proxy instead, or add their origin here (see ARCHITECTURE.md).
     add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'nonce-$csp_nonce'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none';" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
 

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -40,6 +40,11 @@ server {
     # The __CSP_NONCE__ placeholder is replaced per-request by the sub_filter below.
     # In development (without nginx), 'unsafe-inline' is still needed — Vite injects styles directly.
     # $csp_nonce is the single per-request value from the map above.
+    # connect-src 'self' also constrains VITE_SENTRY_DSN / VITE_ERROR_REPORTING_DSN /
+    # VITE_PERFORMANCE_DSN (services/errorReporting.ts, performanceReporting.ts): a
+    # genuinely cross-origin DSN (e.g. a Sentry SaaS *.ingest.sentry.io endpoint) will
+    # have its fetch/sendBeacon calls silently blocked by the browser. Route such DSNs
+    # through this reverse proxy instead, or add their origin here (see ARCHITECTURE.md).
     add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'nonce-$csp_nonce'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none';" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,6 +19,7 @@
         "@mui/icons-material": "^9.2.0",
         "@mui/material": "^9.2.0",
         "@mui/material-pigment-css": "^9.2.0",
+        "@sentry/react": "^10.68.0",
         "@sethbacon/terraform-suite-ui": "0.7.0",
         "@tanstack/react-query": "^5.101.4",
         "@tanstack/react-query-devtools": "^5.101.4",
@@ -41,7 +42,6 @@
       },
       "devDependencies": {
         "@axe-core/react": "^4.12.1",
-        "@sentry/react": "^10.68.0",
         "@testing-library/dom": "^10.0.0",
         "@testing-library/jest-dom": "^7.0.0",
         "@testing-library/react": "^16.3.2",
@@ -2401,7 +2401,6 @@
       "version": "10.68.0",
       "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.68.0.tgz",
       "integrity": "sha512-8xVgk7oG2lajXnbXF6a7H1xMZ/U6icqSldHGzQu1+bajfrK8Gan9ULG/Xsj1VM1LlNeK6/7znDJ3u1jgvIwznw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@sentry/browser-utils": "10.68.0",
@@ -2419,7 +2418,6 @@
       "version": "10.68.0",
       "resolved": "https://registry.npmjs.org/@sentry/browser-utils/-/browser-utils-10.68.0.tgz",
       "integrity": "sha512-be8VtdjCngKc77cstJeV+gO15iH+blyXpBDk8yOehmtX4BkFO33mfTMNCWVR2LA0oOxjIHWRAhf77fIUEhzxPg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@sentry/conventions": "^0.16.0",
@@ -2433,7 +2431,6 @@
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.16.0.tgz",
       "integrity": "sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -2443,7 +2440,6 @@
       "version": "10.68.0",
       "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.68.0.tgz",
       "integrity": "sha512-5Amhx8ltVz7vb1bRGyf3c4J69/iHW8R/H+SJxTRILHlsSOBrnVVc/IQEYDC6PTRdRdZ3x2u7RVjxZi2Mhe525g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@sentry/conventions": "^0.16.0"
@@ -2456,7 +2452,6 @@
       "version": "10.68.0",
       "resolved": "https://registry.npmjs.org/@sentry/feedback/-/feedback-10.68.0.tgz",
       "integrity": "sha512-XbdcXiBnpC3vgw46eHOPeD/ZQ+XzluP75ubdUcaPDW02hCh2nsdXiwjZ2DBImbpvIpTbJgjHf/sIlHWvcZJ2Mg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@sentry/core": "10.68.0"
@@ -2469,7 +2464,6 @@
       "version": "10.68.0",
       "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.68.0.tgz",
       "integrity": "sha512-rIq4QR4ScMHHx9JJZv7Jgw31bMdUVJMx+ykHIJb7htjY6mj78sjKs+KpCsMDnvJxDhSmvftGM1KfKD4BggL7OQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@sentry/browser": "10.68.0",
@@ -2487,7 +2481,6 @@
       "version": "10.68.0",
       "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-10.68.0.tgz",
       "integrity": "sha512-ZoG2n16vbkx4GWSCnLIqUUN9xlUmccQFbQ2US2rhruQeHTUnHl/ukr8NHOQXZaEbwKyMkX9bEMwfmZHJm+wSTQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@sentry/browser-utils": "10.68.0",
@@ -2501,7 +2494,6 @@
       "version": "10.68.0",
       "resolved": "https://registry.npmjs.org/@sentry/replay-canvas/-/replay-canvas-10.68.0.tgz",
       "integrity": "sha512-HusYcr+He+ohnUDHunYrc5St6vdDnBXpUAndnT5ReyUMVSCiWKfY3paXowU/0787HwYfxdcpZgwC5u79+XbEIg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@sentry/core": "10.68.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,6 +31,7 @@
     "@mui/icons-material": "^9.2.0",
     "@mui/material": "^9.2.0",
     "@mui/material-pigment-css": "^9.2.0",
+    "@sentry/react": "^10.68.0",
     "@sethbacon/terraform-suite-ui": "0.7.0",
     "@tanstack/react-query": "^5.101.4",
     "@tanstack/react-query-devtools": "^5.101.4",
@@ -53,7 +54,6 @@
   },
   "devDependencies": {
     "@axe-core/react": "^4.12.1",
-    "@sentry/react": "^10.68.0",
     "@testing-library/dom": "^10.0.0",
     "@testing-library/jest-dom": "^7.0.0",
     "@testing-library/react": "^16.3.2",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,7 @@ import ErrorBoundary from './components/ErrorBoundary'
 import { queryClient } from './queryClient'
 import LazyRoute from './components/LazyRoute'
 import RouteFocusManager from './components/RouteFocusManager'
+import NavigationBreadcrumbTracker from './components/NavigationBreadcrumbTracker'
 import { ADMIN_ROUTE_SCOPES } from './routeScopes'
 // Critical-path pages loaded eagerly (small, always needed on first visit)
 import HomePage from './pages/HomePage'
@@ -64,6 +65,7 @@ function App() {
               <QueryClientProvider client={queryClient}>
                 <Router>
                   <RouteFocusManager />
+                  <NavigationBreadcrumbTracker />
                   <ErrorBoundary>
                     <Routes>
                       {/* Public routes */}

--- a/frontend/src/__tests__/packageDependencies.test.ts
+++ b/frontend/src/__tests__/packageDependencies.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest'
+import pkg from '../../package.json'
+
+/**
+ * `@sentry/react` is dynamically imported by shipped runtime code
+ * (services/errorReporting.ts's init()/captureError()/setUser()) whenever
+ * VITE_SENTRY_DSN is configured, so it must be a real `dependencies` entry.
+ * Leaving it under `devDependencies` works today only because the Docker
+ * build's `npm ci` installs devDependencies too -- a future `--omit=dev`
+ * install would silently drop the package and disable Sentry reporting
+ * with no build error (#610).
+ */
+describe('package.json dependency placement', () => {
+  it('lists @sentry/react as a production dependency, not a devDependency', () => {
+    expect(pkg.dependencies).toHaveProperty('@sentry/react')
+    expect(pkg.devDependencies).not.toHaveProperty('@sentry/react')
+  })
+})

--- a/frontend/src/components/ConfirmDialog.tsx
+++ b/frontend/src/components/ConfirmDialog.tsx
@@ -121,7 +121,12 @@ const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
         await onConfirm()
       }
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'An unexpected error occurred.'
+      // Raw error messages can leak implementation details -- only show them
+      // to developers, same DEV gate as ErrorBoundary.tsx (#618).
+      const message =
+        import.meta.env.DEV && err instanceof Error
+          ? err.message
+          : 'An unexpected error occurred.'
       setError(message)
     } finally {
       setInternalLoading(false)

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -49,7 +49,7 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
             <Typography variant="body2" sx={{ mb: 2 }}>
               {i18n.t('errorBoundary.description')}
             </Typography>
-            {this.state.error && (
+            {import.meta.env.DEV && this.state.error && (
               <Box
                 component="pre"
                 sx={{

--- a/frontend/src/components/NavigationBreadcrumbTracker.tsx
+++ b/frontend/src/components/NavigationBreadcrumbTracker.tsx
@@ -1,0 +1,10 @@
+import { useNavigationBreadcrumbs } from '../hooks/useNavigationBreadcrumbs'
+
+/**
+ * Invisible component that records navigation breadcrumbs for error
+ * reporting on SPA route changes. Must be rendered inside <Router>.
+ */
+export default function NavigationBreadcrumbTracker() {
+  useNavigationBreadcrumbs()
+  return null
+}

--- a/frontend/src/components/__tests__/ConfirmDialog.test.tsx
+++ b/frontend/src/components/__tests__/ConfirmDialog.test.tsx
@@ -129,6 +129,24 @@ describe('ConfirmDialog', () => {
     expect(onClose).not.toHaveBeenCalled()
   })
 
+  it('shows only the generic message when onConfirm fails outside development builds (#618-class)', async () => {
+    vi.stubEnv('DEV', false)
+    const user = userEvent.setup()
+    const onConfirm = vi.fn().mockRejectedValue(new Error('server blew up'))
+    const onClose = vi.fn()
+    render(<ConfirmDialog open onClose={onClose} onConfirm={onConfirm} title="T" />)
+    await user.click(screen.getByRole('button', { name: 'Confirm' }))
+    await waitFor(() => {
+      expect(screen.getByTestId('confirm-dialog-error')).toHaveTextContent(
+        'An unexpected error occurred.',
+      )
+    })
+    expect(screen.queryByText('server blew up')).not.toBeInTheDocument()
+    expect(onClose).not.toHaveBeenCalled()
+
+    vi.unstubAllEnvs()
+  })
+
   it('onClose is called when cancel is clicked', async () => {
     const user = userEvent.setup()
     const onClose = vi.fn()

--- a/frontend/src/components/__tests__/ErrorBoundary.test.tsx
+++ b/frontend/src/components/__tests__/ErrorBoundary.test.tsx
@@ -105,4 +105,15 @@ describe('ErrorBoundary', () => {
     expect(screen.getByText('Custom fallback UI')).toBeInTheDocument()
     expect(screen.queryByText('Something went wrong')).not.toBeInTheDocument()
   })
+
+  it('does not render the raw error message in production builds (#618)', () => {
+    vi.stubEnv('DEV', false)
+
+    render(<ThrowController initialThrow={true} />)
+
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument()
+    expect(screen.queryByText('Test error from child')).not.toBeInTheDocument()
+
+    vi.unstubAllEnvs()
+  })
 })

--- a/frontend/src/components/__tests__/NavigationBreadcrumbTracker.test.tsx
+++ b/frontend/src/components/__tests__/NavigationBreadcrumbTracker.test.tsx
@@ -1,0 +1,20 @@
+import { render } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
+
+vi.mock('../../hooks/useNavigationBreadcrumbs', () => ({
+  useNavigationBreadcrumbs: vi.fn(),
+}))
+
+import NavigationBreadcrumbTracker from '../NavigationBreadcrumbTracker'
+
+describe('NavigationBreadcrumbTracker', () => {
+  it('renders nothing', () => {
+    const { container } = render(
+      <MemoryRouter>
+        <NavigationBreadcrumbTracker />
+      </MemoryRouter>,
+    )
+    expect(container.innerHTML).toBe('')
+  })
+})

--- a/frontend/src/hooks/__tests__/useNavigationBreadcrumbs.test.tsx
+++ b/frontend/src/hooks/__tests__/useNavigationBreadcrumbs.test.tsx
@@ -1,0 +1,102 @@
+import { renderHook, act } from '@testing-library/react'
+import { MemoryRouter, useNavigate } from 'react-router-dom'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { useNavigationBreadcrumbs } from '../useNavigationBreadcrumbs'
+import * as errorReporting from '../../services/errorReporting'
+import * as performanceReporting from '../../services/performanceReporting'
+import type { ReactNode } from 'react'
+
+/** Helper that calls useNavigationBreadcrumbs AND exposes navigate so tests can trigger route changes. */
+let navigateFn: ReturnType<typeof useNavigate>
+function useNavigationBreadcrumbsWithNav() {
+  navigateFn = useNavigate()
+  useNavigationBreadcrumbs()
+}
+
+function createWrapper(initialEntries: string[]) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <MemoryRouter initialEntries={initialEntries}>{children}</MemoryRouter>
+  }
+}
+
+describe('useNavigationBreadcrumbs', () => {
+  beforeEach(() => {
+    vi.spyOn(errorReporting, 'addNavigationBreadcrumb')
+    vi.spyOn(performanceReporting, 'reportNavigation')
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('does not record a breadcrumb on initial render', () => {
+    renderHook(() => useNavigationBreadcrumbsWithNav(), { wrapper: createWrapper(['/home']) })
+
+    expect(errorReporting.addNavigationBreadcrumb).not.toHaveBeenCalled()
+  })
+
+  it('records a breadcrumb with from/to on route change', () => {
+    renderHook(() => useNavigationBreadcrumbsWithNav(), { wrapper: createWrapper(['/home']) })
+
+    act(() => {
+      navigateFn('/modules')
+    })
+
+    expect(errorReporting.addNavigationBreadcrumb).toHaveBeenCalledWith('/home', '/modules')
+  })
+
+  it('reports navigation timing for the destination route on route change', () => {
+    renderHook(() => useNavigationBreadcrumbsWithNav(), { wrapper: createWrapper(['/home']) })
+
+    expect(performanceReporting.reportNavigation).not.toHaveBeenCalled()
+
+    act(() => {
+      navigateFn('/modules')
+    })
+
+    expect(performanceReporting.reportNavigation).toHaveBeenCalledWith(
+      '/modules',
+      expect.any(Number),
+    )
+    const [, durationMs] = vi.mocked(performanceReporting.reportNavigation).mock.calls[0]
+    expect(durationMs).toBeGreaterThanOrEqual(0)
+  })
+
+  it('does not report navigation timing when the path is unchanged', () => {
+    renderHook(() => useNavigationBreadcrumbsWithNav(), { wrapper: createWrapper(['/home']) })
+
+    act(() => {
+      navigateFn('/home')
+    })
+
+    expect(performanceReporting.reportNavigation).not.toHaveBeenCalled()
+  })
+
+  it('records a new breadcrumb for each subsequent navigation', () => {
+    renderHook(() => useNavigationBreadcrumbsWithNav(), { wrapper: createWrapper(['/home']) })
+
+    act(() => {
+      navigateFn('/modules')
+    })
+    act(() => {
+      navigateFn('/providers')
+    })
+
+    expect(errorReporting.addNavigationBreadcrumb).toHaveBeenNthCalledWith(1, '/home', '/modules')
+    expect(errorReporting.addNavigationBreadcrumb).toHaveBeenNthCalledWith(
+      2,
+      '/modules',
+      '/providers',
+    )
+  })
+
+  it('does not record a breadcrumb when the path is unchanged', () => {
+    renderHook(() => useNavigationBreadcrumbsWithNav(), { wrapper: createWrapper(['/home']) })
+
+    act(() => {
+      navigateFn('/home')
+    })
+
+    expect(errorReporting.addNavigationBreadcrumb).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/hooks/useNavigationBreadcrumbs.ts
+++ b/frontend/src/hooks/useNavigationBreadcrumbs.ts
@@ -1,0 +1,35 @@
+import { useEffect, useRef } from 'react'
+import { useLocation } from 'react-router-dom'
+import { addNavigationBreadcrumb } from '../services/errorReporting'
+import { reportNavigation } from '../services/performanceReporting'
+
+/**
+ * Records a navigation breadcrumb via errorReporting's addNavigationBreadcrumb,
+ * and a route-level navigation timing via performanceReporting's reportNavigation,
+ * on every SPA route change -- so a captured error's breadcrumb trail includes
+ * "came from -> went to" context (e.g. for diagnosing login-flow errors), and
+ * performance reporting captures a proxy for route transition cost.
+ *
+ * Note: the reported duration is measured from when the *previous* route's
+ * effect committed to when this one does, i.e. it includes dwell time on the
+ * prior route (think-time, click latency), not just the new route's render
+ * time. There is no earlier "navigation started" signal available from
+ * `useLocation()` alone to isolate pure transition time, so this is a
+ * defensible approximation rather than an exact transition measurement.
+ */
+export function useNavigationBreadcrumbs() {
+  const location = useLocation()
+  const previousPath = useRef<string | null>(null)
+  const lastTransitionAt = useRef<number>(performance.now())
+
+  useEffect(() => {
+    const to = location.pathname
+    const now = performance.now()
+    if (previousPath.current !== null && previousPath.current !== to) {
+      addNavigationBreadcrumb(previousPath.current, to)
+      reportNavigation(to, now - lastTransitionAt.current)
+    }
+    previousPath.current = to
+    lastTransitionAt.current = now
+  }, [location.pathname])
+}

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -1999,7 +1999,8 @@
       "emptyTitle": "No audit entries match the current filters",
       "emptySubtitle": "Audit log entries appear when users make changes. Adjust the filters above or publish a module to see one.",
       "detailTitle": "Audit Log Detail",
-      "close": "Close"
+      "close": "Close",
+      "errLoad": "Failed to load audit logs"
     },
     "notifications": {
       "pageTitle": "Notifications",

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -22,6 +22,16 @@ window.addEventListener('unhandledrejection', (event) => {
   captureError(error, { type: 'unhandledrejection' })
 })
 
+// @axe-core/react stays a devDependency deliberately -- it's genuinely dev-only
+// tooling. Guarding the import with import.meta.env.DEV lets `vite build` in
+// production mode dead-code-eliminate this whole branch (verified: `vite build`
+// succeeds even with @axe-core/react absent from node_modules), so unlike a
+// Sentry-style runtime-conditional import this one is safe under a hypothetical
+// `npm ci --omit=dev` before the Docker image's `vite build` step (see #610).
+// It is NOT safe for `tsc` (the "build" npm script's type-check step, and any
+// standalone typecheck/lint job): tsc still needs to resolve the module's type
+// declarations regardless of runtime reachability, so devDependencies must stay
+// installed for any job that runs `tsc`.
 if (import.meta.env.DEV) {
   import('@axe-core/react').then((axe) => {
     axe.default(React, ReactDOM, 1000)

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -87,7 +87,10 @@ const LoginPage: React.FC = () => {
       await devLogin()
       navigate('/')
     } catch (err) {
-      const message = err instanceof Error ? err.message : t('auth.devLoginFailed')
+      // Raw error messages can leak implementation details -- only show them
+      // to developers, same DEV gate as ErrorBoundary.tsx (#618).
+      const message =
+        import.meta.env.DEV && err instanceof Error ? err.message : t('auth.devLoginFailed')
       setLoginError(message)
     }
   }
@@ -106,7 +109,10 @@ const LoginPage: React.FC = () => {
       await ldapLogin(ldapUsername, ldapPassword)
       navigate('/')
     } catch (err) {
-      const message = err instanceof Error ? err.message : t('auth.ldapLoginFailed')
+      // Raw error messages can leak implementation details -- only show them
+      // to developers, same DEV gate as ErrorBoundary.tsx (#618).
+      const message =
+        import.meta.env.DEV && err instanceof Error ? err.message : t('auth.ldapLoginFailed')
       setLoginError(message)
     } finally {
       setLdapLoading(false)

--- a/frontend/src/pages/__tests__/LoginPage.test.tsx
+++ b/frontend/src/pages/__tests__/LoginPage.test.tsx
@@ -181,4 +181,46 @@ describe('LoginPage', () => {
       expect(screen.getByText('Invalid credentials')).toBeInTheDocument()
     })
   })
+
+  it('shows only the generic message when LDAP login fails outside development builds (#618-class)', async () => {
+    vi.stubEnv('DEV', false)
+    mockLdapLogin.mockRejectedValue(new Error('Invalid credentials'))
+    mockProviders([{ type: 'ldap', name: 'LDAP' }])
+    renderLoginPage()
+    const usernameInput = await screen.findByRole('textbox', { name: /username/i })
+    const passwordInput = screen.getByLabelText(/password/i)
+    const signInBtn = screen.getByRole('button', { name: 'Sign In' })
+    await act(async () => {
+      await userEvent.type(usernameInput, 'testuser')
+      await userEvent.type(passwordInput, 'wrongpass')
+      await userEvent.click(signInBtn)
+    })
+    await waitFor(() => {
+      expect(screen.getByText('LDAP login failed. Check your credentials.')).toBeInTheDocument()
+    })
+    expect(screen.queryByText('Invalid credentials')).not.toBeInTheDocument()
+
+    vi.unstubAllEnvs()
+  })
+
+  it('shows only the generic message when dev login fails outside development builds (#618-class)', async () => {
+    // isDev (button visibility) is driven by MODE, independent of the DEV
+    // flag that gates the raw message -- a `vite build --mode development`
+    // hardened/staging build is the scenario where these two disagree.
+    vi.stubEnv('MODE', 'development')
+    vi.stubEnv('DEV', false)
+    mockDevLogin.mockRejectedValue(new Error('ECONNREFUSED 127.0.0.1:8080'))
+    mockProviders([])
+    renderLoginPage()
+    const devLoginBtn = await screen.findByRole('button', { name: 'Dev Login (Admin)' })
+    await act(async () => {
+      await userEvent.click(devLoginBtn)
+    })
+    await waitFor(() => {
+      expect(screen.getByText('Dev login failed. Check server logs.')).toBeInTheDocument()
+    })
+    expect(screen.queryByText('ECONNREFUSED 127.0.0.1:8080')).not.toBeInTheDocument()
+
+    vi.unstubAllEnvs()
+  })
 })

--- a/frontend/src/pages/admin/AuditLogPage.tsx
+++ b/frontend/src/pages/admin/AuditLogPage.tsx
@@ -37,6 +37,7 @@ import api from '../../services/api'
 import { AuditLog } from '../../types'
 import { queryKeys } from '../../services/queryKeys'
 import { usePagination } from '../../hooks/usePagination'
+import { getErrorMessage } from '../../utils/errors'
 
 const RESOURCE_TYPES = [
   { value: '', label: 'All Resource Types' },
@@ -110,7 +111,10 @@ const AuditLogPage: React.FC = () => {
   const total = data?.pagination?.total ?? 0
 
   if (queryError && !error) {
-    setError(queryError instanceof Error ? queryError.message : 'Failed to load audit logs')
+    // Raw error messages can leak implementation details -- route through the
+    // shared getErrorMessage helper, which DEV-gates native Error messages
+    // the same way ErrorBoundary.tsx does (#618-class).
+    setError(getErrorMessage(queryError, t('admin.auditLog.errLoad')))
   }
 
   // Debounce text filter changes

--- a/frontend/src/pages/admin/__tests__/AuditLogPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/AuditLogPage.test.tsx
@@ -326,4 +326,15 @@ describe('AuditLogPage', () => {
       expect(screen.getByText('kaboom')).toBeInTheDocument()
     })
   })
+
+  it('shows only the generic message when the query fails outside development builds (#618-class)', async () => {
+    vi.stubEnv('DEV', false)
+    listAuditLogsMock.mockRejectedValue(new Error('relation "audit_logs" does not exist'))
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('Failed to load audit logs')).toBeInTheDocument()
+    })
+    expect(screen.queryByText('relation "audit_logs" does not exist')).not.toBeInTheDocument()
+    vi.unstubAllEnvs()
+  })
 })

--- a/frontend/src/services/__tests__/errorReporting.test.ts
+++ b/frontend/src/services/__tests__/errorReporting.test.ts
@@ -302,4 +302,36 @@ describe('errorReporting', () => {
       expect(globalThis.fetch).toHaveBeenCalled()
     })
   })
+
+  describe('buffer bounding without a DSN', () => {
+    it('caps the error buffer when no DSN is configured', async () => {
+      // No DSN => flush() is a no-op, so nothing drains the buffer. Without a
+      // cap this grows for the lifetime of the page (captureError is wired
+      // into every API error path), so assert the retained entries are
+      // bounded: capture well past MAX_BATCH_SIZE with reporting inactive,
+      // then activate a DSN and flush, and inspect what was retained.
+      vi.stubEnv('VITE_ERROR_REPORTING_DSN', '')
+      vi.resetModules()
+      const mod = await import('../errorReporting')
+
+      for (let i = 0; i < 25; i++) {
+        mod.captureError(new Error(`overflow ${i}`))
+      }
+
+      // Activate reporting, then drain.
+      vi.stubEnv('VITE_ERROR_REPORTING_DSN', 'https://errors.example.com/report')
+      mod.init()
+      mod.flush()
+
+      expect(globalThis.fetch).toHaveBeenCalled()
+      const call = (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0]
+      const body = JSON.parse((call[1] as RequestInit).body as string)
+      // MAX_BATCH_SIZE is 10; pre-fix this would be all 25.
+      expect(body.entries.length).toBeLessThanOrEqual(10)
+      // Oldest are evicted first, so the newest error must survive.
+      expect(JSON.stringify(body.entries)).toContain('overflow 24')
+
+      mod.destroy()
+    })
+  })
 })

--- a/frontend/src/services/__tests__/performanceReporting.test.ts
+++ b/frontend/src/services/__tests__/performanceReporting.test.ts
@@ -41,16 +41,66 @@ describe('performanceReporting', () => {
   })
 
   describe('reportNavigation', () => {
-    it('enqueues a navigation entry', () => {
-      // reportNavigation pushes to buffer even without dsn
+    it('logs to the console in dev mode even before the service is active', () => {
+      // Dev-mode logging never leaves the browser, so it stays unconditional
+      // even pre-consent/pre-init -- only buffering (see below) is gated.
       reportNavigation('/admin/users', 150.5)
-      // We can verify the log in dev mode
       expect(console.log).toHaveBeenCalledWith(expect.stringContaining('[Perf] Navigation'))
     })
 
     it('logs the route name and duration in dev mode', () => {
       reportNavigation('/modules', 42.3)
       expect(console.log).toHaveBeenCalledWith(expect.stringContaining('/modules'))
+    })
+
+    it('does not enqueue navigation entries before the service is active (no consent yet)', () => {
+      // useNavigationBreadcrumbs.ts calls reportNavigation unconditionally on
+      // every SPA route change, regardless of consent. Without a guard, these
+      // pre-consent navigations would sit in the buffer and then leak out on
+      // the very first flush once the user later grants consent and init()
+      // configures a DSN -- reporting on browsing history recorded before the
+      // user ever agreed to it.
+      for (let i = 0; i < 100; i++) {
+        reportNavigation(`/route-${i}`, i)
+      }
+
+      // Consent granted afterwards: init() resolves a DSN.
+      vi.stubEnv('VITE_PERFORMANCE_DSN', 'https://perf.example.com/report')
+      init()
+
+      vi.spyOn(navigator, 'sendBeacon').mockReturnValue(false)
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response())
+      flush()
+
+      // None of the pre-consent navigations should ever have been buffered,
+      // so there is nothing to flush.
+      expect(fetchSpy).not.toHaveBeenCalled()
+
+      vi.unstubAllEnvs()
+    })
+
+    it('bounds buffer growth once active, even under a heavy navigation burst', () => {
+      vi.stubEnv('VITE_PERFORMANCE_DSN', 'https://perf.example.com/report')
+      init()
+
+      const sendBeaconSpy = vi.spyOn(navigator, 'sendBeacon').mockReturnValue(true)
+
+      // With the service already active, each batch of MAX_BATCH_SIZE (25)
+      // entries triggers an eager flush, so the buffer should never be
+      // allowed to grow past that regardless of how many navigations fire
+      // in a row.
+      for (let i = 0; i < 100; i++) {
+        reportNavigation(`/route-${i}`, i)
+      }
+
+      // 100 entries at a 25-entry batch size flush in exactly 4 batches.
+      expect(sendBeaconSpy).toHaveBeenCalledTimes(4)
+      const lastCall = sendBeaconSpy.mock.calls[sendBeaconSpy.mock.calls.length - 1]
+      const lastBody = JSON.parse(lastCall[1] as string)
+      expect(lastBody.entries.length).toBe(25)
+      expect(lastBody.entries.at(-1).name).toBe('/route-99')
+
+      vi.unstubAllEnvs()
     })
   })
 

--- a/frontend/src/services/errorReporting.ts
+++ b/frontend/src/services/errorReporting.ts
@@ -231,6 +231,17 @@ function enqueueError(error: Error, context?: Record<string, unknown>): void {
   if (errorBuffer.length >= MAX_BATCH_SIZE) {
     flush()
   }
+  // flush() is a no-op while no DSN is configured (see its own `!dsn` guard),
+  // so without this cap every captured error would accumulate for the lifetime
+  // of the page for users who never consented to telemetry -- and captureError
+  // is wired into every API error path, so that is a real leak, not a
+  // theoretical one. Entries are kept (rather than dropped at the door) so
+  // errors captured before init() resolves the DSN still ship once it does;
+  // capping evicts the oldest first, the same bounded-ring-buffer approach
+  // performanceReporting.ts uses.
+  if (errorBuffer.length > MAX_BATCH_SIZE) {
+    errorBuffer.splice(0, errorBuffer.length - MAX_BATCH_SIZE)
+  }
 }
 
 /**

--- a/frontend/src/services/performanceReporting.ts
+++ b/frontend/src/services/performanceReporting.ts
@@ -74,6 +74,16 @@ function enqueue(entry: PerfEntry): void {
   if (buffer.length >= MAX_BATCH_SIZE) {
     flush()
   }
+  // flush() above clears the buffer synchronously once a DSN is configured,
+  // so this is only a safety net for reentrancy/burst edge cases in the Web
+  // Vitals path (handleMetric below) -- cap at the batch size, evicting the
+  // oldest entries first, the same bounded-ring-buffer approach
+  // errorReporting.ts uses for breadcrumbs. reportNavigation() below never
+  // reaches this function at all until the service is active (see its own
+  // consent/active-service gate), so it cannot contribute unbounded growth.
+  if (buffer.length > MAX_BATCH_SIZE) {
+    buffer.splice(0, buffer.length - MAX_BATCH_SIZE)
+  }
 }
 
 function handleMetric(metric: Metric): void {
@@ -141,10 +151,27 @@ export function init(): void {
 /**
  * Report a route-level navigation timing.
  *
+ * `useNavigationBreadcrumbs.ts` calls this unconditionally on every SPA route
+ * change, regardless of the user's telemetry consent -- unlike the Web Vitals
+ * metrics above, which can't fire at all until `init()` has registered their
+ * callbacks. Without an equivalent guard here, this would be the one
+ * telemetry entry point that keeps recording (and, once a DSN is later
+ * configured via consent, retroactively flushing) navigation history for
+ * users who never consented. So: only enqueue once the service is active
+ * (a DSN has been resolved by `init()`) -- the same active/consent check
+ * `flush()` itself uses. Dev-mode console logging stays unconditional (it
+ * never leaves the browser) so local debugging still works before consent.
+ *
  * @param routeName  The destination route (e.g. "/admin/users").
  * @param durationMs Time taken for the navigation in milliseconds.
  */
 export function reportNavigation(routeName: string, durationMs: number): void {
+  if (import.meta.env.DEV) {
+    console.log(`[Perf] Navigation → ${routeName}: ${durationMs.toFixed(1)}ms`)
+  }
+
+  if (!dsn) return
+
   const entry: PerfEntry = {
     type: 'navigation',
     name: routeName,
@@ -152,10 +179,6 @@ export function reportNavigation(routeName: string, durationMs: number): void {
     timestamp: new Date().toISOString(),
     url: sanitizeUrl(window.location.href),
     sessionId,
-  }
-
-  if (import.meta.env.DEV) {
-    console.log(`[Perf] Navigation → ${routeName}: ${durationMs.toFixed(1)}ms`)
   }
 
   enqueue(entry)

--- a/frontend/src/utils/__tests__/errors.test.ts
+++ b/frontend/src/utils/__tests__/errors.test.ts
@@ -182,6 +182,16 @@ describe('getErrorMessage', () => {
     expect(getErrorMessage(error)).toBe('File not found')
   })
 
+  it('does not leak the raw native Error message in production builds (#618-class)', () => {
+    vi.stubEnv('DEV', false)
+
+    const error = new Error('Cannot read properties of undefined (reading "foo")')
+    expect(getErrorMessage(error)).toBe('An unexpected error occurred')
+    expect(getErrorMessage(error, 'Custom fallback')).toBe('Custom fallback')
+
+    vi.unstubAllEnvs()
+  })
+
   it('returns string error directly', () => {
     expect(getErrorMessage('Connection timeout')).toBe('Connection timeout')
   })

--- a/frontend/src/utils/errors.ts
+++ b/frontend/src/utils/errors.ts
@@ -85,7 +85,11 @@ export function getErrorMessage(err: unknown, fallback = 'An unexpected error oc
     }
     return err.message || fallback
   }
-  if (err instanceof Error) return err.message
+  // A native (non-Axios) Error is typically a client-side bug (TypeError,
+  // ReferenceError, etc.) whose message can leak implementation details
+  // (variable/property names). Only show it to developers, same DEV gate as
+  // ErrorBoundary.tsx (#618).
+  if (err instanceof Error) return import.meta.env.DEV ? err.message : fallback
   if (typeof err === 'string') return err
   return fallback
 }


### PR DESCRIPTION
Closes #610
Closes #611
Closes #618
Closes #620
Closes #630
Closes #634

Batch `c-telemetry-infra` from the 2026-07-22 blind security audit:

- **#618** — `ErrorBoundary` rendered the raw JS `error.message` to every user in production; now DEV-gated (`ErrorBoundary.tsx`, plus the native-`Error` branch in `utils/errors.ts`).
- **#610** — `@sentry/react` was a devDependency despite being dynamically imported by shipped runtime code — latent breakage under a future `--omit=dev` build. Moved to `dependencies`.
- **#611** — `.env.example` and README now carry the "compiled into the public bundle" warning for the DSN vars.
- **#620** — `addNavigationBreadcrumb`/`reportNavigation` were dead code documented as if wired. Now genuinely wired via a `useNavigationBreadcrumbs` hook + `NavigationBreadcrumbTracker` mounted inside the router.
- **#634** — CSP `connect-src 'self'` would have blocked delivery to a cross-origin telemetry DSN; guidance and configuration added to both nginx templates.
- **#630** — `ARCHITECTURE.md`'s Error Reporting section updated (Sentry path, performance reporting, consent gating).

## Extra fix found by the review panel

Wiring `#620` exposed a real leak the panel caught: `enqueueError` pushed to `errorBuffer` unconditionally while `flush()` returns early when no DSN is configured — so for any user without telemetry configured, the buffer grew for the lifetime of the page. With `captureError` now wired into 30+ API error paths (from the merged api-telemetry batch), that was live, not theoretical. Fixed with the same bounded ring buffer its sibling `performanceReporting.ts` already used; entries are retained rather than dropped at the door so errors captured before `init()` resolves still ship once it does. Regression test included — verified to fail with the cap removed (25 entries retained) and pass with it.

## Rebase notes

Conflicts were composed, not picked: `errors.test.ts` keeps main's superset of imports/mocks alongside this branch's #618 case; `AuditLogPage.tsx` keeps both `usePagination` (main) and `getErrorMessage` (branch); `nginx-ecs.conf.template` drops this branch's stale nonce line in favor of main's `map $request_id $csp_nonce` fix while keeping the connect-src/telemetry guidance. `package.json` takes main's newer `@sentry/react` version rather than the branch's stale pin, and `package-lock.json` was regenerated with `npm install --package-lock-only` rather than hand-merged — the resulting diff is exactly the intended 10 lines moving Sentry and its transitive packages out of `dev: true`.

Verification: lint 0 warnings, build green, full vitest suite passes apart from `SetupWizardPage.test.tsx` timeouts under heavy parallel load — that file passes 17/17 in isolation and the same timeouts reproduce on `main` with zero source changes.