### PR TITLE
fix(telemetry): discard error telemetry captured before the user opted in

### DIFF
--- a/frontend/src/services/__tests__/errorReporting.test.ts
+++ b/frontend/src/services/__tests__/errorReporting.test.ts
@@ -308,8 +308,13 @@ describe('errorReporting', () => {
       // No DSN => flush() is a no-op, so nothing drains the buffer. Without a
       // cap this grows for the lifetime of the page (captureError is wired
       // into every API error path), so assert the retained entries are
-      // bounded: capture well past MAX_BATCH_SIZE with reporting inactive,
-      // then activate a DSN and flush, and inspect what was retained.
+      // bounded.
+      //
+      // This used to observe the buffer by activating a DSN and flushing --
+      // which is precisely the pre-consent transmission #689 removed, so that
+      // route no longer exists. The memory bound it was checking is still real
+      // and still matters for users who never consent, so it is now read
+      // directly via the bufferedErrorMessages test seam.
       vi.stubEnv('VITE_ERROR_REPORTING_DSN', '')
       vi.resetModules()
       const mod = await import('../errorReporting')
@@ -318,18 +323,36 @@ describe('errorReporting', () => {
         mod.captureError(new Error(`overflow ${i}`))
       }
 
-      // Activate reporting, then drain.
+      const buffered = mod.bufferedErrorMessages()
+      // MAX_BATCH_SIZE is 10; unbounded this would be all 25.
+      expect(buffered.length).toBeLessThanOrEqual(10)
+      // Oldest are evicted first, so the newest error must survive.
+      expect(buffered).toContain('overflow 24')
+      // ...and the oldest must not, or nothing was actually evicted.
+      expect(buffered).not.toContain('overflow 0')
+
+      mod.destroy()
+    })
+
+    it('discards the bounded buffer on opt-in rather than transmitting it', async () => {
+      // The other half of the behaviour the old version of this test asserted:
+      // those retained entries were captured with reporting inactive, so
+      // granting consent must drop them, not ship them (#689).
+      vi.stubEnv('VITE_ERROR_REPORTING_DSN', '')
+      vi.resetModules()
+      const mod = await import('../errorReporting')
+
+      for (let i = 0; i < 25; i++) {
+        mod.captureError(new Error(`overflow ${i}`))
+      }
+      expect(mod.bufferedErrorMessages().length).toBeGreaterThan(0)
+
       vi.stubEnv('VITE_ERROR_REPORTING_DSN', 'https://errors.example.com/report')
       mod.init()
-      mod.flush()
 
-      expect(globalThis.fetch).toHaveBeenCalled()
-      const call = (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0]
-      const body = JSON.parse((call[1] as RequestInit).body as string)
-      // MAX_BATCH_SIZE is 10; pre-fix this would be all 25.
-      expect(body.entries.length).toBeLessThanOrEqual(10)
-      // Oldest are evicted first, so the newest error must survive.
-      expect(JSON.stringify(body.entries)).toContain('overflow 24')
+      expect(mod.bufferedErrorMessages()).toEqual([])
+      mod.flush()
+      expect(globalThis.fetch).not.toHaveBeenCalled()
 
       mod.destroy()
     })

--- a/frontend/src/services/__tests__/errorReporting.test.ts
+++ b/frontend/src/services/__tests__/errorReporting.test.ts
@@ -334,4 +334,76 @@ describe('errorReporting', () => {
       mod.destroy()
     })
   })
+
+  // ─── #689: nothing captured before opt-in may be transmitted after it ──────
+  //
+  // TelemetryGate is the only caller of init(), and it calls it only once the
+  // user has opted in — so reaching init() IS the consent transition. captureError
+  // runs unconditionally app-wide, so before this fix the first flush after opt-in
+  // shipped everything buffered while telemetry was switched off.
+  //
+  // Every test here stubs a real DSN. Without that, flush() early-returns on
+  // `!dsn` and "fetch was not called" would be true no matter what the buffer
+  // held — the assertion would pass against completely unfixed code.
+  describe('pre-consent buffering (#689)', () => {
+    const DSN = 'https://errors.example.com/report'
+
+    it('discards errors captured before init() instead of shipping them', async () => {
+      vi.stubEnv('VITE_ERROR_REPORTING_DSN', DSN)
+      vi.stubEnv('VITE_SENTRY_DSN', '')
+
+      const mod = await import('../errorReporting')
+      // Captured while telemetry is off — the user has not opted in yet.
+      mod.captureError(new Error('pre-consent secret'))
+      mod.captureError(new Error('another pre-consent one'))
+
+      // The user now opts in.
+      mod.init()
+      mod.flush()
+
+      expect(globalThis.fetch).not.toHaveBeenCalled()
+      mod.destroy()
+    })
+
+    it('still reports errors captured after init()', async () => {
+      // The control. Without it, deleting the whole reporting path would satisfy
+      // the test above, and this suite would be certifying a broken module.
+      vi.stubEnv('VITE_ERROR_REPORTING_DSN', DSN)
+      vi.stubEnv('VITE_SENTRY_DSN', '')
+
+      const mod = await import('../errorReporting')
+      mod.captureError(new Error('pre-consent secret'))
+      mod.init()
+      mod.captureError(new Error('post-consent error'))
+      mod.flush()
+
+      expect(globalThis.fetch).toHaveBeenCalledTimes(1)
+      const body = JSON.parse((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body)
+      expect(body.entries).toHaveLength(1)
+      expect(JSON.stringify(body.entries)).toContain('post-consent error')
+      // And the pre-consent one did not ride along in the same batch.
+      expect(JSON.stringify(body.entries)).not.toContain('pre-consent secret')
+      mod.destroy()
+    })
+
+    it('does not attach breadcrumbs collected before init() to a later error', async () => {
+      // Breadcrumbs are user-activity data (visited URLs, API calls) and they ride
+      // along inside the next error report, so clearing the error buffer alone
+      // would still transmit pre-consent history.
+      vi.stubEnv('VITE_ERROR_REPORTING_DSN', DSN)
+      vi.stubEnv('VITE_SENTRY_DSN', '')
+
+      const mod = await import('../errorReporting')
+      mod.addNavigationBreadcrumb('/secret-page', '/another-secret-page')
+
+      mod.init()
+      mod.captureError(new Error('post-consent error'))
+      mod.flush()
+
+      const body = JSON.parse((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body)
+      expect(body.entries[0].breadcrumbs).toHaveLength(0)
+      expect(JSON.stringify(body.entries)).not.toContain('secret-page')
+      mod.destroy()
+    })
+  })
 })

--- a/frontend/src/services/errorReporting.ts
+++ b/frontend/src/services/errorReporting.ts
@@ -119,6 +119,19 @@ export function flush(): void {
   })
 }
 
+/**
+ * Messages currently buffered, oldest first. **Test seam only.**
+ *
+ * The buffer used to be observable by activating a DSN and flushing, which is
+ * exactly the transmission #689 removed. The MAX_BATCH_SIZE memory bound still
+ * matters for users who never consent -- captureError is wired into every API
+ * error path, so an uncapped buffer would grow for the lifetime of the page --
+ * and without this it could not be asserted at all.
+ */
+export function bufferedErrorMessages(): string[] {
+  return errorBuffer.map((entry) => entry.message)
+}
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
@@ -265,10 +278,12 @@ function enqueueError(error: Error, context?: Record<string, unknown>): void {
   // so without this cap every captured error would accumulate for the lifetime
   // of the page for users who never consented to telemetry -- and captureError
   // is wired into every API error path, so that is a real leak, not a
-  // theoretical one. Entries are kept (rather than dropped at the door) so
-  // errors captured before init() resolves the DSN still ship once it does;
-  // capping evicts the oldest first, the same bounded-ring-buffer approach
-  // performanceReporting.ts uses.
+  // theoretical one. Capping evicts the oldest first, the same bounded
+  // ring-buffer approach performanceReporting.ts uses.
+  //
+  // This cap is now purely a memory bound. Anything buffered while reporting is
+  // inactive is discarded by init() rather than transmitted (#689), so the cap
+  // no longer decides what gets sent -- only how much is held in the meantime.
   if (errorBuffer.length > MAX_BATCH_SIZE) {
     errorBuffer.splice(0, errorBuffer.length - MAX_BATCH_SIZE)
   }

--- a/frontend/src/services/errorReporting.ts
+++ b/frontend/src/services/errorReporting.ts
@@ -125,8 +125,38 @@ export function flush(): void {
 
 /**
  * Initialise error reporting. Call once at app startup.
+ *
+ * Only TelemetryGate calls this, and only once the user has opted in, so
+ * reaching this function IS the consent transition. Anything already buffered
+ * was therefore captured while telemetry was switched off, and is discarded
+ * rather than shipped (#689).
+ *
+ * captureError() is called unconditionally across the app -- by getErrorMessage()
+ * on every handled error, by the unhandledrejection listener, and by
+ * ErrorBoundary -- so without this the first flush after opt-in would transmit
+ * up to MAX_BATCH_SIZE entries, plus their breadcrumb trail of visited URLs,
+ * that were collected before consent existed. PRIVACY.md section 3.3 states
+ * telemetry is opt-in only; shipping data captured before the opt-in does not
+ * honour that, whoever pressed the button afterwards.
+ *
+ * Breadcrumbs are dropped for the same reason: they are user-activity data and
+ * they ride along with the next error report.
+ *
+ * The cost is bounded and deliberate. On a page load where consent was already
+ * stored, errors captured between module load and TelemetryGate's effect are
+ * lost rather than sent. Distinguishing those from genuinely pre-consent
+ * entries would mean reading the consent record here, duplicating a storage
+ * contract owned by @sethbacon/terraform-suite-ui -- not worth a cross-repo
+ * coupling to recover a few milliseconds of startup errors, and the safe
+ * direction to err in is dropping.
+ *
+ * destroy() already clears the same state, so withdrawal was handled; only the
+ * grant transition leaked.
  */
 export function init(): void {
+  errorBuffer.length = 0
+  breadcrumbs.length = 0
+
   sessionId = generateSessionId()
 
   const sentryDsn = import.meta.env.VITE_SENTRY_DSN


### PR DESCRIPTION
Closes #689.

`TelemetryGate` is the only caller of `errorReporting.init()`, and it calls it only once the user has opted in — so **reaching `init()` is the consent transition**. Meanwhile `captureError()` runs unconditionally across the app (`getErrorMessage()` on every handled error, the `unhandledrejection` listener, `ErrorBoundary`), so by then the buffer could already hold up to `MAX_BATCH_SIZE` entries captured while telemetry was switched off. The first flush after opt-in shipped them.

PRIVACY.md §3.3 says telemetry is opt-in only. Transmitting data captured *before* the opt-in doesn't honour that, whoever pressed the button afterwards.

Breadcrumbs are cleared for the same reason — they're user-activity data (visited URLs, API calls) and they ride along *inside* the next error report, so clearing the error buffer alone would still transmit pre-consent history.

`destroy()` already cleared both, so consent **withdrawal** was handled correctly. Only the grant transition leaked.

## I checked the sibling module rather than assuming symmetry

My first instinct was that this was a defect class and I patched `performanceReporting` too. That was wrong, and I reverted it — it does **not** have this bug:

- its Web Vitals callbacks are registered *inside* `init()`, so they cannot fire before it;
- `reportNavigation()` — the one entry point `useNavigationBreadcrumbs` calls on every route change regardless of consent — already returns early on `!dsn`, with a comment describing exactly this scenario.

`errorReporting`'s `enqueueError()` has no equivalent gate. That asymmetry *is* the bug, and the fix is confined to the module that has it. Adding a redundant clear to the other one would have been dead code justified by a false premise.

## The cost, stated plainly

On a page load where consent was already stored, errors captured between module load and `TelemetryGate`'s effect are now dropped rather than sent. Telling those apart from genuinely pre-consent entries would mean reading the consent record inside this module, duplicating a storage contract owned by `@sethbacon/terraform-suite-ui`. Not worth a cross-repo coupling to recover a few milliseconds of startup errors — and dropping is the safe direction to err in.

## Test design

Every test stubs a real DSN. That is load-bearing: `flush()` early-returns on `!dsn`, so "fetch was not called" would be true regardless of what the buffer held, and the assertion would pass against completely unfixed code. There is also a control asserting post-`init()` errors **are** still reported, so deleting the reporting path cannot satisfy the suite.

Three cases: pre-`init()` errors discarded; post-`init()` errors still delivered and the pre-consent one absent from the same batch; pre-`init()` breadcrumbs not attached to a later error.

Frontend deps can't be installed in this environment (`@sethbacon/terraform-suite-ui` needs `read:packages`), so CI is the first execution of these.