### PR TITLE
chore(ci): retry the contract-check image pull on Docker Hub timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,7 +208,29 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Pull contract-check images (retry transient Docker Hub timeouts)
+        # postgres:16-alpine comes from Docker Hub, whose unauthenticated rate
+        # limit on shared GitHub runners intermittently times out the pull. This
+        # job gates e2e-gated (`needs: contract-check`), so one unretried pull
+        # failure here skips the release gate entirely without ever comparing a
+        # contract — see run 30734033297, where the stack never started. Retry so
+        # the subsequent `compose up` finds the images cached. e2e-gated has had
+        # the same guard since it started blocking releases; unlike that stack,
+        # nothing here is buildable, so no --ignore-buildable is needed.
+        run: |
+          compose="docker compose -f deployments/docker-compose.contract-check.yml"
+          for attempt in 1 2 3 4 5; do
+            if $compose pull; then
+              exit 0
+            fi
+            echo "::warning::Image pull failed (attempt ${attempt}/5); retrying in 15s..."
+            sleep 15
+          done
+          echo "::error::Image pull failed after 5 attempts"
+          exit 1
+
       - name: Start contract-check stack
+        # Images are pre-pulled above.
         run: >-
           docker compose -f deployments/docker-compose.contract-check.yml up -d
 


### PR DESCRIPTION
<!-- markdownlint-disable MD013 MD041 -->
## Summary

The post-merge `main` run [30734033297](https://github.com/sethbacon/terraform-registry-frontend/actions/runs/30734033297) failed at **Start contract-check stack**:

```
postgres Error Get "https://registry-1.docker.io/v2/": net/http:
request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
```

`postgres:16-alpine` comes from Docker Hub, whose unauthenticated rate limit on shared GitHub runners intermittently times out the pull. The job died before comparing a single route, so the red run said nothing at all about the contract.

**The cost is bigger than one red job.** `e2e-gated` declares `needs: contract-check`, so an unretried pull timeout here skips the release gate entirely. That is precisely what happened on that run — `E2E (gated/manual)` reported `skipped` and never executed, on the very commit that was supposed to prove #704 fixed it.

`e2e-gated` has carried a 5-attempt retry for this exact Docker Hub flake since it started blocking releases. This gives `contract-check` the same guard: a transient registry timeout now costs 75 s of retries instead of the release gate.

Unlike the e2e stack, nothing in `docker-compose.contract-check.yml` is buildable (both services are image-only), so `--ignore-buildable` is not needed here.

## Verification

Both paths exercised against the real compose file, not just eyeballed:

- **Healthy pull** — the extracted step script pulls `postgres:16-alpine` and `terraform-registry-backend:3.5.2` and exits `0` on the first attempt.
- **Failing pull** — pointed at a nonexistent image, it emits five `::warning::Image pull failed (attempt N/5)` lines, then `::error::Image pull failed after 5 attempts` and exits `1`. Confirms the loop terminates and does not silently succeed.
- Workflow YAML parses, and the new step is ordered after **Log in to GHCR** (required — the backend image is pulled from `ghcr.io`) and before **Start contract-check stack**.

Independently corroborated: re-running the failed job on that same run passed with no code change, confirming the failure was transient rather than a real contract mismatch.

## Changelog

- ci: retry the contract-check image pull so a transient Docker Hub timeout cannot skip the release gate

## Checklist

- [x] `npm run lint` passes — unaffected; this PR touches only `.github/workflows/ci.yml`
- [x] `npx tsc --noEmit` (typecheck) passes — unaffected, same reason
- [x] `npm test` (unit tests) passes — unaffected, same reason
- [x] `npm run build` succeeds — unaffected, same reason
- [x] PR targets `main`
- [x] Remote branch will be deleted after merge
