### PR TITLE
fix(csrf): stop getCookie from throwing on the request path

### DIFF
--- a/frontend/src/services/__tests__/api.test.ts
+++ b/frontend/src/services/__tests__/api.test.ts
@@ -298,6 +298,104 @@ describe('ApiClient', () => {
       const result = capturedReqFulfilled(config)
       expect(result.headers['X-CSRF-Token']).toBe('token/with+special=chars')
     })
+
+    // ─── #679: getCookie must not be able to break the request path ────────
+
+    it('does not throw in the interceptor when tfr_csrf is malformed', async () => {
+      // decodeURIComponent('ab%zz') throws URIError -- '%zz' is not a valid
+      // escape. getCookie runs INSIDE the request interceptor, so an uncaught
+      // throw rejects every mutating request with an opaque URIError instead of
+      // a network error, which is a silent write outage that looks like nothing.
+      //
+      // The getter is stubbed rather than the value assigned through
+      // document.cookie: what matters is that a malformed value REACHES
+      // getCookie, and routing it through jsdom's cookie jar would make this
+      // test depend on tough-cookie's validation rules instead of on the
+      // behaviour under test.
+      Object.defineProperty(document, 'cookie', {
+        configurable: true,
+        get: () => 'tfr_csrf=ab%zz',
+      })
+      await getApiClient()
+
+      const config = {
+        method: 'post',
+        headers: {} as Record<string, string>,
+      } as InternalAxiosRequestConfig
+
+      try {
+        expect(() => capturedReqFulfilled(config)).not.toThrow()
+
+        // And the raw bytes are what get echoed. The backend reads the same
+        // undecoded value from the Cookie header, so this is the value that
+        // actually matches; returning '' would drop the X-CSRF-Token header
+        // entirely and turn a survivable request into a guaranteed rejection.
+        expect(capturedReqFulfilled(config).headers['X-CSRF-Token']).toBe('ab%zz')
+      } finally {
+        delete (document as unknown as { cookie?: unknown }).cookie
+      }
+    })
+
+    it('warns once, not per request, when two tfr_csrf cookies are visible', async () => {
+      const { getCookie, resetDuplicateCookieWarning } = await import('../api/http')
+      resetDuplicateCookieWarning()
+
+      // jsdom's cookie jar keys on name+path+domain, so the setter cannot
+      // produce a genuine shadowing pair. The browser can: a host-only cookie
+      // plus a Domain-scoped one set by a sibling suite app on a shared parent
+      // domain. document.cookie renders them indistinguishably, which is the
+      // whole problem -- so stub the getter to emit what a browser would.
+      Object.defineProperty(document, 'cookie', {
+        configurable: true,
+        get: () => 'tfr_csrf=host-only; other=x; tfr_csrf=domain-scoped',
+      })
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      try {
+        // First match wins. There is no attribute information available to
+        // choose better; the point is that the ambiguity is reported, not that
+        // it is resolved.
+        expect(getCookie('tfr_csrf')).toBe('host-only')
+        expect(getCookie('tfr_csrf')).toBe('host-only')
+        expect(getCookie('tfr_csrf')).toBe('host-only')
+
+        const warnings = consoleError.mock.calls
+          .map((c) => String(c[0] ?? ''))
+          .filter((m) => m.includes('cookies named'))
+        // Exactly one across three reads: this runs on every mutating request,
+        // and a per-call log would bury the first occurrence under thousands.
+        expect(warnings).toHaveLength(1)
+        expect(warnings[0]).toContain('tfr_csrf')
+      } finally {
+        delete (document as unknown as { cookie?: unknown }).cookie
+        resetDuplicateCookieWarning()
+      }
+    })
+
+    it('does not warn when only one tfr_csrf cookie is present', async () => {
+      // The control half. Without it the warning could fire on every ordinary
+      // single-cookie request and the test above would still pass.
+      const { getCookie, resetDuplicateCookieWarning } = await import('../api/http')
+      resetDuplicateCookieWarning()
+
+      Object.defineProperty(document, 'cookie', {
+        configurable: true,
+        get: () => 'other=x; tfr_csrf=only-one; another=y',
+      })
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      try {
+        expect(getCookie('tfr_csrf')).toBe('only-one')
+        expect(
+          consoleError.mock.calls
+            .map((c) => String(c[0] ?? ''))
+            .filter((m) => m.includes('cookies named')),
+        ).toHaveLength(0)
+      } finally {
+        delete (document as unknown as { cookie?: unknown }).cookie
+        resetDuplicateCookieWarning()
+      }
+    })
   })
 
   // ─── 401 Interceptor ──────────────────────────────────────────────────

--- a/frontend/src/services/api/http.ts
+++ b/frontend/src/services/api/http.ts
@@ -18,12 +18,67 @@ const USE_MOCK_DATA = import.meta.env.VITE_USE_MOCK_DATA === 'true' && !import.m
 // connection can legitimately take longer than this.
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000
 
-/** Read a cookie value by name. Returns empty string if not found. */
+// One-shot, because getCookie runs on EVERY mutating request: a per-call log
+// would bury the first (and only useful) occurrence under thousands of repeats.
+let hasWarnedDuplicateCookie = false
+
+/** Reset the duplicate-cookie warning latch. Test seam only. */
+export function resetDuplicateCookieWarning(): void {
+  hasWarnedDuplicateCookie = false
+}
+
+/**
+ * Read a cookie value by name. Returns empty string if not found.
+ *
+ * Both hazards handled here are #679, and both matter because the two callers
+ * (the axios request interceptor below, and the Swagger one in
+ * ApiDocumentation.tsx) run on the request path:
+ *
+ * 1. `decodeURIComponent` throws `URIError` on a stray '%' that is not a valid
+ *    escape -- `tfr_csrf=ab%zz` is enough. Thrown from inside an interceptor
+ *    that rejects every mutating request with an opaque URIError rather than a
+ *    network error. The RAW value is returned on a decode failure rather than
+ *    '': the backend reads those same undecoded bytes from the Cookie header,
+ *    so echoing them back is what actually matches, whereas '' drops the
+ *    X-CSRF-Token header entirely and guarantees rejection.
+ *
+ * 2. `document.cookie` exposes no attributes, so a host-only cookie and a
+ *    Domain-scoped one set by a sibling suite app on a shared parent domain are
+ *    indistinguishable from here. First match is still what is returned --
+ *    there is genuinely no information available to choose better -- but the
+ *    collision is logged, because otherwise the symptom is every mutation
+ *    failing server-side with nothing client-side to explain why.
+ *
+ *    The durable fix for (2) is a `__Host-` prefixed CSRF cookie, whose prefix
+ *    makes a Domain-scoped duplicate impossible to set. That requires the
+ *    backend to change the cookie it issues, so it is not done here.
+ */
 export function getCookie(name: string): string {
-  const match = document.cookie.match(
-    new RegExp('(?:^|; )' + name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '=([^;]*)'),
+  const pattern = new RegExp(
+    '(?:^|; )' + name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '=([^;]*)',
+    'g',
   )
-  return match ? decodeURIComponent(match[1]) : ''
+  const matches = Array.from(document.cookie.matchAll(pattern))
+  if (matches.length === 0) return ''
+
+  if (matches.length > 1 && !hasWarnedDuplicateCookie) {
+    hasWarnedDuplicateCookie = true
+    console.error(
+      `[auth] ${matches.length} cookies named "${name}" are visible to this page. ` +
+        'document.cookie hides their Domain/Path, so the wrong one may be echoed while the ' +
+        'server reads another -- which presents as every mutating request failing CSRF ' +
+        'validation. A sibling app on a shared parent domain is the usual cause.',
+    )
+  }
+
+  const raw = matches[0][1]
+  try {
+    return decodeURIComponent(raw)
+  } catch {
+    // Malformed percent-encoding. Returning raw keeps the request survivable;
+    // see (1) above for why '' would be strictly worse.
+    return raw
+  }
 }
 
 /**


### PR DESCRIPTION
Closes #679.

`getCookie` is called from inside the axios request interceptor and from the Swagger interceptor in `ApiDocumentation.tsx`. Both run on the request path, which is what makes an unguarded `decodeURIComponent` more than a robustness nit: a stray `%` that is not a valid escape — `tfr_csrf=ab%zz` is enough — raises `URIError` from inside the interceptor and takes out **every** mutating request with an opaque failure rather than a network error. Fail-closed, but a silent write outage that looks like nothing from the console.

## Two decisions worth stating

**A decode failure returns the raw value, not `''`.** The backend reads those same undecoded bytes from the `Cookie` header, so the raw value is the one that actually matches. Returning `''` would drop the `X-CSRF-Token` header entirely (the interceptor only sets it `if (csrfToken)`) and convert a survivable request into a guaranteed rejection — strictly worse than the bug.

**Duplicate cookies are reported, not resolved.** `document.cookie` exposes no attributes, so a host-only `tfr_csrf` and a `Domain`-scoped one set by a sibling suite app on a shared parent domain are indistinguishable from JS. First match is still returned — there is genuinely no information available to choose better — but the collision is logged, because the symptom is otherwise every mutation failing CSRF validation server-side with nothing client-side to explain why. Logged **once**, not per call: this runs on every mutating request, and a per-call log would bury the first and only useful occurrence.

## Verification

Frontend deps cannot be installed in this environment (`@sethbacon/terraform-suite-ui` needs `read:packages`, which this token lacks), so I could not run vitest locally and CI is the first execution. To compensate I exercised the parsing logic directly before wiring it up — malformed, duplicate pair, single-among-others, well-formed encoded, and absent — plus the warn-once behaviour across repeated reads. The existing decode expectation at `api.test.ts:288` is unaffected.

The tests stub the `document.cookie` **getter** rather than assigning through it, for two different reasons: jsdom's jar keys on name+path+domain so a genuine shadowing pair cannot be created via the setter at all, and pushing a malformed value through it would make the test depend on tough-cookie's validation rules instead of on the behaviour under test. A single-cookie control case is included so the warning cannot start firing on ordinary requests without failing.

## Not done here

The `__Host-` cookie prefix, which is the durable fix for shadowing — the prefix makes a `Domain`-scoped duplicate impossible to set. The backend issues the cookie, so it cannot be changed from this repo. Worth tracking there if you want it; I have not filed anything.

#677 (the 401 interceptor clearing `tfr_csrf` for non-session 401s) is left open: its real fix needs the structured backend signal that `http.ts`'s own `SCM_OAUTH_SUBRESOURCES` comment already flags as missing.