### PR TITLE
ci: grant contents:read so checkout is not relying on the repo being public

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,14 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
+  # A permissions block REPLACES the default set rather than adding to it, so an
+  # omitted scope is 'none'. Without contents:read every job here ran
+  # actions/checkout with no read access to this repository -- which worked only
+  # because the repository is public and a public clone needs no credential. The
+  # declared set now matches the access the workflow actually exercises.
+  contents: read
+  # npm ci in frontend/ resolves @sethbacon/terraform-suite-ui from
+  # npm.pkg.github.com.
   packages: read
 
 jobs:


### PR DESCRIPTION
## The defect

`ci.yml` declares workflow-level `permissions: packages: read`, and **no job sets its own block**. A permissions block is a *replacement*, not an addition — every unlisted scope drops to `none`, including `contents`.

So every job in this workflow runs `actions/checkout` with a `GITHUB_TOKEN` that has **no read access to the repository's contents**.

## Why it works anyway

The repository is **public**, and cloning a public repository needs no credential at all.

The checkout is not being authorized — it is bypassing authorization. And the declared permission set states something about this pipeline that is not true of it.

## When it stops working

The moment the repository turns private, or is transferred to an organization whose default visibility differs. Then every job fails at its first step with an authentication error, and the cause is a permission that was already wrong months earlier.

Worth noting given the pending `4cloudguru` move — not these repos, but the same mechanism.

## The change

`contents: read` is not a widening in any meaningful sense. It is the access the workflow already exercises, stated. `packages: read` stays: `npm ci` in `frontend/` resolves `@sethbacon/terraform-suite-ui` from `npm.pkg.github.com`.

## Class, not instance

Found by sweeping **every** workflow in the suite for a top-level `permissions` block that omits `contents` while its jobs check out — not by reading the one file the issue named:

| repo | file | checkout jobs at `contents: none` |
|---|---|---|
| terraform-registry-frontend | `ci.yml` | 8 |
| terraform-state-manager-frontend | `ci.yml` | 4 |

No other workflow in any of the seven repos has the shape. The sibling frontend gets the identical change.
