### PR TITLE
fix(export): neutralise spreadsheet formulas in the CSV exports

### DIFF
--- a/frontend/src/components/ScanFindingsModal.tsx
+++ b/frontend/src/components/ScanFindingsModal.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react'
+import { csvCell } from '../utils/csv'
 import { useTranslation } from 'react-i18next'
 import {
   Dialog,
@@ -29,18 +30,11 @@ import { parseScanFindings } from '../utils/scanParsers'
 import ScanDiagnostics from './ScanDiagnostics'
 
 /** Escape a single CSV field value (RFC 4180). */
-function csvEscape(value: string): string {
-  if (value.includes('"') || value.includes(',') || value.includes('\n')) {
-    return `"${value.replace(/"/g, '""')}"`
-  }
-  return value
-}
-
 /** Convert an array of FindingRow records to a CSV string. */
 function findingsToCsv(findings: FindingRow[]): string {
   const header = ['Severity', 'Rule ID', 'Title', 'Resource', 'File', 'Resolution']
   const rows = findings.map((f) =>
-    [f.severity, f.ruleId, f.title, f.resource, f.file, f.resolution].map(csvEscape).join(','),
+    [f.severity, f.ruleId, f.title, f.resource, f.file, f.resolution].map(csvCell).join(','),
   )
   return [header.join(','), ...rows].join('\r\n')
 }

--- a/frontend/src/services/api/auditApi.ts
+++ b/frontend/src/services/api/auditApi.ts
@@ -1,4 +1,5 @@
 import { http, encodeSegment } from './http'
+import { csvCell } from '../../utils/csv'
 import type { AuditLog, AuditLogListResponse } from '../../types'
 
 // ============================================================================
@@ -50,7 +51,7 @@ export function exportAuditLogsCSV(logs: AuditLog[]): void {
       l.organization_id ?? '',
       l.ip_address ?? '',
     ]
-      .map((v) => `"${String(v).replace(/"/g, '""')}"`)
+      .map(csvCell)
       .join(','),
   )
   const csv = [header.join(','), ...rows].join('\n')

--- a/frontend/src/utils/__tests__/csv.test.ts
+++ b/frontend/src/utils/__tests__/csv.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest'
+import { csvCell, toCsv } from '../csv'
+
+/**
+ * #682 — CSV formula injection.
+ *
+ * The table is over the LEAD CHARACTER rather than over "a payload", because
+ * that is what the spreadsheet actually keys on. A test asserting one crafted
+ * `=cmd|...` string passes while `@SUM(...)` still detonates.
+ */
+describe('csvCell', () => {
+  it.each([
+    ['=cmd|\'/c calc\'!A1', '='],
+    ['+1+1', '+'],
+    ['-1+1', '-'],
+    ['@SUM(1,1)', '@'],
+    ['\tSUM(1,1)', 'tab'],
+    ['\rSUM(1,1)', 'CR'],
+  ])('neutralises a leading %s (%s)', (payload) => {
+    const out = csvCell(payload)
+    // The apostrophe must be INSIDE the quotes, immediately before the payload —
+    // outside, it would be CSV data rather than a spreadsheet text marker.
+    expect(out.startsWith('"\'')).toBe(true)
+    expect(out).toContain(payload.replace(/"/g, '""'))
+  })
+
+  it('leaves an ordinary value alone apart from quoting', () => {
+    expect(csvCell('alice@example.com')).toBe('"alice@example.com"')
+    expect(csvCell('plain')).toBe('"plain"')
+  })
+
+  it('does not treat these characters as dangerous away from the start', () => {
+    // Only the FIRST character triggers evaluation. Prefixing on any occurrence
+    // would corrupt ordinary data — arithmetic in a title, a scoped npm package.
+    expect(csvCell('a=b')).toBe('"a=b"')
+    expect(csvCell('x + y')).toBe('"x + y"')
+  })
+
+  it('escapes embedded quotes per RFC 4180', () => {
+    expect(csvCell('say "hi"')).toBe('"say ""hi"""')
+  })
+
+  it('quoting alone does not save you — the apostrophe is the control', () => {
+    // A spreadsheet strips the CSV quotes and evaluates what is inside, which is
+    // why RFC 4180 quoting is not a mitigation and this test exists to say so.
+    const out = csvCell('=1+1')
+    expect(out).toBe('"\'=1+1"')
+    expect(out).not.toBe('"=1+1"')
+  })
+
+  it('renders null and undefined as empty, not as the words', () => {
+    expect(csvCell(null)).toBe('""')
+    expect(csvCell(undefined)).toBe('""')
+  })
+})
+
+describe('toCsv', () => {
+  it('runs headers through the same encoder as cells', () => {
+    // Headers are usually static, but an export that ever takes a dynamic column
+    // name should not have a second, weaker path.
+    expect(toCsv(['=evil'], [])).toBe('"\'=evil"')
+  })
+
+  it('joins rows with newlines and cells with commas', () => {
+    expect(toCsv(['a', 'b'], [['1', '2']])).toBe('"a","b"\n"1","2"')
+  })
+})

--- a/frontend/src/utils/csv.ts
+++ b/frontend/src/utils/csv.ts
@@ -1,0 +1,50 @@
+/**
+ * CSV cell encoding for the app's exports (#682).
+ *
+ * There were two escapers — one in `services/api/auditApi.ts`, one in
+ * `components/ScanFindingsModal.tsx` — and they had already diverged: the first
+ * quoted every cell unconditionally, the second only when the value contained a
+ * quote, comma or newline. Neither did anything about formula injection, so
+ * fixing them separately would have meant fixing the same defect twice and
+ * leaving whichever export gets written next to repeat it.
+ *
+ * ## Formula injection
+ *
+ * Excel, LibreOffice Calc and Google Sheets evaluate a cell whose FIRST
+ * character is `=`, `+`, `-`, `@`, tab or carriage return. RFC 4180 quoting does
+ * not prevent this: the spreadsheet strips the quotes and then evaluates what is
+ * inside, so `"=cmd|'/c calc'!A1"` still runs on open.
+ *
+ * The values here are attacker-influenceable. An audit log row carries
+ * `user_email`, `user_name` and `resource_id`; a scan finding carries `title`,
+ * `resource` and `file`, which come from third-party scanner output about
+ * third-party module content. The person who opens the export is an
+ * administrator.
+ *
+ * The neutraliser is a leading apostrophe, which spreadsheets consume as
+ * "treat the rest as literal text" and which is what OWASP recommends. It is
+ * applied INSIDE the quotes so the CSV grammar is untouched: a reader that is
+ * not a spreadsheet still sees the apostrophe as data, which is the honest
+ * trade — the alternative is silently dropping characters the user typed.
+ */
+
+/** Leading characters that make a spreadsheet evaluate the cell as a formula. */
+const FORMULA_LEAD = /^[=+\-@\t\r]/
+
+/**
+ * Encode one value as a CSV cell: neutralise a formula lead, escape embedded
+ * quotes, and always quote.
+ *
+ * Always quoting is deliberate. Conditional quoting is one predicate to get
+ * wrong, and the failure is a corrupted export rather than a loud error.
+ */
+export function csvCell(value: unknown): string {
+  const s = value === null || value === undefined ? '' : String(value)
+  const neutralised = FORMULA_LEAD.test(s) ? `'${s}` : s
+  return `"${neutralised.replace(/"/g, '""')}"`
+}
+
+/** Encode a header + rows as a CSV document, with every cell run through csvCell. */
+export function toCsv(header: readonly string[], rows: readonly unknown[][]): string {
+  return [header.map(csvCell).join(','), ...rows.map((r) => r.map(csvCell).join(','))].join('\n')
+}


### PR DESCRIPTION
Closes #682.

## The defect

Excel, LibreOffice Calc and Google Sheets evaluate a cell whose **first** character is `=`, `+`, `-`, `@`, tab or carriage return.

**RFC 4180 quoting does not prevent this.** The spreadsheet strips the quotes and evaluates what is inside, so `"=cmd|'/c calc'!A1"` still runs on open. Neither export did anything about it.

The values are attacker-influenceable and the reader is an administrator:

| export | attacker-influenced fields |
|---|---|
| audit log | `user_email`, `user_name`, `resource_id` |
| scan findings | `title`, `resource`, `file` — third-party scanner output about third-party module content |

## Fixed once, not twice

There were **two** escapers, and they had already drifted on a second axis:

- `auditApi.ts` quoted every cell unconditionally
- `ScanFindingsModal.tsx` quoted only when the value contained a quote, comma or newline

Both now go through `utils/csv.ts`, and the local escaper is **deleted** rather than left as a tempting second option. An export written next inherits the fix instead of repeating the bug.

`csvCell` always quotes — conditional quoting is one more predicate to get wrong, and its failure mode is a corrupted export rather than a loud error.

The neutraliser is a leading apostrophe applied **inside** the quotes, so the CSV grammar is untouched. A reader that is not a spreadsheet sees the apostrophe as data; that is the honest trade against silently dropping characters the user typed.

## Tests

Table-driven over the **lead character**, not over one crafted payload — a test asserting a single `=cmd|...` string passes while `@SUM(...)` still detonates. All six leads covered.

They also assert the **negative** direction: `a=b` and `x + y` are untouched, because only the first character triggers evaluation and prefixing on every occurrence would corrupt ordinary data. Plus an explicit case stating that quoting alone is not the control.