### PR TITLE
fix(ci): retire the stale react-router exception and dead packages:read

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,7 @@ permissions:
   # because the repository is public and a public clone needs no credential. The
   # declared set now matches the access the workflow actually exercises.
   contents: read
-  # npm ci in frontend/ resolves @4cloudguru/cloud-suite-ui from
-  # npm.pkg.github.com.
+  # The contract-check jobs pull the backend image from ghcr.io.
   packages: read
 
 jobs:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -78,12 +78,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      # setup-frontend's default `npm ci` in frontend/ authenticates to
-      # npm.pkg.github.com (frontend/.npmrc) with github.token to resolve
-      # @4cloudguru/cloud-suite-ui. A job-level `permissions:` block
-      # zeroes out unlisted scopes, so packages:read must be explicit here
-      # (#598) -- matches ci.yml's workflow-level grant for the same reason.
-      packages: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -112,7 +106,6 @@ jobs:
           (cd e2e && npm audit --json > "$RUNNER_TEMP/e2e-audit.json") || true
           node frontend/scripts/audit-gate.mjs "$RUNNER_TEMP/e2e-audit.json" \
             --exceptions frontend/scripts/npm-audit-exceptions.json
-
 
   # ── Breaking-change declarations survive the squash ────
   # This repository squash-merges with

--- a/.github/workflows/weekly-security.yml
+++ b/.github/workflows/weekly-security.yml
@@ -40,13 +40,8 @@ jobs:
   npm-audit:
     name: Dependency Audit
     runs-on: ubuntu-latest
-    # Same sibling defect as pr-checks.yml's npm-audit job (#598): without
-    # an explicit grant, this job only has the workflow-level `contents:
-    # read`, and setup-frontend's default `npm ci` needs packages:read to
-    # authenticate to npm.pkg.github.com for @4cloudguru/cloud-suite-ui.
     permissions:
       contents: read
-      packages: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/frontend/scripts/npm-audit-exceptions.json
+++ b/frontend/scripts/npm-audit-exceptions.json
@@ -6,12 +6,5 @@
     "block merges on it. Every entry needs a concrete reason and a review date.",
     "Adding an entry is a security decision — it should be reviewed like one."
   ],
-  "exceptions": [
-    {
-      "advisories": ["GHSA-qwww-vcr4-c8h2"],
-      "packages": ["react-router", "react-router-dom"],
-      "reason": "RSC-mode CSRF bypass. This app never enters the affected code path: it is a Vite SPA that mounts BrowserRouter in src/App.tsx for client-side routing only, and uses none of react-router's server/RSC APIs (no createStaticHandler, StaticRouterProvider, react-router/server import, or unstable_* server entrypoint anywhere in src/ — verified by grep). The advisory covers >=7.12.0 <8.3.0, so every 7.x release including the latest is affected; npm's only suggested remedy is a semver-major downgrade to 7.11.0, which would also break the @4cloudguru/cloud-suite-ui pin that itself depends on 7.18.1. Revisit when react-router 8.3.0+ is available and suite-ui supports it.",
-      "review_by": "2026-10-30"
-    }
-  ]
+  "exceptions": []
 }


### PR DESCRIPTION
Companion to sethbacon/terraform-state-manager-frontend#317. No dependency changes here — this
repo is already on `react-router@7.18.2`, `js-yaml@4.3.1` and `dompurify@3.4.13`.

### 1. Retire the react-router accepted-risk entry

The entry for `GHSA-qwww-vcr4-c8h2` is obsolete **and its stated rationale is factually wrong**.
It argued the advisory covered all of 7.x with no forward fix. The advisory has since been
re-scoped into two ranges with a backported fix:

| package | vulnerable range | first patched |
| --- | --- | --- |
| react-router | `>= 7.12.0, < 7.18.2` | **7.18.2** |
| react-router | `>= 8.0.0, < 8.3.0` | 8.3.0 |

This repo is already on 7.18.2 and OSV reports that version clean. This matters beyond tidiness:
the triage looks up the exceptions register *before* it checks whether a fix exists, so the entry
would have permanently suppressed the advisory on an already-patched tree.

Removed in lockstep with the sibling register in `terraform-state-manager-frontend`, as that
file's header requires.

### 2. Drop dead `packages: read` from the two npm-audit jobs

`pr-checks.yml` and `weekly-security.yml` grant it to *"authenticate to npm.pkg.github.com for
@4cloudguru/cloud-suite-ui"*. That is wrong on two counts: the package is on public npmjs, and
this repo has no `frontend/.npmrc` at all — the comment describes a file that does not exist.
`setup-frontend` sets no `NODE_AUTH_TOKEN` and runs a plain `npm ci`.

### Deliberately left alone

`ci.yml`, its `weekly-security.yml` caller job, and `release.yml` keep `packages: read` — they
genuinely pull the backend image from ghcr.io for the contract-check jobs. Only `ci.yml`'s
comment is corrected, since it also cited npm.pkg.github.com as the reason.

### Verification

All three edited workflows parse. The exceptions register is valid JSON. CI exercises the rest.
