### PR TITLE
ci: the checkout pin comment says v6 and the SHA is v7.0.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/setup-frontend
 
       - name: Lint
@@ -34,7 +34,7 @@ jobs:
     name: Typecheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/setup-frontend
 
       - name: Typecheck
@@ -54,7 +54,7 @@ jobs:
       matrix:
         shard: [1, 2, 3, 4]
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/setup-frontend
 
       - name: Run tests (shard ${{ matrix.shard }}/${{ strategy.job-total }})
@@ -90,7 +90,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: unit-test
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/setup-frontend
 
       - name: Download blob reports
@@ -175,7 +175,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/setup-frontend
 
       - name: Build
@@ -198,7 +198,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/setup-frontend
 
       - name: Log in to GHCR
@@ -275,7 +275,7 @@ jobs:
       'workflow_call' || github.ref == 'refs/heads/main'
 
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/setup-frontend
         with:
           install-deps: "false"
@@ -391,7 +391,7 @@ jobs:
     if: github.event_name == 'pull_request'
 
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/setup-frontend
         with:
           install-deps: "false"

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -49,7 +49,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Review dependency changes
         # v5.0.0
@@ -83,7 +83,7 @@ jobs:
       # (#598) -- matches ci.yml's workflow-level grant for the same reason.
       packages: read
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/setup-frontend
         with:
           install-e2e-deps: "true"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
     outputs:
       version: ${{ steps.tag.outputs.value }}
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0 # need full history to walk ancestry
 
@@ -102,7 +102,7 @@ jobs:
       digest: ${{ steps.build.outputs.digest }}
 
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0

--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -23,7 +23,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:

--- a/.github/workflows/weekly-security.yml
+++ b/.github/workflows/weekly-security.yml
@@ -48,7 +48,7 @@ jobs:
       contents: read
       packages: read
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/setup-frontend
         with:
           install-e2e-deps: "true"
@@ -79,7 +79,7 @@ jobs:
     permissions:
       security-events: write
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Run OSV Scanner
         # v2.3.8
@@ -130,7 +130,7 @@ jobs:
       matrix:
         language: [javascript-typescript, actions, python]
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Initialize CodeQL
         # v4

--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: Checkout source repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0


### PR DESCRIPTION
## The comment and the SHA disagree

Every `actions/checkout` pin in this repository reads:

```yaml
uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
```

That SHA is tagged **v7.0.1** (and `v7`) upstream. `v6` is `d23441a48e51` — a
different commit.

```
$ gh api repos/actions/checkout/git/ref/tags/v6     -> d23441a48e516b6c34aea4fa41551a30e30af803
$ gh api repos/actions/checkout/git/ref/tags/v7.0.1 -> 3d3c42e5aac5ba805825da76410c181273ba90b1
```

So CI has been running checkout **v7** while every comment claimed **v6**. The SHA
is what executes; the comment is what a reviewer reads. A major-version bump of
the most privileged action in the pipeline was never reviewed as one.

**Comment-only — no SHA changes.** Nothing about what CI runs changes here.

## Deliberately not touched

`# v4` on `actions/attest-build-provenance` and `# v7` on `actions/github-script`
are **floating major** labels whose tag has since moved past the pinned commit.
That is the normal convention for a major-tag pin, not a false statement about the
major, so they stay. I verified those steps still work rather than assuming: the
`Attest build provenance` steps succeeded in the most recent release run.

## Why this drifted everywhere at once

| repo | mislabelled `# v6` | correct `# v7` | runs zizmor |
|---|---|---|---|
| terraform-registry-backend | 18 | 0 | no |
| terraform-registry-frontend | 17 | 0 | no |
| terraform-state-manager-backend | 12 | 0 | no |
| terraform-state-manager-frontend | 11 | 0 | no |
| terraform-suite-identity | 7 | 0 | no |
| security-orchestration | 7 | 0 | no |
| **terraform-suite-ui** | **0** | **9** | **yes** |

The one repository that labels this SHA correctly is the one running zizmor, whose
`ref-version-mismatch` audit is precisely this check. That is the durable fix, and
it is **not** bundled here — zizmor lints considerably more than pin comments and
adding it to six repositories with established workflows needs its own remediation
pass rather than riding along on a comment correction.
