### PR TITLE
fix(ci): skip coverage badge when GIST_TOKEN is absent in called workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,20 @@ jobs:
         #   vars.COVERAGE_GIST_ID — ID of a pre-created public gist (same gist as backend, different filename)
         # The action writes / overwrites 'frontend-coverage.json' in that gist, which the
         # shields.io endpoint badge in README.md reads.
-        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        #
+        # Also gated on the token actually being present. `github.event_name`
+        # alone is NOT sufficient: in a reusable workflow it reports the
+        # CALLER's event, so when release.yml (tag `push`) or
+        # weekly-security.yml (manual `workflow_dispatch`) calls this workflow,
+        # the event test is true even though neither passes secrets — and the
+        # action then fails the job with "Missing auth secret". The `env`
+        # indirection exists because the `secrets` context is not available to
+        # step-level `if`.
+        env:
+          GIST_TOKEN: ${{ secrets.GIST_TOKEN }}
+        if: >-
+          (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+          && env.GIST_TOKEN != ''
         uses: schneegans/dynamic-badges-action@28b0fa8bdeb46170ac397105ece0c1fe58f68910 # v1.9.0
         with:
           auth: ${{ secrets.GIST_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,10 +75,17 @@ jobs:
   ci:
     name: CI
     needs: guard
-    # No `secrets:` needed here (#613): ci.yml's only secret-consuming step
-    # (GIST_TOKEN for the coverage badge) is gated to `push`/`workflow_dispatch`
-    # events, neither of which is true on this workflow_call path, so nothing
-    # in ci.yml actually reads an inherited secret when invoked from here.
+    # No `secrets:` passed here (#613): ci.yml's only secret-consuming step is
+    # the GIST_TOKEN coverage badge, which this workflow has no reason to
+    # update.
+    #
+    # NOTE: the original justification for this was wrong. It claimed the
+    # badge step's `push`/`workflow_dispatch` event gate could never be true on
+    # a workflow_call path — but a reusable workflow sees the CALLER's
+    # `github.event_name`, so it IS true here (tag push for release.yml, manual
+    # dispatch for weekly-security.yml) and the step failed with
+    # "Missing auth secret". ci.yml now also requires the token to be non-empty,
+    # so omitting secrets skips the step instead of failing the job.
     uses: ./.github/workflows/ci.yml
 
   docker:

--- a/.github/workflows/weekly-security.yml
+++ b/.github/workflows/weekly-security.yml
@@ -21,10 +21,17 @@ jobs:
   ci:
     name: CI
     uses: ./.github/workflows/ci.yml
-    # No `secrets:` needed here (#613): ci.yml's only secret-consuming step
-    # (GIST_TOKEN for the coverage badge) is gated to `push`/`workflow_dispatch`
-    # events, neither of which is true on this workflow_call path, so nothing
-    # in ci.yml actually reads an inherited secret when invoked from here.
+    # No `secrets:` passed here (#613): ci.yml's only secret-consuming step is
+    # the GIST_TOKEN coverage badge, which this workflow has no reason to
+    # update.
+    #
+    # NOTE: the original justification for this was wrong. It claimed the
+    # badge step's `push`/`workflow_dispatch` event gate could never be true on
+    # a workflow_call path — but a reusable workflow sees the CALLER's
+    # `github.event_name`, so it IS true here (tag push for release.yml, manual
+    # dispatch for weekly-security.yml) and the step failed with
+    # "Missing auth secret". ci.yml now also requires the token to be non-empty,
+    # so omitting secrets skips the step instead of failing the job.
     permissions:
       contents: read
       packages: read


### PR DESCRIPTION
## The bug — a regression from #613, and my reasoning was wrong

#613 narrowed `secrets: inherit` on the reusable `ci.yml` calls. The justification I wrote into both callers was:

> ci.yml's only secret-consuming step (GIST_TOKEN for the coverage badge) is gated to `push`/`workflow_dispatch` events, **neither of which is true on this workflow_call path**

That is false. **A reusable workflow sees the *caller's* `github.event_name`.** So the badge step's gate is true whenever:

- `release.yml` runs — it triggers on **tag `push`**, and
- `weekly-security.yml` is **manually dispatched**.

In both cases the step runs, finds no `GIST_TOKEN`, and fails the job with `Missing auth secret`.

Surfaced by manually dispatching the weekly workflow: [run 30590906301](https://github.com/sethbacon/terraform-registry-frontend/actions/runs/30590906301) — every security job passed, and the run still failed on `CI / Unit Test Coverage`. Coverage itself was fine (83.74%); only the badge upload failed.

**This was latent on `main` and would have broken the next release**, since `release.yml` calls `ci.yml` on tag push. It hadn't fired yet only because no release has been cut since #649 merged — the scheduled weekly path happens to report `schedule`, so the gate was false there and the bug stayed hidden.

## The fix

Gate the badge step on the token actually being present, in addition to the event test:

```yaml
env:
  GIST_TOKEN: ${{ secrets.GIST_TOKEN }}
if: >-
  (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
  && env.GIST_TOKEN != ''
```

The `env` indirection is required because the `secrets` context is not available to step-level `if`.

This keeps #613's intent exactly — callers still pass no secrets — while making omission *skip* the step rather than fail the job. Direct pushes to `main` (where the secret exists) still update the badge.

I also corrected the misleading comment in both callers rather than leaving a confident, wrong justification in the tree for the next person to trust.

## Verification

All three workflow files parse. The real test is behavioural: after merge, dispatching `weekly-security.yml` should complete green, and I'd suggest treating a clean manual dispatch as the acceptance check for this one.