### PR TITLE
fix(ci): pin the suite-ui attestation signer repo during the bridge

### DIFF
--- a/.github/actions/setup-frontend/action.yml
+++ b/.github/actions/setup-frontend/action.yml
@@ -100,18 +100,19 @@ runs:
         # indistinguishable from the tampering this step exists to catch.
         #
         # --owner still verifies the signature, the digest binding and that the
-        # artifact was built by a repo owned by sethbacon. What it no longer pins
-        # is WHICH repo. That is weaker, and it is deliberate rather than
-        # accidental.
+        # artifact was built by a repo owned by sethbacon. On its own it would not
+        # pin WHICH repo, so --signer-repo restores that: the predicate records the
+        # signing repo immutably as the pre-move slug, and matching it explicitly
+        # keeps the same repository-level guarantee --repo used to give.
         #
         # This is a bridge, not a destination. Retire it by publishing the library
         # from its new home (which mints attestations under 4cloudguru) and then
-        # restoring the strict form:
+        # switching both flags to the new identity:
         #   gh attestation verify "${tmp}/${tarball}" --repo 4cloudguru/cloud-suite-ui
         # The attestations for 0.8.1 will never migrate -- they are immutable
         # records of a build that happened under the old name -- so this stays
         # until the dependency moves to a version published from the new repo.
-        gh attestation verify "${tmp}/${tarball}" --owner sethbacon
+        gh attestation verify "${tmp}/${tarball}" --owner sethbacon --signer-repo sethbacon/terraform-suite-ui
         rm -rf "$tmp"
 
     - name: Install e2e dependencies


### PR DESCRIPTION
Follow-up to #754, which fixed the outage. Not a correction of it - the `--owner` switch was the right call, since the repo-scoped lookup 404s after the transfer.

This adds back the one thing `--owner` alone gives up: **which** repo signed. The provenance predicate records the signing repo immutably as the pre-move slug, so `--signer-repo` can match it today - the strict guarantee does not have to wait for the dependency to move to 0.9.0.

Verified against the real published 0.8.1 tarball:

| flags | exit |
| --- | --- |
| `--repo sethbacon/terraform-suite-ui` | 1 |
| `--owner sethbacon` | 0 |
| `--owner sethbacon --signer-repo sethbacon/terraform-suite-ui` | 0 |

Root cause for the record: artifact attestations are stored against the **owner**, not the repository. For the same digest, `users/sethbacon/attestations/<digest>` returns both attestations while `repos/4cloudguru/cloud-suite-ui`, `repos/sethbacon/terraform-suite-ui` and `orgs/4cloudguru` all 404.