### PR TITLE
fix(markdown): stop spreading react-markdown's node prop onto heading elements

### DIFF
--- a/frontend/src/components/MarkdownRenderer.tsx
+++ b/frontend/src/components/MarkdownRenderer.tsx
@@ -14,14 +14,23 @@ interface MarkdownRendererProps {
  * Custom heading components that shift markdown headings down by one level
  * (h1 -> h2, h2 -> h3, h3 -> h4) so the page <h1> remains the top-level
  * heading and markdown content maintains proper heading hierarchy.
+ *
+ * `node` is destructured out and discarded on purpose. react-markdown runs with
+ * `passNode: true`, so it hands each custom component the underlying hast node;
+ * spreading it onto a real DOM element renders
+ * `<h2 node="[object Object]">` on every heading in every README. React 19 no
+ * longer warns about unknown props, so it ships silently. Verified against
+ * react-markdown 10 -- `# Hello *world*` produces
+ * `<h2 node="[object Object]">Hello <em>world</em></h2>` with the spread and a
+ * clean `<h2>` without it.
  */
 const markdownComponents: Partial<Components> = {
-  h1: ({ children, ...props }) => <h2 {...props}>{children}</h2>,
-  h2: ({ children, ...props }) => <h3 {...props}>{children}</h3>,
-  h3: ({ children, ...props }) => <h4 {...props}>{children}</h4>,
-  h4: ({ children, ...props }) => <h5 {...props}>{children}</h5>,
-  h5: ({ children, ...props }) => <h6 {...props}>{children}</h6>,
-  h6: ({ children, ...props }) => <h6 {...props}>{children}</h6>,
+  h1: ({ children, node: _node, ...props }) => <h2 {...props}>{children}</h2>,
+  h2: ({ children, node: _node, ...props }) => <h3 {...props}>{children}</h3>,
+  h3: ({ children, node: _node, ...props }) => <h4 {...props}>{children}</h4>,
+  h4: ({ children, node: _node, ...props }) => <h5 {...props}>{children}</h5>,
+  h5: ({ children, node: _node, ...props }) => <h6 {...props}>{children}</h6>,
+  h6: ({ children, node: _node, ...props }) => <h6 {...props}>{children}</h6>,
 }
 
 const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ children }) => {

--- a/frontend/src/components/__tests__/MarkdownRenderer.test.tsx
+++ b/frontend/src/components/__tests__/MarkdownRenderer.test.tsx
@@ -30,6 +30,36 @@ describe('MarkdownRenderer', () => {
     expect(screen.getByText('Heading 2')).toBeInTheDocument()
   })
 
+  // Issue #681. react-markdown runs with passNode: true, so it hands each custom
+  // component the underlying hast node. The heading overrides used to spread it
+  // straight onto the DOM element, producing `<h2 node="[object Object]">` on
+  // every heading of every README. React 19 stopped warning about unknown props,
+  // so nothing surfaced it.
+  //
+  // Verified against react-markdown 10 that this fails without the fix: with the
+  // node prop spread, `# Hello *world*` renders
+  // `<h2 node="[object Object]">Hello <em>world</em></h2>`.
+  //
+  // Asserted across all six levels because the overrides are six separate
+  // closures -- fixing h1 and missing h4 is exactly the kind of partial fix a
+  // single-heading test would certify as done.
+  it('does not leak react-markdown internals onto heading elements', () => {
+    const { container } = renderWithTheme(
+      <MarkdownRenderer>
+        {'# One\n## Two\n### Three\n#### Four\n##### Five\n###### Six'}
+      </MarkdownRenderer>,
+    )
+
+    const headings = container.querySelectorAll('h1, h2, h3, h4, h5, h6')
+    expect(headings).toHaveLength(6)
+    for (const heading of headings) {
+      expect(
+        heading.getAttribute('node'),
+        `<${heading.tagName.toLowerCase()}> carries a node attribute: ${heading.outerHTML}`,
+      ).toBeNull()
+    }
+  })
+
   it('renders inline code', () => {
     renderWithTheme(<MarkdownRenderer>{'Use `terraform init` to start'}</MarkdownRenderer>)
 


### PR DESCRIPTION
Closes #681.

react-markdown runs with `passNode: true`, so it hands each custom component the underlying hast node. The six heading overrides spread it straight onto a real DOM element, so **every heading in every README and provider doc** rendered as `<h2 node="[object Object]">`. React 19 stopped warning about unknown props, so this shipped silently.

Not a security issue — React escapes the attribute and the sanitizer has already run — but it is invalid HTML, it bloats the DOM, and it makes the rendered output confusing to inspect or scrape.

## Reproduced before fixing

I installed react-markdown 10 standalone and rendered both variants rather than taking the report on trust:

| components map | output |
| --- | --- |
| `({ children, ...props })` | `<h2 node="[object Object]">Hello <em>world</em></h2>` |
| `({ children, node: _node, ...props })` | `<h2>Hello <em>world</em></h2>` |

## The test covers all six levels

The overrides are six separate closures, so fixing `h1` and missing `h4` is precisely what a single-heading test would certify as done. Against the six-heading fixture: **6 `node` attributes without the fix, 0 with it** — so the assertion fails six times on unfixed code rather than being a green no-op.

The heading count is asserted as well, because `h5` and `h6` both map to `h6`, so six markdown headings still yield six elements — a count that silently drifted would weaken the loop underneath it.

## Lint

`_node` is covered twice over: the config's `varsIgnorePattern: '^_'`, and typescript-eslint's default `ignoreRestSiblings`, which exists for exactly this omit-a-prop-via-destructuring idiom.

Frontend deps can't be installed here (`@sethbacon/terraform-suite-ui` needs `read:packages`), so CI is the first run of the vitest assertion — but the underlying behaviour is verified above.