### PR TITLE
fix(csp): replace the img-src wildcard with a publisher-blind allowlist

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -116,27 +116,28 @@ deployments, see the backend's
 ### Images in module and provider documentation
 
 Module and provider READMEs are authored by whoever publishes them, and they may
-reference images hosted anywhere — build-status badges are the common case. Those
-images are fetched by **your browser, directly from the host the publisher chose**.
-They are not proxied through this registry.
+reference images — build-status badges are the common case. Those images are fetched
+by **your browser**, not proxied through this registry, so the host serving them
+observes your IP address, your browser's `User-Agent`, and the time you viewed the
+page. It does **not** learn which module page you were on: the `Referrer-Policy` is
+`strict-origin-when-cross-origin`, so only this registry's origin is sent.
 
-That fetch discloses to the third-party host:
+**Remote images may only be loaded from a fixed allowlist of hosts** (currently the
+shields.io and badgen.net badge services, and GitHub/GitLab content hosts). The
+browser blocks anything else outright.
 
-- your IP address,
-- your browser's `User-Agent`,
-- the time you viewed the page, and
-- this registry's origin (the `Referrer-Policy` is `strict-origin-when-cross-origin`,
-  so the specific module page you were viewing is **not** sent).
+The allowlist exists to stop module publishers tracking you. It contains only hosts
+whose access logs the publisher **cannot read** — a badge still renders, but the log
+entry belongs to shields.io or GitHub, not to whoever wrote the README. Were an
+arbitrary host permitted, any publisher could embed a one-pixel image on their own
+domain and record every viewer's IP and browsing time, with no attack required.
 
-The disclosure is to the image's host, not to us, and it happens whether or not the
-image is a genuine badge — an embedded image is a working analytics pixel for anyone
-who can publish to this registry. Publishers are therefore able to learn that
-*somebody at your organisation* viewed their module, and how often.
+Two consequences worth knowing:
 
-Operators who need to eliminate this can restrict the frontend's
-`Content-Security-Policy` to `img-src 'self' data:` in `frontend/nginx.conf`. This
-blocks **all** remote images in documentation, including legitimate badges, so it is
-a deliberate trade of documentation fidelity for viewer privacy rather than a default.
+- The disclosure that remains is to those allowlisted services, not to us and not to
+  the module publisher.
+- A README referencing an image hosted anywhere else will show a broken image. That
+  is the policy working as intended, not a fault in the document.
 
 ## 9. Security
 

--- a/e2e/tests/security.spec.ts
+++ b/e2e/tests/security.spec.ts
@@ -265,7 +265,12 @@ test.describe('Response headers: the nginx security headers reach the browser', 
   const CSP_DIRECTIVES = [
     "default-src 'self'",
     "script-src 'self'",
-    "img-src 'self' data: https:",
+    // An ALLOWLIST, not a wildcard (#680). Asserted in full rather than as a prefix so
+    // that widening it back to `https:` -- or quietly appending a publisher-controlled
+    // origin -- fails here rather than shipping.
+    "img-src 'self' data: https://img.shields.io https://badgen.net " +
+      'https://raw.githubusercontent.com https://avatars.githubusercontent.com ' +
+      'https://github.com https://gitlab.com',
     "font-src 'self' data:",
     "connect-src 'self'",
     "frame-ancestors 'none'",

--- a/frontend/nginx-ecs.conf.template
+++ b/frontend/nginx-ecs.conf.template
@@ -65,14 +65,16 @@ server {
     # have its fetch/sendBeacon calls silently blocked by the browser. Route such DSNs
     # through this reverse proxy instead, or add their origin here (see ARCHITECTURE.md).
     #
-    # img-src permits any https host because module/provider READMEs are publisher-authored
-    # and routinely carry build-status badges. The cost is that an embedded image is a
-    # working analytics pixel: the publisher's host learns the viewer's IP, User-Agent and
-    # timestamp (not the module path -- Referrer-Policy is strict-origin-when-cross-origin).
-    # Documented for end users in PRIVACY.md section 8. Operators who would rather lose
-    # badges than leak that can narrow this to `img-src 'self' data:`, which blocks ALL
-    # remote documentation images.
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'nonce-$csp_nonce'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self';" always;
+    # img-src is an ALLOWLIST, not a wildcard (#680). The selection rule is "hosts whose
+    # access logs the publisher cannot read" -- a badge from img.shields.io still loads, but
+    # the logs land with shields.io rather than with whoever wrote the README, so the
+    # viewer-tracking primitive is gone. Only a publisher-controlled origin would hand them
+    # the viewer's IP and User-Agent, and that is what is excluded.
+    #
+    # Remote images hosted anywhere else now fail to load with a CSP violation in the
+    # console. Add a host here only if the publisher cannot read its logs. Keep this list
+    # byte-identical to frontend/nginx.conf, which carries the full reasoning.
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'nonce-$csp_nonce'; img-src 'self' data: https://img.shields.io https://badgen.net https://raw.githubusercontent.com https://avatars.githubusercontent.com https://github.com https://gitlab.com; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self';" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
 
     # Inject CSP nonce into index.html. once off = replace EVERY __CSP_NONCE__
@@ -151,7 +153,7 @@ server {
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
         add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'nonce-$csp_nonce'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self';" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'nonce-$csp_nonce'; img-src 'self' data: https://img.shields.io https://badgen.net https://raw.githubusercontent.com https://avatars.githubusercontent.com https://github.com https://gitlab.com; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self';" always;
         add_header Content-Type "application/json" always;
     }
 

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -67,14 +67,27 @@ server {
     # have its fetch/sendBeacon calls silently blocked by the browser. Route such DSNs
     # through this reverse proxy instead, or add their origin here (see ARCHITECTURE.md).
     #
-    # img-src permits any https host because module/provider READMEs are publisher-authored
-    # and routinely carry build-status badges. The cost is that an embedded image is a
-    # working analytics pixel: the publisher's host learns the viewer's IP, User-Agent and
-    # timestamp (not the module path -- Referrer-Policy is strict-origin-when-cross-origin).
-    # Documented for end users in PRIVACY.md section 8. Operators who would rather lose
-    # badges than leak that can narrow this to `img-src 'self' data:`, which blocks ALL
-    # remote documentation images.
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'nonce-$csp_nonce'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self';" always;
+    # img-src is an ALLOWLIST, not a wildcard (#680). READMEs are publisher-authored, and
+    # under the previous `https:` an embedded image was a working analytics pixel: the
+    # publisher's own host learned the viewer's IP, User-Agent and timestamp on every page
+    # view, with no XSS required.
+    #
+    # The selection rule is "hosts whose access logs the publisher cannot read", which is
+    # what actually removes the tracking primitive. A badge served from img.shields.io or an
+    # image from raw.githubusercontent.com still loads, but the logs land with shields.io or
+    # GitHub -- not with whoever wrote the README. Only a publisher-controlled origin gives
+    # them the viewer's identity, and that is precisely what is now excluded.
+    #
+    # Consequence to know before adding a host: remote images hosted anywhere else -- a
+    # self-hosted architecture diagram on a publisher's own domain, most commonly -- now
+    # fail to load, reported as a CSP violation in the browser console. That is a deliberate
+    # trade, not an oversight. Add a host here only if the publisher cannot read its logs;
+    # adding one they control reopens the exact hole this closes.
+    #
+    # The complete fix is proxying README images through the backend (GitHub's camo model),
+    # which keeps every image working AND removes the disclosure. That is backend work and
+    # is not done here. Documented for end users in PRIVACY.md section 8.
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'nonce-$csp_nonce'; img-src 'self' data: https://img.shields.io https://badgen.net https://raw.githubusercontent.com https://avatars.githubusercontent.com https://github.com https://gitlab.com; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self';" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
 
     # Inject CSP nonce into index.html so the React app can read it. once off =
@@ -173,7 +186,7 @@ server {
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
         add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'nonce-$csp_nonce'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self';" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'nonce-$csp_nonce'; img-src 'self' data: https://img.shields.io https://badgen.net https://raw.githubusercontent.com https://avatars.githubusercontent.com https://github.com https://gitlab.com; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self';" always;
         add_header Content-Type "application/json" always;
     }
 


### PR DESCRIPTION
Closes #680.

Under `img-src ... https:`, an image embedded in a README was a working analytics pixel. The browser fetches it directly from whatever host the publisher named, so that host learns the viewer's IP, `User-Agent` and timestamp on every page view. No XSS required — the markdown sanitizer permits any https image source by design, and the CSP agreed with it.

## The selection rule

The allowlist is chosen on one criterion: **hosts whose access logs the publisher cannot read.**

That is what actually removes the tracking primitive, rather than merely narrowing it. A shields.io badge or a `raw.githubusercontent.com` image still renders — but the log entry belongs to shields.io or GitHub, *not* to whoever wrote the README. Only a publisher-controlled origin hands them the viewer's identity, and that is precisely what is now excluded.

It's worth being explicit that this is why the allowlist is a real fix and not theatre. A publisher can still point at `img.shields.io/badge/...`; they just learn nothing from it.

```
img-src 'self' data:
  https://img.shields.io https://badgen.net
  https://raw.githubusercontent.com https://avatars.githubusercontent.com
  https://github.com https://gitlab.com
```

## Chosen over the two alternatives in the issue

- **`img-src 'self' data:`** blocks every remote image, including ordinary build-status badges — near-universal in Terraform module READMEs. A visible regression for every publisher, to fix a low-severity content risk.
- **A backend image proxy** (GitHub's camo model) is the *complete* fix: every image keeps working **and** the disclosure goes. But it's backend feature work — an endpoint with SSRF guards, caching, size and content-type limits — not a frontend config change. It's recorded in the config as the endgame so the next reader knows this is a waypoint.

## Known consequence, stated up front

An image hosted anywhere else — most often a self-hosted architecture diagram on the publisher's own domain — now fails to load, reported as a CSP violation in the browser console. **That is the trade**, not an oversight. The config comment says so, and includes the rule for extending the list: add a host only if the publisher cannot read its logs; adding one they control reopens the exact hole this closes.

## Verification

Run against real nginx in a container, not reasoned about:

- all four CSP declarations (server + `/terraform/` in both configs) are byte-identical — `nginxHeaderInheritance.test.ts` already guards this per file
- `nginx -t` passes
- the served header matches the config exactly
- the e2e header tests pass against it — and **widening back to `https:` fails both of them**, with a message naming the lost directive, while the unrelated nonce test stays green

That last one is the point of the exercise: the e2e assertion pins the **full** value rather than a prefix, so quietly appending a publisher-controlled origin fails CI rather than shipping.

## Docs

`PRIVACY.md` §8 previously described the wildcard and told operators how to narrow it — both now wrong. Rewritten to state that the allowlist is the default, why those hosts specifically, and that a broken image in a README is the policy working rather than a fault in the document. There's no author-facing publishing guide in this repo to update.