### PR TITLE
fix(a11y): lighten swagger dark-mode path text to meet WCAG AA contrast

### DIFF
--- a/frontend/src/utils/__tests__/swaggerTheme.test.ts
+++ b/frontend/src/utils/__tests__/swaggerTheme.test.ts
@@ -104,4 +104,10 @@ describe('getSwaggerThemeCss', () => {
     expect(css).toContain('.swagger-ui .scheme-container select { color-scheme: dark;')
     expect(css).not.toContain('.swagger-ui .scheme-container { background: #fafafa !important;')
   })
+
+  it('lightens the opblock summary path text in dark mode (color-contrast fix)', () => {
+    const darkRule = '.swagger-ui .opblock-summary-path .nostyle { color: #e0e0e0 !important; }'
+    expect(getSwaggerThemeCss(true)).toContain(darkRule)
+    expect(getSwaggerThemeCss(false)).not.toContain(darkRule)
+  })
 })

--- a/frontend/src/utils/swaggerTheme.ts
+++ b/frontend/src/utils/swaggerTheme.ts
@@ -14,9 +14,10 @@
 //      today's class names, so at minimum confirms this module's own logic
 //      is unchanged.
 //   2. Manually load /api-docs in both light and dark mode and confirm:
-//      method badges keep white-on-colour text, version stamps/URL/info
-//      links/authorize button keep readable contrast, and the page still
-//      matches the app's Inter font + palette (no default Swagger blue).
+//      method badges keep white-on-colour text, endpoint path text/version
+//      stamps/URL/info links/authorize button keep readable contrast, and the
+//      page still matches the app's Inter font + palette (no default Swagger
+//      blue).
 // ---------------------------------------------------------------------------
 
 const METHOD_COLORS: Record<string, string> = {
@@ -290,6 +291,8 @@ const DARK_EXTRA = `
     border-bottom: 1px solid #333;
   }
   .swagger-ui .opblock-summary-description { color: #aaa !important; }
+  .swagger-ui .opblock-summary-path,
+  .swagger-ui .opblock-summary-path .nostyle { color: #e0e0e0 !important; }
 
   .swagger-ui label,
   .swagger-ui .parameter__name,


### PR DESCRIPTION
<!-- markdownlint-disable MD013 MD041 -->
## Summary

An axe scan of `/api-docs` in dark mode reports a serious color-contrast violation that CI never sees — the weekly E2E accessibility audit scans light mode only. The endpoint path text (`.opblock-summary-path > .nostyle`) keeps swagger-ui's default `#3b4151` foreground on the `#1a1a1a` dark opblock background set by `DARK_EXTRA`, a 1.7:1 ratio against the 4.5:1 WCAG AA minimum.

This adds a dark-mode override in the `DARK_EXTRA` block of `swaggerTheme.ts` setting `.opblock-summary-path` (and its `.nostyle` child) to `#e0e0e0` (~13.2:1 on `#1a1a1a`), consistent with the block's other dark-mode text overrides. Targeting both the element and its child covers the raw swagger-ui anchor as well as the span `enforceSwaggerA11yStyles()` swaps in for the nested-interactive fix (it keeps the classes). Light mode is untouched — the default `#3b4151` on the light opblock tints is ~10:1.

Verified with an axe scan (`@axe-core/playwright` via the raw Playwright API) against a local vite dev server, fulfilling `/swagger.json` with a minimal spec: in dark mode the path text computes to `rgb(224, 224, 224)` and `/api-docs` reports zero serious/critical violations; light mode also reports zero.

Sibling to #659, which fixes the light-mode authorize-button contrast in the same module.

## Changelog

- fix: lighten the API docs endpoint path text in dark mode to meet WCAG AA contrast

## Checklist

- [x] `npm run lint` passes
- [x] `npx tsc --noEmit` (typecheck) passes
- [x] `npm test` (unit tests) passes
- [x] `npm run build` succeeds
- [x] PR targets `main`
- [x] Remote branch will be deleted after merge
