### PR TITLE
fix(ci): give dependabot GitHub Packages auth for the private dep

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,25 @@
 version: 2
 
+# Dependabot resolves the frontend dependency tree, which includes the private
+# @sethbacon/* package hosted on GitHub Packages. The repository Dependabot
+# secret SUITE_READ_TOKEN (a token with read:packages) lets the npm updater
+# resolve it; the private package itself is excluded from automated version
+# updates below (it is released and pinned in lockstep with the suite, out of
+# band).
+registries:
+  npm-github-packages:
+    type: npm-registry
+    url: https://npm.pkg.github.com
+    token: ${{secrets.SUITE_READ_TOKEN}}
+
 updates:
   # ---------------------------------------------------------------------------
   # npm (frontend/)
   # ---------------------------------------------------------------------------
   - package-ecosystem: npm
     directory: /frontend
+    registries:
+      - npm-github-packages
     schedule:
       interval: weekly
       day: monday
@@ -23,21 +37,24 @@ updates:
         patterns:
           - "*"
     ignore:
+      # Private, released and version-pinned in lockstep with the suite; not
+      # auto-bumped here (resolved via the registry above only).
+      - dependency-name: "@sethbacon/*"
       # Major React/MUI bumps require manual migration work.
       - dependency-name: "react"
-        update-types: [ "version-update:semver-major" ]
+        update-types: ["version-update:semver-major"]
       - dependency-name: "react-dom"
-        update-types: [ "version-update:semver-major" ]
+        update-types: ["version-update:semver-major"]
       - dependency-name: "@mui/material"
-        update-types: [ "version-update:semver-major" ]
+        update-types: ["version-update:semver-major"]
       - dependency-name: "@mui/icons-material"
-        update-types: [ "version-update:semver-major" ]
+        update-types: ["version-update:semver-major"]
       # Major TypeScript bumps break the toolchain before app code: tsup's
       # bundled rollup-plugin-dts and @typescript-eslint/typescript-estree
       # both crash against TS7's changed internals (2026-07-13 incident).
       # Revisit once both ship TS7-compatible releases.
       - dependency-name: "typescript"
-        update-types: [ "version-update:semver-major" ]
+        update-types: ["version-update:semver-major"]
     cooldown:
       default-days: 7
 


### PR DESCRIPTION
`frontend/package.json` depends on `@sethbacon/terraform-suite-ui` and `frontend/.npmrc` points the `@sethbacon` scope at `npm.pkg.github.com`, but `.github/dependabot.yml` had **no `registries:` block at all**. The npm updater therefore had no credential for that host and could never resolve the private dependency tree.

The `SUITE_READ_TOKEN` Dependabot secret was already configured on this repository — it was simply never referenced.

Like its sibling, this fails **silently**: no PRs for that tree looks identical to nothing to update.

## Changes

1. **Add the registry** and reference it from the `/frontend` npm update:

```yaml
registries:
  npm-github-packages:
    type: npm-registry
    url: https://npm.pkg.github.com
    token: ${{secrets.SUITE_READ_TOKEN}}
```

2. **Ignore `@sethbacon/*` for version updates**, matching `terraform-state-manager-frontend`.

The second change deserves scrutiny — it is not strictly part of the bug. Without it, fixing resolution would *newly* start raising bump PRs against the private package, which contradicts the documented estate policy that it is "released and pinned in lockstep with the suite, out of band". Drop this hunk if you'd rather it be auto-bumped here.

`/e2e` and the Docker/Actions ecosystems are untouched — they have no private dependency.

## Prerequisite

`SUITE_READ_TOKEN` must carry **`read:packages`**. Code/issues/metadata scopes are not sufficient to read from GitHub Packages, and the failure mode stays silent if it is under-scoped.

Found while wiring the same registry auth into the two new repos in [pipeline-task-core#initiative-1](https://github.com/sethbacon/pipeline-task-core/blob/main/docs/initiatives/initiative-1-shared-task-core.md). The sibling has the mirror-image bug (referenced a secret name that does not exist) — sethbacon/terraform-state-manager-frontend#306.
