### PR TITLE
fix(telemetry): sanitize the captureError context at the point it enters

### DIFF
--- a/frontend/src/services/__tests__/errorReporting.test.ts
+++ b/frontend/src/services/__tests__/errorReporting.test.ts
@@ -114,6 +114,53 @@ describe('errorReporting', () => {
       window.history.pushState({}, '', originalLocation)
     })
 
+    // ─── #698: context is sanitized once, at the point it enters ────────────
+    //
+    // Three exits carry the context out, and the Sentry hooks in init() cover
+    // none of them: this console.error (Sentry's console integration records the
+    // arguments verbatim, a shape beforeBreadcrumb's url/from/to loop never
+    // inspects), Sentry's `extra` (beforeSend only rewrites request.url), and
+    // the custom reporter's stored entry.
+    it('strips a session token from the context passed to console.error', async () => {
+      vi.stubEnv('VITE_ERROR_REPORTING_DSN', '')
+      vi.stubEnv('VITE_SENTRY_DSN', '')
+
+      const { captureError: freshCapture } = await import('../errorReporting')
+      freshCapture(new Error('boom'), {
+        returnTo: 'https://app.example.com/auth/callback?token=super-secret-jwt',
+      })
+
+      const logged = (console.error as ReturnType<typeof vi.fn>).mock.calls.find(
+        (c) => c[0] === '[ErrorReporting]',
+      )
+      expect(logged, 'captureError logged nothing').toBeDefined()
+      expect(JSON.stringify(logged?.[2])).not.toContain('super-secret-jwt')
+      // The rest of the URL survives, or the diagnostic is worthless.
+      expect(JSON.stringify(logged?.[2])).toContain('/auth/callback')
+    })
+
+    it('strips a session token from the context stored by the custom reporter', async () => {
+      vi.stubEnv('VITE_ERROR_REPORTING_DSN', 'https://errors.example.com/report')
+      vi.stubEnv('VITE_SENTRY_DSN', '')
+
+      const {
+        init: freshInit,
+        captureError: freshCapture,
+        flush: freshFlush,
+      } = await import('../errorReporting')
+      freshInit()
+      freshCapture(new Error('boom'), {
+        returnTo: '/auth/callback?token=super-secret-jwt',
+        component: 'OrganizationsPage',
+      })
+      freshFlush()
+
+      const body = JSON.parse((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body)
+      expect(JSON.stringify(body.entries[0].context)).not.toContain('super-secret-jwt')
+      // Non-URL values must pass through untouched, or ordinary context is mangled.
+      expect(body.entries[0].context.component).toBe('OrganizationsPage')
+    })
+
     it('does not call fetch when no DSN is configured', () => {
       const error = new Error('No DSN error')
       captureError(error)
@@ -174,6 +221,34 @@ describe('errorReporting', () => {
       }) as { data: { from: string; to: string } }
       expect(navBreadcrumb.data.from).toBe('/auth/callback')
       expect(navBreadcrumb.data.to).toBe('/')
+    })
+
+    // #698's third exit. beforeSend only rewrites event.request.url, so a
+    // sensitive value in the context reaches Sentry through `extra` untouched
+    // by any hook above -- it has to be sanitized before it is handed over.
+    it('strips a session token from the context handed to Sentry as extra', async () => {
+      const initMock = vi.fn()
+      const captureExceptionMock = vi.fn()
+      vi.doMock('@sentry/react', () => ({
+        init: initMock,
+        captureException: captureExceptionMock,
+      }))
+      vi.stubEnv('VITE_SENTRY_DSN', 'https://sentry.example.com/dsn')
+
+      const { init: freshInit, captureError: freshCapture } = await import('../errorReporting')
+      freshInit()
+      await vi.waitFor(() => expect(initMock).toHaveBeenCalled())
+
+      freshCapture(new Error('boom'), {
+        returnTo: 'https://app.example.com/auth/callback?token=super-secret-jwt',
+        component: 'UsersPage',
+      })
+      await vi.waitFor(() => expect(captureExceptionMock).toHaveBeenCalled())
+
+      const extra = captureExceptionMock.mock.calls[0][1].extra as Record<string, unknown>
+      expect(JSON.stringify(extra)).not.toContain('super-secret-jwt')
+      expect(String(extra.returnTo)).toContain('/auth/callback')
+      expect(extra.component).toBe('UsersPage')
     })
   })
 

--- a/frontend/src/services/errorReporting.ts
+++ b/frontend/src/services/errorReporting.ts
@@ -190,26 +190,62 @@ export function init(): void {
 }
 
 /**
+ * Sanitize a captureError context once, at the point the data enters, so every
+ * exit below is covered by construction (#698).
+ *
+ * There are three of them, and the Sentry hooks in init() cover none:
+ *
+ *   1. `console.error` here. Sentry's default console integration records the
+ *      arguments verbatim as a breadcrumb, and that breadcrumb's shape is an
+ *      arguments array -- not the url/from/to keys beforeBreadcrumb inspects.
+ *   2. `Sentry.captureException(..., { extra })`. beforeSend only rewrites
+ *      `event.request.url`; it never touches `event.extra`.
+ *   3. The custom reporter, which stores the context on the queued entry.
+ *
+ * Sanitizing the breadcrumb instead would not have worked: sanitizeUrl returns
+ * non-URL strings unchanged, so a URL embedded in a serialized arguments array
+ * is not something it can find. Sanitizing at the source is both simpler and
+ * the only version that holds.
+ *
+ * Deliberately SHALLOW -- top-level string values only. Every call site
+ * reviewed passes flat objects of short static strings, and recursive
+ * traversal of arbitrary context would be speculative. A URL nested inside an
+ * object value is therefore still passed through; that is a known limit, not
+ * an oversight.
+ */
+function sanitizeContext(context?: Record<string, unknown>): Record<string, unknown> | undefined {
+  if (!context) return context
+
+  const sanitized: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(context)) {
+    sanitized[key] = typeof value === 'string' ? sanitizeUrl(value) : value
+  }
+  return sanitized
+}
+
+/**
  * Capture an error with optional context. The error is batched and will be
  * sent to the configured DSN (or Sentry) on the next flush cycle.
  */
 export function captureError(error: Error, context?: Record<string, unknown>): void {
-  console.error('[ErrorReporting]', error.message, context)
+  const safeContext = sanitizeContext(context)
+
+  console.error('[ErrorReporting]', error.message, safeContext)
 
   // Delegate to Sentry when available
   if (useSentry) {
     import('@sentry/react')
       .then((Sentry) => {
-        Sentry.captureException(error, { extra: context })
+        Sentry.captureException(error, { extra: safeContext })
       })
       .catch(() => {
         // Sentry not available — queue for custom reporter
-        enqueueError(error, context)
+        enqueueError(error, safeContext)
       })
     return
   }
 
-  enqueueError(error, context)
+  enqueueError(error, safeContext)
 }
 
 function enqueueError(error: Error, context?: Record<string, unknown>): void {


### PR DESCRIPTION
Closes #698.

The context object leaves `captureError` by **three** routes, and the Sentry hooks in `init()` cover none of them:

1. **`console.error` here.** Sentry's default console integration records the arguments verbatim as a breadcrumb, and that breadcrumb's shape is an arguments array — not the `url`/`from`/`to` keys `beforeBreadcrumb` inspects. This is what the issue reported.
2. **`Sentry.captureException(..., { extra })`.** `beforeSend` only rewrites `event.request.url`; it never touches `event.extra`.
3. **The custom reporter**, which stores the context on the queued entry.

(2) and (3) weren't in the report. They're the same defect reached by different paths, so rather than patch one exit I sanitized where the data *enters* — which covers all three by construction and can't be reopened by someone adding a fourth consumer.

## Why not sanitize the breadcrumb

That was the issue's other suggestion, and I tried to reason it through before writing anything: it doesn't work. `sanitizeUrl` returns non-URL strings unchanged, so a URL embedded inside a serialized arguments array is not something it can locate. Sanitizing at the source is both simpler and the only version that actually holds.

I also didn't disable Sentry's console integration outright — that would drop console breadcrumbs from every other source in the app, which are genuinely useful diagnostics, to fix a problem that isn't really about breadcrumbs.

## Deliberately shallow

Top-level string values only. Every reviewed call site passes flat objects of short static strings, and recursive traversal of arbitrary context would be speculative. **A URL nested inside an object value is still passed through** — a stated limit, not an oversight.

## Verification

I ran `sanitizeUrl` against the exact values the tests use: the token is stripped while the path survives (`.../auth/callback?token=…` → `.../auth/callback`), and non-URL strings come back untouched. That second half matters as much as the first — the pre-existing assertion passes `{ page: '/modules' }` and must keep passing, and ordinary context like a component name must not be mangled.

Tests cover all three exits, each asserting both that the token is gone *and* that the surrounding value survived.

Frontend deps can't be installed here (`@sethbacon/terraform-suite-ui` needs `read:packages`), so CI is the first vitest run.