### PR TITLE
fix: replace low-entropy test encryption keys rejected by new backend image

### DIFF
--- a/deployments/docker-compose.contract-check.yml
+++ b/deployments/docker-compose.contract-check.yml
@@ -32,9 +32,11 @@ services:
       - TFR_DATABASE_SSL_MODE=disable
       - TFR_SERVER_HOST=0.0.0.0
       - TFR_SERVER_PORT=8080
-      # Test-only secrets; never used in production.
+      # Test-only secrets; never used in production. The encryption key must
+      # look CSPRNG-generated — the backend refuses to boot on low-entropy
+      # keys (its issue #560), so an all-zeros placeholder fails startup.
       - TFR_JWT_SECRET=test-jwt-secret-for-contract-check-only
-      - ENCRYPTION_KEY=00000000000000000000000000000000
+      - ENCRYPTION_KEY=b8aa8087d97d609b15d2f818dd9ddb9e
     ports:
       - "8080:8080"
     depends_on:

--- a/deployments/docker-compose.test.yml
+++ b/deployments/docker-compose.test.yml
@@ -39,8 +39,11 @@ services:
       - TFR_SERVER_PORT=8080
       # JWT secret required by backend — fixed value for test environment only
       - TFR_JWT_SECRET=test-jwt-secret-for-e2e-only-not-for-production
-      # ENCRYPTION_KEY required for SCM integration — fixed 32-byte value for test only
-      - ENCRYPTION_KEY=00000000000000000000000000000000
+      # ENCRYPTION_KEY required for SCM integration — fixed value for test only.
+      # Must look CSPRNG-generated: the backend refuses to start on
+      # low-entropy keys (its issue #560), so an all-zeros placeholder fails
+      # boot. Public in this repo by design — this stack never holds real data.
+      - ENCRYPTION_KEY=b8aa8087d97d609b15d2f818dd9ddb9e
       # Disable rate limiting so the E2E suite (40+ tests each making API calls) does not
       # trigger 429 responses mid-run.
       - TFR_SECURITY_RATE_LIMITING_ENABLED=false

--- a/deployments/docker-compose.yml
+++ b/deployments/docker-compose.yml
@@ -75,8 +75,11 @@ services:
       TFR_TELEMETRY_METRICS_ENABLED: "true"
       TFR_TELEMETRY_METRICS_PROMETHEUS_PORT: 9090
 
-      # Security — development values only, not for production use
-      ENCRYPTION_KEY: "01234567890123456789012345678901"
+      # Security — development values only, not for production use. The
+      # encryption key must look CSPRNG-generated: the backend refuses to
+      # boot on low-entropy keys (its issue #560), so sequential/all-zero
+      # placeholders fail startup.
+      ENCRYPTION_KEY: "b8aa8087d97d609b15d2f818dd9ddb9e"
       TFR_JWT_SECRET: "development-jwt-secret-change-in-production-01234567890"
 
       # DEV_MODE enables the /api/v1/dev/login shortcut used by local dev and E2E tests.


### PR DESCRIPTION
## Summary

The weekly acceptance run ([30648814515](https://github.com/sethbacon/terraform-registry-frontend/actions/runs/30648814515)) failed in `CI / E2E (gated/manual)` — but not on tests: the **backend container refused to start**:

> `ENCRYPTION_KEY has low estimated entropy and may not have been generated with a CSPRNG. Refusing to start (issue #560).`

The backend image published today (**v3.5.1**) carries the backend audit's #560 low-entropy-key guard. All three compose stacks in this repo used exactly the placeholder patterns it rejects (`0000…` in the test + contract-check stacks, `0123…` in the dev stack), so **every job pulling `:latest` breaks**: gated E2E, Contract Check, and local dev. This morning's green run simply predated the image publish.

## Fix

Replace the placeholders with a fixed `openssl rand -hex 16` key, committed in plaintext like the neighboring test JWT secrets — these stacks never hold real data; the backend check is an entropy heuristic, not a secrecy requirement. Comments in each file explain the constraint so nobody "simplifies" it back to zeros.

## Verification

- `docker-compose.test.yml` stack booted locally against the freshly-pulled **v3.5.1** image: backend healthy, seed-db completed (previously reproduced the refusing-to-start log with the zeros key)
- Contract Check on this PR exercises `docker-compose.contract-check.yml` against v3.5.1 in CI

After merge, re-dispatching the weekly scan is the remaining acceptance step for closing #643.