### PR TITLE
fix: remove nested interactive control from modules provider group header

### DIFF
--- a/frontend/src/pages/ModulesPage.tsx
+++ b/frontend/src/pages/ModulesPage.tsx
@@ -21,7 +21,6 @@ import {
   Select,
   MenuItem,
   Collapse,
-  IconButton,
 } from '@mui/material'
 import type { SelectChangeEvent } from '@mui/material'
 import SearchIcon from '@mui/icons-material/Search'
@@ -470,9 +469,15 @@ const ModulesPage: React.FC = () => {
                     userSelect: 'none',
                   }}
                 >
-                  <IconButton size="small" tabIndex={-1} aria-hidden="true">
+                  {/* Decorative chevron: must not be a real <button> — a focusable
+                      element nested inside this role="button" header is an axe
+                      "nested-interactive" violation (negative tabindex + aria-hidden
+                      do not stop assistive tech from focusing it). A plain span
+                      keeps the IconButton's small-size footprint without the
+                      interactive semantics. */}
+                  <Box component="span" aria-hidden="true" sx={{ display: 'inline-flex', p: '5px' }}>
                     {isCollapsed ? <ExpandMore /> : <ExpandLess />}
-                  </IconButton>
+                  </Box>
                   <ProviderIcon provider={provider} size={28} />
                   <Typography variant="h6" sx={{ fontWeight: 600 }}>
                     {providerDisplayName(provider)}


### PR DESCRIPTION
## Summary

Fixes the `E2E (gated/manual)` failure on `main` (run [30604040642](https://github.com/sethbacon/terraform-registry-frontend/actions/runs/30604040642)): the enforced accessibility check `Modules (/modules) has no critical or serious a11y violations` fails on firefox with axe rule **nested-interactive** (serious).

The provider group header is a `div role="button"` that contained a real MUI `IconButton` for the expand chevron. `tabIndex={-1}` + `aria-hidden` do not stop assistive tech from reaching a natively focusable element inside an interactive control — axe rejects exactly this pattern.

**Why it only surfaced now:** the check is data-dependent. Grouped headers only render when modules exist, and until #657 the registry was empty for every a11y scan. The real-upload tests (#605/#650) now publish a module mid-run, so later scans (firefox's, in suite order) see the grouped header. Chromium's scan runs before any module exists — that's the whole chromium/firefox split; the defect is engine-independent.

## Fix

Replace the nested `IconButton` with a plain decorative `span` with the same footprint. The outer header div remains the single interactive control — click/keyboard toggling unchanged (covered by existing unit tests, which target the outer `role=button`).

Audited for siblings: this `role=button`-wrapping-`IconButton` pattern exists nowhere else (ProvidersPage has no grouped headers).

## Verification

- `tsc`, `eslint --max-warnings 0`, and all 20 ModulesPage unit tests pass
- Axe scan against the compose stack **with a published module** (the exact condition that triggers the failure): grouped header rendered, no nested `<button>`, **zero critical/serious violations**, `nested-interactive` absent
- Local scan was chromium (firefox download does not survive this network's TLS interception); the rule is DOM-structural, and the post-merge gated E2E is the definitive firefox check