### PR TITLE
fix(nginx): make nginx the single emitter of security headers on proxied paths

### DIFF
--- a/e2e/tests/security.spec.ts
+++ b/e2e/tests/security.spec.ts
@@ -291,44 +291,38 @@ test.describe('Response headers: the nginx security headers reach the browser', 
   // re-declarations from the /terraform/ block takes that path from six security
   // headers to ZERO while / still reports six. A test that only checked / would
   // have stayed green through exactly that regression.
-  const PATHS: [string, string, boolean][] = [
-    ['/', 'the SPA document (server level)', false],
+  // The second entry is the proxied one. That distinction used to select a weaker
+  // assertion; since #743 both are asserted identically, so it survives only as
+  // the reason these two paths in particular are covered.
+  const PATHS: [string, string][] = [
+    ['/', 'the SPA document (server level)'],
     [
       '/terraform/example.com/hashicorp/aws/index.json',
       'the network-mirror proxy (location level)',
-      true,
     ],
   ];
 
-  // On PROXIED paths both nginx and the backend emit these: the Go service runs
-  // its own SecurityHeaders middleware, and nginx adds the same names on top, so
-  // the delivered header carries BOTH. Two shapes are observed in CI:
+  // Every path now asserts EXACT equality, including the proxied one.
   //
-  //   x-frame-options:  "DENY, DENY"                                (agreeing)
+  // It did not used to. Both nginx and the backend emit these headers, so a
+  // proxied response carried BOTH sets and the browser saw, on the wire:
+  //
+  //   x-frame-options:  "DENY, DENY"                                    (agreeing)
   //   referrer-policy:  "no-referrer, strict-origin-when-cross-origin"  (conflicting)
   //
-  // The second is a real defect -- the backend's APISecurityHeadersConfig sends
-  // the stricter `no-referrer` for API responses and nginx appends the looser
-  // value, and Referrer-Policy resolution takes the LAST value the agent
-  // understands, so nginx silently overrides the backend's stricter intent. It
-  // is reported separately. Gating #691 behind that fix would be wrong, so the
-  // proxied path asserts the strongest thing it can while the duplication
-  // stands: that OUR value is present as a whole comma-separated element.
+  // The second was a real defect: the backend deliberately sends the stricter
+  // `no-referrer` for API responses, and Referrer-Policy resolution takes the
+  // LAST value understood, so nginx's looser value silently won. While that
+  // stood, this test could only assert that OUR value appeared as one
+  // comma-separated element -- weaker, but the strongest thing available without
+  // gating an unrelated fix on it.
   //
-  // Membership is matched with an anchored `(^|, )value(, |$)` rather than by
-  // splitting on ',' -- Permissions-Policy's own value contains commas
-  // ("camera=(), microphone=()..."), so a naive split would shred it. It is also
-  // why plain substring matching is not used: "DENY" must not be satisfied by
-  // "DENYX".
-  //
-  // The non-proxied path keeps EXACT equality: nothing else emits there, so
-  // there is no reason to accept less.
-  const hasValueAsElement = (received: string, expected: string): boolean => {
-    const lit = expected.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    return new RegExp(`(^|, )${lit}(, |$)`).test(received);
-  };
+  // #743 made nginx the single authority on proxied paths via proxy_hide_header,
+  // so the tolerance is no longer needed and is removed rather than left behind.
+  // Leaving it would mean this test keeps passing if the duplication ever returns
+  // -- which is exactly the regression it should now catch.
 
-  for (const [path, what, proxied] of PATHS) {
+  for (const [path, what] of PATHS) {
     test(`sends every security header on ${what}`, async ({ request }) => {
       // No status assertion: these are declared `always`, so they must ship on
       // error responses too. Pinning a status here would make the test depend on
@@ -339,14 +333,10 @@ test.describe('Response headers: the nginx security headers reach the browser', 
       for (const [name, value] of Object.entries(EXPECTED)) {
         const received = headers[name] ?? '';
         const where = `${name} on ${path} (status ${res.status()}, raw: ${JSON.stringify(headers[name])})`;
-        if (proxied) {
-          // Still catches the regression this test exists for: strip the
-          // re-declarations from the /terraform/ block and the header is absent
-          // entirely, so nothing is present as an element.
-          expect(hasValueAsElement(received, value), `${where} does not carry our value`).toBe(true);
-        } else {
-          expect(received, `${where} missing or wrong`).toBe(value);
-        }
+        // Exact, not membership: a duplicated header now FAILS here, which is the
+        // point. It also still catches the original regression -- strip the
+        // re-declarations from the /terraform/ block and the header is absent.
+        expect(received, `${where} missing, wrong, or duplicated`).toBe(value);
       }
 
       const csp = headers['content-security-policy'];

--- a/frontend/nginx-ecs.conf.template
+++ b/frontend/nginx-ecs.conf.template
@@ -41,6 +41,28 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Drop the backend's own copies of the six security headers before adding ours
+    # below (#743). The backend runs SecurityHeadersMiddleware on every response, so
+    # without this a proxied path returns BOTH sets and the browser sees e.g.
+    # `x-frame-options: DENY, DENY` and
+    # `referrer-policy: no-referrer, strict-origin-when-cross-origin` — where the
+    # backend's deliberately stricter API value is overridden by nginx's looser one,
+    # because Referrer-Policy resolution takes the last value understood.
+    #
+    # This template matters MORE than nginx.conf here, not less: on ECS the ALB
+    # routes /api/* straight to the backend target group, so the backend's own
+    # headers are the only ones on those requests and must stay. This hides them only
+    # on requests that actually pass through nginx, where nginx is the outer hop.
+    #
+    # Declared once at server level; proxy_hide_header inherits into every location
+    # that does not declare its own, and none below do.
+    proxy_hide_header X-Frame-Options;
+    proxy_hide_header X-Content-Type-Options;
+    proxy_hide_header Referrer-Policy;
+    proxy_hide_header Strict-Transport-Security;
+    proxy_hide_header Content-Security-Policy;
+    proxy_hide_header Permissions-Policy;
+
     # ${BACKEND_URL} is https on Cloud Run / ACA — send SNI on proxied TLS.
     proxy_ssl_server_name on;
 

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -47,6 +47,41 @@ server {
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_ciphers HIGH:!aNULL:!MD5;
 
+    # Drop the backend's own copies of the six security headers before adding ours
+    # below (#743).
+    #
+    # The backend runs SecurityHeadersMiddleware on every response, so on a proxied
+    # path both it and nginx emitted these and the browser received BOTH. Observed:
+    #
+    #   x-frame-options:  "DENY, DENY"
+    #   referrer-policy:  "no-referrer, strict-origin-when-cross-origin"
+    #
+    # The second is the reason this is a defect rather than untidiness. The backend
+    # deliberately sends the stricter `no-referrer` for API responses, and
+    # Referrer-Policy resolution takes the LAST value the agent understands -- so
+    # nginx's looser value silently overrode the backend's stricter intent. A
+    # repeated X-Frame-Options is also not well specified and browsers have treated
+    # duplicates as invalid, i.e. the clickjacking control became unreliable rather
+    # than doubled.
+    #
+    # nginx is the outermost hop whenever it is in the path, so it is made the single
+    # authority here. The backend keeps sending its own headers, deliberately: it is
+    # the ONLY emitter in the topology where the ALB routes /api/* straight to the
+    # backend target group and nginx never sees the request (see
+    # nginx-ecs.conf.template). Stripping them upstream would silently unprotect that
+    # deployment.
+    #
+    # Declared once at server level. proxy_hide_header inherits into every location
+    # that does not declare its own -- unlike add_header, none of the proxied
+    # locations below do -- so this covers all ten without repetition. Verified
+    # against real nginx rather than assumed.
+    proxy_hide_header X-Frame-Options;
+    proxy_hide_header X-Content-Type-Options;
+    proxy_hide_header Referrer-Policy;
+    proxy_hide_header Strict-Transport-Security;
+    proxy_hide_header Content-Security-Policy;
+    proxy_hide_header Permissions-Policy;
+
     # Security headers
     add_header X-Frame-Options "DENY" always;
     add_header X-Content-Type-Options "nosniff" always;

--- a/frontend/src/__tests__/nginxHeaderInheritance.test.ts
+++ b/frontend/src/__tests__/nginxHeaderInheritance.test.ts
@@ -35,6 +35,51 @@ const REQUIRED = [
 ] as const
 
 /**
+ * Blank out `#` comments, replacing each with spaces of the SAME length so
+ * every byte offset below stays valid.
+ *
+ * Without this the parser reads comment text as config, and both failure modes
+ * make this guard report green while the invariant is broken:
+ *
+ *   1. The block regex is /location\s+([^{]+)\{/ and `[^{]+` spans NEWLINES.
+ *      So the bare word "location" in a server-level comment opens a match that
+ *      runs to the next `{` — the first real location block — and
+ *      serverLevelOnly() then deletes that whole span BY INDEX, taking the
+ *      server-level add_header directives out with it. The assertions then run
+ *      against a config the parser has edited the headers out of. Latent until
+ *      the first server-level comment said "location": every earlier such
+ *      comment sat INSIDE a location block, which the parser skips.
+ *
+ *   2. A commented-out `# add_header X-Frame-Options ...` would satisfy the
+ *      re-declaration check for a header nginx never sends.
+ *
+ * `#` inside a quoted value is literal to nginx, so quotes are tracked rather
+ * than scanning for a bare `#`.
+ */
+function maskComments(conf: string): string {
+  let out = ''
+  let quote: string | null = null
+  for (let i = 0; i < conf.length; i++) {
+    const c = conf[i]
+    if (quote) {
+      out += c
+      if (c === quote) quote = null
+    } else if (c === '"' || c === "'") {
+      quote = c
+      out += c
+    } else if (c === '#') {
+      let j = i
+      while (j < conf.length && conf[j] !== '\n') j++
+      out += ' '.repeat(j - i)
+      i = j - 1
+    } else {
+      out += c
+    }
+  }
+  return out
+}
+
+/**
  * Extract `location <match> { ... }` blocks, brace-balanced, keeping the index
  * range of each body.
  *
@@ -44,7 +89,10 @@ const REQUIRED = [
  * with identical bodies, or a body that also occurs verbatim earlier, silently
  * strip the wrong region and take real server-level directives with them.
  */
-function locationBlocks(conf: string): { match: string; body: string; start: number; end: number }[] {
+function locationBlocks(rawConf: string): { match: string; body: string; start: number; end: number }[] {
+  // Parse the MASKED text throughout: offsets are identical, so the ranges stay
+  // valid against the raw config, and no directive is read out of a comment.
+  const conf = maskComments(rawConf)
   const out: { match: string; body: string; start: number; end: number }[] = []
   const re = /location\s+([^{]+)\{/g
   let m: RegExpExecArray | null
@@ -64,9 +112,10 @@ function locationBlocks(conf: string): { match: string; body: string; start: num
   return out
 }
 
-/** The config with every location block removed, by index. */
-function serverLevelOnly(conf: string): string {
-  const blocks = locationBlocks(conf)
+/** The config with every location block removed, by index. Comments masked. */
+function serverLevelOnly(rawConf: string): string {
+  const conf = maskComments(rawConf)
+  const blocks = locationBlocks(rawConf)
   let out = ''
   let cursor = 0
   for (const b of blocks) {
@@ -75,6 +124,38 @@ function serverLevelOnly(conf: string): string {
   }
   return out + conf.slice(cursor)
 }
+
+describe('config parser', () => {
+  // These two cases are why maskComments() exists. Both fail OPEN — the parser
+  // silently mis-reads the config and every assertion above still passes — so
+  // they are asserted directly rather than trusted to surface via the real
+  // files. Case 1 is a live regression: it is exactly what the #743
+  // proxy_hide_header comment did to nginx.conf.
+  it('does not read a location block out of a comment', () => {
+    const conf = [
+      'server {',
+      '    # proxy_hide_header inherits into every location below.',
+      '    add_header X-Frame-Options "DENY" always;',
+      '',
+      '    location / {',
+      '        try_files $uri /index.html;',
+      '    }',
+      '}',
+    ].join('\n')
+
+    expect(locationBlocks(conf).map((b) => b.match)).toEqual(['/'])
+    expect(serverLevelOnly(conf)).toContain('add_header X-Frame-Options')
+  })
+
+  it('does not count a commented-out add_header as declared', () => {
+    const conf = ['server {', '    location /x/ {', '        # add_header X-Frame-Options "DENY";', '    }', '}'].join(
+      '\n',
+    )
+
+    expect(locationBlocks(conf)[0].body).not.toContain('add_header')
+    expect(serverLevelOnly(conf)).not.toContain('add_header')
+  })
+})
 
 const CONFIGS: [string, string][] = [
   ['nginx.conf', nginxConf],


### PR DESCRIPTION
Closes #743 — the defect found while landing the e2e header assertions in #691.

The backend runs `SecurityHeadersMiddleware` on every response and nginx adds the same six names on top, so a proxied response carried **both** sets:

```
x-frame-options:  "DENY, DENY"                                    (agreeing)
referrer-policy:  "no-referrer, strict-origin-when-cross-origin"  (conflicting)
```

## Why the second line makes this a defect, not untidiness

The backend **deliberately** sends the stricter `no-referrer` for API responses — that's the entire reason `APISecurityHeadersConfig` differs from the default. Referrer-Policy resolution takes the **last** value the agent understands, so nginx's looser value silently discarded the backend's decision.

A repeated `X-Frame-Options` is also not well specified, and browsers have treated duplicates as invalid — so the clickjacking control became *unreliable*, not doubled.

## The fix, and why it's on this side

nginx is the outermost hop whenever it's in the path, so it becomes the single authority there via `proxy_hide_header`.

**The backend keeps emitting its own headers, deliberately.** In the ECS topology the ALB routes `/api/*` straight to the backend target group and nginx never sees those requests — its headers are then the *only* ones present. Stripping them upstream would silently unprotect exactly that deployment. That's why the fix is on the receiving side rather than the sending side.

Declared **once at server level** in each config: `proxy_hide_header` inherits into every location that doesn't declare its own and — unlike `add_header` — none of the ten proxied locations do.

## Verified with a two-tier harness, not by reading

A backend emitting the middleware's headers, behind the real frontend config:

| | result |
| --- | --- |
| with the fix | exactly one of each header, carrying nginx's value |
| control | backend confirmed emitting `Referrer-Policy: no-referrer` |
| mutant (six lines removed) | doubling reproduced **verbatim**, including `no-referrer, strict-origin-when-cross-origin` in that order |

## The e2e assertion is tightened back to exact equality

It had been relaxed to "our value appears as one comma-separated element" *only* because the duplication stood — the comment in that file said so and named this as the end state. Leaving the tolerance would mean the test keeps passing if duplication ever returns, which is precisely the regression it should now catch.

Confirmed both ways against the harness: exact assertions pass on the fixed config, and fail on the mutant with `raw: "DENY, DENY"`.

The now-unused `proxied` flag is removed from the test's `PATHS` rather than left as a dead field.