### PR TITLE
fix(ci): drop the dead GitHub Packages registry from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,25 +1,15 @@
 version: 2
 
-# Dependabot resolves the frontend dependency tree, which includes the private
-# @sethbacon/* package hosted on GitHub Packages. The repository Dependabot
-# secret SUITE_READ_TOKEN (a token with read:packages) lets the npm updater
-# resolve it; the private package itself is excluded from automated version
-# updates below (it is released and pinned in lockstep with the suite, out of
-# band).
-registries:
-  npm-github-packages:
-    type: npm-registry
-    url: https://npm.pkg.github.com
-    token: ${{secrets.SUITE_READ_TOKEN}}
-
+# The shared suite UI package is public on npmjs, so the frontend tree needs no
+# registry credentials. The package itself is still excluded from automated
+# version updates below: it is released and pinned in lockstep with the suite,
+# out of band.
 updates:
   # ---------------------------------------------------------------------------
   # npm (frontend/)
   # ---------------------------------------------------------------------------
   - package-ecosystem: npm
     directory: /frontend
-    registries:
-      - npm-github-packages
     schedule:
       interval: weekly
       day: monday
@@ -39,7 +29,7 @@ updates:
     ignore:
       # Private, released and version-pinned in lockstep with the suite; not
       # auto-bumped here (resolved via the registry above only).
-      - dependency-name: "@sethbacon/*"
+      - dependency-name: "@4cloudguru/*"
       # Major React/MUI bumps require manual migration work.
       - dependency-name: "react"
         update-types: ["version-update:semver-major"]


### PR DESCRIPTION
The frontend tree no longer contains anything from GitHub Packages after the move to `@4cloudguru/cloud-suite-ui` on npmjs, but Dependabot was still configured to resolve it through one.

**Two problems, one of them silent.**

The `npm-github-packages` registry and its `SUITE_READ_TOKEN` are dead config the npm updater still tried to use. That is the visible one - the Dependabot update job on `main` failed after the migration merged.

The `ignore` rule is the one that would not have announced itself. It matched `"@sethbacon/*"`, which nothing is named any more, so the shared UI package would quietly have started receiving automated version bumps - despite the comment right above it saying the package is released and pinned in lockstep with the suite, out of band. Repointed to `"@4cloudguru/*"`.

**Verified**: zero `npm-github-packages`, `SUITE_READ_TOKEN` or `sethbacon` references remain in the file; the ignore rule now reads `@4cloudguru/*`.

Missed during the migration because the survey grepped for `@sethbacon/terraform-suite-ui` and `NODE_AUTH_TOKEN` - this file names the package only as a `@sethbacon/*` glob, and the registry block names no package at all.
