### PR TITLE
test: deflake TerraformMirrorPage error-state test under parallel load

### DIFF
--- a/frontend/src/pages/admin/__tests__/TerraformMirrorPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/TerraformMirrorPage.test.tsx
@@ -14,6 +14,7 @@ const listVersionsMock = vi.fn()
 const listVersionPlatformsMock = vi.fn()
 const deleteVersionMock = vi.fn()
 const getHistoryMock = vi.fn()
+const getReleasesGPGKeysMock = vi.fn()
 
 vi.mock('../../../services/api', () => ({
   default: {
@@ -27,6 +28,11 @@ vi.mock('../../../services/api', () => ({
     listTerraformVersionPlatforms: (...args: unknown[]) => listVersionPlatformsMock(...args),
     deleteTerraformVersion: (...args: unknown[]) => deleteVersionMock(...args),
     getTerraformMirrorHistory: (...args: unknown[]) => getHistoryMock(...args),
+    // The page renders <ReleasesGPGKeyStatus />, which calls this. Leaving it out
+    // makes the call a TypeError, so that panel renders its own "Failed to load
+    // GPG key status." alert in every test here — a second element matching any
+    // loose /error|failed/ assertion.
+    getReleasesGPGKeys: (...args: unknown[]) => getReleasesGPGKeysMock(...args),
   },
 }))
 
@@ -84,6 +90,7 @@ describe('TerraformMirrorPage', () => {
     listVersionsMock.mockResolvedValue({ versions: [] })
     listVersionPlatformsMock.mockResolvedValue({ platforms: [] })
     getHistoryMock.mockResolvedValue({ history: [] })
+    getReleasesGPGKeysMock.mockResolvedValue({ keys: [] })
   })
 
   it('shows loading spinner initially', () => {
@@ -119,9 +126,11 @@ describe('TerraformMirrorPage', () => {
   it('shows error state on API failure', async () => {
     listTerraformMirrorConfigsMock.mockRejectedValue(new Error('Server error'))
     renderPage()
-    await waitFor(() => {
-      expect(screen.getByText(/error|failed|server error/i)).toBeInTheDocument()
-    })
+    // Assert the page's own alert text exactly. A loose /error|failed/ regex also
+    // matches any other alert on the page, and getByText throws on multiple
+    // matches — so the assertion only held in the window before the second alert
+    // rendered, which a loaded parallel worker can miss.
+    expect(await screen.findByText('Server error')).toBeInTheDocument()
   })
 
   it('renders page heading', async () => {


### PR DESCRIPTION
## Summary

`TerraformMirrorPage > shows error state on API failure` failed once during a full parallel `vitest run`, then passed in isolation and on re-run. The root cause is not a short timeout — the assertion was **unsatisfiable** once the page finished settling, so it only passed by winning a race against a transient DOM state.

`TerraformMirrorPage` renders `<ReleasesGPGKeyStatus />`, whose hook calls `api.getReleasesGPGKeys()`. That method was missing from this file's `vi.mock` of `services/api`, so the call was `undefined(...)` → TypeError → the panel rendered its own **"Failed to load GPG key status."** alert in *every* test in the file.

The failing test asserted `getByText(/error|failed|server error/i)`, which therefore matched **two** elements: the page's own "Server error" alert and the GPG panel's. `getByText` throws on multiple matches, so once both had rendered the callback could never succeed and `waitFor` simply retried to timeout.

It passed most of the time because the GPG panel sits in the non-loading branch, so its query starts only *after* the configs query rejects — leaving a brief window where the page alert exists and the panel is still a spinner. A worker descheduled past that window fails, and raising the timeout makes it strictly worse (more retries, same outcome).

Reproduced deterministically with a throwaway probe: delaying the assertion until both queries settled logged `n=2` matches on all 17 retry ticks and failed with `Found multiple elements with the text: /error|failed|server error/i`.

### Fix

- Add `getReleasesGPGKeys` to the api mock (default `{ keys: [] }` in `beforeEach`) so the mock covers the whole tree the page renders. This removes the spurious error alert from all 43 tests in the file.
- Assert the page's exact message — `await screen.findByText('Server error')` — so the check cannot go ambiguous again. Consistent with the file's other error tests (`'create failed'`, `'sync failed'`).

### Verification

- Fixed assertion passes with the check deliberately delayed 0/50/200/400/800 ms after render, and also with the GPG panel forced into its own error state. The loose regex now matches exactly 1 element at every delay.
- `TerraformMirrorPage.test.tsx`: 43/43 pass. Full suite: 138 files / 2078 tests pass.

Test-only change; no production code touched.

## Changelog

- test: deflake `TerraformMirrorPage` error-state assertion that could match two alerts

## Checklist

- [x] `npm run lint` passes
- [x] `npx tsc --noEmit` (typecheck) passes
- [x] `npm test` (unit tests) passes
- [x] `npm run build` succeeds
- [x] PR targets `main`
- [x] Remote branch will be deleted after merge
