### PR TITLE
fix(nginx): /terraform/ served with none of the security headers

### DIFF
--- a/frontend/nginx-ecs.conf.template
+++ b/frontend/nginx-ecs.conf.template
@@ -46,7 +46,7 @@ server {
     # genuinely cross-origin DSN (e.g. a Sentry SaaS *.ingest.sentry.io endpoint) will
     # have its fetch/sendBeacon calls silently blocked by the browser. Route such DSNs
     # through this reverse proxy instead, or add their origin here (see ARCHITECTURE.md).
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'nonce-$csp_nonce'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none';" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'nonce-$csp_nonce'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self';" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
 
     # Inject CSP nonce into index.html. once off = replace EVERY __CSP_NONCE__
@@ -125,7 +125,7 @@ server {
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
         add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'nonce-$csp_nonce'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none';" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'nonce-$csp_nonce'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self';" always;
         add_header Content-Type "application/json" always;
     }
 

--- a/frontend/nginx-ecs.conf.template
+++ b/frontend/nginx-ecs.conf.template
@@ -41,6 +41,17 @@ server {
     add_header X-Frame-Options "DENY" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    # Strict-Transport-Security was absent from THIS template only. nginx.conf
+    # (compose/E2E) has always sent it; the template that actually ships whenever
+    # BACKEND_URL is set never has, and nothing claimed that was deliberate.
+    # Found by nginxHeaderInheritance.test.ts asserting the SERVER level, not by
+    # reading the file -- the two configs had drifted on exactly the header whose
+    # absence is invisible in a browser.
+    #
+    # Harmless where TLS terminates at an ALB or CloudFront in front of this
+    # container: a browser ignores HSTS delivered over plain HTTP, so this is
+    # correct when nginx serves TLS and inert when it does not.
+    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
     # connect-src 'self' also constrains VITE_SENTRY_DSN / VITE_ERROR_REPORTING_DSN /
     # VITE_PERFORMANCE_DSN (services/errorReporting.ts, performanceReporting.ts): a
     # genuinely cross-origin DSN (e.g. a Sentry SaaS *.ingest.sentry.io endpoint) will

--- a/frontend/nginx-ecs.conf.template
+++ b/frontend/nginx-ecs.conf.template
@@ -107,6 +107,25 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        # nginx add_header is REPLACE-BY-LEVEL, not additive: "these directives are
+        # inherited from the previous configuration level if and only if there are
+        # no add_header directives defined on the current level". The
+        # Content-Type line below is one, so without re-declaring them here this
+        # location serves with NONE of the six server-level security headers.
+        #
+        # This is the one same-origin path carrying content the operator does not
+        # author -- /terraform/ is the network-mirror protocol, proxying provider
+        # metadata from third-party upstream registries -- so it is the worst
+        # place in the config to lose nosniff and the CSP.
+        #
+        # Duplication here is deliberate and guarded: nginxHeaderInheritance.test.ts
+        # fails if any location that defines add_header omits one of these.
+        add_header X-Frame-Options "DENY" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
+        add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'nonce-$csp_nonce'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none';" always;
         add_header Content-Type "application/json" always;
     }
 

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -45,7 +45,7 @@ server {
     # genuinely cross-origin DSN (e.g. a Sentry SaaS *.ingest.sentry.io endpoint) will
     # have its fetch/sendBeacon calls silently blocked by the browser. Route such DSNs
     # through this reverse proxy instead, or add their origin here (see ARCHITECTURE.md).
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'nonce-$csp_nonce'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none';" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'nonce-$csp_nonce'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self';" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
 
     # Inject CSP nonce into index.html so the React app can read it. once off =
@@ -144,7 +144,7 @@ server {
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
         add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'nonce-$csp_nonce'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none';" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'nonce-$csp_nonce'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self';" always;
         add_header Content-Type "application/json" always;
     }
 

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -126,6 +126,25 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        # nginx add_header is REPLACE-BY-LEVEL, not additive: "these directives are
+        # inherited from the previous configuration level if and only if there are
+        # no add_header directives defined on the current level". The
+        # Content-Type line below is one, so without re-declaring them here this
+        # location serves with NONE of the six server-level security headers.
+        #
+        # This is the one same-origin path carrying content the operator does not
+        # author -- /terraform/ is the network-mirror protocol, proxying provider
+        # metadata from third-party upstream registries -- so it is the worst
+        # place in the config to lose nosniff and the CSP.
+        #
+        # Duplication here is deliberate and guarded: nginxHeaderInheritance.test.ts
+        # fails if any location that defines add_header omits one of these.
+        add_header X-Frame-Options "DENY" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
+        add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'nonce-$csp_nonce'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none';" always;
         add_header Content-Type "application/json" always;
     }
 

--- a/frontend/src/__tests__/nginxHeaderInheritance.test.ts
+++ b/frontend/src/__tests__/nginxHeaderInheritance.test.ts
@@ -34,9 +34,18 @@ const REQUIRED = [
   'Permissions-Policy',
 ] as const
 
-/** Extract `location <match> { ... }` blocks, brace-balanced. */
-function locationBlocks(conf: string): { match: string; body: string }[] {
-  const out: { match: string; body: string }[] = []
+/**
+ * Extract `location <match> { ... }` blocks, brace-balanced, keeping the index
+ * range of each body.
+ *
+ * The ranges matter: the server level is computed by removing these spans by
+ * INDEX, not by `String.replace(body, '')`. Replace-by-content takes the first
+ * textual match, which is not necessarily the block it came from — two blocks
+ * with identical bodies, or a body that also occurs verbatim earlier, silently
+ * strip the wrong region and take real server-level directives with them.
+ */
+function locationBlocks(conf: string): { match: string; body: string; start: number; end: number }[] {
+  const out: { match: string; body: string; start: number; end: number }[] = []
   const re = /location\s+([^{]+)\{/g
   let m: RegExpExecArray | null
   while ((m = re.exec(conf)) !== null) {
@@ -47,9 +56,24 @@ function locationBlocks(conf: string): { match: string; body: string }[] {
       else if (conf[i] === '}') depth--
       i++
     }
-    out.push({ match: m[1].trim(), body: conf.slice(re.lastIndex, i - 1) })
+    out.push({ match: m[1].trim(), body: conf.slice(re.lastIndex, i - 1), start: m.index, end: i })
+    // Skip past this block so a NESTED location is not also reported as a
+    // top-level one, which would strip the same span twice.
+    re.lastIndex = i
   }
   return out
+}
+
+/** The config with every location block removed, by index. */
+function serverLevelOnly(conf: string): string {
+  const blocks = locationBlocks(conf)
+  let out = ''
+  let cursor = 0
+  for (const b of blocks) {
+    out += conf.slice(cursor, b.start)
+    cursor = b.end
+  }
+  return out + conf.slice(cursor)
 }
 
 const CONFIGS: [string, string][] = [
@@ -65,9 +89,7 @@ describe.each(CONFIGS)('%s — add_header inheritance (#668)', (name, conf) => {
   })
 
   it('declares every security header at the server level', () => {
-    // Strip location bodies so we are looking at the server level only.
-    let serverLevel = conf
-    for (const { body } of locationBlocks(conf)) serverLevel = serverLevel.replace(body, '')
+    const serverLevel = serverLevelOnly(conf)
     for (const h of REQUIRED) {
       expect(serverLevel, `${name} lost server-level ${h}`).toContain(`add_header ${h}`)
     }

--- a/frontend/src/__tests__/nginxHeaderInheritance.test.ts
+++ b/frontend/src/__tests__/nginxHeaderInheritance.test.ts
@@ -87,6 +87,20 @@ describe.each(CONFIGS)('%s — add_header inheritance (#668)', (name, conf) => {
     ).toEqual([])
   })
 
+  it('declares the CSP directives that do NOT fall back to default-src', () => {
+    // CSP3 §6.1: only the FETCH directives fall back to default-src. base-uri
+    // and form-action do not, so `default-src 'self'` does not cover them and
+    // their absence is silent (#669).
+    //
+    // Without base-uri, an injected <base href="https://attacker/"> re-roots
+    // every relative script and asset off-origin, straight through
+    // `script-src 'self'`. Without form-action, an injected form posts
+    // credentials anywhere without tripping `connect-src 'self'`.
+    for (const directive of ["base-uri 'self'", "form-action 'self'"]) {
+      expect(conf, `${name} CSP is missing ${directive}`).toContain(directive)
+    }
+  })
+
   it('keeps the location CSP byte-identical to the server-level one', () => {
     // Two CSPs that drift are worse than one: the weaker one wins on whichever
     // path uses it, and nothing says which path that is.

--- a/frontend/src/__tests__/nginxHeaderInheritance.test.ts
+++ b/frontend/src/__tests__/nginxHeaderInheritance.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest'
+import nginxConf from '../../nginx.conf?raw'
+import nginxEcsConf from '../../nginx-ecs.conf.template?raw'
+
+/**
+ * nginx `add_header` is REPLACE-BY-LEVEL, not additive (#668):
+ *
+ *   "These directives are inherited from the previous configuration level if and
+ *    only if there are no add_header directives defined on the current level."
+ *
+ * So a `location` block that sets ONE header silently drops every server-level
+ * security header. `location /terraform/` set `Content-Type` and therefore
+ * served with no `X-Frame-Options`, no `nosniff`, no CSP, no HSTS, no
+ * `Referrer-Policy` and no `Permissions-Policy` — on the network-mirror path,
+ * which proxies provider metadata from third-party upstream registries and is
+ * the one same-origin path carrying content the operator does not author.
+ *
+ * The fix re-declares them inside the location, which means the config now
+ * contains the same six headers twice. This test is what makes that duplication
+ * safe: remove one and it fails, rather than the headers quietly vanishing from
+ * a path nobody curls.
+ *
+ * It is a STATIC check of the config, not a runtime one. It cannot prove nginx
+ * emits the headers (that needs a container); it enforces the invariant that
+ * causes the bug. #691 tracks the runtime half.
+ */
+
+const REQUIRED = [
+  'X-Frame-Options',
+  'X-Content-Type-Options',
+  'Referrer-Policy',
+  'Strict-Transport-Security',
+  'Content-Security-Policy',
+  'Permissions-Policy',
+] as const
+
+/** Extract `location <match> { ... }` blocks, brace-balanced. */
+function locationBlocks(conf: string): { match: string; body: string }[] {
+  const out: { match: string; body: string }[] = []
+  const re = /location\s+([^{]+)\{/g
+  let m: RegExpExecArray | null
+  while ((m = re.exec(conf)) !== null) {
+    let depth = 1
+    let i = re.lastIndex
+    while (i < conf.length && depth > 0) {
+      if (conf[i] === '{') depth++
+      else if (conf[i] === '}') depth--
+      i++
+    }
+    out.push({ match: m[1].trim(), body: conf.slice(re.lastIndex, i - 1) })
+  }
+  return out
+}
+
+const CONFIGS: [string, string][] = [
+  ['nginx.conf', nginxConf],
+  ['nginx-ecs.conf.template', nginxEcsConf],
+]
+
+describe.each(CONFIGS)('%s — add_header inheritance (#668)', (name, conf) => {
+  it('parses at least one location block', () => {
+    // An empty parse would make every assertion below vacuously true, which is
+    // the failure mode this guard exists to prevent.
+    expect(locationBlocks(conf).length).toBeGreaterThan(0)
+  })
+
+  it('declares every security header at the server level', () => {
+    // Strip location bodies so we are looking at the server level only.
+    let serverLevel = conf
+    for (const { body } of locationBlocks(conf)) serverLevel = serverLevel.replace(body, '')
+    for (const h of REQUIRED) {
+      expect(serverLevel, `${name} lost server-level ${h}`).toContain(`add_header ${h}`)
+    }
+  })
+
+  it('re-declares every security header in any location that sets add_header', () => {
+    const offenders: string[] = []
+    for (const { match, body } of locationBlocks(conf)) {
+      if (!/add_header/.test(body)) continue // inherits cleanly — nothing to do
+      const missing = REQUIRED.filter((h) => !body.includes(`add_header ${h}`))
+      if (missing.length) offenders.push(`location ${match} is missing: ${missing.join(', ')}`)
+    }
+    expect(
+      offenders,
+      `${name}: a location that sets any add_header must re-declare ALL server-level ` +
+        `security headers — nginx drops the inherited ones entirely (#668)`,
+    ).toEqual([])
+  })
+
+  it('keeps the location CSP byte-identical to the server-level one', () => {
+    // Two CSPs that drift are worse than one: the weaker one wins on whichever
+    // path uses it, and nothing says which path that is.
+    const all = [...conf.matchAll(/add_header Content-Security-Policy\s+(.*?);?\s*always;/g)].map(
+      (m) => m[1].trim(),
+    )
+    expect(all.length, `${name} should declare CSP at server level and in /terraform/`).toBe(2)
+    expect(new Set(all).size, `${name} has two DIFFERENT Content-Security-Policy values`).toBe(1)
+  })
+})


### PR DESCRIPTION
Closes #668.

## The defect

nginx's `add_header` is **replace-by-level**, not additive:

> These directives are inherited from the previous configuration level **if and only if there are no `add_header` directives defined on the current level.**

`location /terraform/` sets one (`Content-Type: application/json`) — so it discarded **all six** server-level security headers: `X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`, `Strict-Transport-Security`, the full `Content-Security-Policy`, and `Permissions-Policy`.

## Of every path, the worst one to lose them on

`/terraform/` is the Terraform network-mirror protocol — it proxies provider metadata from **third-party upstream registries**. It is the one same-origin path serving content the operator does not author, and therefore the one that most needs `nosniff` and a CSP.

The appended `Content-Type` gave accidental partial cover, but that is a side effect of an unrelated directive rather than a control, and does nothing for the lost framing, referrer or transport headers.

**Both configs carried it** — `nginx.conf` (compose/E2E) and `nginx-ecs.conf.template`, which is what actually ships whenever `BACKEND_URL` is set. Fixing only the first would have left production exactly as it was.

## The fix, and why the duplication is safe

The six headers are re-declared inside the location, with the CSP copied **verbatim** from the server level rather than retyped — two CSPs that drift are worse than one, because the weaker wins on whichever path uses it and nothing says which.

`nginxHeaderInheritance.test.ts` encodes the inheritance rule so that duplication cannot be "cleaned up":

- any location setting **any** `add_header` must re-declare all six
- the two CSPs must be **byte-identical**
- the server level must still declare all six
- the parse must find at least one location — an empty parse would make every other assertion vacuously true, which is the failure mode the guard exists to prevent

Mutation-verified: deleting one re-declared header makes it fail naming the location and the header.

## Scope

Static, not runtime. It enforces the invariant that causes the bug; it cannot prove nginx emits the headers. That needs a container and is **#691**.