### PR TITLE
docs: disclose that README images are fetched directly from publisher hosts

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -113,6 +113,31 @@ Data residency depends on where this instance is deployed. For multi-region
 deployments, see the backend's
 [data residency guide](https://github.com/sethbacon/terraform-registry-backend/blob/main/docs/data-residency.md).
 
+### Images in module and provider documentation
+
+Module and provider READMEs are authored by whoever publishes them, and they may
+reference images hosted anywhere — build-status badges are the common case. Those
+images are fetched by **your browser, directly from the host the publisher chose**.
+They are not proxied through this registry.
+
+That fetch discloses to the third-party host:
+
+- your IP address,
+- your browser's `User-Agent`,
+- the time you viewed the page, and
+- this registry's origin (the `Referrer-Policy` is `strict-origin-when-cross-origin`,
+  so the specific module page you were viewing is **not** sent).
+
+The disclosure is to the image's host, not to us, and it happens whether or not the
+image is a genuine badge — an embedded image is a working analytics pixel for anyone
+who can publish to this registry. Publishers are therefore able to learn that
+*somebody at your organisation* viewed their module, and how often.
+
+Operators who need to eliminate this can restrict the frontend's
+`Content-Security-Policy` to `img-src 'self' data:` in `frontend/nginx.conf`. This
+blocks **all** remote images in documentation, including legitimate badges, so it is
+a deliberate trade of documentation fidelity for viewer privacy rather than a default.
+
 ## 9. Security
 
 We implement technical and organizational measures including:

--- a/frontend/nginx-ecs.conf.template
+++ b/frontend/nginx-ecs.conf.template
@@ -57,6 +57,14 @@ server {
     # genuinely cross-origin DSN (e.g. a Sentry SaaS *.ingest.sentry.io endpoint) will
     # have its fetch/sendBeacon calls silently blocked by the browser. Route such DSNs
     # through this reverse proxy instead, or add their origin here (see ARCHITECTURE.md).
+    #
+    # img-src permits any https host because module/provider READMEs are publisher-authored
+    # and routinely carry build-status badges. The cost is that an embedded image is a
+    # working analytics pixel: the publisher's host learns the viewer's IP, User-Agent and
+    # timestamp (not the module path -- Referrer-Policy is strict-origin-when-cross-origin).
+    # Documented for end users in PRIVACY.md section 8. Operators who would rather lose
+    # badges than leak that can narrow this to `img-src 'self' data:`, which blocks ALL
+    # remote documentation images.
     add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'nonce-$csp_nonce'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self';" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
 

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -45,6 +45,14 @@ server {
     # genuinely cross-origin DSN (e.g. a Sentry SaaS *.ingest.sentry.io endpoint) will
     # have its fetch/sendBeacon calls silently blocked by the browser. Route such DSNs
     # through this reverse proxy instead, or add their origin here (see ARCHITECTURE.md).
+    #
+    # img-src permits any https host because module/provider READMEs are publisher-authored
+    # and routinely carry build-status badges. The cost is that an embedded image is a
+    # working analytics pixel: the publisher's host learns the viewer's IP, User-Agent and
+    # timestamp (not the module path -- Referrer-Policy is strict-origin-when-cross-origin).
+    # Documented for end users in PRIVACY.md section 8. Operators who would rather lose
+    # badges than leak that can narrow this to `img-src 'self' data:`, which blocks ALL
+    # remote documentation images.
     add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'nonce-$csp_nonce'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self';" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
 


### PR DESCRIPTION
Refs #680.

## What this is

#680 is explicit that it is a **content** risk, not a code defect: the markdown sanitizer's `protocols.src` allowlist permits any https host by design, and the CSP's `img-src 'self' data: https:` agrees with it. Nothing is misbehaving. The consequence is still real — any module publisher can embed a tracking pixel in a README and learn the IP, User-Agent and timestamp of every authenticated viewer.

## What I verified before writing it down

`Referrer-Policy` is already `strict-origin-when-cross-origin` at all four header sites, so a cross-origin image discloses this registry's **origin** but not the module path. The issue's evidence didn't state that bound, and it materially narrows what a publisher learns — they can tell somebody at your organisation looked, not which module. That distinction is now written down rather than left for a reader to re-derive.

## What this PR does, and what it deliberately doesn't

The issue's recommendation has three tiers. This lands the one that is unambiguously correct and breaks nothing:

- **PRIVACY.md section 8** gains a subsection stating plainly that these images are fetched by the viewer's browser, not proxied by the registry; exactly which fields the third-party host learns; and that the disclosure is to the publisher, not to us.
- **Both nginx configs** get the rationale beside the CSP, in the same style as the existing `connect-src`/Sentry-DSN note, so an operator reading the policy finds the `img-src 'self' data:` knob at the point of decision.

It does **not** tighten the CSP. Doing so blocks every remote documentation image, build-status badges included, and in a private registry READMEs routinely carry self-hosted architecture diagrams. Silent image breakage is a bad failure mode, and choosing it is a product call rather than a security default — so it is surfaced, not taken.

A camo-style backend image proxy (the posture the issue cites GitHub for) is the only option that keeps images working *and* removes the disclosure. That is cross-repo feature work in the backend, not a frontend config change.

## Scope

No code paths change. `MarkdownRenderer`, the sanitizer config and every emitted header are untouched — the CSP strings are byte-identical, so `nginxHeaderInheritance.test.ts` is unaffected. Prettier's glob is `src/**/*.{ts,tsx,css,json}`, so neither edited file is in its scope.

#680 stays open pending the CSP decision.