### PR TITLE
chore(deps): bump @sethbacon/terraform-suite-ui to 0.7.1

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,7 +20,7 @@
         "@mui/material": "^9.2.0",
         "@mui/material-pigment-css": "^9.2.0",
         "@sentry/react": "^10.68.0",
-        "@sethbacon/terraform-suite-ui": "0.7.0",
+        "@sethbacon/terraform-suite-ui": "0.7.1",
         "@tanstack/react-query": "^5.101.4",
         "@tanstack/react-query-devtools": "^5.101.4",
         "@testing-library/dom": "^10.4.1",
@@ -2504,9 +2504,9 @@
       }
     },
     "node_modules/@sethbacon/terraform-suite-ui": {
-      "version": "0.7.0",
-      "resolved": "https://npm.pkg.github.com/download/@sethbacon/terraform-suite-ui/0.7.0/fd8a9701e480ee4e509fa80b777974728ae7da75",
-      "integrity": "sha512-tLSskv/KmTKwXZmfKb1zRZG7BjAFlT+xGaJFgRypG3xBNuCjBdx+2Hno588XRD+tuNbkWARbIUya99f0UubHLQ==",
+      "version": "0.7.1",
+      "resolved": "https://npm.pkg.github.com/download/@sethbacon/terraform-suite-ui/0.7.1/2f876015a6733a8c3c5f708f0a6f28013d32fcd4",
+      "integrity": "sha512-ypwH7VUNXGTb+GZDXZ38Q6wFIAcUkNx3tD7RTIvRaNJBr0g5WxFledyjyk5ppF2eJZW/ld2JJT3jh57XwGFeCw==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=22.0.0 <25"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,7 +32,7 @@
     "@mui/material": "^9.2.0",
     "@mui/material-pigment-css": "^9.2.0",
     "@sentry/react": "^10.68.0",
-    "@sethbacon/terraform-suite-ui": "0.7.0",
+    "@sethbacon/terraform-suite-ui": "0.7.1",
     "@tanstack/react-query": "^5.101.4",
     "@tanstack/react-query-devtools": "^5.101.4",
     "@testing-library/dom": "^10.4.1",


### PR DESCRIPTION
## Summary
Bumps the shared, security-load-bearing `@sethbacon/terraform-suite-ui` package from `0.7.0` to `0.7.1` per the manual, reviewed-update process in `SECURITY.md`'s "Shared private package" section.

**Upstream changelog reviewed** ([suite-ui v0.7.1](https://github.com/sethbacon/terraform-suite-ui/blob/main/CHANGELOG.md#071-2026-07-31)): one fix, auth-relevant —
> **identity:** hydrate the session under StrictMode's dev double-mount ([#89](https://github.com/sethbacon/terraform-suite-ui/pull/89))

Fixes a dev-only bug where `AuthProvider`'s mounted-ref latched `false` during React StrictMode's double-mount and discarded a valid session response, rendering every app signed-out on local dev despite a valid cookie. Production builds were unaffected (StrictMode is inert there). No API surface change.

## Changelog
- deps: bump @sethbacon/terraform-suite-ui to 0.7.1

## Verification
- `npm ci` clean install, `npm test` isolated (no concurrent load): 2070/2073 passing; the 3 remaining failures are pre-existing, unrelated `SetupWizardPage` "Security Scanning step" timeouts also present against `0.7.0` on this machine — confirmed by re-running the same suite pinned at `0.7.0` in place, same file fails there too.
- `npm run lint`, `npx tsc --noEmit`, `npm run build` all pass.

## Checklist

- [x] `npm run lint` passes
- [x] `npx tsc --noEmit` (typecheck) passes
- [x] `npm test` (unit tests) passes
- [x] `npm run build` succeeds
- [x] PR targets `main`
- [x] Remote branch will be deleted after merge
