### PR TITLE
fix(hooks): order module and provider versions with one shared comparator

### DIFF
--- a/frontend/src/hooks/__tests__/useModuleDetail.test.ts
+++ b/frontend/src/hooks/__tests__/useModuleDetail.test.ts
@@ -145,6 +145,44 @@ describe('useModuleDetail', () => {
     expect(result.current.versions[1].version).toBe('1.0.0')
   })
 
+  it('orders stable ahead of pre-releases, identically to useProviderDetail (#673)', async () => {
+    // Deliberately the same fixture and expectation as the matching test in
+    // useProviderDetail.test.tsx and in utils/__tests__/semver.test.ts. Both
+    // hooks used to carry their own copy of the comparator, and the copies had
+    // drifted: this hook had no stable-vs-pre-release tiebreak at all, and
+    // neither copy ordered two pre-releases of the same version against each
+    // other, so the rendered order depended on the API's response order.
+    // Asserting the same list in both places is what makes a future re-fork
+    // show up as a failure instead of a quiet difference between two pages.
+    mockApi.getModuleVersions.mockResolvedValue({
+      modules: [
+        {
+          versions: [
+            { version: '1.0.0' },
+            { version: '2.0.0-beta.2' },
+            { version: '2.0.0-beta.10' },
+            { version: '2.0.0-rc.1' },
+            { version: '2.0.0' },
+          ],
+        },
+      ],
+    })
+
+    const { result } = renderHook(() => useModuleDetail(), { wrapper: createWrapper() })
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(result.current.versions.map((v) => v.version)).toEqual([
+      '2.0.0',
+      '2.0.0-rc.1',
+      '2.0.0-beta.10',
+      '2.0.0-beta.2',
+      '1.0.0',
+    ])
+  })
+
   it('allows changing selected version', async () => {
     const { result } = renderHook(() => useModuleDetail(), { wrapper: createWrapper() })
 

--- a/frontend/src/hooks/__tests__/useProviderDetail.test.tsx
+++ b/frontend/src/hooks/__tests__/useProviderDetail.test.tsx
@@ -84,6 +84,39 @@ describe('useProviderDetail', () => {
     expect(result.current.selectedVersion?.version).toBe('5.1.0')
   })
 
+  it('orders stable ahead of pre-releases, identically to useModuleDetail (#673)', async () => {
+    // Deliberately the same fixture and expectation as the matching test in
+    // useModuleDetail.test.ts and in utils/__tests__/semver.test.ts. The two
+    // hooks each carried a private copy of the comparator and they had already
+    // drifted apart once; asserting the same list from both is what turns a
+    // future re-fork into a failure instead of a quiet difference between the
+    // module page and the provider page.
+    //
+    // The case above passes against the old private copy too — it only has one
+    // pre-release, so nothing distinguishes the implementations. This one adds
+    // two pre-releases of the same version, which the old copy left in whatever
+    // order the API returned.
+    mockApi.getProviderVersions.mockResolvedValue({
+      versions: [
+        version('1.0.0'),
+        version('2.0.0-beta.2'),
+        version('2.0.0-beta.10'),
+        version('2.0.0-rc.1'),
+        version('2.0.0'),
+      ],
+    })
+    const { result } = renderProviderDetail()
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.versions.map((v) => v.version)).toEqual([
+      '2.0.0',
+      '2.0.0-rc.1',
+      '2.0.0-beta.10',
+      '2.0.0-beta.2',
+      '1.0.0',
+    ])
+  })
+
   it('surfaces a not-found error when no provider matches the route', async () => {
     mockApi.searchProviders.mockResolvedValue({ providers: [] })
     const { result } = renderProviderDetail()

--- a/frontend/src/hooks/useModuleDetail.ts
+++ b/frontend/src/hooks/useModuleDetail.ts
@@ -11,22 +11,7 @@ import { REGISTRY_HOST } from '../config'
 import { getErrorMessage, getErrorStatus } from '../utils/errors'
 import { queryKeys } from '../services/queryKeys'
 import { isSafeExternalUrl } from '../utils/externalUrl'
-
-// ---------------------------------------------------------------------------
-// Semver sort helper (shared by query & version selection)
-// ---------------------------------------------------------------------------
-function sortVersionsDesc(raw: ModuleVersion[]): ModuleVersion[] {
-  return [...raw].sort((a, b) => {
-    const parseParts = (v: string): [number, number, number] => {
-      const clean = v.replace(/^v/, '').split('-')[0]
-      const [maj = 0, min = 0, pat = 0] = clean.split('.').map(Number)
-      return [maj, min, pat]
-    }
-    const [aMaj, aMin, aPat] = parseParts(a.version)
-    const [bMaj, bMin, bPat] = parseParts(b.version)
-    return bMaj !== aMaj ? bMaj - aMaj : bMin !== aMin ? bMin - aMin : bPat - aPat
-  })
-}
+import { sortByVersionDesc } from '../utils/semver'
 
 const POLL_DELAYS = [2000, 5000, 12000] as const
 
@@ -105,7 +90,7 @@ export function useModuleDetail() {
       const moduleVersions = Array.isArray(mod?.versions) ? mod.versions : []
       const rawVersions: ModuleVersion[] =
         protocolVersions.length > 0 ? protocolVersions : moduleVersions
-      const mergedVersions = sortVersionsDesc(rawVersions)
+      const mergedVersions = sortByVersionDesc(rawVersions)
 
       return { module: mod, versions: mergedVersions }
     },

--- a/frontend/src/hooks/useProviderDetail.ts
+++ b/frontend/src/hooks/useProviderDetail.ts
@@ -7,33 +7,10 @@ import { captureError } from '../services/errorReporting'
 import { Provider, ProviderVersion, ProviderDocEntry } from '../types'
 import { useAuth } from '../contexts/AuthContext'
 import { REGISTRY_HOST } from '../config'
+import { sortByVersionDesc } from '../utils/semver'
 
 /** Page size used when walking the paginated provider doc index. */
 const DOCS_PAGE_SIZE = 1000
-
-/**
- * Sort versions newest-first by semver, with stable releases ahead of
- * pre-releases that share the same numeric version.
- */
-function sortVersionsDesc(raw: ProviderVersion[]): ProviderVersion[] {
-  return [...raw].sort((a, b) => {
-    const parseParts = (v: string): [number, number, number] => {
-      const clean = v.replace(/^v/, '').split('-')[0]
-      const [maj = 0, min = 0, pat = 0] = clean.split('.').map(Number)
-      return [maj, min, pat]
-    }
-    const [aMaj, aMin, aPat] = parseParts(a.version)
-    const [bMaj, bMin, bPat] = parseParts(b.version)
-    if (bMaj !== aMaj) return bMaj - aMaj
-    if (bMin !== aMin) return bMin - aMin
-    if (bPat !== aPat) return bPat - aPat
-    // Same numeric version: stable releases (no pre-release suffix) sort before pre-releases
-    const aStable = !a.version.replace(/^v/, '').includes('-')
-    const bStable = !b.version.replace(/^v/, '').includes('-')
-    if (aStable !== bStable) return aStable ? -1 : 1
-    return 0
-  })
-}
 
 /**
  * Data fetching, mutation and UI state for ProviderDetailPage.
@@ -106,7 +83,7 @@ export function useProviderDetail() {
       setProvider(matchingProvider)
 
       // Backend returns { versions: [...] } directly — sort by semver descending
-      const sortedVersions = sortVersionsDesc(versionsData.versions || [])
+      const sortedVersions = sortByVersionDesc(versionsData.versions || [])
       setVersions(sortedVersions)
 
       if (sortedVersions.length > 0) {

--- a/frontend/src/utils/__tests__/semver.test.ts
+++ b/frontend/src/utils/__tests__/semver.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect } from 'vitest'
+// Vite's `?raw` import, following src/__tests__/routeScopeParity.test.ts: it
+// needs no @types/node and no path arithmetic relative to the test's runtime
+// location, and it is resolved by the same bundler that builds the app, so the
+// text read here is unambiguously the source that ships.
+import moduleHookSource from '../../hooks/useModuleDetail.ts?raw'
+import providerHookSource from '../../hooks/useProviderDetail.ts?raw'
+import { compareVersionsDesc, sortByVersionDesc } from '../semver'
+
+/** Sorts bare version strings, so the cases below read as the list they describe. */
+function order(versions: string[]): string[] {
+  return sortByVersionDesc(versions.map((version) => ({ version }))).map((v) => v.version)
+}
+
+describe('sortByVersionDesc', () => {
+  it('orders by numeric precedence, not lexically', () => {
+    // '1.10.0' beats '1.2.0' numerically but loses as a string — the case that
+    // rules out ever replacing this with a plain localeCompare.
+    expect(order(['1.0.0', '2.0.0', '1.10.0', '1.2.0'])).toEqual([
+      '2.0.0',
+      '1.10.0',
+      '1.2.0',
+      '1.0.0',
+    ])
+  })
+
+  it('ignores a leading v', () => {
+    expect(order(['v1.0.0', '2.0.0', 'v10.0.0'])).toEqual(['v10.0.0', '2.0.0', 'v1.0.0'])
+  })
+
+  it('does not mutate its input', () => {
+    const input = [{ version: '1.0.0' }, { version: '2.0.0' }]
+    sortByVersionDesc(input)
+    expect(input.map((v) => v.version)).toEqual(['1.0.0', '2.0.0'])
+  })
+
+  it('returns an empty list unchanged', () => {
+    expect(order([])).toEqual([])
+  })
+
+  it('keeps equal versions in input order', () => {
+    // Two records can share a version (e.g. a re-published row). Sort stability
+    // is the only thing that makes the rendered list deterministic here.
+    const input = [
+      { version: '1.0.0', id: 'a' },
+      { version: '1.0.0', id: 'b' },
+    ]
+    expect(sortByVersionDesc(input).map((v) => v.id)).toEqual(['a', 'b'])
+  })
+})
+
+describe('sortByVersionDesc — pre-releases', () => {
+  it('puts a stable release ahead of a pre-release of the same version', () => {
+    // The #673 divergence itself. useProviderDetail had the stable-first
+    // tiebreak and useModuleDetail did not, and neither ordered pre-releases
+    // against each other, so this list rendered three different ways depending
+    // on the page and on the order the API happened to return. The hook tests
+    // in useModuleDetail.test.ts and useProviderDetail.test.tsx assert this
+    // exact fixture and expectation, which is what pins the two together.
+    expect(order(['1.0.0', '2.0.0-beta.2', '2.0.0-beta.10', '2.0.0-rc.1', '2.0.0'])).toEqual([
+      '2.0.0',
+      '2.0.0-rc.1',
+      '2.0.0-beta.10',
+      '2.0.0-beta.2',
+      '1.0.0',
+    ])
+  })
+
+  it('orders pre-releases by semver.org §11.4 precedence', () => {
+    // The precedence chain published in the semver spec, fed in reverse so a
+    // comparator that returned 0 for every pre-release pair (what both original
+    // copies did) would fail rather than pass on input order.
+    const newestFirst = [
+      '1.0.0',
+      '1.0.0-rc.1',
+      '1.0.0-beta.11',
+      '1.0.0-beta.2',
+      '1.0.0-beta',
+      '1.0.0-alpha.beta',
+      '1.0.0-alpha.1',
+      '1.0.0-alpha',
+    ]
+    expect(order([...newestFirst].reverse())).toEqual(newestFirst)
+  })
+
+  it('treats a pre-release identifier containing a dash as part of the tag', () => {
+    // Splitting on every '-' rather than the first would read this as '1.0.0'
+    // with tag 'alpha', losing the '-1'.
+    expect(order(['1.0.0-alpha-1', '1.0.0-alpha-2', '1.0.0'])).toEqual([
+      '1.0.0',
+      '1.0.0-alpha-2',
+      '1.0.0-alpha-1',
+    ])
+  })
+})
+
+describe('sortByVersionDesc — malformed input', () => {
+  it('treats a missing component as zero', () => {
+    expect(order(['1.2', '1.2.1', '2'])).toEqual(['2', '1.2.1', '1.2'])
+  })
+
+  it('ignores build metadata', () => {
+    expect(order(['1.0.0+build.9', '1.0.1', '1.0.0-alpha+001'])).toEqual([
+      '1.0.1',
+      '1.0.0+build.9',
+      '1.0.0-alpha+001',
+    ])
+  })
+
+  it('sinks unparseable versions below every real one, in input order', () => {
+    // The previous copies produced NaN here (Number('nightly')), which the sort
+    // spec silently coerces to 0 — every junk entry then compared "equal" to
+    // every real one and the whole list order became engine-dependent.
+    expect(order(['nightly', '0.0.1', 'main', '0.0.0'])).toEqual([
+      '0.0.1',
+      '0.0.0',
+      'nightly',
+      'main',
+    ])
+  })
+
+  it('sinks an empty version string rather than reading it as 0.0.0', () => {
+    // Number('') is 0, so the naive parse ranked '' alongside a real 0.0.0.
+    expect(order(['', '1.0.0', '0.0.0'])).toEqual(['1.0.0', '0.0.0', ''])
+  })
+})
+
+describe('compareVersionsDesc is a total order', () => {
+  // A comparator that returns NaN, or that is asymmetric or intransitive, makes
+  // Array#sort's output implementation-defined. Asserting the contract directly
+  // is cheaper than trying to guess which list will expose the violation.
+  const cases = [
+    '1.0.0',
+    'v1.0.0',
+    '1.0.0-alpha',
+    '1.0.0-alpha.1',
+    '1.0.0+b',
+    '',
+    'x',
+    '1.2',
+    '2.0.0',
+    '0.0.0',
+    '1.0.0-rc.1',
+    '10.0.0',
+    '1.0.0-1',
+    '1.0.0-1.2',
+  ]
+
+  it('never returns NaN and is antisymmetric', () => {
+    const violations: string[] = []
+    for (const a of cases) {
+      for (const b of cases) {
+        const forward = compareVersionsDesc(a, b)
+        if (Number.isNaN(forward)) violations.push(`NaN for (${a}, ${b})`)
+        if (Math.sign(forward) !== -Math.sign(compareVersionsDesc(b, a))) {
+          violations.push(`asymmetric for (${a}, ${b})`)
+        }
+      }
+    }
+    expect(violations).toEqual([])
+  })
+
+  it('is transitive, including for versions it considers equal', () => {
+    const violations: string[] = []
+    for (const a of cases) {
+      for (const b of cases) {
+        for (const c of cases) {
+          const ab = Math.sign(compareVersionsDesc(a, b))
+          const bc = Math.sign(compareVersionsDesc(b, c))
+          const ac = Math.sign(compareVersionsDesc(a, c))
+          if (ab < 0 && bc < 0 && ac >= 0) violations.push(`${a} < ${b} < ${c}`)
+          if (ab === 0 && bc === 0 && ac !== 0) violations.push(`${a} = ${b} = ${c}`)
+        }
+      }
+    }
+    expect(violations).toEqual([])
+  })
+})
+
+/**
+ * Guard against the two hooks re-growing private copies of this comparator
+ * (#673). Deduplicating them is only half the fix — the copies drifted silently
+ * once already, and nothing in the type system stops it happening again.
+ *
+ * Scoped to the two files the issue names rather than sweeping all of src:
+ * `?raw` on named files is the mechanism routeScopeParity.test.ts already
+ * proves works here. A repo-wide sweep is the thing to add if a third copy
+ * ever turns up.
+ */
+describe('single version comparator (#673)', () => {
+  const hooks = [
+    { name: 'useModuleDetail.ts', source: moduleHookSource },
+    { name: 'useProviderDetail.ts', source: providerHookSource },
+  ]
+
+  for (const { name, source } of hooks) {
+    it(`${name} is actually loaded and sorts versions`, () => {
+      // If a hook were renamed or the ?raw import started resolving to something
+      // empty, every assertion below would vacuously pass. An empty universe is
+      // the failure mode this guard exists to prevent, so it is asserted first.
+      expect(source.length).toBeGreaterThan(500)
+      expect(source).toContain('sortByVersionDesc')
+    })
+
+    it(`${name} imports the shared helper instead of defining one`, () => {
+      expect(source).toMatch(
+        /import\s*\{[^}]*sortByVersionDesc[^}]*\}\s*from\s*'\.\.\/utils\/semver'/,
+      )
+      expect(source).not.toContain('function sortVersionsDesc')
+    })
+
+    it(`${name} contains no hand-rolled version parsing`, () => {
+      // The fingerprint of the forked helper: strip a leading 'v', then split
+      // the pre-release off. Either alone starts a private reimplementation.
+      expect(source).not.toContain('/^v/')
+      expect(source).not.toContain(".split('-')")
+    })
+  }
+})

--- a/frontend/src/utils/semver.ts
+++ b/frontend/src/utils/semver.ts
@@ -1,0 +1,117 @@
+/**
+ * Version ordering for registry version lists (#673).
+ *
+ * `useModuleDetail` and `useProviderDetail` each carried their own copy of a
+ * `sortVersionsDesc` helper. The copies were forked from one source and then
+ * only the provider one was fixed to put stable releases ahead of pre-releases,
+ * so the same version list sorted differently depending on which page you were
+ * looking at. This module is the single implementation both hooks now call;
+ * `semver.test.ts` also guards the hooks against growing a private copy again.
+ *
+ * The ordering follows semver.org §11 precedence, descending (newest first):
+ *   1. major, then minor, then patch, compared numerically
+ *   2. at equal numeric version, a stable release outranks any pre-release
+ *   3. between two pre-releases, dot-separated identifiers are compared
+ *      left to right — numeric identifiers numerically, alphanumeric ones
+ *      by ASCII order, numeric always below alphanumeric, and a shorter set
+ *      of identifiers below a longer one that shares its prefix.
+ *
+ * Build metadata (`+sha`) is stripped before comparison, as semver requires.
+ *
+ * Unparseable input is *ordered*, not ignored. Returning NaN from a comparator
+ * is undefined behaviour (the spec coerces it to 0), which makes the resulting
+ * order non-transitive and engine-dependent — the previous copies did exactly
+ * that for any non-numeric component. Here a present-but-unparseable component
+ * is treated as lower than any real version, so junk sinks to the bottom of the
+ * list deterministically instead of scrambling the entries around it.
+ */
+
+/**
+ * Sentinel for a version component that is present but not a number. Below any
+ * real component (which is a non-negative integer), so such versions sort last.
+ */
+const UNPARSEABLE = -1
+
+interface ParsedVersion {
+  major: number
+  minor: number
+  patch: number
+  /** Pre-release identifiers as written, without the leading '-'. '' = stable. */
+  prerelease: string
+}
+
+/** A missing component is 0 (`1.2` means `1.2.0`); a malformed one is UNPARSEABLE. */
+function numericComponent(part: string | undefined): number {
+  if (part === undefined) return 0
+  return /^\d+$/.test(part) ? Number(part) : UNPARSEABLE
+}
+
+function parseVersion(raw: string): ParsedVersion {
+  // Order matters: build metadata may follow a pre-release ('1.0.0-rc.1+abc'),
+  // so it is stripped first; the pre-release is then everything after the FIRST
+  // '-' (identifiers may themselves contain '-', e.g. '1.0.0-alpha-1').
+  const withoutBuild = String(raw ?? '')
+    .trim()
+    .replace(/^v/i, '')
+    .split('+')[0]
+  const dash = withoutBuild.indexOf('-')
+  const core = dash === -1 ? withoutBuild : withoutBuild.slice(0, dash)
+  const prerelease = dash === -1 ? '' : withoutBuild.slice(dash + 1)
+  const parts = core.split('.')
+  return {
+    major: numericComponent(parts[0]),
+    minor: numericComponent(parts[1]),
+    patch: numericComponent(parts[2]),
+    prerelease,
+  }
+}
+
+/** semver.org §11.4 precedence, ascending. '' (a stable release) ranks highest. */
+function comparePrerelease(a: string, b: string): number {
+  if (a === b) return 0
+  if (a === '') return 1
+  if (b === '') return -1
+  const aIds = a.split('.')
+  const bIds = b.split('.')
+  const len = Math.max(aIds.length, bIds.length)
+  for (let i = 0; i < len; i++) {
+    const x = aIds[i]
+    const y = bIds[i]
+    // A smaller set of identifiers ranks lower when all preceding ones match.
+    if (x === undefined) return -1
+    if (y === undefined) return 1
+    const xNumeric = /^\d+$/.test(x)
+    const yNumeric = /^\d+$/.test(y)
+    if (xNumeric && yNumeric) {
+      if (Number(x) !== Number(y)) return Number(x) - Number(y)
+    } else if (xNumeric !== yNumeric) {
+      return xNumeric ? -1 : 1
+    } else if (x !== y) {
+      return x < y ? -1 : 1
+    }
+  }
+  return 0
+}
+
+/**
+ * Compare two version strings newest-first. Suitable as an Array#sort
+ * comparator; never returns NaN, so the resulting order is a total order.
+ */
+export function compareVersionsDesc(a: string, b: string): number {
+  const left = parseVersion(a)
+  const right = parseVersion(b)
+  if (left.major !== right.major) return right.major - left.major
+  if (left.minor !== right.minor) return right.minor - left.minor
+  if (left.patch !== right.patch) return right.patch - left.patch
+  // Arguments swapped: comparePrerelease is ascending, this comparator is not.
+  return comparePrerelease(right.prerelease, left.prerelease)
+}
+
+/**
+ * Sort any list of version-bearing records newest-first, without mutating the
+ * input. Generic over the record type so module and provider version lists keep
+ * their own element types — the helper only ever reads `version`.
+ */
+export function sortByVersionDesc<T extends { version: string }>(items: readonly T[]): T[] {
+  return [...items].sort((a, b) => compareVersionsDesc(a.version, b.version))
+}


### PR DESCRIPTION
Closes #673.

## Verified first

The issue is accurate and still live on `main`. `useModuleDetail.ts` and `useProviderDetail.ts` each defined their own `sortVersionsDesc`; the provider copy had a stable-before-pre-release tiebreak and the module copy did not. They are the only two such copies in `src/` — `TerraformMirrorPage`/`useTerraformBinaryDetail` sort by `localeCompare({numeric:true})` keyed on `is_latest`, a different ordering for a different list (see "Not done" below).

## What changed

`src/utils/semver.ts` is now the single implementation, exporting `compareVersionsDesc` and a generic `sortByVersionDesc<T extends { version: string }>`. Both hooks call it.

Deduplicating is only half of #673 — the copies drifted once already and nothing typed stops it happening again. So `semver.test.ts` also reads both hook sources through Vite's `?raw` import (the mechanism `src/__tests__/routeScopeParity.test.ts` already proves works in this setup) and fails if either file grows a private comparator. Following the lesson baked into `routeScopeParity`, it asserts its own universe is non-empty **first**, so a renamed hook or a broken `?raw` resolution fails loudly instead of passing vacuously.

Two behaviours are deliberately tightened rather than just merged, both specified by tests:

| case | before | after |
|---|---|---|
| `2.0.0` vs `2.0.0-rc.1` | module: input order; provider: stable first | stable first, both |
| `2.0.0-beta.10` vs `2.0.0-beta.2` | both returned `0` — i.e. whatever order the API sent | semver.org §11.4 precedence |
| `nightly`, `''`, `1.2.x` | comparator returns `NaN` | ranks below any real version |

The `NaN` one matters beyond tidiness: `Number('nightly')` is `NaN`, and `Array#sort` coerces a `NaN` comparator result to `0`, so a single junk entry made the **entire** list's order non-transitive and engine-dependent. `compareVersionsDesc` is now asserted to be a total order (no `NaN`, antisymmetric, transitive) over a 14-case matrix.

Trade-off: provider ordering changes in exactly one case — two pre-releases of the same numeric version. It changes from "undefined" to "correct".

## Would these tests fail if the change were reverted?

Checked mechanically rather than assumed, because both hooks already had a passing sort test that could not tell the implementations apart. The existing provider test uses a list with a single pre-release, which the old and new comparators order identically — it would have gone green against unfixed code.

The new fixture `['1.0.0', '2.0.0-beta.2', '2.0.0-beta.10', '2.0.0-rc.1', '2.0.0']` was chosen by running it through re-implementations of **both** original comparators:

```
expected (new shared)  : 2.0.0, 2.0.0-rc.1, 2.0.0-beta.10, 2.0.0-beta.2, 1.0.0
old useModuleDetail    : 2.0.0-beta.2, 2.0.0-beta.10, 2.0.0-rc.1, 2.0.0, 1.0.0   -> FAILS
old useProviderDetail  : 2.0.0, 2.0.0-beta.2, 2.0.0-beta.10, 2.0.0-rc.1, 1.0.0   -> FAILS
```

The same fixture and expectation are asserted in three places (`semver.test.ts`, `useModuleDetail.test.ts`, `useProviderDetail.test.tsx`) on purpose — that is what pins the two hooks to each other.

The source guard was mutation-verified the same way: its predicates were run against `git show origin/main:` copies of both hooks (guard fails on both) and against the fixed tree (guard passes on both). A guard that cannot fail is not a guard.

No existing test asserted the buggy behaviour, so nothing had to be inverted.

## CI is the first execution of these tests

`npm ci` cannot run in the environment this was written in — `frontend/package.json` depends on a private package needing a `read:packages` token that isn't available there — so vitest could not be run locally. In place of guessing:

- The comparator was re-implemented standalone in node and every case in `semver.test.ts` run through it, including the semver.org §11.4 precedence chain fed in reverse and the total-order matrix.
- The guard's scanning predicates were run standalone against both the pre-fix and post-fix sources (result above).
- `src/utils/semver.ts` was typechecked with a standalone `tsc` **6.0.3** — the exact version this repo pins — under a copy of the repo's `compilerOptions` (`strict`, `noUnusedLocals`, …). That harness was itself mutation-verified by injecting a type error and confirming it was caught.
- All changed files were run through standalone prettier **3.9.6**, again the exact pin, with the repo's `.prettierrc`. For the record: no workflow in `.github/workflows/` actually runs prettier, and two pre-existing lines in the touched files already do not conform; those were left alone rather than reformatted, to keep the diff to the fix.

The hook files themselves could not be typechecked in isolation (they pull in react / react-query / react-router), but the edits there are an import swap and a call-site rename.

## Not done, deliberately

- `TerraformMirrorPage.tsx` and `useTerraformBinaryDetail.ts` sort Terraform **binary** versions with `is_latest` as the primary key and `localeCompare({numeric:true})` as the tiebreak. Different ordering, different domain, not what #673 describes — and `TerraformMirrorPage.tsx` is being edited concurrently, so sweeping it in would have been scope creep with a merge conflict attached.
- The guard is scoped to the two files the issue names rather than globbing all of `src/`. `?raw` on named files is the mechanism already proven in this repo; a repo-wide `import.meta.glob` sweep is the thing to add if a third copy ever appears, and introducing an unverifiable new mechanism was not worth it here.
- `sortByVersionDesc` was not added to the `src/utils/index.ts` barrel — that barrel exports a subset, and the hooks already import siblings like `getErrorMessage` directly from their modules.