### PR TITLE
chore: pin the contract check to backend 3.5.2 and drop the logout allowlist

### DIFF
--- a/deployments/docker-compose.contract-check.yml
+++ b/deployments/docker-compose.contract-check.yml
@@ -20,9 +20,9 @@ services:
     # Pinned backend image. Bump this tag in lockstep with backend releases
     # whose API surface the frontend wants to depend on. The contract check
     # validates that every route api.ts calls exists on this exact backend.
-    # 3.2.0 is the first release with the admin notification-channel routes
-    # (/api/v1/admin/notifications/channels[/{id}][/test]) the UI now calls.
-    image: ${BACKEND_IMAGE:-ghcr.io/sethbacon/terraform-registry-backend:3.2.0}
+    # 3.5.2 is the first release with POST /api/v1/auth/logout, which the UI
+    # now calls instead of the removed, CSRF-forgeable GET form.
+    image: ${BACKEND_IMAGE:-ghcr.io/sethbacon/terraform-registry-backend:3.5.2}
     environment:
       - TFR_DATABASE_HOST=postgres
       - TFR_DATABASE_PORT=5432

--- a/frontend/scripts/contract-check.allowlist.json
+++ b/frontend/scripts/contract-check.allowlist.json
@@ -25,11 +25,6 @@
       "method": "GET",
       "path": "/api/v1/ui/config",
       "reason": "Backend handler uiConfigHandler (terraform-registry-backend/backend/internal/api/suite.go) has no swag annotations and the route is absent from backend/docs/swagger.json -- unlike the sibling /api/v1/ui/theme route, which is documented. Tracked in #600; remove this entry once the backend adds @Router/@Summary annotations for uiConfigHandler and regenerates swagger.json."
-    },
-    {
-      "method": "POST",
-      "path": "/api/v1/auth/logout",
-      "reason": "TEMPORARY -- release-ordering only, not a missing route. Logout moved from a forgeable GET navigation to a CSRF-protected POST (terraform-registry-backend#729, merged to main). The contract check runs against the PINNED RELEASED backend image in deployments/docker-compose.contract-check.yml (currently 3.2.0), and no release yet contains the POST route -- the latest, 3.5.1, predates it. The backend still serves GET as well, so deploying this frontend against any current backend works. REMOVE THIS ENTRY and bump BACKEND_IMAGE to the first release containing POST /api/v1/auth/logout; that same release is the prerequisite for terraform-registry-backend#731, which deletes the GET route."
     }
   ]
 }


### PR DESCRIPTION
Follow-up to #664, which added a deliberately temporary allowlist entry with a stated removal condition. That condition is now met.

## Summary

The `POST /api/v1/auth/logout` allowlist entry existed purely as a **release-ordering placeholder**: the frontend had moved to the CSRF-protected POST while the contract check still ran against backend `3.2.0`, which predated the route. `terraform-registry-backend` **3.5.2** is the first release carrying it, so:

- `BACKEND_IMAGE` pinned `3.2.0` → `3.5.2`
- The `POST /api/v1/auth/logout` allowlist entry deleted

The route is now genuinely verified by the contract check rather than skipped — which is the point of removing a placeholder rather than letting it linger.

## Why this needed verifying, not assuming

Bumping across three minors risked leaving **other** entries stale. The allowlist is explicitly documented to fail the check when an entry is no longer needed ("Stale entries fail the check, so this list stays honest"), so a jump that quietly satisfied, say, the `/api/v1/ui/config` entry would have turned this into a red check.

Ran the real check against the real image rather than reasoning about it:

```
Backend has 222 (method, path) tuples      (was 220 on 3.2.0)
Found 189 call sites
Allowlist has 5 entries
OK: every frontend route exists on backend (or is on the allowlist)
```

All five remaining entries are still required — the four `DEV_MODE` ones (permanent, conditionally-registered routes) and `/api/v1/ui/config`, whose upstream issue #600 is still open and whose handler still lacks swag annotations in 3.5.2.

## Verification

Contract check run locally against `ghcr.io/sethbacon/terraform-registry-backend:3.5.2` via the actual compose stack: **passes**. No source changes, so no test/lint impact.
