### PR TITLE
test(e2e): fix the webkit logout race that has kept main red since #664

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -329,6 +329,10 @@ jobs:
           --reporter=list --grep-invert="Visual regression"
 
       - name: Upload Playwright artifacts
+        # always() — without it this step inherits the default success()
+        # condition, so the traces/videos/screenshots are uploaded only when the
+        # suite passes and are missing from exactly the runs that need them.
+        if: always()
         # v7
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
@@ -430,6 +434,8 @@ jobs:
           --workers=2 --max-failures=1 --retries=1 --reporter=list
 
       - name: Upload Playwright artifacts
+        # always() — see the identical step in e2e-gated above for the rationale.
+        if: always()
         # v7
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:

--- a/e2e/tests/auth.spec.ts
+++ b/e2e/tests/auth.spec.ts
@@ -7,7 +7,7 @@ import { test, expect } from '@playwright/test';
  *  - Login page renders correctly
  *  - Dev login flow redirects to main app
  *  - Invalid/missing auth on a protected route redirects to login
- *  - Logout returns user to login page
+ *  - Logout returns user to home page
  */
 
 test.describe('Login page', () => {
@@ -68,21 +68,41 @@ test.describe('Logout', () => {
     await devLoginBtn.click();
     await page.waitForURL((url) => !url.pathname.endsWith('/login'), { timeout: 10_000 });
 
+    // Seed the key the security assertion at the end of this test guards. Nothing
+    // else in this flow writes it, so without seeding that assertion reads null
+    // whether or not logout clears anything, and can never fail.
+    await page.evaluate(() =>
+      localStorage.setItem('authorized', JSON.stringify({ apiKey: { value: 'e2e-canary' } }))
+    );
+
     // Open account menu (top-right AppBar button, aria-label "Account")
     await page.getByRole('button', { name: 'Account' }).click();
+
+    // Since #664, logout is a CSRF-protected POST: authApi.logout() awaits the
+    // response and only THEN assigns window.location.href, and the suite AppBar
+    // fires it without awaiting. With no OIDC configured the backend answers
+    // {"redirect_url": TFR_SERVER_PUBLIC_URL + "/"} -- i.e. the SPA's own home
+    // page, which is already the current URL because dev login navigates to '/'.
+    //
+    // So waitForURL(pathname === '/') would match the *pre-logout* document and
+    // resolve before the navigation had even started, leaving everything after it
+    // racing the reload: on webkit the localStorage read below lost that race in
+    // every main run since #664, failing with "Execution context was destroyed,
+    // most likely because of a navigation".
+    //
+    // Wait for the document the logout navigation actually loads instead. The
+    // listener must be armed before the click. 30 s covers the backend round-trip
+    // plus a full SPA page load on slow CI runners.
+    const loggedOut = page.waitForEvent('load', { timeout: 30_000 });
 
     // Click the logout menu item. Labelled "Sign out" since #438 moved this menu into
     // the shared @sethbacon/terraform-suite-ui AppBar, whose SuiteLayout renders
     // t('auth.signOut', { defaultValue: 'Sign out' }) -- a key this app doesn't
     // override, so the literal default is what's actually on screen.
     await page.getByRole('menuitem', { name: 'Sign out' }).click();
+    await loggedOut;
 
-    // Logout redirects to the backend /auth/logout endpoint which terminates any
-    // OIDC SSO session and then redirects back to the frontend home page ('/').
-    // In dev mode (no OIDC) the backend falls back directly to the home page.
-    // 30 s — covers the backend redirect latency + full SPA page load on slow CI runners.
-    await page.waitForURL((url) => url.pathname === '/', { timeout: 30_000 });
-    expect(page.url()).not.toContain('/login');
+    expect(new URL(page.url()).pathname).toBe('/');
 
     // Security check: swagger-ui-react persists Authorize dialog entries under
     // the key "authorized" in localStorage.  AuthContext.logout() must clear it


### PR DESCRIPTION
<!-- markdownlint-disable MD013 MD041 -->
## Summary

The **E2E (gated/manual)** job has failed on every `main` run since `9f84ae4`. It is skipped on `pull_request` events, so it never blocked a merge — which is why it went unnoticed while `main` stayed red.

Every red run has exactly **one** genuine failure:

```
1 failed
  [webkit] › tests/auth.spec.ts:61:7 › Logout › logout returns user to home page
  Error: page.evaluate: Execution context was destroyed, most likely because of a navigation
```

### Root cause

#664 changed `logout()` from a synchronous navigation into an async one: it awaits the CSRF-protected POST and only *then* assigns `window.location.href`, and the suite AppBar fires it without awaiting. With no OIDC configured the backend answers `{"redirect_url": TFR_SERVER_PUBLIC_URL + "/"}` — the SPA's own home page, which is **already the current URL** because dev login navigates to `/`.

So the test's only synchronization point:

```js
await page.waitForURL((url) => url.pathname === '/', { timeout: 30_000 });
```

matched the *pre-logout* document and returned before the navigation had even started. Measured against the real stack on webkit:

```
waitForURL resolved at +2852ms
logout navigation 'load' fired at +5004ms
```

The sync point resolved 2.1 s before the navigation it was meant to wait for. Everything after it raced the reload, and webkit — whose evaluate round-trip under `--workers=2` is slow enough to straddle the commit — lost every time.

This is a test-synchronization bug exposed by a correct product change. The logout behaviour itself is fine; no product code is touched here.

### Fix

Wait for the document the logout navigation actually loads, arming the listener before the click.

Also seed the `authorized` key before logging out: nothing in this flow ever wrote it, so the security assertion guarding it read `null` whether or not logout cleared anything and **could never fail**.

### Verification

Reproduced and fixed against the real stack (dockerised backend + Vite over TLS), not just by reasoning:

- Old sequencing → **fails** on webkit with the exact CI error.
- New sequencing → **passes** under identical forced-race conditions.
- Fixed `auth.spec.ts` passes on chromium and webkit; firefox covered via a standalone harness (a locally generated cert is rejected by firefox at `page.goto`, failing all six tests in the file before any test code runs).
- Seeded assertion confirmed load-bearing by making `clearAuthStorage` skip that key — the test then fails, as it should.

### Also included

The Playwright artifact upload steps had no `if:` condition, so they inherited the default `success()` and uploaded traces/videos/screenshots **only for runs that passed** — missing from exactly the runs that need them. This is why the trace for this failure was unavailable and it had to be reproduced locally. Added `if: always()` to both E2E jobs.

### Notes for reviewers

Two items in the original report turned out to be artifacts, worth recording so they are not chased again:

- The **accessibility admin-pages audit** was never failing. It shows as `1 interrupted` — `--max-failures=1` aborts the run and kills whatever is in flight. That is why it named a different page each run (Module Upload / Home / Dashboard / Provider Upload).
- There is **no infrastructure problem**. `::error::Image pull failed after 5 attempts` and `ERROR: frontend never became ready` appear in the log as GitHub Actions echoing the *script source* (the `^[[36;1m` command-echo prefix), not as output. Actual output was `frontend Skipped - No image to be pulled` and `Frontend ready (HTTP 200)`.

**Not addressed here:** the firefox flakes (`policies.spec.ts:147`, `setup-wizard.spec.ts:41`, `admin.spec.ts:453`, `terraform-mirror-admin.spec.ts:83`, `upload.spec.ts:253`). A different test each run, all passing on retry, all visibility/selector timeouts under parallel load — they never fail the job, so `main` should go green with this change alone. The obvious shared cause (the `networkidle` hang noted in the CI comment) does not fit: three of the four do not use it. Worth a separate effort if they worsen.

## Changelog

- test: fix the webkit logout race that kept the gated E2E job red on main

## Checklist

- [x] `npm run lint` passes
- [x] `npx tsc --noEmit` (typecheck) passes
- [x] `npm test` (unit tests) passes — verified by CI (all 4 shards + coverage merge)
- [x] `npm run build` succeeds — verified by CI
- [x] PR targets `main`
- [x] Remote branch will be deleted after merge

