### PR TITLE
fix(ci): replace low-entropy compose encryption keys rejected by backend guard

### DIFF
--- a/deployments/docker-compose.contract-check.yml
+++ b/deployments/docker-compose.contract-check.yml
@@ -32,9 +32,11 @@ services:
       - TFR_DATABASE_SSL_MODE=disable
       - TFR_SERVER_HOST=0.0.0.0
       - TFR_SERVER_PORT=8080
-      # Test-only secrets; never used in production.
+      # Test-only secrets; never used in production. The ENCRYPTION_KEY must
+      # look CSPRNG-generated (openssl rand -hex 16): backends newer than the
+      # pin below refuse to start on trivial keys (backend issue #560).
       - TFR_JWT_SECRET=test-jwt-secret-for-contract-check-only
-      - ENCRYPTION_KEY=00000000000000000000000000000000
+      - ENCRYPTION_KEY=7b125842d68d5bdc73668f0afd626bdc
     ports:
       - "8080:8080"
     depends_on:

--- a/deployments/docker-compose.test.yml
+++ b/deployments/docker-compose.test.yml
@@ -39,8 +39,11 @@ services:
       - TFR_SERVER_PORT=8080
       # JWT secret required by backend — fixed value for test environment only
       - TFR_JWT_SECRET=test-jwt-secret-for-e2e-only-not-for-production
-      # ENCRYPTION_KEY required for SCM integration — fixed 32-byte value for test only
-      - ENCRYPTION_KEY=00000000000000000000000000000000
+      # ENCRYPTION_KEY required for SCM integration — fixed test-only value.
+      # Must look CSPRNG-generated (openssl rand -hex 16): the backend's
+      # low-entropy guard (backend issue #560) refuses to start on trivial
+      # keys like all-zeros.
+      - ENCRYPTION_KEY=bea74a7a7088621a84f5eccb8cf337c5
       # Disable rate limiting so the E2E suite (40+ tests each making API calls) does not
       # trigger 429 responses mid-run.
       - TFR_SECURITY_RATE_LIMITING_ENABLED=false

--- a/deployments/docker-compose.yml
+++ b/deployments/docker-compose.yml
@@ -75,8 +75,12 @@ services:
       TFR_TELEMETRY_METRICS_ENABLED: "true"
       TFR_TELEMETRY_METRICS_PROMETHEUS_PORT: 9090
 
-      # Security — development values only, not for production use
-      ENCRYPTION_KEY: "01234567890123456789012345678901"
+      # Security — development values only, not for production use.
+      # ENCRYPTION_KEY must look CSPRNG-generated (openssl rand -hex 16): the
+      # backend's low-entropy guard (backend issue #560) refuses to start on
+      # sequential/trivial keys. Changing this key orphans SCM credentials
+      # already encrypted in an existing local postgres volume.
+      ENCRYPTION_KEY: "590b7570037dc019c17189e76ce9b73e"
       TFR_JWT_SECRET: "development-jwt-secret-change-in-production-01234567890"
 
       # DEV_MODE enables the /api/v1/dev/login shortcut used by local dev and E2E tests.


### PR DESCRIPTION
## Summary

The required **E2E (security subset)** check is now failing on every PR (first seen on #659): the E2E compose stack tracks `ghcr.io/sethbacon/terraform-registry-backend:latest`, and the latest backend image ships the ENCRYPTION_KEY low-entropy guard (backend issue #560), which refuses to start on the all-zeros test key in `docker-compose.test.yml`. `main` was last green at 16:31 today, before the new image was published — the breakage is cross-repo, not caused by any frontend change. Same adaptation pattern as `TFR_CONFIRM_NON_PRODUCTION` for backend issue #559.

This replaces the trivial keys with fixed CSPRNG-generated values (`openssl rand -hex 16`), test/dev only:

- `docker-compose.test.yml` — the broken E2E stack (all-zeros key)
- `docker-compose.contract-check.yml` — pins backend `3.2.0` (pre-guard) so it still passes today, but its all-zeros key would break the next pin bump
- `docker-compose.yml` — the dev stack's sequential `01234567…` key will hit the same guard on the next `latest` pull. Note: changing this key orphans SCM credentials already encrypted in an existing local postgres volume; re-add them after pulling.

Verified locally: with the patched test compose, the same `:latest` backend image that exited (1) in CI now starts cleanly ("Starting server on 0.0.0.0:8080").

After this merges, #659 (and any other open PR) needs a branch update to pick up the fixed compose file.

## Changelog

- fix: use CSPRNG-generated test/dev encryption keys so the backend's entropy guard (backend #560) allows the compose stacks to start

## Checklist

- [x] `npm run lint` passes (no frontend source changed)
- [x] `npx tsc --noEmit` (typecheck) passes (no frontend source changed)
- [x] `npm test` (unit tests) passes (no frontend source changed)
- [x] `npm run build` succeeds (no frontend source changed)
- [x] PR targets `main`
- [x] Remote branch will be deleted after merge