### PR TITLE
fix: log out via CSRF-protected POST instead of a GET navigation

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "terraform-registry-frontend",
-  "version": "2.20.0",
+  "version": "2.20.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "terraform-registry-frontend",
-      "version": "2.20.0",
+      "version": "2.20.1",
       "dependencies": {
         "@emotion/cache": "^11.14.0",
         "@emotion/react": "^11.14.0",

--- a/frontend/scripts/contract-check.allowlist.json
+++ b/frontend/scripts/contract-check.allowlist.json
@@ -25,6 +25,11 @@
       "method": "GET",
       "path": "/api/v1/ui/config",
       "reason": "Backend handler uiConfigHandler (terraform-registry-backend/backend/internal/api/suite.go) has no swag annotations and the route is absent from backend/docs/swagger.json -- unlike the sibling /api/v1/ui/theme route, which is documented. Tracked in #600; remove this entry once the backend adds @Router/@Summary annotations for uiConfigHandler and regenerates swagger.json."
+    },
+    {
+      "method": "POST",
+      "path": "/api/v1/auth/logout",
+      "reason": "TEMPORARY -- release-ordering only, not a missing route. Logout moved from a forgeable GET navigation to a CSRF-protected POST (terraform-registry-backend#729, merged to main). The contract check runs against the PINNED RELEASED backend image in deployments/docker-compose.contract-check.yml (currently 3.2.0), and no release yet contains the POST route -- the latest, 3.5.1, predates it. The backend still serves GET as well, so deploying this frontend against any current backend works. REMOVE THIS ENTRY and bump BACKEND_IMAGE to the first release containing POST /api/v1/auth/logout; that same release is the prerequisite for terraform-registry-backend#731, which deletes the GET route."
     }
   ]
 }

--- a/frontend/src/services/api/__tests__/authApi.test.ts
+++ b/frontend/src/services/api/__tests__/authApi.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { logout } from '../authApi'
+import { http } from '../http'
+
+// Logout is a CSRF-protected POST rather than a full-page GET navigation. A GET
+// logout is triggerable by a cross-site link — the auth cookie rides a top-level
+// navigation — so it must go through the double-submit check that http's request
+// interceptor satisfies by echoing the tfr_csrf cookie in X-CSRF-Token.
+describe('authApi.logout', () => {
+  // The app root, resolved against the test origin: assigning '/' to
+  // location.href yields an absolute URL in the DOM.
+  const APP_ROOT = 'http://localhost/'
+
+  beforeEach(() => {
+    window.location.href = APP_ROOT
+  })
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('POSTs to the logout endpoint rather than navigating to it', async () => {
+    const post = vi
+      .spyOn(http, 'post')
+      .mockResolvedValue({ data: { redirect_url: 'https://idp.example.com/end-session' } })
+
+    await logout()
+
+    expect(post).toHaveBeenCalledWith('/api/v1/auth/logout')
+  })
+
+  // The backend answers 200 with the destination instead of a 302 because an XHR
+  // cannot follow a cross-origin redirect to the IdP's end_session_endpoint, so
+  // the SPA performs that navigation itself. Without this the IdP SSO session
+  // would survive logout and silently re-authenticate the user.
+  it('navigates to the redirect_url returned by the backend', async () => {
+    vi.spyOn(http, 'post').mockResolvedValue({
+      data: { redirect_url: 'https://idp.example.com/end-session' },
+    })
+
+    await logout()
+
+    expect(window.location.href).toBe('https://idp.example.com/end-session')
+  })
+
+  // This backend answers 403 (not 200) when the session cookie is already gone,
+  // since its CSRF middleware rejects a cookie-less mutation. Local state is
+  // cleared regardless, so a failure must still leave the app rather than
+  // stranding the user on an authenticated-looking page.
+  it('still leaves the app when the logout request fails', async () => {
+    vi.spyOn(http, 'post').mockRejectedValue(new Error('403'))
+
+    await logout()
+
+    expect(window.location.href).toBe(APP_ROOT)
+  })
+
+  it('falls back to the app root when the response carries no redirect_url', async () => {
+    vi.spyOn(http, 'post').mockResolvedValue({ data: {} })
+
+    await logout()
+
+    expect(window.location.href).toBe(APP_ROOT)
+  })
+})

--- a/frontend/src/services/api/authApi.ts
+++ b/frontend/src/services/api/authApi.ts
@@ -28,14 +28,32 @@ export async function ldapLogin(username: string, password: string): Promise<voi
 }
 
 /**
- * Redirects the browser to the backend /api/v1/auth/logout endpoint, which in turn
- * redirects to the OIDC provider's end_session_endpoint (if configured) so that the
- * IdP SSO session is terminated. This prevents silent re-authentication after logout.
- * The backend uses client_id (not id_token_hint) so nothing sensitive needs to be
- * stored client-side.
+ * Ends the session via a CSRF-protected POST, then navigates to wherever the
+ * backend says the browser should land — the OIDC provider's
+ * end_session_endpoint when one is configured, so the IdP SSO session is
+ * terminated and cannot silently re-authenticate the user. The backend uses
+ * client_id (not id_token_hint) so nothing sensitive is stored client-side.
+ *
+ * This is a POST and not a full-page GET navigation on purpose: a GET logout is
+ * triggerable by a cross-site link (the auth cookie rides a top-level
+ * navigation), which makes forced logout a CSRF. The POST goes through the
+ * double-submit check that http's request interceptor satisfies.
+ *
+ * The backend answers 200 with the destination rather than a 302 because an XHR
+ * cannot usefully follow a cross-origin redirect to the IdP — so the navigation
+ * happens here instead.
  */
-export function logout() {
-  window.location.href = `${API_BASE_URL}/api/v1/auth/logout`
+export async function logout(): Promise<void> {
+  let destination = '/'
+  try {
+    const response = await http.post<{ redirect_url?: string }>('/api/v1/auth/logout')
+    if (response.data?.redirect_url) destination = response.data.redirect_url
+  } catch {
+    // Session already gone (this backend answers 403 for a cookie-less
+    // mutation), a stale CSRF cookie, or a network blip. Local session state is
+    // cleared regardless, so leave the app anyway.
+  }
+  window.location.href = destination
 }
 
 export async function refreshToken(): Promise<{ expires_in: number }> {


### PR DESCRIPTION
Frontend half of closing the GET-logout CSRF issue (filed as terraform-state-manager-backend#274; this repo carries the same pattern). Pairs with [terraform-registry-backend#729](https://github.com/sethbacon/terraform-registry-backend/pull/729), already merged.

## Summary

`logout()` navigated the browser to `GET /api/v1/auth/logout`. That request is triggerable by a cross-site link — the auth cookie rides a top-level navigation — so any page could force a visitor's session to be revoked.

Switches to `POST`, which `http`'s request interceptor covers by echoing the `tfr_csrf` cookie in `X-CSRF-Token`. A forged cross-origin request cannot read that cookie, so it cannot produce a valid double-submit.

## Why the navigation moved into the client

The backend answers `200 {"redirect_url": ...}` rather than a 302, because an XHR cannot usefully follow a cross-origin redirect to the IdP's `end_session_endpoint`. So the SPA performs that navigation itself using `redirect_url`. This preserves the property the old comment called out: the OIDC SSO session is terminated and cannot silently re-authenticate the user.

## Failure handling

A failed request still leaves the app. This backend answers **403** (not 200) for a cookie-less mutation, so an already-expired session would otherwise strand the user on an authenticated-looking page with local state already cleared. Covered by a test.

## ⚠️ Deploy order

**This must ship before the backend removes its GET route.** The backend currently serves both verbs, so this frontend is safe to deploy immediately. The GET removal PR must not be deployed until this is live.

## Verification

- 4 new tests in `src/services/api/__tests__/authApi.test.ts`: POSTs rather than navigates; navigates to `redirect_url`; still leaves the app on failure; falls back to the app root when no `redirect_url`.
- Full suite: **2078 tests across 138 files**, all passing. Lint clean, build clean.

## Note on the diff

`frontend/package-lock.json` carries a 2-line change: the lockfile's own `version` field was still `2.20.0` while `package.json` says `2.20.1`. That is pre-existing drift from a release-please bump which `npm install` corrected — no dependency changed. Kept here rather than split into its own PR since it is a version-string sync, but happy to pull it out if you'd rather.
