### PR TITLE
fix(auth): a route can no longer become public by losing a map key

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -82,31 +82,31 @@ function App() {
                         <Route path="/modules" element={<ModulesPage />} />
                         <Route
                           path="/modules/:namespace/:name/:system"
-                          element={<LazyRoute Component={ModuleDetailPage} />}
+                          element={<LazyRoute Component={ModuleDetailPage} isPublic />}
                         />
 
                         {/* Providers */}
                         <Route path="/providers" element={<ProvidersPage />} />
                         <Route
                           path="/providers/:namespace/:type"
-                          element={<LazyRoute Component={ProviderDetailPage} />}
+                          element={<LazyRoute Component={ProviderDetailPage} isPublic />}
                         />
 
                         {/* Terraform Binaries */}
                         <Route path="/terraform-binaries" element={<TerraformBinariesPage />} />
                         <Route
                           path="/terraform-binaries/:name"
-                          element={<LazyRoute Component={TerraformBinaryDetailPage} />}
+                          element={<LazyRoute Component={TerraformBinaryDetailPage} isPublic />}
                         />
 
                         {/* API Documentation */}
                         <Route
                           path="/api-docs"
-                          element={<LazyRoute Component={ApiDocumentation} />}
+                          element={<LazyRoute Component={ApiDocumentation} isPublic />}
                         />
 
                         {/* Settings & Privacy */}
-                        <Route path="/settings" element={<LazyRoute Component={SettingsPage} />} />
+                        <Route path="/settings" element={<LazyRoute Component={SettingsPage} isPublic />} />
 
                         {/* Admin routes (protected with scope requirements from routeScopes.ts) */}
                         <Route
@@ -307,7 +307,7 @@ function App() {
                         {import.meta.env.DEV && (
                           <Route
                             path="/dev/components"
-                            element={<LazyRoute Component={ComponentShowcase} />}
+                            element={<LazyRoute Component={ComponentShowcase} isPublic />}
                           />
                         )}
 

--- a/frontend/src/__tests__/routeScopeParity.test.ts
+++ b/frontend/src/__tests__/routeScopeParity.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest'
+// Vite's `?raw` import rather than node:fs. It needs no @types/node and no
+// path arithmetic relative to the test file's runtime location, and it is
+// resolved by the same bundler that builds the app, so the file this reads is
+// unambiguously the file that ships. vite-env.d.ts already references
+// vite/client, which declares the `*?raw` module shape.
+import appSource from '../App.tsx?raw'
+import { ADMIN_ROUTE_SCOPES } from '../routeScopes'
+
+/**
+ * Parity guard between App.tsx's route wiring and routeScopes.ts (#693).
+ *
+ * The typing added for #686 makes a MISSING map key a compile error, which is
+ * the strong half of that fix. This is the half the compiler cannot do: it
+ * reads App.tsx as text and checks the two files still describe the same set of
+ * routes, in both directions.
+ *
+ * Bidirectional on purpose. A one-way check ("every route has a key") passes
+ * forever while the map accumulates entries for routes that no longer exist,
+ * and a stale entry is how the sidebar keeps advertising a page that 404s. The
+ * same reasoning as any allowlist guard: an entry that no longer corresponds to
+ * anything is a finding, not a leftover.
+ */
+
+/** Every `<Route path="/admin...">` block, with its element markup. */
+function adminRouteBlocks(): { path: string; element: string }[] {
+  const blocks: { path: string; element: string }[] = []
+  const routeRe = /<Route\s+path="(\/admin[^"]*)"\s+element=\{([\s\S]*?)\}\s*\/>/g
+  let m: RegExpExecArray | null
+  while ((m = routeRe.exec(appSource)) !== null) {
+    blocks.push({ path: m[1], element: m[2] })
+  }
+  return blocks
+}
+
+describe('admin route scope parity (#693)', () => {
+  const blocks = adminRouteBlocks()
+
+  it('finds the admin routes at all', () => {
+    // If the regex stops matching (App.tsx reformatted, Route spelled
+    // differently), every assertion below would vacuously pass over an empty
+    // list. An empty universe is the failure mode this whole guard exists to
+    // prevent, so it is asserted first.
+    expect(blocks.length).toBeGreaterThanOrEqual(
+      Object.keys(ADMIN_ROUTE_SCOPES).length,
+    )
+  })
+
+  it('every gated admin route reads its scope from ADMIN_ROUTE_SCOPES', () => {
+    const gated = blocks.filter((b) => b.element.includes('<LazyRoute'))
+    const missing = gated
+      .filter((b) => !(b.path in ADMIN_ROUTE_SCOPES))
+      .map((b) => b.path)
+    expect(missing, 'admin routes with no entry in ADMIN_ROUTE_SCOPES').toEqual([])
+  })
+
+  it('no admin route is marked public', () => {
+    // `isPublic` on an /admin route compiles cleanly — it is a legitimate shape
+    // for the public pages — but on an admin path it is the #686 fail-open
+    // reintroduced deliberately rather than by accident.
+    const publicAdmin = blocks
+      .filter((b) => b.element.includes('isPublic'))
+      .map((b) => b.path)
+    expect(publicAdmin, 'admin routes wired with isPublic').toEqual([])
+  })
+
+  it('every ADMIN_ROUTE_SCOPES entry corresponds to a real route', () => {
+    const routed = new Set(blocks.map((b) => b.path))
+    const orphaned = Object.keys(ADMIN_ROUTE_SCOPES).filter((p) => !routed.has(p))
+    expect(orphaned, 'ADMIN_ROUTE_SCOPES keys with no route in App.tsx').toEqual([])
+  })
+
+  it('redirect-only admin routes are allowed to have no scope entry', () => {
+    // /admin/upload is a <Navigate> to /admin/upload/module. It renders no page,
+    // so it has nothing to gate; the target route carries the scope. This is
+    // asserted rather than merely tolerated, so that turning a redirect into a
+    // real page without adding a scope entry fails the test above instead of
+    // quietly matching this exemption.
+    const redirects = blocks.filter((b) => b.element.includes('<Navigate'))
+    for (const r of redirects) {
+      expect(
+        r.element.includes('<LazyRoute'),
+        `${r.path} is exempt as a redirect but also renders a LazyRoute`,
+      ).toBe(false)
+    }
+  })
+})

--- a/frontend/src/components/LazyRoute.tsx
+++ b/frontend/src/components/LazyRoute.tsx
@@ -6,22 +6,38 @@ import type { ScopeValue } from '../types/rbac'
 
 const loader = <div>Loading...</div>
 
-interface LazyRouteProps {
-  Component: ComponentType
-  /**
-   * Omit for a public route (no auth gate). Pass `null` for a route that
-   * requires an authenticated user but no specific scope. Pass a scope
-   * string for a route gated on that scope (via ProtectedRoute).
-   */
-  requiredScope?: ScopeValue | null
-}
+/**
+ * A route is either explicitly public, or it states a scope requirement. There
+ * is no third shape.
+ *
+ * Omitting `requiredScope` used to mean "public", which made "public" the value
+ * a MISSING map key produced -- so a renamed admin path silently downgraded an
+ * admin page to fully anonymous, the strongest possible fail-open, with no
+ * compile error (#686). Public is now something a route has to SAY.
+ */
+type LazyRouteProps = { Component: ComponentType } & (
+  | {
+      /** No auth gate at all. Must be stated; it is never inferred. */
+      isPublic: true
+      requiredScope?: never
+    }
+  | {
+      isPublic?: false
+      /**
+       * `null` requires an authenticated user but no specific scope; a scope
+       * string gates the route on it (via ProtectedRoute). Required -- there is
+       * no value that means "no gate" here.
+       */
+      requiredScope: ScopeValue | null
+    }
+)
 
 /**
  * Composes the ErrorBoundary + Suspense (+ optional ProtectedRoute) wrapper
  * that every lazy-loaded route in App.tsx needs, so route definitions only
  * specify the component and its scope requirement.
  */
-const LazyRoute = ({ Component, requiredScope }: LazyRouteProps) => {
+const LazyRoute = ({ Component, ...gate }: LazyRouteProps) => {
   const body = (
     <ErrorBoundary>
       <Suspense fallback={loader}>
@@ -30,11 +46,13 @@ const LazyRoute = ({ Component, requiredScope }: LazyRouteProps) => {
     </ErrorBoundary>
   )
 
-  if (requiredScope === undefined) {
+  if (gate.isPublic) {
     return body
   }
 
-  return <ProtectedRoute requiredScope={requiredScope ?? undefined}>{body}</ProtectedRoute>
+  // `requiredScope` is non-optional on this branch of the union, so there is no
+  // undefined case left to fall through to the ungated `body` above.
+  return <ProtectedRoute requiredScope={gate.requiredScope ?? undefined}>{body}</ProtectedRoute>
 }
 
 export default LazyRoute

--- a/frontend/src/navigation.tsx
+++ b/frontend/src/navigation.tsx
@@ -21,7 +21,7 @@ import Security from '@mui/icons-material/Security'
 import History from '@mui/icons-material/History'
 import Notifications from '@mui/icons-material/Notifications'
 import type { NavItem, NavGroup } from '@sethbacon/terraform-suite-ui'
-import { ADMIN_ROUTE_SCOPES } from './routeScopes'
+import { adminRouteScopeForPath } from './routeScopes'
 import type { ScopeValue } from './types/rbac'
 
 // Reads the scope for an admin nav item from the shared route-scope map
@@ -32,7 +32,7 @@ import type { ScopeValue } from './types/rbac'
 // package), but this keeps ADMIN_ROUTE_SCOPES's compile-time protection
 // intact through this call site instead of discarding it here.
 function adminScope(path: string): ScopeValue | null {
-  return ADMIN_ROUTE_SCOPES[path] ?? null
+  return adminRouteScopeForPath(path)
 }
 
 // Home — shown standalone at the top of the drawer.

--- a/frontend/src/routeScopes.ts
+++ b/frontend/src/routeScopes.ts
@@ -11,7 +11,16 @@ import type { ScopeValue } from './types/rbac'
 // authenticated users" convention). Values are typed as the canonical
 // ScopeValue union (#633) so a typo'd/retired scope is a compile error
 // instead of silently drifting from types/rbac.ts's AVAILABLE_SCOPES.
-export const ADMIN_ROUTE_SCOPES: Record<string, ScopeValue | null> = {
+//
+// The object is `as const satisfies ...` rather than annotated
+// `Record<string, ScopeValue | null>`. That annotation gave the map an INDEX
+// SIGNATURE, so `ADMIN_ROUTE_SCOPES['/admin/typo']` type-checked and evaluated
+// to `undefined` at runtime -- and `undefined` was LazyRoute's sentinel for
+// "public route, no auth gate at all". A renamed admin path or an entry dropped
+// in a refactor therefore downgraded an admin page from scope-gated to fully
+// anonymous, with no compile error and nothing failing (#686). Keying on the
+// literal union makes that a compile error at every call site instead.
+export const ADMIN_ROUTE_SCOPES = {
   '/admin': null,
   '/admin/users': 'users:read',
   '/admin/organizations': 'organizations:read',
@@ -33,4 +42,22 @@ export const ADMIN_ROUTE_SCOPES: Record<string, ScopeValue | null> = {
   '/admin/security-scanning': 'admin',
   '/admin/notifications': 'admin',
   '/admin/branding': 'admin',
+} as const satisfies Record<string, ScopeValue | null>
+
+/** Every path ADMIN_ROUTE_SCOPES knows about. Indexing with anything else is a
+ * compile error, which is the point. */
+export type AdminRoutePath = keyof typeof ADMIN_ROUTE_SCOPES
+
+/**
+ * Scope lookup for consumers that hold a plain `string` and cannot narrow it --
+ * today, the sidebar, whose NavItem paths come from the out-of-tree
+ * @sethbacon/terraform-suite-ui package.
+ *
+ * It defaults to `null` (authenticated users only), NOT to "public". That
+ * asymmetry is deliberate: an unrecognised path should hide a nav item behind
+ * auth, never expose a route. The route side does not use this function at all
+ * -- it indexes the map directly, so a missing key stops the build.
+ */
+export function adminRouteScopeForPath(path: string): ScopeValue | null {
+  return (ADMIN_ROUTE_SCOPES as Record<string, ScopeValue | null>)[path] ?? null
 }


### PR DESCRIPTION
Closes #686. Closes #693.

## The fail-open

`ADMIN_ROUTE_SCOPES` was annotated `Record<string, ScopeValue | null>`, which gave it an **index signature**. So `ADMIN_ROUTE_SCOPES['/admin/typo']` type-checked and evaluated to `undefined` — and `LazyRoute` read `undefined` as *"public route, no auth gate at all"*.

A renamed admin path, or an entry dropped in a refactor, therefore silently downgraded an admin page from scope-gated to **fully anonymous**. No compile error. Nothing failing to say so.

The two consumers even degraded in **opposite directions** from the same missing key:

| consumer | missing key becomes |
|---|---|
| `navigation.tsx` (`?? null`) | sidebar item hidden behind auth |
| `App.tsx` route guard | **route open to everyone** |

So the file's own "the two can't drift out of sync" guarantee held asymmetrically, in the wrong direction.

Current parity was intact — all 21 gated routes had keys — so this was **latent**, not an active exposure.

## Both halves closed

- `ADMIN_ROUTE_SCOPES` is now `as const satisfies Record<...>`, so it keys on the **literal union**. Indexing with an unknown path is a compile error at every call site.
- `LazyRoute` takes a **discriminated union**: either `isPublic`, or a *required* `requiredScope`. There is no third shape and no value meaning "no gate", so a missing key cannot produce a public route even in principle. The six genuinely public routes now say so.
- `navigation.tsx` keeps its fail-closed default through `adminRouteScopeForPath()` — the one place the widened `string` lookup lives, because sidebar paths come from the out-of-tree suite-ui package and cannot be narrowed here. It defaults to `null` (authenticated only), never to public.

## The parity guard (#693) — what the compiler can't do

Reads App.tsx as text, checks **both directions**. A one-way "every route has a key" check passes forever while the map accumulates entries for routes that no longer exist, and a stale entry is how a sidebar keeps advertising a page that 404s.

It also asserts:

- no `/admin` route is wired `isPublic` — which compiles fine, and is the same fail-open reintroduced deliberately rather than by accident;
- that it matched a **non-empty** route set at all, since a reformat of App.tsx would otherwise make every assertion vacuously pass over zero blocks.

Redirect-only routes are exempt and the exemption is **asserted, not tolerated**: `/admin/upload` is a `<Navigate>` with nothing to gate, and turning it into a real page without a scope entry fails the parity check rather than quietly matching the exemption.

The test reads App.tsx through Vite's `?raw` import rather than `node:fs` — no `@types/node`, no path arithmetic, and it is resolved by the same bundler that builds the app, so the file it reads is the file that ships.

## Verification

Each mutation simulated against the real App.tsx:

| mutation | flagged |
|---|---|
| map entry whose route was deleted | `/admin/removed-page` |
| admin route wired `isPublic` | `/admin/users` |
| reformat so the regex stops matching | 0 blocks vs the `>= 21` assertion |

Typecheck clean (the only local errors are `BrandingSettingsCard` from this checkout's stale suite-ui 0.7.1 vs the pinned 0.8.1 — unrelated, and CI resolves the real version).