### PR TITLE
fix(api-docs): stop replacing DOM nodes swagger-ui's React tree still owns

### DIFF
--- a/frontend/src/utils/__tests__/swaggerTheme.test.ts
+++ b/frontend/src/utils/__tests__/swaggerTheme.test.ts
@@ -67,15 +67,46 @@ describe('enforceSwaggerA11yStyles', () => {
     expect(btn.querySelector<SVGElement>('svg')!.style.fill).toBe('#007a52')
   })
 
-  it('replaces the nested anchor inside opblock-summary-control with a span (nested-interactive a11y fix)', () => {
+  // #683 — this used to assert the <a> was REPLACED by a <span>. That
+  // replacement removed a node swagger-ui's React tree still referenced, and
+  // React's later removeChild against a parent no longer containing it threw
+  // NotFoundError, taking the whole /api-docs route to the ErrorBoundary.
+  //
+  // The nested-interactive violation is now cleared by dropping href instead:
+  // an <a> without href has no implicit link role and is not focusable. The
+  // assertions therefore invert -- the element must SURVIVE, in place, with its
+  // identity intact.
+  it('clears the nested-interactive violation without replacing the anchor node', () => {
     renderFixture()
+    const control = document.querySelector('.opblock-summary-control')!
+    const before = control.querySelector('a')!
+
     enforceSwaggerA11yStyles(false)
 
-    const control = document.querySelector('.opblock-summary-control')!
-    expect(control.querySelector('a')).toBeNull()
-    const span = control.querySelector('span.opblock-summary-path')!
-    expect(span.textContent).toBe('/things')
-    expect(span.getAttribute('data-foo')).toBe('bar')
+    const after = control.querySelector('a')
+    // Same node object, still attached: anything else is the crash this fixes.
+    expect(after).toBe(before)
+    expect(after!.isConnected).toBe(true)
+    // The violation itself is gone.
+    expect(after!.hasAttribute('href')).toBe(false)
+    // And nothing else about the element was discarded -- the old replacement
+    // dropped every non-data attribute and rebuilt the class list by hand.
+    expect(after!.textContent).toBe('/things')
+    expect(after!.className).toBe('opblock-summary-path')
+    expect(after!.getAttribute('data-foo')).toBe('bar')
+  })
+
+  it('is idempotent, because the MutationObserver re-runs it constantly', () => {
+    renderFixture()
+    const before = document.querySelector('.opblock-summary-control a')!
+
+    enforceSwaggerA11yStyles(false)
+    enforceSwaggerA11yStyles(false)
+    enforceSwaggerA11yStyles(false)
+
+    const after = document.querySelector('.opblock-summary-control a')
+    expect(after).toBe(before)
+    expect(after!.hasAttribute('href')).toBe(false)
   })
 
   it('is a no-op when no matching elements exist', () => {

--- a/frontend/src/utils/swaggerTheme.ts
+++ b/frontend/src/utils/swaggerTheme.ts
@@ -78,17 +78,34 @@ export function enforceSwaggerA11yStyles(dark: boolean): void {
     if (svg) svg.style.setProperty('fill', authColor, 'important')
   })
 
-  // Nested-interactive fix: replace <a> inside summary buttons with <span>
+  // Nested-interactive fix: swagger-ui renders an <a> inside the summary
+  // button, which is a nested-interactive a11y violation.
+  //
+  // This used to replace the <a> with a <span>, and that removed a node
+  // swagger-ui's own React tree still held a reference to. When React later
+  // unmounted or re-rendered the subtree -- collapsing an operation, switching
+  // tags, toggling deep-link state -- it called removeChild/insertBefore
+  // against a parent that no longer contained the node, throwing
+  // "NotFoundError: Failed to execute 'removeChild' on 'Node'". That propagates
+  // to the ErrorBoundary LazyRoute wraps around this page, so the entire
+  // /api-docs route dropped to the error fallback (#683).
+  //
+  // Dropping href is sufficient: an <a> with no href has no implicit link role
+  // and is not focusable, so the nested-interactive rule is satisfied. The node
+  // stays exactly where React put it and every reconciler reference stays
+  // valid.
+  //
+  // It is also strictly less destructive than the replacement it supersedes,
+  // which discarded the anchor's identity, class list and all non-data
+  // attributes. And it removes the feedback loop: the MutationObserver in
+  // ApiDocumentation.tsx watches { childList, subtree } and not attributes, so
+  // swapping nodes re-triggered it on every pass while an attribute removal
+  // does not. Re-running is a no-op once href is gone, which matters because
+  // the observer fires constantly during normal interaction.
   document
-    .querySelectorAll<HTMLAnchorElement>('.swagger-ui .opblock-summary-control a')
+    .querySelectorAll<HTMLAnchorElement>('.swagger-ui .opblock-summary-control a[href]')
     .forEach((a) => {
-      const span = document.createElement('span')
-      span.className = a.className
-      span.textContent = a.textContent
-      Array.from(a.attributes).forEach((attr) => {
-        if (attr.name.startsWith('data-')) span.setAttribute(attr.name, attr.value)
-      })
-      a.replaceWith(span)
+      a.removeAttribute('href')
     })
 }
 


### PR DESCRIPTION
Closes #683.

The nested-interactive a11y fix replaced the `<a>` inside each summary control with a `<span>`. That removed a node **swagger-ui's own React tree still held a reference to**, so when React later unmounted or re-rendered that subtree — collapsing an operation, switching tags, toggling deep-link state — it called `removeChild`/`insertBefore` against a parent that no longer contained the node and threw `NotFoundError: Failed to execute 'removeChild' on 'Node'`. That propagates to the `ErrorBoundary` `LazyRoute` wraps around this page, so the **entire `/api-docs` route** dropped to the error fallback.

The `MutationObserver` in `ApiDocumentation.tsx` re-invokes this on every swagger-ui mutation, so the race was hit repeatedly during ordinary interaction rather than once at mount.

## The fix

Drop `href` instead of replacing the node. An `<a>` with no `href` has no implicit link role and is not focusable, so the nested-interactive rule is satisfied — while the node stays exactly where React put it and every reconciler reference stays valid.

Two properties worth naming:

- **It is strictly less destructive than what it replaces.** The old code discarded the anchor's identity and every non-`data-` attribute, rebuilding the class list by hand. Dropping one attribute preserves everything else.
- **It removes a feedback loop.** That observer watches `{ childList: true, subtree: true }` — not attributes. So swapping nodes re-triggered the observer on every pass, while an attribute removal does not. The selector is `a[href]`, so re-running is a genuine no-op.

## The existing test asserted the bug

`replaces the nested anchor ... with a span` encoded exactly the behaviour causing the crash. I inverted its assertions rather than deleting it, so the coverage gets stronger: the anchor must be the **same node object**, still `isConnected`, with its text, class list and `data-*` intact, and `href` gone. Anything else is the crash this fixes. An idempotence test is added because the observer re-runs this constantly.

I checked for other consumers of `.opblock-summary-path` / `.opblock-summary-control` in app code and CSS before changing the shape — there are none, so nothing depended on the element being a `span`.

Frontend deps can't be installed here (`@sethbacon/terraform-suite-ui` needs `read:packages`), so CI is the first vitest run.

## Not addressed

The module's header comment already concedes the underlying fragility — it reaches into swagger-ui's DOM via hard-coded class selectors with no compile-time signal. This PR removes the crash, not that coupling.