### PR TITLE
ci(security): triage OSV findings through the shared audit gate

### DIFF
--- a/.github/workflows/weekly-security.yml
+++ b/.github/workflows/weekly-security.yml
@@ -76,11 +76,31 @@ jobs:
 
       - name: Run OSV Scanner
         # v2.3.8
+        id: osv
         uses: google/osv-scanner-action/osv-scanner-action@9a498708959aeaef5ef730655706c5a1df1edbc2
+        continue-on-error: true
         with:
+          # JSON so the triage step below can classify findings; it prints a
+          # readable summary in place of the table.
           scan-args: |-
+            --format=json
+            --output=osv-results.json
             --lockfile=frontend/package-lock.json
             --lockfile=e2e/package-lock.json
+
+      # Triaged through the same gate the npm-audit jobs use, against the same
+      # exceptions file, so the two scanners cannot reach opposite conclusions
+      # about one advisory. Blocking is reserved for advisories that have a
+      # non-breaking fix; ones with no published fix, ones fixable only by a
+      # semver-major, and documented accepted risks are reported as warnings.
+      #
+      # Without this the weekly run failed indefinitely on GHSA-qwww-vcr4-c8h2
+      # (react-router): OSV lists a fix of 8.3.0, but that is a breaking major
+      # that also breaks the @sethbacon/terraform-suite-ui pin, so the job was
+      # red every week with no action anyone could take (issue #643).
+      - name: Triage OSV findings
+        run: node frontend/scripts/audit-gate.mjs osv-results.json \
+          --exceptions frontend/scripts/npm-audit-exceptions.json
 
   # ── CodeQL ────────────────────────────────────────────
   # Scans the application source (javascript-typescript), the repo's GitHub

--- a/frontend/scripts/__tests__/audit-gate.test.ts
+++ b/frontend/scripts/__tests__/audit-gate.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 // @ts-expect-error -- plain ESM script, no type declarations by design
-import { triage, render, loadExceptions } from '../audit-gate.mjs'
+import { triage, triageOsv, triageReport, render, loadExceptions } from '../audit-gate.mjs'
 
 type Fix = boolean | { name: string; version: string; isSemVerMajor: boolean }
 
@@ -108,5 +108,92 @@ describe('audit-gate triage', () => {
     const { byAdvisory, byPackage } = loadExceptions('does-not-exist.json')
     expect(byAdvisory.size).toBe(0)
     expect(byPackage.size).toBe(0)
+  })
+})
+
+describe('audit-gate OSV mode', () => {
+  const osvReport = (name: string, installed: string, fixed: string | null, id = 'GHSA-test-1111') => ({
+    results: [
+      {
+        source: { path: 'frontend/package-lock.json' },
+        packages: [
+          {
+            package: { name, version: installed, ecosystem: 'npm' },
+            vulnerabilities: [
+              {
+                id,
+                summary: 'Example advisory',
+                database_specific: { severity: 'HIGH' },
+                affected: [
+                  {
+                    package: { name },
+                    ranges: [
+                      {
+                        type: 'SEMVER',
+                        events: fixed ? [{ introduced: '0' }, { fixed }] : [{ introduced: '0' }],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  })
+
+  const NONE = { byAdvisory: new Map(), byPackage: new Map() }
+
+  it('blocks a same-major (non-breaking) fix', () => {
+    const { blocking } = triageOsv(osvReport('brace-expansion', '5.0.7', '5.0.8'), NONE)
+    expect(blocking).toHaveLength(1)
+    expect(blocking[0].fix.version).toBe('5.0.8')
+  })
+
+  it('does not block when the only fix crosses a major — the react-router case', () => {
+    // OSV reports a fixed version (8.3.0) for react-router 7.18.1, so a naive
+    // "a fix exists" rule would block forever on a breaking upgrade that also
+    // breaks the suite-ui pin. npm audit calls the same advisory breaking.
+    const { blocking, advisory } = triageOsv(osvReport('react-router', '7.18.1', '8.3.0'), NONE)
+    expect(blocking).toHaveLength(0)
+    expect(advisory[0].why).toBe('only a semver-major (breaking) fix is available')
+  })
+
+  it('does not block when OSV publishes no fixed version', () => {
+    const { blocking, advisory } = triageOsv(osvReport('lib', '1.0.0', null), NONE)
+    expect(blocking).toHaveLength(0)
+    expect(advisory[0].why).toBe('no fixed version published')
+  })
+
+  it('honours the shared exceptions file by advisory id', () => {
+    const exceptions = {
+      byAdvisory: new Map([['GHSA-qwww-vcr4-c8h2', { reason: 'RSC mode unused', review_by: '2026-10-30' }]]),
+      byPackage: new Map(),
+    }
+    const { blocking, accepted } = triageOsv(
+      osvReport('react-router', '7.18.1', '7.19.0', 'GHSA-qwww-vcr4-c8h2'),
+      exceptions,
+    )
+    expect(blocking).toHaveLength(0)
+    expect(accepted[0].reason).toBe('RSC mode unused')
+  })
+
+  it('ignores advisories below the high threshold', () => {
+    const r = osvReport('lib', '1.0.0', '1.0.1')
+    r.results[0].packages[0].vulnerabilities[0].database_specific.severity = 'MODERATE'
+    const { blocking, advisory, accepted } = triageOsv(r, NONE)
+    expect([blocking, advisory, accepted].every((l) => l.length === 0)).toBe(true)
+  })
+
+  it('auto-detects report format so callers need not declare the scanner', () => {
+    const osv = triageReport(osvReport('brace-expansion', '5.0.7', '5.0.8'), NONE)
+    expect(osv.blocking).toHaveLength(1)
+
+    const npm = triageReport(
+      { vulnerabilities: { lib: { severity: 'high', dev: false, fixAvailable: false, via: [{ title: 't', url: 'u/GHSA-x' }] } } },
+      NONE,
+    )
+    expect(npm.advisory).toHaveLength(1)
   })
 })

--- a/frontend/scripts/audit-gate.mjs
+++ b/frontend/scripts/audit-gate.mjs
@@ -20,9 +20,20 @@
  * Written in Node (not Python) on purpose: this same gate runs inside the
  * frontend Dockerfile's node:alpine builder stage, which has no python3.
  *
+ * Handles BOTH report formats, auto-detected from the JSON shape:
+ *   - `npm audit --json`      (a `vulnerabilities` object)
+ *   - `osv-scanner --format json` (a `results` array)
+ *
+ * One gate and one exceptions file for both scanners is deliberate: they
+ * disagree about the same advisory otherwise. OSV lists react-router's fix as
+ * 8.3.0 — technically "a fix exists", but a semver-major that also breaks the
+ * @sethbacon/terraform-suite-ui pin — so a naive fixed-version-exists rule
+ * would block forever on it while npm audit correctly reports it as breaking.
+ *
  * Usage:
  *   npm audit --json > audit.json || true
- *   node scripts/audit-gate.mjs audit.json [--exceptions scripts/npm-audit-exceptions.json]
+ *   osv-scanner --format json --output osv.json ... || true
+ *   node scripts/audit-gate.mjs <report.json> [--exceptions scripts/npm-audit-exceptions.json]
  *
  * Exit codes: 0 = nothing blocking, 1 = blocking findings (or unreadable report).
  */
@@ -56,6 +67,80 @@ function advisoryKeys(via) {
     }
   }
   return keys
+}
+
+// Normalises an osv-scanner JSON report into the same entry shape the npm
+// triage produces, so downstream reporting and exception handling are shared.
+//
+// OSV has no dev/prod distinction and no semver-major flag, so severity of the
+// *upgrade* is inferred: a fix whose major version differs from the installed
+// major is treated as breaking, matching how npm audit labels it. That keeps
+// the two scanners from reaching opposite conclusions on one advisory.
+export function triageOsv(report, exceptions = { byAdvisory: new Map(), byPackage: new Map() }) {
+  const blocking = []
+  const advisory = []
+  const accepted = []
+
+  const major = (v) => {
+    const m = /^\D*(\d+)/.exec(String(v ?? ''))
+    return m ? Number(m[1]) : null
+  }
+
+  for (const result of report?.results ?? []) {
+    const source = result?.source?.path ?? '?'
+    for (const pkg of result?.packages ?? []) {
+      const name = pkg?.package?.name ?? '?'
+      const installed = pkg?.package?.version ?? '?'
+      for (const vuln of pkg?.vulnerabilities ?? []) {
+        const severity = (vuln?.database_specific?.severity ?? 'HIGH').toLowerCase()
+        if (!BLOCKING_SEVERITIES.has(severity)) continue
+
+        // Collect fixed versions this advisory publishes for THIS package.
+        const fixed = []
+        for (const affected of vuln?.affected ?? []) {
+          if (affected?.package?.name && affected.package.name !== name) continue
+          for (const range of affected?.ranges ?? []) {
+            for (const event of range?.events ?? []) {
+              if (event?.fixed) fixed.push(event.fixed)
+            }
+          }
+        }
+
+        const ids = [vuln?.id, ...(vuln?.aliases ?? [])].filter(Boolean)
+        const target = fixed[0]
+        const breaking =
+          target != null && major(target) != null && major(installed) != null && major(target) !== major(installed)
+
+        const entry = {
+          package: name,
+          severity,
+          advisories: ids,
+          titles: [vuln?.summary ?? ''],
+          devOnly: false,
+          source,
+          fix: target ? { name, version: target, isSemVerMajor: breaking } : false,
+        }
+
+        const hit = ids.map((k) => exceptions.byAdvisory.get(k)).find(Boolean) ?? exceptions.byPackage.get(name)
+        if (hit) {
+          accepted.push({ ...entry, reason: hit.reason ?? '', reviewBy: hit.review_by ?? '' })
+        } else if (!target) {
+          advisory.push({ ...entry, why: 'no fixed version published' })
+        } else if (breaking) {
+          advisory.push({ ...entry, why: 'only a semver-major (breaking) fix is available' })
+        } else {
+          blocking.push(entry)
+        }
+      }
+    }
+  }
+  return { blocking, advisory, accepted }
+}
+
+// Dispatches on report shape so callers need not say which scanner produced it.
+export function triageReport(report, exceptions) {
+  if (report && Array.isArray(report.results)) return triageOsv(report, exceptions)
+  return triage(report, exceptions)
 }
 
 export function triage(report, exceptions = { byAdvisory: new Map(), byPackage: new Map() }) {
@@ -105,7 +190,7 @@ function line(e) {
 }
 
 export function render({ blocking, advisory, accepted }) {
-  const out = ['## npm audit triage', '']
+  const out = ['## Vulnerability triage', '']
   if (blocking.length) {
     out.push(`### Blocking (${blocking.length}) — non-breaking fix available`, '')
     out.push(...blocking.map((e) => `- ${line(e)}`), '')
@@ -138,11 +223,11 @@ function main(argv) {
   } catch (err) {
     // A missing/!unparseable report means npm audit died before writing output —
     // fail closed rather than silently passing the gate.
-    console.error(`::error::npm audit report unreadable (${reportPath}): ${err.message}`)
+    console.error(`::error::vulnerability report unreadable (${reportPath}): ${err.message}`)
     return 1
   }
 
-  const result = triage(report, loadExceptions(excPath))
+  const result = triageReport(report, loadExceptions(excPath))
   for (const e of [...result.advisory, ...result.accepted]) console.log(`::warning::${line(e)}`)
   for (const e of result.blocking) console.log(`::error::${line(e)}`)
 


### PR DESCRIPTION
Closes #643

## Why the weekly scan keeps failing

#643's run failed on three advisories:

- `brace-expansion` 5.0.7 and 1.1.16 — **already fixed** on main by #649 (now 5.0.9 / 1.1.18).
- `react-router` 7.18.1, GHSA-qwww-vcr4-c8h2 — the documented accepted risk (RSC mode is never entered; this app mounts `BrowserRouter` and uses no server/RSC APIs).

So the alert was one resolved item plus one unactionable one — but the OSV job runs `osv-scanner` raw, so it will fail **every week** on react-router regardless of anything anyone does. That is the same permanently-red-gate problem #707 fixed for the backend and #649 fixed for `npm audit`; the OSV job was simply missed.

## The subtlety that made this more than a copy-paste

The backend's rule is "fail only when a fixed version exists". That is **not sufficient here**: OSV lists react-router's fix as **8.3.0**, so a fixed version does exist — it is just a semver-major that also breaks the `@sethbacon/terraform-suite-ui` pin. A naive port would have kept the job red forever while `npm audit` correctly classified the same advisory as breaking.

The two scanners must not reach opposite conclusions about one advisory, so this extends the **existing** `audit-gate.mjs` rather than adding a second gate:

- Auto-detects report shape (`vulnerabilities` object ⇒ npm audit, `results` array ⇒ OSV), so callers don't declare the scanner.
- For OSV, infers breaking-ness by comparing the fix's major against the installed major, matching how npm audit labels it.
- Shares one `npm-audit-exceptions.json`, so the react-router acceptance and its review date apply to both.

## Tests

Six new cases (15 total in the file): same-major fix blocks, cross-major fix does not, no-published-fix does not, the shared exceptions file is honoured by advisory id, sub-high severities are ignored, and format auto-detection works for both shapes.

Validated against the real report shapes from the failing run: `brace-expansion` 5.0.7→5.0.8 classifies as **blocking** (correct — it was actionable, and #649 duly fixed it), while react-router lands in **accepted risk** with its rationale and 2026-10-30 review date.

Verification: lint clean, 25 script tests pass, build green, workflow YAML parses.