### PR TITLE
fix(ci): repair the empty `with:` blocks that broke five workflows at startup

### DIFF
--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -24,7 +24,6 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 # zizmor: ignore[artipacked] -- opens the translations PR
-        with:
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:

--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -43,7 +43,6 @@ jobs:
     steps:
       - name: Checkout source repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 # zizmor: ignore[artipacked] -- pushes the generated wiki
-        with:
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -48,3 +48,30 @@ jobs:
           # on the diff instead, which is where the person who can fix them is.
           advanced-security: false
           annotations: true
+
+  # ── Workflow schema (actionlint) ───────────────────────
+  # zizmor lints workflows for SECURITY; it does not check that they are valid
+  # GitHub Actions files. That gap shipped a real outage: removing a key left an
+  # empty `with:` behind, which is a schema error, and five workflows across
+  # three repositories failed at STARTUP -- zero jobs, no logs, and a run listed
+  # by file path instead of name because GitHub could not parse far enough to
+  # read it. Both yaml.safe_load and zizmor accepted the file.
+  #
+  # A startup failure runs no jobs, so it cannot fail a required check either.
+  # Nothing in the pipeline was in a position to notice.
+  actionlint:
+    name: Workflow schema (actionlint)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: actionlint
+        run: |
+          set -euo pipefail
+          bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/v1.7.7/scripts/download-actionlint.bash) 1.7.7
+          # shellcheck/pyflakes are separate concerns and not installed here; the
+          # schema check is the part that prevents a startup failure.
+          ./actionlint -shellcheck= -pyflakes= -color


### PR DESCRIPTION
**I broke these.** `main` currently has five workflows that do not run at all.

## What happened

Removing `persist-credentials: false` from the checkouts that legitimately need their credential left an **empty `with:`** behind wherever that line was the only key under it. An empty `with:` is a GitHub Actions **schema** error.

| repo | workflows that stopped running |
|---|---|
| terraform-registry-backend | `ci.yml`, `wiki-sync.yml` |
| terraform-registry-frontend | `translate.yml`, `wiki-sync.yml` |
| terraform-state-manager-frontend | `translate.yml` |

`weekly-security.yml` failed as a *consequence*, not a cause: it calls `ci.yml`, and a caller of an invalid reusable workflow fails with it.

## Why nothing caught it

- **`yaml.safe_load` accepted it** — an empty mapping value is valid YAML, and that is what I validated every edit with.
- **zizmor accepted it** — it audits workflows for *security*, not schema validity.
- **A required status check cannot catch it** — a startup failure runs **zero jobs**, so there is no check to fail. The run shows `conclusion=failure`, no logs, and is listed by *file path* instead of workflow name, because GitHub never parsed far enough to read the `name:`.

Every gate in the pipeline was looking somewhere else, including the ones added earlier today.

## The fix

The empty `with:` blocks are removed, and **actionlint runs alongside zizmor in every repository**. That is the check which would have caught this in review rather than on `main`, and it closes the category rather than the instance — any future schema error fails a PR.

## Verification

- `actionlint` clean in **all seven** repositories
- `zizmor` still clean over the full `.github/` tree with **online** audits enabled
