### PR TITLE
fix(deps): bump @sethbacon/terraform-suite-ui to 0.8.1 and verify its provenance

### DIFF
--- a/.github/actions/setup-frontend/action.yml
+++ b/.github/actions/setup-frontend/action.yml
@@ -37,6 +37,24 @@ runs:
         cache: "npm"
         cache-dependency-path: frontend/package-lock.json
 
+    # The @sethbacon scope on the PUBLIC npm registry is owned by an unrelated account, so a
+    # missing scope mapping here would silently resolve @sethbacon/* from npmjs.org instead of
+    # GitHub Packages and land third-party code in the bundle. frontend/.npmrc supplies the
+    # mapping; this asserts it is actually in effect rather than trusting it is.
+    - name: Assert the @sethbacon scope resolves to GitHub Packages
+      if: inputs.install-deps == 'true'
+      working-directory: frontend
+      shell: bash
+      run: |
+        set -euo pipefail
+        actual=$(npm config get @sethbacon:registry)
+        expected="https://npm.pkg.github.com"
+        if [ "${actual%/}" != "$expected" ]; then
+          echo "::error::@sethbacon:registry resolves to '${actual}', expected '${expected}'. Refusing to install - @sethbacon on the public registry is not ours."
+          exit 1
+        fi
+        echo "@sethbacon:registry -> ${actual}"
+
     - name: Install frontend dependencies
       if: inputs.install-deps == 'true'
       working-directory: frontend
@@ -44,6 +62,25 @@ runs:
       env:
         NODE_AUTH_TOKEN: ${{ github.token }}
       run: npm ci
+
+    # The library publishes a SLSA provenance attestation bound to the packed tarball. Without
+    # this, the attestation is an audit trail nobody reads; here it gates the build. Verified
+    # locally before adding: a genuine tarball passes, and one with a single appended byte fails
+    # with HTTP 404 for its altered digest.
+    - name: Verify @sethbacon/terraform-suite-ui provenance
+      if: inputs.install-deps == 'true'
+      working-directory: frontend
+      shell: bash
+      env:
+        NODE_AUTH_TOKEN: ${{ github.token }}
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        set -euo pipefail
+        version=$(node -p "require('./package.json').dependencies['@sethbacon/terraform-suite-ui']")
+        tmp=$(mktemp -d)
+        tarball=$(cd "$tmp" && npm pack "@sethbacon/terraform-suite-ui@${version}" --silent | tail -n1)
+        gh attestation verify "${tmp}/${tarball}" --repo sethbacon/terraform-suite-ui
+        rm -rf "$tmp"
 
     - name: Install e2e dependencies
       if: inputs.install-e2e-deps == 'true'

--- a/.github/actions/setup-frontend/action.yml
+++ b/.github/actions/setup-frontend/action.yml
@@ -78,7 +78,13 @@ runs:
         set -euo pipefail
         version=$(node -p "require('./package.json').dependencies['@sethbacon/terraform-suite-ui']")
         tmp=$(mktemp -d)
-        tarball=$(cd "$tmp" && npm pack "@sethbacon/terraform-suite-ui@${version}" --silent | tail -n1)
+        # Pack FROM frontend/, writing to $tmp -- never `cd "$tmp"` first. npm reads
+        # .npmrc from the cwd upward, so packing inside a temp directory drops the
+        # @sethbacon -> npm.pkg.github.com mapping the step above just asserted and
+        # resolves the tarball from the PUBLIC registry, where the scope is not ours.
+        # That is the very substitution this step exists to detect, performed by the
+        # step itself.
+        tarball=$(basename "$(npm pack "@sethbacon/terraform-suite-ui@${version}" --silent --pack-destination "$tmp" | tail -n1)")
         gh attestation verify "${tmp}/${tarball}" --repo sethbacon/terraform-suite-ui
         rm -rf "$tmp"
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "terraform-registry-frontend",
-  "version": "2.20.2",
+  "version": "2.21.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "terraform-registry-frontend",
-      "version": "2.20.2",
+      "version": "2.21.0",
       "dependencies": {
         "@emotion/cache": "^11.14.0",
         "@emotion/react": "^11.14.0",
@@ -20,7 +20,7 @@
         "@mui/material": "^9.2.0",
         "@mui/material-pigment-css": "^9.2.0",
         "@sentry/react": "^10.69.0",
-        "@sethbacon/terraform-suite-ui": "0.8.0",
+        "@sethbacon/terraform-suite-ui": "0.8.1",
         "@tanstack/react-query": "^5.101.4",
         "@tanstack/react-query-devtools": "^5.101.4",
         "@testing-library/dom": "^10.4.1",
@@ -2522,9 +2522,9 @@
       }
     },
     "node_modules/@sethbacon/terraform-suite-ui": {
-      "version": "0.8.0",
-      "resolved": "https://npm.pkg.github.com/download/@sethbacon/terraform-suite-ui/0.8.0/793b695b6a138be8e3258f3e4512cff9f862f9fc",
-      "integrity": "sha512-lH5dI/xI47aOq1tC3j8oG6PfZcRT+du55rYuVeW4CXVMfd53p5vneJLuhPpNFDl/BY71RfWmGo2vfJ7+qsZnbg==",
+      "version": "0.8.1",
+      "resolved": "https://npm.pkg.github.com/download/@sethbacon/terraform-suite-ui/0.8.1/aa5fef1db1ee9c0d65a65df2402d4cea40367a90",
+      "integrity": "sha512-MK7or+K2nbecCByRi9ojt7kTfPdjxIIEfiELbrZM7MxDbe2tMRgh5lAj7Q9Ms4tOjuwxcw9KVrYHKau1OLFyUQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=22.0.0 <25"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,7 +32,7 @@
     "@mui/material": "^9.2.0",
     "@mui/material-pigment-css": "^9.2.0",
     "@sentry/react": "^10.69.0",
-    "@sethbacon/terraform-suite-ui": "0.8.0",
+    "@sethbacon/terraform-suite-ui": "0.8.1",
     "@tanstack/react-query": "^5.101.4",
     "@tanstack/react-query-devtools": "^5.101.4",
     "@testing-library/dom": "^10.4.1",

--- a/frontend/src/contexts/__tests__/AuthContext.test.tsx
+++ b/frontend/src/contexts/__tests__/AuthContext.test.tsx
@@ -76,13 +76,22 @@ describe('AuthProvider', () => {
     expect(latest.hasScope('modules:write')).toBe(true)
   })
 
-  it('flags an already-expired session immediately', async () => {
+  it('ends an already-expired session immediately rather than warning about it', async () => {
+    // @sethbacon/terraform-suite-ui 0.8.1 changed this to fail closed: a session
+    // already past its expiry when /me resolves is ENDED, not flagged with
+    // sessionExpiresSoon. Warning about a session the client already knows is dead
+    // leaves the UI rendered against it until the user acts on the warning, so the
+    // assertion here is that authentication is gone -- sessionExpiresSoon staying
+    // false is the point, not an omission.
     mockApi.getCurrentUserWithRole.mockResolvedValue({
       ...me,
       session_expires_at: new Date(Date.now() - 1000).toISOString(),
     })
     await renderAuth()
-    expect(latest.sessionExpiresSoon).toBe(true)
+    await waitFor(() => expect(latest.isAuthenticated).toBe(false))
+    expect(latest.user).toBeNull()
+    expect(latest.allowedScopes).toEqual([])
+    expect(latest.sessionExpiresSoon).toBe(false)
   })
 
   it('devLogin establishes a cookie session then re-resolves the user (no localStorage write)', async () => {


### PR DESCRIPTION
Closes sethbacon/terraform-suite-ui#58.

Bumps `@sethbacon/terraform-suite-ui` to **0.8.1**, which carries the remediation of audit issues #96–#118, and adds the two supply-chain checks that issue asked for.

Both go in the shared `setup-frontend` composite action rather than a single workflow, so they apply to **every** job that installs dependencies.

## 1. Assert the scope resolves to GitHub Packages (before `npm ci`)

The `@sethbacon` scope on the **public** npm registry is owned by an unrelated account — confirmed, and it is not recoverable. So a missing `frontend/.npmrc` mapping would silently resolve `@sethbacon/*` from npmjs.org and land third-party code in an authenticated SPA bundle.

The mapping already exists here and the Dockerfile already copies `.npmrc` before installing. This asserts the mapping is *in effect* rather than trusting that it is — the failure mode being guarded is a new job, a new Dockerfile stage, or an npm invocation from the wrong working directory.

## 2. Verify the library's SLSA provenance (after install)

`#58`'s actual complaint was that provenance is *produced but never verified downstream*. This makes the attestation gate the build.

## Verified before committing, not assumed

- **The attestation check discriminates.** The genuine 0.8.1 tarball verifies against an attestation from `publish.yml@refs/tags/v0.8.1`. The same tarball with a single appended byte fails with `HTTP 404` for its altered digest, exit 1. A verification step whose failure mode nobody has observed is worth very little, so this was tested explicitly.
- **Both apps typecheck clean** against 0.8.1 (`tsc --noEmit`, exit 0). This matters because 0.8.1 widened `refreshSession`'s return type from `Promise<void>` to a discriminated result and added an optional `organizationId` argument to `hasScope`. Both changes are source-compatible, and the typecheck confirms it rather than assuming it.
- **The lockfile agrees with `package.json`** at 0.8.1, with integrity matching the registry. Worth flagging: `npm install` silently rewrote the exact pin `0.8.0` to the caret range `^0.8.1`. This repo's convention is an exact pin, so it was restored — otherwise `npm ci` would resolve differently from what was reviewed.

## Correcting one thing from the issue

`#58` says provenance was "bound to on-disk dist, not the tarball", and that the upstream fix in sethbacon/terraform-suite-ui#122 was a precondition for consumer-side verification. That turns out to be only half right: **0.8.0 also verifies** against a tarball-digest attestation, because `npm publish` generates its own provenance independently of the `attest-build-provenance` step. #122 made the explicitly-attested subject correct, but tarball-level attestation already existed — so this verification did not actually depend on the 0.8.1 release.

## Changelog

- fix: bump @sethbacon/terraform-suite-ui to 0.8.1 and verify its provenance in CI
