### PR TITLE
docs: correct three claims the code does not support

### DIFF
--- a/ACCESSIBILITY.md
+++ b/ACCESSIBILITY.md
@@ -16,7 +16,7 @@ components.
 
 | Area                      | Approach                                                                                                                                    |
 | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Automated testing**     | `@axe-core/react` runs in development; Playwright + `@axe-core/playwright` enforces zero critical/serious violations across all pages in CI |
+| **Automated testing**     | `@axe-core/react` runs in development. In CI, Playwright + `@axe-core/playwright` **enforce** zero critical/serious violations on the four core public pages (Home, Login, Modules, Providers); the other 20 audited routes — every `/admin/*` page, plus Terraform Binaries and API Documentation — are scanned and their violations logged as warnings, but do **not** fail the build. See [Enforcement tiers](#enforcement-tiers). |
 | **Linting**               | `eslint-plugin-jsx-a11y` enforces accessible JSX patterns at **error** level in CI                                                          |
 | **Keyboard navigation**   | All interactive elements are reachable via keyboard; the command palette (`Ctrl+K` / `⌘K`) provides keyboard-first navigation               |
 | **Skip link**             | A "Skip to main content" link is the first focusable element on every page                                                                  |
@@ -25,8 +25,31 @@ components.
 | **Screen reader support** | ARIA landmarks, roles, and labels are applied; route changes are announced via a live region                                                |
 | **Reduced motion**        | All MUI transitions are disabled when `prefers-reduced-motion: reduce` is active                                                            |
 
+## Enforcement tiers
+
+Automated accessibility coverage is **tiered**, not uniform. `e2e/tests/accessibility.spec.ts`
+is the source of truth; this table describes what it actually does.
+
+| Tier | Routes | On a critical/serious violation |
+| --- | --- | --- |
+| **Enforced** | Home, Login, Modules, Providers (4) | the build **fails** |
+| **Audited** | Terraform Binaries, API Documentation (2) | logged as a warning |
+| **Audited** | every `/admin/*` page (18) | logged as a warning |
+
+The audited tiers call `warnA11yViolations()`, which only `console.warn`s and
+never asserts, so they cannot fail CI. Roughly 20 of the ~24 scanned routes are
+therefore warn-only.
+
+This is a deliberate staging position, not a claim of full coverage: violations
+on admin pages are visible in CI output and tracked for incremental remediation,
+and routes graduate to the enforced tier as they are cleared. Anyone assessing
+WCAG 2.1 AA conformance evidence should read the enforced list as the guaranteed
+surface and treat the rest as audited-but-unblocking.
+
 ## Known Limitations
 
+- Automated enforcement covers only the four core public pages; see
+  [Enforcement tiers](#enforcement-tiers).
 - Some third-party components (Swagger UI, cmdk command palette) have partial
   ARIA coverage — we apply workarounds where possible.
 - Chart/graph visualizations on the admin dashboard do not yet include

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -103,7 +103,7 @@ The following are stored in the browser's `localStorage`, not as cookies:
 | `user`                         | Cached profile info (id, email, name) for the signed-in user. Cleared on logout or session expiry. | Session  |
 | `role_template`                | Cached role template for the signed-in user. Cleared on logout or session expiry. | Session  |
 | `allowed_scopes`                | Cached authorization scopes for the signed-in user. Cleared on logout or session expiry. | Session  |
-| `authorized`                   | Swagger UI's own "Authorize" dialog state (`/api-docs`), persisted by the third-party `swagger-ui-react` component when a user authorizes a request there. May contain an API key if one was entered. Cleared on logout or session expiry. | Session  |
+| `authorized`                   | Swagger UI's own "Authorize" dialog state (`/api-docs`). **Nothing writes this key.** The `swagger-ui-react` component only persists it when `persistAuthorization` is enabled, which this app deliberately does not enable (asserted by a test). Kept here only so a one-time cleanup can purge a stale value left by a build from before that was settled. Cleared on logout or session expiry. | Session  |
 | `terraform-registry-theme`   | UI theme (light/dark) | Persistent |
 | `terraform-registry-consent` | Consent preferences   | Persistent |
 

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -11,6 +11,12 @@ interface ImportMetaEnv {
   readonly VITE_ERROR_REPORTING_DSN?: string
   readonly VITE_SENTRY_DSN?: string
   readonly VITE_PERFORMANCE_DSN?: string
+  // Comma-separated extra origins that isSafeExternalUrl() will treat as
+  // in-app. Read in utils/externalUrl.ts and documented in README.md and
+  // SECURITY.md; without it here, import.meta.env access to it was untyped, so
+  // a typo in the NAME degraded silently to undefined -- which this variable
+  // reads as "no extra origins allowed" rather than as a configuration error.
+  readonly VITE_ALLOWED_EXTERNAL_ORIGINS?: string
 }
 
 interface ImportMeta {


### PR DESCRIPTION
Closes #676. Closes #694. Closes #699.

All three are the same defect — **a document asserting a behaviour the code does not have**. Each verified against the implementation rather than taken from the report.

## ACCESSIBILITY.md — "across all pages" describes a different control

The claim was that axe *"enforces zero critical/serious violations across all pages in CI"*. What `e2e/tests/accessibility.spec.ts` actually does:

| tier | routes | on a critical/serious violation |
|---|---|---|
| `enforcedRoutes` | Home, Login, Modules, Providers (**4**) | build **fails** |
| `auditedRoutes` | Terraform Binaries, API Documentation (**2**) | `console.warn` |
| `adminRoutes` | every `/admin/*` page (**18**) | `console.warn` |

The audited tiers call `warnA11yViolations()`, which never asserts — **20 of ~24 scanned routes cannot fail CI**.

This is not an overstatement of degree; it names a different control from the one implemented, and it is the sentence an enterprise auditor reads as WCAG 2.1 AA conformance evidence.

Replaced with the tiered reality plus an **Enforcement tiers** section carrying the real counts and naming the spec file as the source of truth — so the claim is *checkable*, not merely rephrased.

## PRIVACY.md — overstated collection

It listed an `authorized` localStorage key as an active flow that *"may contain an API key if one was entered"*.

`swagger-ui-react` only writes that key under `persistAuthorization`, which this app **deliberately does not enable** — asserted by a test:

```
ApiDocumentation.test.tsx:295
  it('does not enable persistAuthorization (nothing auth-shaped may persist to localStorage)')
```

So the notice told users their API key might be sitting in localStorage when the code specifically prevents it. A privacy notice that *overstates* collection is still wrong, and it is the direction that erodes trust in the rest of the document.

Rewritten to match the `auth_token` row directly above it, which already uses the accurate "nothing writes this, kept only for one-time cleanup" phrasing. The key stays in `AUTH_STORAGE_KEYS` so `clearAuthStorage()` still purges stale values left by older builds.

## vite-env.d.ts — an untyped env var

`VITE_ALLOWED_EXTERNAL_ORIGINS` is documented in README.md and SECURITY.md and read by `utils/externalUrl.ts:29`, but was absent from `ImportMetaEnv`.

That interface is the enumeration of this app's environment surface, so the omission left the access untyped: a typo in the variable **name** degraded silently to `undefined`, which `externalUrl.ts` reads as *"no extra origins allowed"* rather than as a misconfiguration. Now declared, with the reason.

## Note

The a11y tier table is prose describing route counts in a spec file — the same drift can recur. A parity guard like the one in #717 would fix that durably, but the route lists live in `e2e/`, outside the frontend Vite root, so it needs more than a `?raw` import. Flagging rather than half-building it.