### PR TITLE
fix(ci): point the suite-ui checkout at its new owner

### DIFF
--- a/.github/workflows/signature-replay.yml
+++ b/.github/workflows/signature-replay.yml
@@ -104,9 +104,23 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           {
-            repository: sethbacon/terraform-suite-ui,
+            # Moved out of the sethbacon org and renamed (2026-08-11), which is
+            # what broke this checkout with "Not Found" on every PR in every
+            # repo running this gate.
+            #
+            # The checkout PATH is deliberately unchanged: the replay tool keys
+            # off it, and renaming the working directory would bundle a second,
+            # riskier change into a one-line ownership fix.
+            #
+            # No token: the repo is public now, so SUITE_READ_TOKEN adds nothing
+            # here — and if it is a fine-grained PAT scoped to sethbacon-owned
+            # repos, keeping it is exactly what would leave this still failing.
+            #
+            # NOTE: this repo ALSO consumes the moved project as the npm package
+            # @sethbacon/terraform-suite-ui. That dependency is untouched here —
+            # whether it still resolves under the old scope is a separate call.
+            repository: 4cloudguru/cloud-suite-ui,
             path: suite/terraform-suite-ui,
-            token: "${{ secrets.SUITE_READ_TOKEN }}",
             persist-credentials: false,
           }
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
Companion to terraform-state-manager-backend#363, terraform-registry-backend#847, terraform-suite-identity#197.

`terraform-suite-ui` moved out of the `sethbacon` org and was renamed to **`4cloudguru/cloud-suite-ui`** on 2026-08-11, so `actions/checkout` returned `Not Found` and the replay gate failed on **every PR across the estate**.

The failure was misleading: the job died **in checkout, before any signature ran**, and reported zero findings.

**Path stays `suite/terraform-suite-ui`** (the replay tool keys off it); **token dropped, not repointed** (public repo now, and a fine-grained PAT scoped to sethbacon would keep failing).

## This repo has a second, larger exposure — not fixed here

It also consumes the moved project as the **npm package** `@sethbacon/terraform-suite-ui`, pinned at `0.8.1`, referenced across 11 files (`package.json`, the lockfile, `.github/actions/setup-frontend`, three workflows, and docs).

Whether that package still resolves under the old scope — or has to be republished under `@4cloudguru` — needs `read:packages` to answer, which I don't have. It's a decision, not a mechanical rename, so it's flagged rather than guessed at. **This CI fix does not make that risk go away**: if the package has moved, frontend installs will fail independently of this change.