### PR TITLE
docs(csp): record that the nonce is style-scoped and must not reach script-src

### DIFF
--- a/frontend/nginx-ecs.conf.template
+++ b/frontend/nginx-ecs.conf.template
@@ -24,6 +24,13 @@
 # `set $csp_nonce $request_id` re-runs after that redirect and yields a SECOND,
 # different id, so the header nonce and the <meta>/emotion nonce disagree and the
 # browser blocks every injected style. See frontend/nginx.conf for the same fix.
+#
+# THIS NONCE IS STYLE-SCOPED. Do not reuse it for script-src (#696). It is
+# published to the DOM via <meta name="csp-nonce"> so Emotion can consume it, so
+# any script that can read the document can read the nonce and authorise itself;
+# and it derives from $request_id, nginx's request identifier, not a CSPRNG
+# (CWE-330). script-src stays 'self', which is stronger than a nonce built this
+# way. Full reasoning in frontend/nginx.conf.
 map $request_id $csp_nonce {
     default $request_id;
 }

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -4,6 +4,27 @@
 # `set $csp_nonce $request_id` re-runs after that redirect and yields a SECOND,
 # different id, so the header nonce and the <meta>/emotion nonce disagree and the
 # browser blocks every injected style.
+#
+# THIS NONCE IS STYLE-SCOPED. Do not reuse it for script-src (#696).
+#
+# Two independent reasons, either of which is disqualifying:
+#
+#   1. It is published to the DOM. sub_filter writes it into
+#      <meta name="csp-nonce"> so main.tsx can hand it to Emotion, which means
+#      any script that can read the document can read the nonce and stamp it on
+#      an injected <script>. A script nonce an attacker can read authorises the
+#      attacker. That is fine for style-src, whose threat model here is
+#      Emotion's injected <style> tags, and fatal for script-src.
+#
+#   2. It comes from nginx's $request_id, which is a request identifier from
+#      nginx's internal PRNG, not a CSPRNG (CWE-330). Script nonces must be
+#      unpredictable.
+#
+# script-src stays 'self'. That is STRONGER than a nonce built this way, not a
+# placeholder for one. Adopting script nonces properly means a
+# cryptographically-random source (njs/Lua, or a value minted upstream) AND
+# dropping the <meta> publication in favour of a server-rendered inline
+# bootstrap -- i.e. a different design, not an edit to this line.
 map $request_id $csp_nonce {
     default $request_id;
 }


### PR DESCRIPTION
Closes #696.

The nonce plumbing in `nginx.conf` looks like a script-src nonce waiting to be switched on. It isn't — and the next person to widen `style-src 'nonce-…'` to `script-src` would weaken the policy while believing they'd strengthened it. This records why, at the map that defines it.

## Two independent reasons, either disqualifying on its own

1. **It is published to the DOM.** `sub_filter` writes it into `<meta name="csp-nonce">` so `main.tsx` can hand it to Emotion. That means any script able to read the document can read the nonce and stamp it on an injected `<script>` — a script nonce the attacker can read authorises the attacker. Harmless for `style-src`, whose threat model here is Emotion's injected `<style>` tags. Fatal for `script-src`.

2. **It derives from `$request_id`** — nginx's request identifier, from its internal PRNG rather than a CSPRNG (CWE-330). Script nonces must be unpredictable.

I put (1) first deliberately, because it's the one that holds *regardless of entropy*. The issue leads with the randomness, but fixing the randomness alone would not make this safe while the nonce is still published to the DOM. Anyone reading only the CWE reference could reasonably conclude "swap in a CSPRNG and we're done" — they wouldn't be.

## What stays

`script-src 'self'`, unchanged. That is **stronger** than a nonce built this way, not a placeholder for one. Adopting script nonces properly means a cryptographically-random source (njs/Lua, or a value minted upstream) *and* dropping the `<meta>` publication in favour of a server-rendered inline bootstrap — a different design, not an edit to this line. The comment says so, so the next reader doesn't have to re-derive it.

## Scope

Comment-only; no directive changes. Both configs are updated — `nginx-ecs.conf.template` carries the same map and gets a short version pointing at the full reasoning. I ran `nginx -t` against the edited config to confirm it still parses.