### PR TITLE
fix(ci): Dependabot auto-merge read the App ID from the wrong place

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -48,7 +48,12 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.DEPENDABOT_APP_ID }}
+          # `client-id` + `vars.`, matching release-please.yml and every other
+          # app-token step in the suite. This step alone said
+          # `app-id: ${{ secrets.DEPENDABOT_APP_ID }}`, and the ID is a repository
+          # VARIABLE, not a secret -- so the expression resolved to empty and the
+          # step failed every run with "must be set to a non-empty string".
+          client-id: ${{ vars.DEPENDABOT_APP_ID }}
           private-key: ${{ secrets.DEPENDABOT_APP_PRIVATE_KEY }}
 
       - name: Fetch Dependabot metadata


### PR DESCRIPTION
## Not a credentials problem

The token step said:

```yaml
app-id: ${{ secrets.DEPENDABOT_APP_ID }}
```

`DEPENDABOT_APP_ID` is a repository **variable**, not a secret. `secrets.` of a name that exists only in `vars.` resolves to empty, so every run failed at the first step with:

> The 'client-id' (or deprecated 'app-id') input must be set to a non-empty string. If using a secret or variable, ensure it is available in this workflow context.

That message reads like a missing credential. It isn't one — the value has been present as a variable since **2026-07-10**, the same day `DEPENDABOT_APP_PRIVATE_KEY` was added as a secret. Both halves were configured; only the expression was wrong.

## It was also the last user of the deprecated input

| workflow | how it reads the App ID |
|---|---|
| `release-please.yml` (here) | `client-id: ${{ vars.RELEASE_DISPATCH_APP_ID }}` |
| the other five repos | `client-id: ${{ vars.RELEASE_DISPATCH_APP_ID }}` |
| **`dependabot-automerge.yml`** | **`app-id: ${{ secrets.DEPENDABOT_APP_ID }}`** |

The stored value is a client ID (`Iv23li…` format), which is what `client-id` expects — so this fixes the lookup *and* drops the deprecation warning the logs have been printing next to the failure.

## What it cost

**No Dependabot PR in this repository has ever auto-merged.** They have all sat waiting for a human — including security updates, which is the one category this workflow exists to land quickly. Today's `dompurify` bump (#715) was merged by hand for exactly this reason.

Verified: the trigger is `pull_request_target`, so this runs in the base-repo context with ordinary Actions secrets and variables — the Dependabot secret store is not involved and does not need populating.