### PR TITLE
fix(a11y): darken swagger authorize green to meet WCAG AA contrast

### DIFF
--- a/frontend/src/utils/__tests__/swaggerTheme.test.ts
+++ b/frontend/src/utils/__tests__/swaggerTheme.test.ts
@@ -62,9 +62,9 @@ describe('enforceSwaggerA11yStyles', () => {
     enforceSwaggerA11yStyles(false)
 
     const btn = document.querySelector<HTMLElement>('.btn.authorize')!
-    expect(btn.style.borderColor).toBe('#00875a')
-    expect(btn.querySelector<HTMLElement>('span')!.style.color).toBe('#00875a')
-    expect(btn.querySelector<SVGElement>('svg')!.style.fill).toBe('#00875a')
+    expect(btn.style.borderColor).toBe('#007a52')
+    expect(btn.querySelector<HTMLElement>('span')!.style.color).toBe('#007a52')
+    expect(btn.querySelector<SVGElement>('svg')!.style.fill).toBe('#007a52')
   })
 
   it('replaces the nested anchor inside opblock-summary-control with a span (nested-interactive a11y fix)', () => {

--- a/frontend/src/utils/swaggerTheme.ts
+++ b/frontend/src/utils/swaggerTheme.ts
@@ -65,8 +65,9 @@ export function enforceSwaggerA11yStyles(dark: boolean): void {
       el.style.setProperty('color', linkColor, 'important')
     })
 
-  // Authorize button
-  const authColor = dark ? '#2ea77a' : '#00875a'
+  // Authorize button — light green must clear 4.5:1 on the #fafafa
+  // scheme-container background (#00875a was only 4.36:1)
+  const authColor = dark ? '#2ea77a' : '#007a52'
   document.querySelectorAll<HTMLElement>('.swagger-ui .btn.authorize').forEach((btn) => {
     btn.style.setProperty('border-color', authColor, 'important')
     btn.style.setProperty('color', authColor, 'important')
@@ -215,9 +216,9 @@ const BASE_CSS = `
 
   /* ---------- authorize button contrast fix ---------- */
   .swagger-ui .btn.authorize,
-  .swagger-ui .auth-wrapper .btn.authorize { border-color: #00875a !important; color: #00875a !important; }
-  .swagger-ui .btn.authorize span { color: #00875a !important; }
-  .swagger-ui .btn.authorize svg { fill: #00875a !important; }
+  .swagger-ui .auth-wrapper .btn.authorize { border-color: #007a52 !important; color: #007a52 !important; }
+  .swagger-ui .btn.authorize span { color: #007a52 !important; }
+  .swagger-ui .btn.authorize svg { fill: #007a52 !important; }
 
   /* ---------- response code pills ---------- */
   .swagger-ui .response-col_status { font-weight: 600; }


### PR DESCRIPTION
## Summary

The weekly E2E accessibility audit logs a warn-tier serious color-contrast violation on `/api-docs` (first logged in run 30647467846): the light-mode Authorize button renders `#00875a` on the `#fafafa` scheme-container background, which is 4.36:1 — under the 4.5:1 WCAG AA minimum for its 14px bold text. Since `/api-docs` is on the warn-only audited list, this would become a hard failure if the page is ever promoted to the enforced list.

This darkens the light-mode authorize green to `#007a52` (5.15:1) in both places `swaggerTheme.ts` applies it: the injected CSS override and the inline-style enforcement in `enforceSwaggerA11yStyles()` (the inline `!important` style is what axe flags, since swagger-ui's own markup can't be edited). Dark mode (`#2ea77a` on `#1e1e1e`, 5.50:1) already passes and is unchanged, as is the POST method badge, which uses `#00875a` only as a background under white text (4.55:1).

Verified with an axe scan (`@axe-core/playwright` via the raw Playwright API) against a local dev server: `/api-docs` reports zero color-contrast violations in light mode and the authorize span computes to `rgb(0, 122, 82)`, confirming the override beats swagger-ui's styling.

## Changelog

- fix: darken the API docs Authorize button green to meet WCAG AA contrast

## Checklist

- [x] `npm run lint` passes
- [x] `npx tsc --noEmit` (typecheck) passes
- [x] `npm test` (unit tests) passes
- [x] `npm run build` succeeds
- [x] PR targets `main`
- [x] Remote branch will be deleted after merge