### PR TITLE
test: fix upload e2e strict-mode selector collisions with nav tooltips

### DIFF
--- a/e2e/tests/upload.spec.ts
+++ b/e2e/tests/upload.spec.ts
@@ -277,8 +277,13 @@ test.describe('Real file upload (#605)', () => {
 
     await page.getByLabel('Namespace').fill('e2e-fixtures');
     await page.getByLabel('Module Name').fill(moduleName);
-    await page.getByLabel('Provider').fill('aws');
-    await page.getByLabel('Version').fill('1.0.0');
+    // Role-scoped: getByLabel substring-matches the sidebar nav tooltips'
+    // aria-labels too ("Configure SCM providers...", "...pending mirrored
+    // versions", etc.), which is a strict-mode violation. Restricting to the
+    // textbox role excludes those spans while keeping substring matching
+    // (required-field labels render as "Provider *").
+    await page.getByRole('textbox', { name: 'Provider' }).fill('aws');
+    await page.getByRole('textbox', { name: 'Version' }).fill('1.0.0');
 
     await page.getByTestId('module-upload-dropzone-input').setInputFiles(VALID_MODULE_ARCHIVE);
 
@@ -321,7 +326,9 @@ test.describe('Real file upload (#605)', () => {
 
     await page.getByLabel('Namespace').fill('e2e-fixtures');
     await page.getByLabel('Provider Name').fill(providerName);
-    await page.getByLabel('Version').fill('1.0.0');
+    // Role-scoped for the same nav-tooltip aria-label collision as the module
+    // upload test above ("...pending mirrored versions" contains "version").
+    await page.getByRole('textbox', { name: 'Version' }).fill('1.0.0');
 
     // The OS/Architecture Selects don't wire an aria-labelledby to their
     // InputLabel, so getByLabel() can't find them -- scope by the FormControl


### PR DESCRIPTION
## Summary

The gated full E2E (`CI / E2E (gated/manual)`) is red on `main` — first observed in weekly-security run [30593037025](https://github.com/sethbacon/terraform-registry-frontend/actions/runs/30593037025). Root cause is in the **tests added by #650** (issue #605), not the app and not the backend:

- The real-upload tests had **never executed** before that run: per-PR CI only runs the E2E security subset, and every full-suite attempt since #650 merged failed earlier at the Docker-build `npm audit` gate (fixed by #654/#655).
- On first execution, `getByLabel('Provider')` hit a strict-mode violation: `getByLabel` substring-matches aria-labels, so it resolved **6 elements** — the form input plus 5 sidebar nav-tooltip spans whose text contains "provider".
- `getByLabel('Version')` (both upload tests) has the same latent collision — **2 elements** via the "Review and approve pending mirrored versions" tooltip — that the run died before reaching.

## Fix

Scope the three colliding locators to `getByRole('textbox', ...)`, which excludes the tooltip spans while keeping substring matching (required-field labels render as `Provider *`). Playwright's own strict-mode error output names this role-scoped locator as the unique resolution.

Audited the rest of the suite for the same pattern: `approvals.spec.ts` (`/Provider Namespace/i`) matches no tooltip, and the `policies.spec.ts` regex labels are dialog-scoped — both safe.

## Verification

Against the `docker-compose.test.yml` stack (backend :latest = v3.5.0) with the vite dev frontend:

- Old locators reproduce CI exactly: Provider → 6 matches, Version → 2
- Fixed locators resolve to exactly 1 element in all three spots
- **Both previously-unexecuted happy paths pass end-to-end**: module publish → `/modules/e2e-fixtures/<name>/aws`, provider publish → `/providers/e2e-fixtures/<name>`

Note: the E2E runner itself cannot run on a Node 26 host (repo pins Node 24; the worker fixture produces phantom instant timeouts under 26) — verification above was done through the raw Playwright API, and the definitive gate is the full E2E on the post-merge run.