### PR TITLE
fix(docs-page): bound the Swagger CSRF echo to same-origin requests

### DIFF
--- a/frontend/src/pages/ApiDocumentation.tsx
+++ b/frontend/src/pages/ApiDocumentation.tsx
@@ -19,16 +19,16 @@ const TagsSorterPlugin = (): any => ({
       wrapSelectors: {
         taggedOperations:
           (origSelector: any) =>
-            (...args: any[]) => {
-              const taggedOps = origSelector(...args)
-              if (taggedOps && typeof taggedOps.sortBy === 'function') {
-                return taggedOps.sortBy(
-                  (_val: any, key: string) => key,
-                  (a: string, b: string) => a.localeCompare(b),
-                )
-              }
-              return taggedOps
-            },
+          (...args: any[]) => {
+            const taggedOps = origSelector(...args)
+            if (taggedOps && typeof taggedOps.sortBy === 'function') {
+              return taggedOps.sortBy(
+                (_val: any, key: string) => key,
+                (a: string, b: string) => a.localeCompare(b),
+              )
+            }
+            return taggedOps
+          },
       },
     },
   },
@@ -70,6 +70,24 @@ function buildNavTags(spec: OpenAPISpec): NavTag[] {
 
 const NAV_WIDTH = 200
 
+/**
+ * isSameOriginRequest reports whether a Swagger UI request target resolves to
+ * the app's own origin.
+ *
+ * Exported for testing: the interceptor that uses it is created inside the
+ * component via useCallback, so the rule itself is only reachable through a
+ * rendered SwaggerUI mock. Testing the decision directly keeps the rule covered
+ * even if that mock's shape changes.
+ */
+export function isSameOriginRequest(url: unknown): boolean {
+  if (typeof url !== 'string' || url === '') return false
+  try {
+    return new URL(url, window.location.origin).origin === window.location.origin
+  } catch {
+    return false
+  }
+}
+
 const ApiDocumentation: React.FC = () => {
   const { t } = useTranslation()
   const theme = useTheme()
@@ -100,10 +118,29 @@ const ApiDocumentation: React.FC = () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- swagger-ui-react's Request type lacks headers
   const requestInterceptor = useCallback((req: any) => {
     const method = String(req.method || 'GET').toUpperCase()
-    if (method === 'POST' || method === 'PUT' || method === 'PATCH' || method === 'DELETE') {
-      const csrfToken = getCookie('tfr_csrf')
-      if (csrfToken) req.headers['X-CSRF-Token'] = csrfToken
+    if (method !== 'POST' && method !== 'PUT' && method !== 'PATCH' && method !== 'DELETE') {
+      return req
     }
+    // Same-origin only (issue #697).
+    //
+    // Swagger UI derives request targets from the fetched OpenAPI document's
+    // `servers`/`host` fields, which come from the backend-generated spec — so a
+    // spec declaring (or misconfigured into declaring) a non-same-origin server
+    // would ship the user's tfr_csrf value to that host as a request header.
+    // The axios interceptor this mirrors is bounded by a same-origin baseURL and
+    // is accompanied by checkCsrfOriginConfig; this sink had no such bound.
+    //
+    // Fails CLOSED on an unparseable or absent URL: without the header the
+    // request is rejected by the CSRF middleware, which is a visible failure,
+    // whereas attaching it anyway would be a silent disclosure. A double-submit
+    // token is low-value on its own — the custom header needs a CORS preflight
+    // the server would have to allow — but it is the user's, and there is no
+    // reason for it to leave the origin that issued it.
+    if (!isSameOriginRequest(req.url)) {
+      return req
+    }
+    const csrfToken = getCookie('tfr_csrf')
+    if (csrfToken) req.headers['X-CSRF-Token'] = csrfToken
     return req
   }, [])
 
@@ -204,7 +241,11 @@ const ApiDocumentation: React.FC = () => {
   return (
     <Box sx={{ overflow: 'hidden' }}>
       {/* Page title */}
-      <PageHeader icon={<PageTitleIcon />} title={t('apiDocumentation.title')} description={t('apiDocumentation.subtitle')} />
+      <PageHeader
+        icon={<PageTitleIcon />}
+        title={t('apiDocumentation.title')}
+        description={t('apiDocumentation.subtitle')}
+      />
       {/* Layout: sticky left nav + Swagger UI content */}
       <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 0 }}>
         {/* ---- Left navigation panel ---- */}

--- a/frontend/src/pages/__tests__/ApiDocumentation.test.tsx
+++ b/frontend/src/pages/__tests__/ApiDocumentation.test.tsx
@@ -8,7 +8,11 @@ import { ThemeProvider, createTheme } from '@mui/material/styles'
 interface SwaggerProps {
   url: string
   onComplete?: (system: unknown) => void
-  requestInterceptor?: (req: { method?: string; headers: Record<string, string> }) => unknown
+  requestInterceptor?: (req: {
+    method?: string
+    url?: string
+    headers: Record<string, string>
+  }) => unknown
   plugins?: Array<() => unknown>
 }
 
@@ -250,7 +254,7 @@ describe('ApiDocumentation', () => {
   it('requestInterceptor does not attach Authorization even when a stray legacy token exists in localStorage', () => {
     localStorage.setItem('auth_token', 'stale-legacy-jwt')
     renderWithTheme()
-    const req = { method: 'GET', headers: {} as Record<string, string> }
+    const req = { method: 'GET', url: '/api/v1/modules', headers: {} as Record<string, string> }
     const result = capturedProps?.requestInterceptor?.(req)
     expect(result).toBe(req)
     expect(req.headers['Authorization']).toBeUndefined()
@@ -262,7 +266,10 @@ describe('ApiDocumentation', () => {
       document.cookie = 'tfr_csrf=swagger-csrf-token; path=/'
       try {
         renderWithTheme()
-        const req = { method, headers: {} as Record<string, string> }
+        // A url is supplied because the interceptor is same-origin bound
+        // (#697); Swagger UI always sets one, so a request without it is not a
+        // shape production produces.
+        const req = { method, url: '/api/v1/modules', headers: {} as Record<string, string> }
         capturedProps?.requestInterceptor?.(req)
         expect(req.headers['X-CSRF-Token']).toBe('swagger-csrf-token')
         expect(req.headers['Authorization']).toBeUndefined()
@@ -271,6 +278,47 @@ describe('ApiDocumentation', () => {
       }
     },
   )
+
+  // Issue #697: the token must not leave the origin that issued it.
+  //
+  // Swagger UI derives request targets from the fetched OpenAPI document's
+  // servers/host fields, which come from the backend-generated spec. A spec
+  // declaring a non-same-origin server would otherwise ship the user's tfr_csrf
+  // to that host as a request header.
+  it.each([
+    ['absolute cross-origin', 'https://evil.example.com/api/v1/modules'],
+    ['protocol-relative cross-origin', '//evil.example.com/api/v1/modules'],
+    ['different port on the same host', 'http://localhost:9999/api/v1/modules'],
+  ])('requestInterceptor withholds tfr_csrf for a %s target', (_label, url) => {
+    document.cookie = 'tfr_csrf=swagger-csrf-token; path=/'
+    try {
+      renderWithTheme()
+      const req = { method: 'POST', url, headers: {} as Record<string, string> }
+      capturedProps?.requestInterceptor?.(req)
+      expect(req.headers['X-CSRF-Token']).toBeUndefined()
+    } finally {
+      document.cookie = 'tfr_csrf=; Max-Age=0; path=/'
+    }
+  })
+
+  // Fails closed: without the header the request is rejected by the CSRF
+  // middleware, which is visible. Attaching it anyway would be a silent
+  // disclosure.
+  it.each([
+    ['missing', undefined],
+    ['empty', ''],
+    ['unparseable', 'http://['],
+  ])('requestInterceptor withholds tfr_csrf when the url is %s', (_label, url) => {
+    document.cookie = 'tfr_csrf=swagger-csrf-token; path=/'
+    try {
+      renderWithTheme()
+      const req = { method: 'POST', url, headers: {} as Record<string, string> }
+      capturedProps?.requestInterceptor?.(req)
+      expect(req.headers['X-CSRF-Token']).toBeUndefined()
+    } finally {
+      document.cookie = 'tfr_csrf=; Max-Age=0; path=/'
+    }
+  })
 
   it('requestInterceptor omits X-CSRF-Token on GET even when the cookie is present', () => {
     document.cookie = 'tfr_csrf=swagger-csrf-token; path=/'

--- a/frontend/src/pages/__tests__/isSameOriginRequest.test.ts
+++ b/frontend/src/pages/__tests__/isSameOriginRequest.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+
+import { isSameOriginRequest } from '../ApiDocumentation'
+
+// Issue #697 — the rule that bounds the Swagger CSRF echo, tested directly.
+//
+// The interceptor using it is created inside the component via useCallback, so
+// through the component it is only reachable via a rendered SwaggerUI mock.
+// Testing the decision here keeps the rule covered even if that mock's shape
+// changes.
+describe('isSameOriginRequest', () => {
+  it('accepts same-origin absolute and relative targets', () => {
+    expect(isSameOriginRequest('/api/v1/modules')).toBe(true)
+    expect(isSameOriginRequest('api/v1/modules')).toBe(true)
+    expect(isSameOriginRequest(`${window.location.origin}/api/v1/modules`)).toBe(true)
+  })
+
+  it('rejects cross-origin targets', () => {
+    expect(isSameOriginRequest('https://evil.example.com/x')).toBe(false)
+    // Protocol-relative: resolves against the app's scheme but a foreign host.
+    expect(isSameOriginRequest('//evil.example.com/x')).toBe(false)
+    // Same host, different port — still a different origin.
+    expect(isSameOriginRequest('http://localhost:9999/x')).toBe(false)
+  })
+
+  it('fails closed on values that are not usable URLs', () => {
+    // Without the header the request is rejected by the CSRF middleware, which
+    // is visible; attaching it anyway would be a silent disclosure.
+    expect(isSameOriginRequest(undefined)).toBe(false)
+    expect(isSameOriginRequest('')).toBe(false)
+    expect(isSameOriginRequest('http://[')).toBe(false)
+    expect(isSameOriginRequest(42)).toBe(false)
+    expect(isSameOriginRequest(null)).toBe(false)
+  })
+})


### PR DESCRIPTION
Closes #697.

The "Try it out" request interceptor attached the `tfr_csrf` double-submit token to **every** mutating request regardless of target. Swagger UI derives those targets from the fetched OpenAPI document's `servers`/`host` fields, which come from the backend-generated spec — so a spec declaring (or misconfigured into declaring) a non-same-origin server would ship the user's token to that host as a request header.

The axios interceptor this mirrors doesn't have that exposure: it's bounded by a same-origin `baseURL` and accompanied by `checkCsrfOriginConfig` — the startup check whose wiring #692 just covered. This sink had no equivalent bound. Now it has the same one.

## Fails closed

On an absent or unparseable URL, the header is withheld. Without it the request is rejected by the CSRF middleware — a **visible** failure. Attaching it anyway would be a **silent disclosure**.

The token is low-value on its own (the custom header needs a CORS preflight the server would have to allow, and `connect-src 'self'` blocks the request in production) — but it's the user's, and nothing needs it off-origin.

## Two existing tests were asserting the unbounded behaviour

They constructed a request with **no `url`** and asserted the header was attached. Those now fail closed, correctly — Swagger UI always sets a url, so a request without one isn't a shape production produces. They're updated to be faithful rather than worked around.

## Coverage

The rule is exported and tested directly, because the interceptor is built inside the component via `useCallback` and is otherwise reachable only through a rendered SwaggerUI mock — so it stays covered if that mock's shape changes.

Cross-origin cases include the two an absolute-URL check alone would miss:

- `//evil.example.com/x` — protocol-relative, resolves to the app's scheme but a foreign host
- `http://localhost:9999/x` — same host, **different port**, still a different origin

## Not run locally

No `node_modules` here: `.npmrc` needs `NODE_AUTH_TOKEN` for the private `@sethbacon/terraform-suite-ui`, and the available token lacks `read:packages`. Prettier parsed and reformatted all three files, so the syntax is valid; CI is the first place the assertions execute.
