### PR TITLE
ci: fail a PR whose breaking-change declarations cannot survive the squash

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -108,3 +108,101 @@ jobs:
           (cd e2e && npm audit --json > "$RUNNER_TEMP/e2e-audit.json") || true
           node frontend/scripts/audit-gate.mjs "$RUNNER_TEMP/e2e-audit.json" \
             --exceptions frontend/scripts/npm-audit-exceptions.json
+
+
+  # ── Breaking-change declarations survive the squash ────
+  # This repository squash-merges with
+  # squash_merge_commit_message=COMMIT_MESSAGES, so every commit body in a PR
+  # is concatenated into ONE merge commit. release-please then keeps only the
+  # FIRST `BREAKING CHANGE:` footer of that commit, and reads a `!` marker only
+  # from its header. A second declaration anywhere in the PR is therefore
+  # dropped in silence: the change ships with no changelog entry, no upgrade
+  # note, and nothing failing to say so.
+  #
+  # This is not hypothetical. terraform-registry-backend v4.0.0 shipped two
+  # undocumented breaking changes this way -- including one that breaks CI
+  # tokens -- and terraform-state-manager-backend 3.1.0 lost three before the
+  # release was cut.
+  #
+  # Splitting the footers across separate commits does not help; the squash
+  # concatenates them back. One merged commit can announce exactly one breaking
+  # change. Either open one PR per breaking change, or combine them into a
+  # single footer and write each up in the upgrade guide.
+  breaking-change-footers:
+    name: Breaking-change footers survive the squash
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Count breaking-change declarations across this PR's commits
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/commits" \
+            --jq '.[] | {sha: .sha[0:7], msg: .commit.message}' > commits.ndjson
+
+          total=0
+          report=""
+          while IFS= read -r line; do
+            [ -n "$line" ] || continue
+            sha=$(jq -r '.sha' <<<"$line")
+            msg=$(jq -r '.msg' <<<"$line")
+            subject=$(head -n1 <<<"$msg")
+
+            # Spec allows both spellings of the footer token.
+            footers=$(grep -cE '^BREAKING[ -]CHANGE:' <<<"$msg" || true)
+            if [ "$footers" -gt 0 ]; then
+              # A footer wins over the header's `!`, so they are not additive.
+              n="$footers"
+            elif printf '%s' "$subject" | grep -qE '^[a-zA-Z]+(\([^)]*\))?!:'; then
+              n=1
+            else
+              n=0
+            fi
+
+            if [ "$n" -gt 0 ]; then
+              report="${report}  ${sha}  ${n} declaration(s)  ${subject}"$'\n'
+            fi
+            total=$((total + n))
+          done < commits.ndjson
+
+          echo "Breaking-change declarations in this PR: $total"
+          if [ -n "$report" ]; then
+            printf 'Where they are:\n%s' "$report"
+          fi
+
+          if [ "$total" -le 1 ]; then
+            echo "OK: at most one declaration, so the squash loses nothing."
+            exit 0
+          fi
+
+          {
+            echo "### Breaking-change declarations do not survive the squash"
+            echo
+            echo "This PR declares **$total** breaking changes. The squash-merge"
+            echo "concatenates every commit body into one commit, and release-please"
+            echo "keeps only the **first** \`BREAKING CHANGE:\` footer of a commit."
+            echo "The other $((total - 1)) would ship with no changelog entry and no notice."
+            echo
+            echo '```'
+            printf '%s' "$report"
+            echo '```'
+            echo
+            echo "Two ways out:"
+            echo
+            echo "1. **One PR per breaking change.** Preferred when they are independent."
+            echo "2. **One footer.** Combine the declarations into a single"
+            echo "   \`BREAKING CHANGE:\` footer and write each one up in the upgrade"
+            echo "   guide, which is where an operator preparing an upgrade looks."
+            echo
+            echo "Moving the footers into separate commits within this PR does **not**"
+            echo "work -- the squash concatenates them back into one commit body."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          echo "::error::This PR declares $total breaking changes; the squash keeps only the first. See the job summary."
+          exit 1


### PR DESCRIPTION
## The defect

Every repo in this suite squash-merges with
`squash_merge_commit_message=COMMIT_MESSAGES`, so a PR's commit bodies concatenate
into **one** merge commit. release-please then keeps only the **first**
`BREAKING CHANGE:` footer of that commit, and reads a `!` marker only from its
header. Any further declaration is dropped in silence — no changelog entry, no
upgrade note, and nothing failing to say so.

## It has already happened twice

| repo | PR | footers | announced | caught |
|---|---|---|---|---|
| terraform-registry-backend | #786 | 3 | 1 | **no — v4.0.0 is published** |
| terraform-state-manager-backend | #346 | 4 | 1 | yes, by reading the notes before the cut |

The registry case is the bad one: two breaking changes are live in the released
binary with no notice, and one of them `403`s any CI job that calls
`/auth/refresh` with an API key.

## What this adds

One job in `pr-checks.yml`. It reads the PR's commits, counts breaking-change
declarations (`BREAKING CHANGE:` / `BREAKING-CHANGE:` footers, or a `type(scope)!:`
header when a commit has no footer), and fails above one — with a job summary
naming the offending commits and the two shapes that do work:

1. **One PR per breaking change** — preferred when they are independent.
2. **One footer**, with each change written up in the upgrade guide.

Moving footers into separate commits *within* the PR is explicitly called out as
not working, since that is the intuitive fix and it silently isn't one.

## Validation

The counter was run against real history before landing:

```
registry #786  -> 3   (the failure)          FAIL
TSM      #346  -> 4   (the failure)          FAIL
registry #784  -> 0                          pass
registry #790  -> 1   (`chore(identity)!:`)  pass
TSM      #344  -> 1   (`chore(identity)!:`)  pass
```

So it catches both real incidents and does not fire on ordinary PRs, including
the `!`-header-without-footer shape.

## Not required yet

Left as a non-required check. Promote it in branch protection once it has run
green on a few PRs.
