### PR TITLE
ci: pin actions/setup-node to one version across the repository

### DIFF
--- a/.github/actions/setup-frontend/action.yml
+++ b/.github/actions/setup-frontend/action.yml
@@ -31,7 +31,7 @@ runs:
   using: composite
   steps:
     - name: Set up Node
-      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: ${{ inputs.node-version }}
         cache: "npm"


### PR DESCRIPTION
Closes #688.

`setup-frontend/action.yml` pinned **v6.4.0** while `translate.yml` pinned **v7.0.0** — so which Node toolchain a job got depended on which entry point it came through.

| file | was | now |
|---|---|---|
| `.github/actions/setup-frontend/action.yml` | `48b55a011bda` # v6.4.0 | `820762786026` # v7.0.0 |
| `.github/workflows/translate.yml` | `820762786026` # v7.0.0 | unchanged |

Two pins for one action is not itself an exploit, but it is the shape that makes a supply-chain review answer *"it depends"*: a reviewer clearing the newer pin has no reason to look for an older one still live elsewhere, and a Dependabot bump moves one and leaves the other.

The **composite action** was the stale side — the harder one to notice, since it has no `uses:` line in any workflow file to grep past. Same reason the template-injection High in that file survived until zizmor scanned outside `.github/workflows/`.

Verified: no action under `.github/` is pinned to more than one SHA, and zizmor is still clean over the full tree with online audits enabled.