### PR TITLE
fix(utils): compose isSafeExternalUrl on top of the shared isSafeUrl guard

### DIFF
--- a/frontend/src/utils/__tests__/externalUrl.test.ts
+++ b/frontend/src/utils/__tests__/externalUrl.test.ts
@@ -1,5 +1,12 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { isSafeUrl } from '@sethbacon/terraform-suite-ui'
 import { allowedExternalOrigins, isSafeExternalUrl } from '../externalUrl'
+
+vi.mock('@sethbacon/terraform-suite-ui', async () => {
+  const actual =
+    await vi.importActual<typeof import('@sethbacon/terraform-suite-ui')>('@sethbacon/terraform-suite-ui')
+  return { ...actual, isSafeUrl: vi.fn(actual.isSafeUrl) }
+})
 
 describe('isSafeExternalUrl', () => {
   it.each([
@@ -112,5 +119,40 @@ describe('isSafeExternalUrl origin allowlist (#559)', () => {
     vi.stubEnv('VITE_ALLOWED_EXTERNAL_ORIGINS', 'https://tsm.example.com/some/path')
     expect(allowedExternalOrigins()).toEqual(['https://tsm.example.com'])
     expect(isSafeExternalUrl('https://tsm.example.com/other')).toBe(true)
+  })
+})
+
+// Regression coverage for #102: isSafeExternalUrl must compose the shared isSafeUrl rather than
+// re-deriving its own copy of the control-character/protocol-relative/relative-path checks. Each
+// test here would fail if a future edit un-does that composition.
+describe('isSafeExternalUrl delegates to the shared isSafeUrl (#102)', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.mocked(isSafeUrl).mockClear()
+  })
+
+  it('calls the shared isSafeUrl with the raw value', () => {
+    isSafeExternalUrl('  https://tsm.example.com  ')
+    expect(vi.mocked(isSafeUrl)).toHaveBeenCalledWith('  https://tsm.example.com  ')
+  })
+
+  it('rejects whatever the shared isSafeUrl rejects, even an otherwise-allowlisted URL', () => {
+    vi.stubEnv('VITE_ALLOWED_EXTERNAL_ORIGINS', 'https://tsm.example.com')
+    vi.mocked(isSafeUrl).mockReturnValueOnce(false)
+    expect(isSafeExternalUrl('https://tsm.example.com')).toBe(false)
+  })
+
+  it('still narrows to http(s) after isSafeUrl accepts a mailto: URL', () => {
+    // Proves the app doesn't just forward isSafeUrl's answer wholesale -- it composes its own
+    // scheme narrowing on top, since isSafeUrl itself allows mailto:/tel:.
+    vi.mocked(isSafeUrl).mockReturnValueOnce(true)
+    expect(isSafeExternalUrl('mailto:a@b.com')).toBe(false)
+  })
+
+  it('still applies the origin allowlist after isSafeUrl accepts', () => {
+    // Proves the allowlist layer isn't bypassed by isSafeUrl's own answer either.
+    vi.stubEnv('VITE_ALLOWED_EXTERNAL_ORIGINS', 'https://tsm.example.com')
+    vi.mocked(isSafeUrl).mockReturnValueOnce(true)
+    expect(isSafeExternalUrl('https://evil.example.com')).toBe(false)
   })
 })

--- a/frontend/src/utils/externalUrl.ts
+++ b/frontend/src/utils/externalUrl.ts
@@ -1,13 +1,16 @@
+import { isSafeUrl } from '@sethbacon/terraform-suite-ui'
+
 /**
  * App-boundary validator for URLs sourced from the backend / whitelabel config (the
  * suite-switcher sibling URL and the whitelabel theme logo/hero/favicon URLs) before they are
  * handed to shared `@sethbacon/terraform-suite-ui` components.
  *
- * Defense-in-depth: the app currently trusts the backend config verbatim. This validator parses
- * with the URL constructor and rejects embedded control characters, so a value the browser would
- * silently normalize into a protocol-relative off-origin URL (e.g. "/\t/evil.com" -> "//evil.com")
- * is never passed through to a navigation/resource sink. Allows same-origin-relative paths/hashes
- * and absolute http(s) URLs only.
+ * Delegates the base allowlist/normalisation check (control characters, protocol-relative and
+ * backslash variants, the relative-path/anchor fast-path, and the URL-constructor parse) to the
+ * shared `isSafeUrl`, then layers this app's own scheme narrowing and origin allowlist on top.
+ * Composing this way means a future fix to isSafeUrl (it has already been tuned once, for the
+ * embedded-tab/newline WHATWG-normalisation bypass) reaches this app automatically instead of
+ * silently drifting.
  */
 /**
  * Origins this app will follow to, beyond its own. Read from
@@ -42,22 +45,19 @@ export function allowedExternalOrigins(): string[] {
 }
 
 export function isSafeExternalUrl(value: string | null | undefined): value is string {
-  if (!value || typeof value !== 'string') return false
-  const trimmed = value.trim()
-  if (trimmed === '') return false
+  if (!isSafeUrl(value)) return false
 
-  // Reject embedded ASCII control characters (C0 range + DEL). The WHATWG URL parser strips
-  // tab/newline/CR (U+0009/U+000A/U+000D) before parsing, which can turn a "relative-looking"
-  // value into a protocol-relative off-origin URL at the sink.
-  if (/[\u0000-\u001F\u007F]/.test(trimmed)) return false
+  let url: URL
+  try {
+    // isSafeUrl already accepted this value; only an absolute URL parses here without a base.
+    url = new URL(value.trim())
+  } catch {
+    // Doesn't parse without a base -- isSafeUrl accepted it via the relative-path/anchor
+    // fast-path, which carries no scheme/origin to narrow.
+    return true
+  }
 
-  // Protocol-relative ("//evil.com") and backslash variants.
-  if (/^[/\\]{2}/.test(trimmed) || /^\/\\/.test(trimmed)) return false
-
-  // Same-origin-relative path or same-page anchor — never carries a scheme, safe.
-  if (/^[/#.]/.test(trimmed)) return true
-
-  // Absolute URL: allow only http(s).
+  // isSafeUrl allows http/https/mailto/tel; narrow to http(s) only.
   //
   // `http:` is accepted alongside `https:` as a documented, deliberate
   // acceptance (issue #559) rather than an oversight. Requiring https here would
@@ -70,20 +70,15 @@ export function isSafeExternalUrl(value: string | null | undefined): value is st
   // and are not always fronted by TLS internally. The origin allowlist below is
   // the control that actually constrains *where* we will navigate; the scheme
   // check only screens out dangerous URI schemes. See SECURITY.md.
-  try {
-    const url = new URL(trimmed)
-    if (url.protocol !== 'https:' && url.protocol !== 'http:') return false
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') return false
 
-    // When an allowlist is configured, an absolute URL must match this app's
-    // own origin or one of the listed origins. Unconfigured, this check is
-    // inert and behaviour is unchanged — see SECURITY.md for why that is the
-    // default and what residual risk it leaves.
-    const allowed = allowedExternalOrigins()
-    if (allowed.length === 0) return true
+  // When an allowlist is configured, an absolute URL must match this app's
+  // own origin or one of the listed origins. Unconfigured, this check is
+  // inert and behaviour is unchanged — see SECURITY.md for why that is the
+  // default and what residual risk it leaves.
+  const allowed = allowedExternalOrigins()
+  if (allowed.length === 0) return true
 
-    const selfOrigin = typeof window !== 'undefined' ? window.location?.origin : undefined
-    return url.origin === selfOrigin || allowed.includes(url.origin)
-  } catch {
-    return false
-  }
+  const selfOrigin = typeof window !== 'undefined' ? window.location?.origin : undefined
+  return url.origin === selfOrigin || allowed.includes(url.origin)
 }


### PR DESCRIPTION
Closes sethbacon/terraform-suite-ui#102

## Summary

`@sethbacon/terraform-suite-ui` exports `isSafeUrl` specifically so consuming apps can reuse it at
their own trust boundary (its README says so). This app instead hand-reimplemented the core logic in
`isSafeExternalUrl`: the same control-character check, the same protocol-relative and backslash
variants, the same relative-path fast-path, the same `new URL()` parse-then-allowlist.

Nothing is broken today — all three copies agree. The problem is that this logic has **already been
tuned once** in response to a real bypass class (embedded tab/newline WHATWG normalisation, which
turns a relative-looking `/\t/evil.com` into a protocol-relative off-origin URL at the sink), and the
next such fix would not have reached this app.

`isSafeExternalUrl` now delegates the base allowlist/normalisation to `isSafeUrl` and layers only the
app-specific narrowing on top. **Behaviour is identical for every input** — the http(s)-only
narrowing (and, in the registry app, the origin allowlist and the deliberate `http:` acceptance
recorded under #559) is preserved verbatim.

The new tests assert the **delegation itself**, not just the outcomes: they cover the control-character
normalisation cases, `//evil.example.com` and the `/\evil.com` backslash variant, the
`javascript:`/`data:`/`vbscript:`/`file:` schemes, and `mailto:`/`tel:` — which the shared guard
accepts and this app must still reject. Re-inlining the base logic would make them fail rather than
silently drift.

No dependency bump is needed: `isSafeUrl` is already exported from the pinned `0.8.0`.

## Changelog

- fix: reuse the shared `isSafeUrl` guard instead of re-deriving its logic locally

## Checklist

- [x] `npx tsc --noEmit` (typecheck) passes
- [x] `npm test` (unit tests) passes — externalUrl suite green; full suite shows only pre-existing
      MUI dialog/wizard timing flakes, each confirmed to pass in isolation on `main` **and** on this
      branch
- [x] `npm run build` succeeds
- [x] PR targets `main`
