### PR TITLE
ci: make a failing test shard say which test failed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,7 @@ jobs:
         run: >-
           npx vitest run --coverage
           --reporter=blob
+          --reporter=default
           --outputFile.blob=.vitest-reports/blob-${{ matrix.shard }}.json
           --shard=${{ matrix.shard }}/${STRATEGY_JOB_TOTAL}
           --coverage.thresholds.statements=0
@@ -91,6 +92,11 @@ jobs:
         run: ls -la .vitest-reports/ || echo "no .vitest-reports/ directory"
 
       - name: Upload blob report
+        # always(): a shard that FAILED is the one whose report is worth reading.
+        # Without this the upload is skipped exactly when it matters, and the
+        # blob reporter writes nothing to stdout -- so a red shard left no
+        # failure detail anywhere at all.
+        if: always()
         # v7
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:


### PR DESCRIPTION
## The problem

The unit-test shards ran with `--reporter=blob` **alone**. That reporter writes a machine-readable file and **nothing to stdout** — and the upload step had no `if: always()`, so it was skipped on exactly the runs whose report was worth reading.

A red shard therefore produced **no failure detail anywhere**:

- not in the job log (blob writes to a file)
- not in an artifact (upload skipped on failure)
- not in the annotations — which said only `Process completed with exit code 1`

Diagnosing a failing PR meant reproducing locally, which needs an npm token for the `@sethbacon` scope that not every contributor has.

## The change

| | |
|---|---|
| `--reporter=default` alongside the blob | failures print in the job log, where the person reading the red check already is |
| `if: always()` on the blob upload | a failed shard leaves its report behind instead of discarding it at the moment it becomes useful |

The blob still feeds the merge-and-coverage job downstream; nothing about that changes.

## Why it is worth its own PR

This is the same shape as the defects this batch has been fixing — a check that fails without being able to say why is only marginally better than one that does not run.

It cost me a diagnosis on #727 and #728 today, which is how it surfaced.