### PR TITLE
fix(auth): gate Dev Login on the backend, not on the build mode

### DIFF
--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -18,6 +18,7 @@ import { useAuth } from '../contexts/AuthContext'
 import { useThemeMode } from '../contexts/ThemeContext'
 import { useNavigate } from 'react-router-dom'
 import api from '../services/api'
+import * as devApi from '../services/api/devApi'
 
 interface AuthProvider {
   type: string
@@ -54,7 +55,32 @@ const LoginPage: React.FC = () => {
   const { productName } = useThemeMode()
   const navigate = useNavigate()
   const [loginError, setLoginError] = React.useState<string | null>(null)
-  const isDev = import.meta.env.MODE === 'development'
+  // Gated on the BACKEND's dev status, not on import.meta.env.MODE (#667).
+  //
+  // MODE is baked in at build time by `vite build --mode`, so a single
+  // `--build-arg VITE_MODE=development` used to open this button in an image
+  // that is otherwise indistinguishable from a production one. The backend is
+  // the only thing that actually knows whether POST /api/v1/dev/login will
+  // work, so it decides whether the button exists.
+  //
+  // Fails CLOSED: the endpoint is absent in production, the request rejects,
+  // and the catch leaves this false. Same pattern DevUserSwitcher already uses.
+  const [isDev, setIsDev] = React.useState(false)
+
+  React.useEffect(() => {
+    let cancelled = false
+    devApi
+      .getDevStatus()
+      .then((status) => {
+        if (!cancelled) setIsDev(Boolean(status.dev_mode))
+      })
+      .catch(() => {
+        if (!cancelled) setIsDev(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
   const [providers, setProviders] = React.useState<AuthProvider[]>([])
   const [loading, setLoading] = React.useState(true)
 

--- a/frontend/src/pages/__tests__/LoginPage.test.tsx
+++ b/frontend/src/pages/__tests__/LoginPage.test.tsx
@@ -112,7 +112,12 @@ describe('LoginPage', () => {
     expect(screen.getByText(/single sign-on for authentication/)).toBeInTheDocument()
   })
 
-  it('does not render dev login button in test mode', () => {
+  it('does not render dev login button when the backend is not in dev mode', () => {
+    // Renamed with #667: this used to pass because MODE was "test", and it now
+    // passes because the mocked backend reports dev_mode: false (the default in
+    // beforeEach). Same assertion, different reason -- and a test whose name
+    // states the old reason is one that goes on passing after the thing it
+    // described stops existing.
     mockProviders([{ type: 'oidc', name: 'OpenID Connect' }])
     renderLoginPage()
     expect(screen.queryByText('Dev Login (Admin)')).not.toBeInTheDocument()
@@ -214,10 +219,15 @@ describe('LoginPage', () => {
   })
 
   it('shows only the generic message when dev login fails outside development builds (#618-class)', async () => {
-    // isDev (button visibility) is driven by MODE, independent of the DEV
-    // flag that gates the raw message -- a `vite build --mode development`
-    // hardened/staging build is the scenario where these two disagree.
-    vi.stubEnv('MODE', 'development')
+    // Button visibility now comes from the BACKEND's dev status, not from MODE
+    // (#667) — so this test has to say the backend is in dev mode for the button
+    // to exist at all. What it is actually asserting is unchanged and is about
+    // the OTHER flag: `DEV` still gates whether the raw error text is surfaced,
+    // and a build where the two disagree must show only the generic message.
+    //
+    // The previous comment here said visibility was "driven by MODE". That was
+    // true when it was written and is not any more.
+    mockGetDevStatus.mockResolvedValue({ dev_mode: true })
     vi.stubEnv('DEV', false)
     mockDevLogin.mockRejectedValue(new Error('ECONNREFUSED 127.0.0.1:8080'))
     mockProviders([])

--- a/frontend/src/pages/__tests__/LoginPage.test.tsx
+++ b/frontend/src/pages/__tests__/LoginPage.test.tsx
@@ -23,6 +23,15 @@ vi.mock('../../services/api', () => ({
   },
 }))
 
+// #667: the Dev Login button is gated on the BACKEND's dev status, not on
+// import.meta.env.MODE. A build-time gate meant `--build-arg VITE_MODE=development`
+// opened an unauthenticated login path in an image otherwise indistinguishable
+// from production. Mocked here so the tests below can drive both answers.
+const mockGetDevStatus = vi.fn()
+vi.mock('../../services/api/devApi', () => ({
+  getDevStatus: (...args: unknown[]) => mockGetDevStatus(...args),
+}))
+
 vi.mock('../../contexts/ThemeContext', () => ({
   useThemeMode: () => ({
     mode: 'light',
@@ -49,6 +58,7 @@ function renderLoginPage() {
 }
 
 beforeEach(() => {
+  mockGetDevStatus.mockResolvedValue({ dev_mode: false })
   vi.clearAllMocks()
 })
 
@@ -222,5 +232,33 @@ describe('LoginPage', () => {
     expect(screen.queryByText('ECONNREFUSED 127.0.0.1:8080')).not.toBeInTheDocument()
 
     vi.unstubAllEnvs()
+  })
+})
+
+describe('Dev Login gate (#667)', () => {
+  it('does not render Dev Login when the backend reports dev_mode false', async () => {
+    mockProviders([])
+    mockGetDevStatus.mockResolvedValue({ dev_mode: false })
+    renderLoginPage()
+    await waitFor(() => expect(mockGetDevStatus).toHaveBeenCalled())
+    expect(screen.queryByRole('button', { name: /dev login/i })).not.toBeInTheDocument()
+  })
+
+  it('renders Dev Login when the backend reports dev_mode true', async () => {
+    mockProviders([])
+    mockGetDevStatus.mockResolvedValue({ dev_mode: true })
+    renderLoginPage()
+    expect(await screen.findByRole('button', { name: /dev login/i })).toBeInTheDocument()
+  })
+
+  it('FAILS CLOSED when the dev-status call rejects', async () => {
+    // Production does not serve /api/v1/dev/status at all, so the request
+    // rejecting is the ordinary production path -- not an edge case. If this
+    // ever renders the button, a network blip becomes an auth-bypass affordance.
+    mockProviders([])
+    mockGetDevStatus.mockRejectedValue(new Error('404'))
+    renderLoginPage()
+    await waitFor(() => expect(mockGetDevStatus).toHaveBeenCalled())
+    expect(screen.queryByRole('button', { name: /dev login/i })).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
Partially addresses #667 — the affordance half. **Deliberately not closing it**; see the bottom.

## The defect

`LoginPage` rendered the Dev Login button on `import.meta.env.MODE === 'development'`. That is baked in at **build time** by `vite build --mode`, so a single `--build-arg VITE_MODE=development` opened an unauthenticated login path — `POST /api/v1/dev/login` — in an image otherwise **indistinguishable from production**. No banner, nothing in `/version`, nothing at runtime to tell them apart.

Dev-mode images are routinely built here: `deployments/docker-compose.yml` and `docker-compose.test.yml` both pass `VITE_MODE: development`. The release workflow passes no build-args, so the published image is currently safe — but the entire distance between safe and not is one build-arg on one pipeline.

## The fix

The backend is the only thing that actually knows whether `/api/v1/dev/login` will work, so it decides whether the button exists. This is the pattern `DevUserSwitcher` **already used correctly** — the login page is now consistent with its sibling rather than the odd one out.

**It fails closed, and that path is the ordinary one**: production does not serve the dev-status endpoint at all, so the request rejects, the catch leaves the flag false, and no button renders.

## Tests

| case | expectation |
|---|---|
| backend reports `dev_mode: false` | no button |
| backend reports `dev_mode: true` | button renders |
| dev-status call **rejects** | no button |

That third one matters most: rejection *is* production. If it ever rendered the button, a network blip would become an auth-bypass affordance.

## Why this does not close #667

The issue asks for three things. This is one:

- ✅ gate the dev affordances on a runtime signal
- ⬜ surface the build mode in `/version` and a persistent UI banner, so a dev-mode deployment is visually obvious
- ⬜ make the dev-mode image a separately-named artifact rather than a build-arg away from production

The remaining `import.meta.env.DEV` uses in this file and `utils/errors.ts` still widen error verbosity in a dev build. That is information disclosure rather than an auth path, and belongs with the same follow-up.