### PR TITLE
refactor(admin): shared useStatusMessage hook + StatusAlerts for the duplicated admin banners

### DIFF
--- a/frontend/src/components/StatusAlerts.tsx
+++ b/frontend/src/components/StatusAlerts.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import { Alert } from '@mui/material'
+import type { StatusMessage } from '../hooks/useStatusMessage'
+
+export interface StatusAlertsProps {
+  status: StatusMessage
+  /**
+   * Bottom margin (MUI spacing units) applied to each alert. Required rather
+   * than defaulted so every call site restates the spacing its page already
+   * used instead of silently inheriting a different one.
+   */
+  mb: number
+}
+
+/**
+ * The dismissible error/success banner pair that admin pages render above their
+ * content, extracted from the identical JSX each page carried by hand.
+ *
+ * Renders a fragment, so the alerts stay direct children of whatever laid them
+ * out before. Error is rendered above success, matching every page that adopted
+ * this component; pages that deliberately render success first keep their own
+ * markup.
+ */
+const StatusAlerts: React.FC<StatusAlertsProps> = ({ status, mb }) => (
+  <>
+    {status.error && (
+      <Alert severity="error" sx={{ mb }} onClose={() => status.setError(null)}>
+        {status.error}
+      </Alert>
+    )}
+    {status.success && (
+      <Alert severity="success" sx={{ mb }} onClose={() => status.setSuccess(null)}>
+        {status.success}
+      </Alert>
+    )}
+  </>
+)
+
+export default StatusAlerts

--- a/frontend/src/components/__tests__/StatusAlerts.test.tsx
+++ b/frontend/src/components/__tests__/StatusAlerts.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent, within } from '@testing-library/react'
+import StatusAlerts from '../StatusAlerts'
+import type { StatusMessage } from '../../hooks/useStatusMessage'
+
+function makeStatus(overrides: Partial<StatusMessage> = {}): StatusMessage {
+  return {
+    error: null,
+    success: null,
+    setError: vi.fn(),
+    setSuccess: vi.fn(),
+    showSuccess: vi.fn(),
+    clear: vi.fn(),
+    ...overrides,
+  }
+}
+
+describe('StatusAlerts', () => {
+  it('renders nothing when there is no message', () => {
+    const { container } = render(<StatusAlerts status={makeStatus()} mb={2} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  // The pages relied on MUI's default role="alert" to announce the banner;
+  // that is the behaviour this component has to keep.
+  it('announces the error message to assistive technology', () => {
+    render(<StatusAlerts status={makeStatus({ error: 'boom' })} mb={2} />)
+    const alert = screen.getByRole('alert')
+    expect(alert).toHaveTextContent('boom')
+  })
+
+  it('announces the success message to assistive technology', () => {
+    render(<StatusAlerts status={makeStatus({ success: 'saved' })} mb={2} />)
+    expect(screen.getByRole('alert')).toHaveTextContent('saved')
+  })
+
+  it('renders the error above the success when both are set', () => {
+    render(<StatusAlerts status={makeStatus({ error: 'boom', success: 'saved' })} mb={2} />)
+    const alerts = screen.getAllByRole('alert')
+    expect(alerts).toHaveLength(2)
+    expect(alerts[0]).toHaveTextContent('boom')
+    expect(alerts[1]).toHaveTextContent('saved')
+  })
+
+  it('dismisses the error without touching the success message', () => {
+    const status = makeStatus({ error: 'boom', success: 'saved' })
+    render(<StatusAlerts status={status} mb={2} />)
+    const errorAlert = screen.getAllByRole('alert')[0]
+    fireEvent.click(within(errorAlert).getByRole('button'))
+    expect(status.setError).toHaveBeenCalledWith(null)
+    expect(status.setSuccess).not.toHaveBeenCalled()
+  })
+
+  it('dismisses the success without touching the error message', () => {
+    const status = makeStatus({ error: 'boom', success: 'saved' })
+    render(<StatusAlerts status={status} mb={2} />)
+    const successAlert = screen.getAllByRole('alert')[1]
+    fireEvent.click(within(successAlert).getByRole('button'))
+    expect(status.setSuccess).toHaveBeenCalledWith(null)
+    expect(status.setError).not.toHaveBeenCalled()
+  })
+
+  // mb varies per page (2 or 3), so prove it actually reaches the alert's sx
+  // rather than being dropped on the floor.
+  it('applies the requested bottom margin', () => {
+    const status = makeStatus({ error: 'boom' })
+    const { rerender } = render(<StatusAlerts status={status} mb={2} />)
+    const spacingTwo = screen.getByRole('alert').className
+    rerender(<StatusAlerts status={status} mb={3} />)
+    expect(screen.getByRole('alert').className).not.toBe(spacingTwo)
+  })
+})

--- a/frontend/src/hooks/__tests__/useStatusMessage.test.ts
+++ b/frontend/src/hooks/__tests__/useStatusMessage.test.ts
@@ -1,0 +1,71 @@
+import { renderHook, act } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { useStatusMessage } from '../useStatusMessage'
+
+describe('useStatusMessage', () => {
+  it('starts with no messages', () => {
+    const { result } = renderHook(() => useStatusMessage())
+    expect(result.current.error).toBeNull()
+    expect(result.current.success).toBeNull()
+  })
+
+  it('records an error and a success independently', () => {
+    const { result } = renderHook(() => useStatusMessage())
+    act(() => result.current.setError('boom'))
+    expect(result.current.error).toBe('boom')
+    expect(result.current.success).toBeNull()
+
+    act(() => result.current.setSuccess('saved'))
+    expect(result.current.success).toBe('saved')
+  })
+
+  // The pages this hook replaced never cleared a success banner when a later
+  // action failed, so setError must not do it either.
+  it('leaves an existing success in place when an error arrives', () => {
+    const { result } = renderHook(() => useStatusMessage())
+    act(() => result.current.setSuccess('saved'))
+    act(() => result.current.setError('boom'))
+    expect(result.current.error).toBe('boom')
+    expect(result.current.success).toBe('saved')
+  })
+
+  // This is the clear-on-next-action wiring the pages each carried by hand as
+  // `setSuccess(msg); setError(null)`.
+  it('showSuccess records the success and drops the error still on screen', () => {
+    const { result } = renderHook(() => useStatusMessage())
+    act(() => result.current.setError('boom'))
+    act(() => result.current.showSuccess('saved'))
+    expect(result.current.success).toBe('saved')
+    expect(result.current.error).toBeNull()
+  })
+
+  it('clear wipes both messages', () => {
+    const { result } = renderHook(() => useStatusMessage())
+    act(() => {
+      result.current.setError('boom')
+      result.current.setSuccess('saved')
+    })
+    act(() => result.current.clear())
+    expect(result.current.error).toBeNull()
+    expect(result.current.success).toBeNull()
+  })
+
+  it('dismisses one message without disturbing the other', () => {
+    const { result } = renderHook(() => useStatusMessage())
+    act(() => {
+      result.current.setError('boom')
+      result.current.setSuccess('saved')
+    })
+    act(() => result.current.setError(null))
+    expect(result.current.error).toBeNull()
+    expect(result.current.success).toBe('saved')
+  })
+
+  it('keeps showSuccess and clear stable across renders', () => {
+    const { result, rerender } = renderHook(() => useStatusMessage())
+    const { showSuccess, clear } = result.current
+    rerender()
+    expect(result.current.showSuccess).toBe(showSuccess)
+    expect(result.current.clear).toBe(clear)
+  })
+})

--- a/frontend/src/hooks/useStatusMessage.ts
+++ b/frontend/src/hooks/useStatusMessage.ts
@@ -1,0 +1,43 @@
+import { useCallback, useState } from 'react'
+
+/** The error/success banner state an admin page shows above its content. */
+export interface StatusMessage {
+  error: string | null
+  success: string | null
+  setError: (message: string | null) => void
+  setSuccess: (message: string | null) => void
+  /** Record a success and drop any error still on screen. */
+  showSuccess: (message: string) => void
+  /** Clear both messages. */
+  clear: () => void
+}
+
+/**
+ * Shared "one error banner + one success banner" state for admin pages.
+ *
+ * Extracted from the `useState<string | null>(null)` pair that was repeated
+ * verbatim across the admin pages, each with its own copy of the
+ * clear-the-error-when-an-action-succeeds wiring. Render the messages with
+ * `<StatusAlerts status={status} mb={n} />`, which takes this whole object so
+ * that a dismiss handler cannot be wired to the wrong message.
+ *
+ * `setError` and `setSuccess` are deliberately independent: setting an error
+ * does not clear a previous success, because none of the pages did that.
+ * `showSuccess` is the one combination the pages did share.
+ */
+export function useStatusMessage(): StatusMessage {
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState<string | null>(null)
+
+  const showSuccess = useCallback((message: string) => {
+    setSuccess(message)
+    setError(null)
+  }, [])
+
+  const clear = useCallback(() => {
+    setError(null)
+    setSuccess(null)
+  }, [])
+
+  return { error, success, setError, setSuccess, showSuccess, clear }
+}

--- a/frontend/src/pages/admin/APIKeysPage.tsx
+++ b/frontend/src/pages/admin/APIKeysPage.tsx
@@ -42,12 +42,14 @@ import { ApiKeyExpirySettingsCard, type ApiKeyExpirySettingsInput } from '@4clou
 import EmptyState from '../../components/EmptyState'
 import Page from '../../components/Page'
 import PageHeader from '../../components/PageHeader'
+import StatusAlerts from '../../components/StatusAlerts'
 import PageTitleIcon from '@mui/icons-material/Key'
 import CopyIcon from '@mui/icons-material/ContentCopy'
 import InfoIcon from '@mui/icons-material/Info'
 import EditIcon from '@mui/icons-material/Edit'
 import AutorenewIcon from '@mui/icons-material/Autorenew'
 import api from '../../services/api'
+import { useStatusMessage } from '../../hooks/useStatusMessage'
 import { APIKey } from '../../types'
 import type { NotificationsConfigInput } from '../../types'
 import { REGISTRY_HOST } from '../../config'
@@ -94,7 +96,7 @@ const APIKeysPage: React.FC = () => {
   // otherwise see fully actionable buttons that only fail once clicked,
   // relying entirely on the server to say no.
   const canManage = isAdmin || allowedScopes.includes('api_keys:manage')
-  const [error, setError] = useState<string | null>(null)
+  const status = useStatusMessage()
 
   // API-key-expiry notification settings (admin-only). Shares the notifications
   // config query/endpoint with admin/NotificationsPage -- saving here reads the
@@ -140,8 +142,8 @@ const APIKeysPage: React.FC = () => {
   })
 
   useEffect(() => {
-    if (queryError && !error) {
-      setError(t('admin.apiKeys.errLoad'))
+    if (queryError && !status.error) {
+      status.setError(t('admin.apiKeys.errLoad'))
     }
   }, [queryError]) // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -204,7 +206,7 @@ const APIKeysPage: React.FC = () => {
       scopes: defaultScopes,
       expires_at: '',
     })
-    setError(null)
+    status.setError(null)
     setOpenDialog(true)
   }
 
@@ -214,11 +216,11 @@ const APIKeysPage: React.FC = () => {
 
   const handleCreateAPIKey = async () => {
     try {
-      setError(null)
+      status.setError(null)
       const orgId =
         formData.organization_id || (memberships.length > 0 ? memberships[0].organization_id : '')
       if (!orgId) {
-        setError(t('admin.apiKeys.errNoOrg'))
+        status.setError(t('admin.apiKeys.errNoOrg'))
         return
       }
       const response = await api.createAPIKey({
@@ -232,7 +234,7 @@ const APIKeysPage: React.FC = () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.apiKeys._def })
     } catch (err: unknown) {
       console.error('Failed to create API key:', err)
-      setError(getErrorMessage(err, t('admin.apiKeys.errCreate')))
+      status.setError(getErrorMessage(err, t('admin.apiKeys.errCreate')))
     }
   }
 
@@ -245,7 +247,7 @@ const APIKeysPage: React.FC = () => {
       scopes: key.scopes || [],
       expires_at: toDatetimeLocalValue(key.expires_at),
     })
-    setError(null)
+    status.setError(null)
     setEditDialogOpen(true)
   }
 
@@ -261,7 +263,7 @@ const APIKeysPage: React.FC = () => {
   const handleEditSave = async () => {
     if (!keyToEdit) return
     try {
-      setError(null)
+      status.setError(null)
       await api.updateAPIKey(keyToEdit.id, {
         name: editFormData.name,
         scopes: editFormData.scopes,
@@ -274,7 +276,7 @@ const APIKeysPage: React.FC = () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.apiKeys._def })
     } catch (err: unknown) {
       console.error('Failed to update API key:', err)
-      setError(getErrorMessage(err, t('admin.apiKeys.errUpdate')))
+      status.setError(getErrorMessage(err, t('admin.apiKeys.errUpdate')))
     }
   }
 
@@ -286,14 +288,14 @@ const APIKeysPage: React.FC = () => {
     setGracePeriodHours(24)
     setRotatedKeyValue(null)
     setRotateResult(null)
-    setError(null)
+    status.setError(null)
     setRotateDialogOpen(true)
   }
 
   const handleRotateConfirm = async () => {
     if (!keyToRotate) return
     try {
-      setError(null)
+      status.setError(null)
       const hours = rotateMode === 'immediate' ? 0 : gracePeriodHours
       const response = await api.rotateAPIKey(keyToRotate.id, hours)
       const newKey = response.new_key
@@ -305,7 +307,7 @@ const APIKeysPage: React.FC = () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.apiKeys._def })
     } catch (err: unknown) {
       console.error('Failed to rotate API key:', err)
-      setError(getErrorMessage(err, t('admin.apiKeys.errRotate')))
+      status.setError(getErrorMessage(err, t('admin.apiKeys.errRotate')))
     }
   }
 
@@ -326,14 +328,14 @@ const APIKeysPage: React.FC = () => {
   const handleDeleteConfirm = async () => {
     if (!keyToDelete) return
     try {
-      setError(null)
+      status.setError(null)
       await api.deleteAPIKey(keyToDelete.id)
       setDeleteDialogOpen(false)
       setKeyToDelete(null)
       queryClient.invalidateQueries({ queryKey: queryKeys.apiKeys._def })
     } catch (err: unknown) {
       console.error('Failed to delete API key:', err)
-      setError(getErrorMessage(err, t('admin.apiKeys.errDelete')))
+      status.setError(getErrorMessage(err, t('admin.apiKeys.errDelete')))
     }
   }
 
@@ -512,11 +514,7 @@ const APIKeysPage: React.FC = () => {
           ) : undefined
         }
       />
-      {error && (
-        <Alert severity="error" sx={{ mb: 3 }} onClose={() => setError(null)}>
-          {error}
-        </Alert>
-      )}
+      <StatusAlerts status={status} mb={3} />
       {!membershipsLoading && memberships.length === 0 && (
         <Alert severity="warning" sx={{ mb: 3 }}>
           {t('admin.apiKeys.warnNoOrg')}

--- a/frontend/src/pages/admin/ApprovalsPage.tsx
+++ b/frontend/src/pages/admin/ApprovalsPage.tsx
@@ -15,7 +15,6 @@ import {
   DialogContent,
   DialogActions,
   TextField,
-  Alert,
   CircularProgress,
   Select,
   MenuItem,
@@ -29,8 +28,10 @@ import CancelIcon from '@mui/icons-material/Cancel'
 import HourglassEmptyIcon from '@mui/icons-material/HourglassEmpty'
 import Page from '../../components/Page'
 import PageHeader from '../../components/PageHeader'
+import StatusAlerts from '../../components/StatusAlerts'
 import PageTitleIcon from '@mui/icons-material/HourglassEmpty'
 import api from '../../services/api'
+import { useStatusMessage } from '../../hooks/useStatusMessage'
 import { formatDate } from '../../utils'
 import { MirrorApprovalRequest } from '../../types/rbac'
 import { getErrorMessage } from '../../utils/errors'
@@ -48,8 +49,7 @@ const ApprovalsPage: React.FC = () => {
   // viewer would otherwise see fully actionable controls that only fail once
   // clicked (#609).
   const canManage = allowedScopes.includes('admin') || allowedScopes.includes('mirrors:manage')
-  const [error, setError] = useState<string | null>(null)
-  const [success, setSuccess] = useState<string | null>(null)
+  const status = useStatusMessage()
 
   // Create dialog state
   const [createDialogOpen, setCreateDialogOpen] = useState(false)
@@ -86,8 +86,8 @@ const ApprovalsPage: React.FC = () => {
     },
   })
 
-  if (queryError && !error) {
-    setError(getErrorMessage(queryError, t('admin.approvals.errLoad')))
+  if (queryError && !status.error) {
+    status.setError(getErrorMessage(queryError, t('admin.approvals.errLoad')))
   }
 
   const createMutation = useMutation({
@@ -101,12 +101,11 @@ const ApprovalsPage: React.FC = () => {
     onSuccess: () => {
       setCreateDialogOpen(false)
       setCreateForm({ mirror_config_id: '', provider_namespace: '', provider_name: '', reason: '' })
-      setSuccess(t('admin.approvals.msgCreated'))
-      setError(null)
+      status.showSuccess(t('admin.approvals.msgCreated'))
       queryClient.invalidateQueries({ queryKey: queryKeys.approvals._def })
     },
     onError: (err: unknown) => {
-      setError(getErrorMessage(err, t('admin.approvals.errCreate')))
+      status.setError(getErrorMessage(err, t('admin.approvals.errCreate')))
     },
   })
 
@@ -122,14 +121,13 @@ const ApprovalsPage: React.FC = () => {
     }) => api.reviewApproval(id, { status, notes }),
     onSuccess: () => {
       setReviewDialogOpen(false)
-      setSuccess(t('admin.approvals.reviewed', { status: reviewForm.status }))
-      setError(null)
+      status.showSuccess(t('admin.approvals.reviewed', { status: reviewForm.status }))
       setReviewingApproval(null)
       setReviewForm({ status: 'approved', notes: '' })
       queryClient.invalidateQueries({ queryKey: queryKeys.approvals._def })
     },
     onError: (err: unknown) => {
-      setError(getErrorMessage(err, t('admin.approvals.errReview')))
+      status.setError(getErrorMessage(err, t('admin.approvals.errReview')))
     },
   })
 
@@ -246,17 +244,7 @@ const ApprovalsPage: React.FC = () => {
             }
           />
 
-          {error && (
-            <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
-              {error}
-            </Alert>
-          )}
-
-          {success && (
-            <Alert severity="success" sx={{ mb: 2 }} onClose={() => setSuccess(null)}>
-              {success}
-            </Alert>
-          )}
+          <StatusAlerts status={status} mb={2} />
 
           <Grid container spacing={3}>
             {approvals.map((approval) => (

--- a/frontend/src/pages/admin/AuditLogPage.tsx
+++ b/frontend/src/pages/admin/AuditLogPage.tsx
@@ -19,7 +19,6 @@ import {
   DialogActions,
   TextField,
   CircularProgress,
-  Alert,
   FormControl,
   InputLabel,
   Select,
@@ -32,8 +31,10 @@ import HistoryIcon from '@mui/icons-material/History'
 import EmptyState from '../../components/EmptyState'
 import Page from '../../components/Page'
 import PageHeader from '../../components/PageHeader'
+import StatusAlerts from '../../components/StatusAlerts'
 import PageTitleIcon from '@mui/icons-material/History'
 import api from '../../services/api'
+import { useStatusMessage } from '../../hooks/useStatusMessage'
 import { AuditLog } from '../../types'
 import { queryKeys } from '../../services/queryKeys'
 import { usePagination } from '../../hooks/usePagination'
@@ -63,7 +64,7 @@ const resourceTypeLabel = (value: string | null | undefined): string => {
 
 const AuditLogPage: React.FC = () => {
   const { t } = useTranslation()
-  const [error, setError] = useState<string | null>(null)
+  const status = useStatusMessage()
 
   // Pagination (MUI TablePagination uses 0-based page)
   const { page, rowsPerPage, setPage, handleChangePage, handleChangeRowsPerPage } =
@@ -110,11 +111,11 @@ const AuditLogPage: React.FC = () => {
   const logs = data?.logs ?? []
   const total = data?.pagination?.total ?? 0
 
-  if (queryError && !error) {
+  if (queryError && !status.error) {
     // Raw error messages can leak implementation details -- route through the
     // shared getErrorMessage helper, which DEV-gates native Error messages
     // the same way ErrorBoundary.tsx does (#618-class).
-    setError(getErrorMessage(queryError, t('admin.auditLog.errLoad')))
+    status.setError(getErrorMessage(queryError, t('admin.auditLog.errLoad')))
   }
 
   // Debounce text filter changes
@@ -180,7 +181,7 @@ const AuditLogPage: React.FC = () => {
       })
       api.exportAuditLogsCSV(result.logs ?? [])
     } catch {
-      setError('Failed to export audit logs')
+      status.setError('Failed to export audit logs')
     }
   }
 
@@ -197,7 +198,7 @@ const AuditLogPage: React.FC = () => {
       })
       api.exportAuditLogsJSON(result.logs ?? [])
     } catch {
-      setError('Failed to export audit logs')
+      status.setError('Failed to export audit logs')
     }
   }
 
@@ -299,12 +300,7 @@ const AuditLogPage: React.FC = () => {
           </Button>
         </Box>
       </Paper>
-      {/* Error */}
-      {error && (
-        <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
-          {error}
-        </Alert>
-      )}
+      <StatusAlerts status={status} mb={2} />
       {/* Table */}
       <Paper>
         {loading ? (

--- a/frontend/src/pages/admin/MirrorPoliciesPage.tsx
+++ b/frontend/src/pages/admin/MirrorPoliciesPage.tsx
@@ -35,8 +35,10 @@ import BlockIcon from '@mui/icons-material/Block'
 import PlayArrowIcon from '@mui/icons-material/PlayArrow'
 import Page from '../../components/Page'
 import PageHeader from '../../components/PageHeader'
+import StatusAlerts from '../../components/StatusAlerts'
 import PageTitleIcon from '@mui/icons-material/Policy'
 import api from '../../services/api'
+import { useStatusMessage } from '../../hooks/useStatusMessage'
 import { MirrorPolicy, PolicyEvaluationResult } from '../../types/rbac'
 import { getErrorMessage } from '../../utils/errors'
 import { queryKeys } from '../../services/queryKeys'
@@ -68,8 +70,7 @@ const defaultFormData: PolicyFormData = {
 const MirrorPoliciesPage: React.FC = () => {
   const { t } = useTranslation()
   const queryClient = useQueryClient()
-  const [error, setError] = useState<string | null>(null)
-  const [success, setSuccess] = useState<string | null>(null)
+  const status = useStatusMessage()
 
   // Create / Edit dialog
   const [formDialogOpen, setFormDialogOpen] = useState(false)
@@ -99,8 +100,8 @@ const MirrorPoliciesPage: React.FC = () => {
     },
   })
 
-  if (queryError && !error) {
-    setError(getErrorMessage(queryError, t('admin.mirrorPolicies.errLoad')))
+  if (queryError && !status.error) {
+    status.setError(getErrorMessage(queryError, t('admin.mirrorPolicies.errLoad')))
   }
 
   const saveMutation = useMutation({
@@ -111,17 +112,16 @@ const MirrorPoliciesPage: React.FC = () => {
       return api.createMirrorPolicy(payload)
     },
     onSuccess: () => {
-      setSuccess(
+      status.showSuccess(
         editingPolicy ? t('admin.mirrorPolicies.msgUpdated') : t('admin.mirrorPolicies.msgCreated'),
       )
-      setError(null)
       setFormDialogOpen(false)
       setEditingPolicy(null)
       setFormData(defaultFormData)
       queryClient.invalidateQueries({ queryKey: queryKeys.policies._def })
     },
     onError: (err: unknown) => {
-      setError(getErrorMessage(err, t('admin.mirrorPolicies.errSave')))
+      status.setError(getErrorMessage(err, t('admin.mirrorPolicies.errSave')))
     },
   })
 
@@ -130,19 +130,18 @@ const MirrorPoliciesPage: React.FC = () => {
     onSuccess: () => {
       setDeleteDialogOpen(false)
       setPolicyToDelete(null)
-      setSuccess(t('admin.mirrorPolicies.msgDeleted'))
-      setError(null)
+      status.showSuccess(t('admin.mirrorPolicies.msgDeleted'))
       queryClient.invalidateQueries({ queryKey: queryKeys.policies._def })
     },
     onError: (err: unknown) => {
-      setError(getErrorMessage(err, t('admin.mirrorPolicies.errDelete')))
+      status.setError(getErrorMessage(err, t('admin.mirrorPolicies.errDelete')))
     },
   })
 
   const saving = saveMutation.isPending
 
   const handleSave = () => {
-    setError(null)
+    status.setError(null)
     saveMutation.mutate({
       name: formData.name,
       description: formData.description || undefined,
@@ -158,7 +157,7 @@ const MirrorPoliciesPage: React.FC = () => {
 
   const handleDelete = () => {
     if (!policyToDelete) return
-    setError(null)
+    status.setError(null)
     deleteMutation.mutate(policyToDelete.id)
   }
 
@@ -173,7 +172,7 @@ const MirrorPoliciesPage: React.FC = () => {
       })
       setEvaluateResult(result)
     } catch (err: unknown) {
-      setError(getErrorMessage(err, t('admin.mirrorPolicies.errEvaluate')))
+      status.setError(getErrorMessage(err, t('admin.mirrorPolicies.errEvaluate')))
     } finally {
       setEvaluating(false)
     }
@@ -272,17 +271,7 @@ const MirrorPoliciesPage: React.FC = () => {
             }
           />
 
-          {error && (
-            <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
-              {error}
-            </Alert>
-          )}
-
-          {success && (
-            <Alert severity="success" sx={{ mb: 2 }} onClose={() => setSuccess(null)}>
-              {success}
-            </Alert>
-          )}
+          <StatusAlerts status={status} mb={2} />
 
           <Grid container spacing={3}>
             {policies.map((policy) => (

--- a/frontend/src/pages/admin/MirrorsPage.tsx
+++ b/frontend/src/pages/admin/MirrorsPage.tsx
@@ -63,8 +63,10 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import ScheduleIcon from '@mui/icons-material/Schedule'
 import Page from '../../components/Page'
 import PageHeader from '../../components/PageHeader'
+import StatusAlerts from '../../components/StatusAlerts'
 import PageTitleIcon from '@mui/icons-material/CloudDownload'
 import api from '../../services/api'
+import { useStatusMessage } from '../../hooks/useStatusMessage'
 import { useAuth } from '../../contexts/AuthContext'
 import {
   type MirrorConfiguration,
@@ -295,8 +297,7 @@ const MirrorsPage: React.FC = () => {
   // mirrors:manage/admin — a mirrors:read-only viewer would otherwise see
   // fully actionable controls that only fail once clicked (#609).
   const canManage = allowedScopes.includes('admin') || allowedScopes.includes('mirrors:manage')
-  const [error, setError] = useState<string | null>(null)
-  const [success, setSuccess] = useState<string | null>(null)
+  const status = useStatusMessage()
   const [createDialogOpen, setCreateDialogOpen] = useState(false)
   const [editingMirror, setEditingMirror] = useState<MirrorConfiguration | null>(null)
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false)
@@ -355,8 +356,8 @@ const MirrorsPage: React.FC = () => {
     },
   })
 
-  if (queryError && !error) {
-    setError(getErrorMessage(queryError, t('admin.mirrors.errLoadMirrors')))
+  if (queryError && !status.error) {
+    status.setError(getErrorMessage(queryError, t('admin.mirrors.errLoadMirrors')))
   }
 
   // Auto-open the Add Mirror dialog when navigated here with ?action=add.
@@ -374,12 +375,11 @@ const MirrorsPage: React.FC = () => {
     onSuccess: () => {
       setCreateDialogOpen(false)
       resetForm()
-      setSuccess(t('admin.mirrors.msgCreated'))
-      setError(null)
+      status.showSuccess(t('admin.mirrors.msgCreated'))
       queryClient.invalidateQueries({ queryKey: queryKeys.mirrors._def })
     },
     onError: (err: unknown) => {
-      setError(getErrorMessage(err, t('admin.mirrors.errCreate')))
+      status.setError(getErrorMessage(err, t('admin.mirrors.errCreate')))
     },
   })
 
@@ -389,12 +389,11 @@ const MirrorsPage: React.FC = () => {
     onSuccess: () => {
       setEditingMirror(null)
       resetForm()
-      setSuccess(t('admin.mirrors.msgUpdated'))
-      setError(null)
+      status.showSuccess(t('admin.mirrors.msgUpdated'))
       queryClient.invalidateQueries({ queryKey: queryKeys.mirrors._def })
     },
     onError: (err: unknown) => {
-      setError(getErrorMessage(err, t('admin.mirrors.errUpdate')))
+      status.setError(getErrorMessage(err, t('admin.mirrors.errUpdate')))
     },
   })
 
@@ -403,12 +402,11 @@ const MirrorsPage: React.FC = () => {
     onSuccess: () => {
       setDeleteConfirmOpen(false)
       setMirrorToDelete(null)
-      setSuccess(t('admin.mirrors.msgDeleted'))
-      setError(null)
+      status.showSuccess(t('admin.mirrors.msgDeleted'))
       queryClient.invalidateQueries({ queryKey: queryKeys.mirrors._def })
     },
     onError: (err: unknown) => {
-      setError(getErrorMessage(err, t('admin.mirrors.errDelete')))
+      status.setError(getErrorMessage(err, t('admin.mirrors.errDelete')))
     },
   })
 
@@ -430,7 +428,7 @@ const MirrorsPage: React.FC = () => {
   }
 
   const handleCreate = () => {
-    setError(null)
+    status.setError(null)
     const data = {
       ...formData,
       namespace_filter: namespaceFilterInput
@@ -450,7 +448,7 @@ const MirrorsPage: React.FC = () => {
 
   const handleUpdate = () => {
     if (!editingMirror) return
-    setError(null)
+    status.setError(null)
     const data = {
       name: formData.name,
       description: formData.description,
@@ -477,18 +475,18 @@ const MirrorsPage: React.FC = () => {
 
   const handleDelete = () => {
     if (!mirrorToDelete) return
-    setError(null)
+    status.setError(null)
     deleteMutation.mutate(mirrorToDelete.id)
   }
 
   const handleTriggerSync = async (mirror: MirrorConfiguration) => {
     try {
-      setError(null)
+      status.setError(null)
       await api.triggerMirrorSync(mirror.id)
-      setSuccess(t('admin.mirrors.syncTriggered', { name: mirror.name }))
+      status.setSuccess(t('admin.mirrors.syncTriggered', { name: mirror.name }))
       queryClient.invalidateQueries({ queryKey: queryKeys.mirrors._def })
     } catch (err: unknown) {
-      setError(getErrorMessage(err, t('admin.mirrors.errTriggerSync')))
+      status.setError(getErrorMessage(err, t('admin.mirrors.errTriggerSync')))
     }
   }
 
@@ -644,17 +642,7 @@ const MirrorsPage: React.FC = () => {
             }
           />
 
-          {error && (
-            <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
-              {error}
-            </Alert>
-          )}
-
-          {success && (
-            <Alert severity="success" sx={{ mb: 2 }} onClose={() => setSuccess(null)}>
-              {success}
-            </Alert>
-          )}
+          <StatusAlerts status={status} mb={2} />
 
           <Grid container spacing={3}>
             {mirrors

--- a/frontend/src/pages/admin/OIDCSettingsPage.tsx
+++ b/frontend/src/pages/admin/OIDCSettingsPage.tsx
@@ -36,9 +36,11 @@ import EditIcon from '@mui/icons-material/Edit'
 import DeleteIcon from '@mui/icons-material/Delete'
 import ManageAccountsIcon from '@mui/icons-material/ManageAccounts'
 import PageHeader from '../../components/PageHeader'
+import StatusAlerts from '../../components/StatusAlerts'
 import SaveIcon from '@mui/icons-material/Save'
 import Page from '../../components/Page'
 import api from '../../services/api'
+import { useStatusMessage } from '../../hooks/useStatusMessage'
 import type {
   OIDCConfigResponse,
   OIDCGroupMapping,
@@ -57,8 +59,7 @@ const emptyMapping: OIDCGroupMapping = { group: '', organization: '', role: 'vie
 const OIDCSettingsPage: React.FC = () => {
   const { t } = useTranslation()
   const queryClient = useQueryClient()
-  const [error, setError] = useState<string | null>(null)
-  const [success, setSuccess] = useState<string | null>(null)
+  const status = useStatusMessage()
 
   // Group claim name + default role (top-level form fields)
   const [groupClaimName, setGroupClaimName] = useState('')
@@ -104,11 +105,11 @@ const OIDCSettingsPage: React.FC = () => {
     }
   }, [config])
 
-  if (queryError && !error) {
+  if (queryError && !status.error) {
     // Route through getErrorMessage so a leaked backend string is sanitized and
     // bounded before it reaches the <Alert> below, exactly like every other admin
     // page — never render response.data.error verbatim (CWE-209, #601).
-    setError(getErrorMessage(queryError, t('admin.oidcSettings.errLoad')))
+    status.setError(getErrorMessage(queryError, t('admin.oidcSettings.errLoad')))
   }
 
   const saveMutation = useMutation({
@@ -117,21 +118,19 @@ const OIDCSettingsPage: React.FC = () => {
       setGroupClaimName(updated.group_claim_name ?? '')
       setDefaultRole(updated.default_role ?? '')
       setMappings(updated.group_mappings ?? [])
-      setSuccess(t('admin.oidcSettings.msgSaved'))
-      setError(null)
+      status.showSuccess(t('admin.oidcSettings.msgSaved'))
       queryClient.invalidateQueries({ queryKey: queryKeys.oidcConfig._def })
     },
     onError: (err: unknown) => {
       // Same sanitization choke point as the query-error path above (#601).
-      setError(getErrorMessage(err, t('admin.oidcSettings.errSave')))
+      status.setError(getErrorMessage(err, t('admin.oidcSettings.errSave')))
     },
   })
 
   const saving = saveMutation.isPending
 
   const handleSave = () => {
-    setError(null)
-    setSuccess(null)
+    status.clear()
     saveMutation.mutate({
       group_claim_name: groupClaimName,
       group_mappings: mappings,
@@ -200,16 +199,7 @@ const OIDCSettingsPage: React.FC = () => {
             description={t('admin.oidcSettings.pageSubtitle')}
           />
 
-          {error && (
-            <Alert severity="error" sx={{ mb: 3 }} onClose={() => setError(null)}>
-              {error}
-            </Alert>
-          )}
-          {success && (
-            <Alert severity="success" sx={{ mb: 3 }} onClose={() => setSuccess(null)}>
-              {success}
-            </Alert>
-          )}
+          <StatusAlerts status={status} mb={3} />
 
           {/* Active config summary */}
           {config && (

--- a/frontend/src/pages/admin/SCMProvidersPage.tsx
+++ b/frontend/src/pages/admin/SCMProvidersPage.tsx
@@ -21,7 +21,6 @@ import {
   FormControl,
   InputLabel,
   FormHelperText,
-  Alert,
   CircularProgress,
   Tooltip,
   Divider,
@@ -38,8 +37,10 @@ import CheckCircleIcon from '@mui/icons-material/CheckCircle'
 import LinkOffIcon from '@mui/icons-material/LinkOff'
 import Page from '../../components/Page'
 import PageHeader from '../../components/PageHeader'
+import StatusAlerts from '../../components/StatusAlerts'
 import PageTitleIcon from '@mui/icons-material/GitHub'
 import api from '../../services/api'
+import { useStatusMessage } from '../../hooks/useStatusMessage'
 import { getErrorMessage } from '../../utils/errors'
 import { isSafeExternalUrl } from '../../utils/externalUrl'
 import { useAuth } from '../../contexts/AuthContext'
@@ -71,7 +72,7 @@ const SCMProvidersPage: React.FC = () => {
   // admin — a scm:read-only viewer would otherwise see fully actionable
   // credential controls that only fail once clicked (#609).
   const canManage = allowedScopes.includes('admin') || allowedScopes.includes('scm:manage')
-  const [error, setError] = useState<string | null>(null)
+  const status = useStatusMessage()
   const [createDialogOpen, setCreateDialogOpen] = useState(false)
   const [editingProvider, setEditingProvider] = useState<SCMProvider | null>(null)
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false)
@@ -141,8 +142,8 @@ const SCMProvidersPage: React.FC = () => {
     enabled: providers.length > 0,
   })
 
-  if (queryError && !error) {
-    setError(getErrorMessage(queryError, t('admin.scmProviders.errLoad')))
+  if (queryError && !status.error) {
+    status.setError(getErrorMessage(queryError, t('admin.scmProviders.errLoad')))
   }
 
   const createMutation = useMutation({
@@ -150,11 +151,11 @@ const SCMProvidersPage: React.FC = () => {
     onSuccess: () => {
       setCreateDialogOpen(false)
       resetForm()
-      setError(null)
+      status.setError(null)
       queryClient.invalidateQueries({ queryKey: queryKeys.scmProviders._def })
     },
     onError: (err: unknown) => {
-      setError(getErrorMessage(err, t('admin.scmProviders.errCreate')))
+      status.setError(getErrorMessage(err, t('admin.scmProviders.errCreate')))
     },
   })
 
@@ -177,11 +178,11 @@ const SCMProvidersPage: React.FC = () => {
     onSuccess: () => {
       setEditingProvider(null)
       resetForm()
-      setError(null)
+      status.setError(null)
       queryClient.invalidateQueries({ queryKey: queryKeys.scmProviders._def })
     },
     onError: (err: unknown) => {
-      setError(getErrorMessage(err, t('admin.scmProviders.errUpdate')))
+      status.setError(getErrorMessage(err, t('admin.scmProviders.errUpdate')))
     },
   })
 
@@ -190,27 +191,27 @@ const SCMProvidersPage: React.FC = () => {
     onSuccess: () => {
       setDeleteConfirmOpen(false)
       setProviderToDelete(null)
-      setError(null)
+      status.setError(null)
       queryClient.invalidateQueries({ queryKey: queryKeys.scmProviders._def })
     },
     onError: (err: unknown) => {
-      setError(getErrorMessage(err, t('admin.scmProviders.errDelete')))
+      status.setError(getErrorMessage(err, t('admin.scmProviders.errDelete')))
     },
   })
 
   const handleCreate = () => {
-    setError(null)
+    status.setError(null)
     createMutation.mutate()
   }
 
   const handleUpdate = () => {
-    setError(null)
+    status.setError(null)
     updateMutation.mutate()
   }
 
   const handleDelete = () => {
     if (!providerToDelete) return
-    setError(null)
+    status.setError(null)
     deleteMutation.mutate(providerToDelete.id)
   }
 
@@ -226,12 +227,12 @@ const SCMProvidersPage: React.FC = () => {
         // SCM provider's own OAuth config); validate it at the app boundary before
         // this full-page redirect navigation sink, instead of trusting it verbatim (#559).
         if (!isSafeExternalUrl(response.authorization_url)) {
-          setError(t('admin.scmProviders.errOAuthInvalidUrl'))
+          status.setError(t('admin.scmProviders.errOAuthInvalidUrl'))
           return
         }
         window.location.href = response.authorization_url
       } catch (err: unknown) {
-        setError(getErrorMessage(err, t('admin.scmProviders.errOAuth')))
+        status.setError(getErrorMessage(err, t('admin.scmProviders.errOAuth')))
       }
     }
   }
@@ -239,13 +240,13 @@ const SCMProvidersPage: React.FC = () => {
   const handleSavePAT = async () => {
     if (!patProvider || !patValue) return
     try {
-      setError(null)
+      status.setError(null)
       await api.saveSCMToken(patProvider.id, patValue)
       setPatDialogOpen(false)
       setPatValue('')
       setPatProvider(null)
     } catch (err: unknown) {
-      setError(getErrorMessage(err, t('admin.scmProviders.errSaveToken')))
+      status.setError(getErrorMessage(err, t('admin.scmProviders.errSaveToken')))
     }
   }
 
@@ -439,11 +440,7 @@ const SCMProvidersPage: React.FC = () => {
             }
           />
 
-          {error && (
-            <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
-              {error}
-            </Alert>
-          )}
+          <StatusAlerts status={status} mb={2} />
 
           <Grid container spacing={3}>
             {providers.map((provider) => (
@@ -710,7 +707,7 @@ const SCMProvidersPage: React.FC = () => {
                                     queryKey: queryKeys.scmProviders._def,
                                   })
                                 } catch (err: unknown) {
-                                  setError(
+                                  status.setError(
                                     getErrorMessage(err, t('admin.scmProviders.errDisconnect')),
                                   )
                                 }

--- a/frontend/src/pages/admin/StoragePage.tsx
+++ b/frontend/src/pages/admin/StoragePage.tsx
@@ -50,6 +50,7 @@ import SyncIcon from '@mui/icons-material/Sync'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import HistoryIcon from '@mui/icons-material/History'
 import api from '../../services/api'
+import { useStatusMessage } from '../../hooks/useStatusMessage'
 import { getErrorMessage, sanitizeServerErrorMessage } from '../../utils/errors'
 import type {
   StorageConfigResponse,
@@ -60,14 +61,14 @@ import type {
 import { queryKeys } from '../../services/queryKeys'
 import Page from '../../components/Page'
 import PageHeader from '../../components/PageHeader'
+import StatusAlerts from '../../components/StatusAlerts'
 import PageTitleIcon from '@mui/icons-material/Storage'
 import StorageMigrationWizard from '../../components/StorageMigrationWizard'
 
 const StoragePage: React.FC = () => {
   const { t } = useTranslation()
   const queryClient = useQueryClient()
-  const [error, setError] = useState<string | null>(null)
-  const [success, setSuccess] = useState<string | null>(null)
+  const status = useStatusMessage()
   const [saving, setSaving] = useState(false)
   const [testing, setTesting] = useState(false)
   const [migrationWizardOpen, setMigrationWizardOpen] = useState(false)
@@ -118,19 +119,19 @@ const StoragePage: React.FC = () => {
   const activateMutation = useMutation({
     mutationFn: (id: string) => api.activateStorageConfig(id),
     onSuccess: (data) => {
-      setSuccess(data.message || t('admin.storage.msgActivated'))
+      status.setSuccess(data.message || t('admin.storage.msgActivated'))
       queryClient.invalidateQueries({ queryKey: queryKeys.storageConfigs._def })
     },
-    onError: (err) => setError(getErrorMessage(err, t('admin.storage.errActivate'))),
+    onError: (err) => status.setError(getErrorMessage(err, t('admin.storage.errActivate'))),
   })
 
   const deleteMutation = useMutation({
     mutationFn: (id: string) => api.deleteStorageConfig(id),
     onSuccess: () => {
-      setSuccess(t('admin.storage.msgDeleted'))
+      status.setSuccess(t('admin.storage.msgDeleted'))
       queryClient.invalidateQueries({ queryKey: queryKeys.storageConfigs._def })
     },
-    onError: (err) => setError(getErrorMessage(err, t('admin.storage.errDelete'))),
+    onError: (err) => status.setError(getErrorMessage(err, t('admin.storage.errDelete'))),
   })
 
   const testMutation = useMutation({
@@ -159,19 +160,21 @@ const StoragePage: React.FC = () => {
     },
     onSuccess: (result) => {
       if (result.success) {
-        setSuccess(t('admin.storage.msgTestPassed'))
+        status.setSuccess(t('admin.storage.msgTestPassed'))
       } else {
         // Never render the backend test-failure string verbatim: a storage
         // connection test is a prime leak point for host:port / paths (CWE-209,
         // #601). Sanitize, falling back to the generic message.
-        setError(sanitizeServerErrorMessage(result.message) ?? t('admin.storage.errTestFailed'))
+        status.setError(
+          sanitizeServerErrorMessage(result.message) ?? t('admin.storage.errTestFailed'),
+        )
       }
     },
-    onError: (err) => setError(getErrorMessage(err, t('admin.storage.errConfigTest'))),
+    onError: (err) => status.setError(getErrorMessage(err, t('admin.storage.errConfigTest'))),
   })
 
-  if (queryError && !error) {
-    setError(getErrorMessage(queryError, t('admin.storage.errLoad')))
+  if (queryError && !status.error) {
+    status.setError(getErrorMessage(queryError, t('admin.storage.errLoad')))
   }
 
   const handleBackendChange = (type: StorageBackendType) => {
@@ -204,13 +207,13 @@ const StoragePage: React.FC = () => {
   const handleTestConfig = async () => {
     try {
       setTesting(true)
-      setError(null)
+      status.setError(null)
       const result = await api.testStorageConfig(formData)
       if (result.success) {
-        setSuccess(t('admin.storage.msgValid'))
+        status.setSuccess(t('admin.storage.msgValid'))
       }
     } catch (err: unknown) {
-      setError(getErrorMessage(err, t('admin.storage.errConfigTest')))
+      status.setError(getErrorMessage(err, t('admin.storage.errConfigTest')))
     } finally {
       setTesting(false)
     }
@@ -219,14 +222,14 @@ const StoragePage: React.FC = () => {
   const handleSaveConfig = async () => {
     try {
       setSaving(true)
-      setError(null)
+      status.setError(null)
       await api.createStorageConfig(formData)
-      setSuccess(t('admin.storage.msgSaved'))
+      status.setSuccess(t('admin.storage.msgSaved'))
       queryClient.invalidateQueries({ queryKey: queryKeys.storageConfigs._def })
       setActiveStep(0)
       setShowAddWizard(false)
     } catch (err: unknown) {
-      setError(getErrorMessage(err, t('admin.storage.errSave')))
+      status.setError(getErrorMessage(err, t('admin.storage.errSave')))
     } finally {
       setSaving(false)
     }
@@ -680,17 +683,7 @@ const StoragePage: React.FC = () => {
         ))}
       </Stepper>
 
-      {error && (
-        <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
-          {error}
-        </Alert>
-      )}
-
-      {success && (
-        <Alert severity="success" sx={{ mb: 2 }} onClose={() => setSuccess(null)}>
-          {success}
-        </Alert>
-      )}
+      <StatusAlerts status={status} mb={2} />
 
       <Paper sx={{ p: 3, mb: 3 }}>
         {activeStep === 0 && renderBackendSelection()}
@@ -779,17 +772,7 @@ const StoragePage: React.FC = () => {
         }
       />
 
-      {error && (
-        <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
-          {error}
-        </Alert>
-      )}
-
-      {success && (
-        <Alert severity="success" sx={{ mb: 2 }} onClose={() => setSuccess(null)}>
-          {success}
-        </Alert>
-      )}
+      <StatusAlerts status={status} mb={2} />
 
       <Alert severity="info" sx={{ mb: 3 }}>
         <Box

--- a/frontend/src/pages/admin/TerraformMirrorPage.tsx
+++ b/frontend/src/pages/admin/TerraformMirrorPage.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { queryKeys } from '../../services/queryKeys'
 import PageHeader from '../../components/PageHeader'
+import StatusAlerts from '../../components/StatusAlerts'
 import PageTitleIcon from '@mui/icons-material/GetApp'
 import {
   Autocomplete,
@@ -64,6 +65,7 @@ import RefreshIcon from '@mui/icons-material/Refresh'
 import SyncIcon from '@mui/icons-material/Sync'
 
 import api from '../../services/api'
+import { useStatusMessage } from '../../hooks/useStatusMessage'
 import { getErrorMessage } from '../../utils/errors'
 import { useAuth } from '../../contexts/AuthContext'
 import ReleasesGPGKeyStatus from '../../components/ReleasesGPGKeyStatus'
@@ -531,8 +533,7 @@ const TerraformMirrorPage: React.FC = () => {
   // mirrors:read-only viewer would otherwise see fully actionable controls
   // that only fail once clicked (#609).
   const canManage = allowedScopes.includes('admin') || allowedScopes.includes('mirrors:manage')
-  const [error, setError] = useState<string | null>(null)
-  const [success, setSuccess] = useState<string | null>(null)
+  const status = useStatusMessage()
 
   // ---- create dialog ----
   const [createOpen, setCreateOpen] = useState(false)
@@ -582,8 +583,8 @@ const TerraformMirrorPage: React.FC = () => {
     },
   })
 
-  if (queryError && !error) {
-    setError(getErrorMessage(queryError, t('admin.terraformMirror.errLoad')))
+  if (queryError && !status.error) {
+    status.setError(getErrorMessage(queryError, t('admin.terraformMirror.errLoad')))
   }
 
   // Lazy-load status for each card when configs change
@@ -610,7 +611,7 @@ const TerraformMirrorPage: React.FC = () => {
       })
     },
     onSuccess: () => {
-      setSuccess(t('admin.terraformMirror.msgCreated', { name: createForm.name }))
+      status.setSuccess(t('admin.terraformMirror.msgCreated', { name: createForm.name }))
       setCreateOpen(false)
       setCreateForm(emptyCreate())
       setCreateVersionFilter('')
@@ -618,7 +619,7 @@ const TerraformMirrorPage: React.FC = () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.terraformMirrors._def })
     },
     onError: (err: unknown) => {
-      setError(getErrorMessage(err, t('admin.terraformMirror.errCreate')))
+      status.setError(getErrorMessage(err, t('admin.terraformMirror.errCreate')))
     },
   })
 
@@ -656,12 +657,12 @@ const TerraformMirrorPage: React.FC = () => {
       })
     },
     onSuccess: () => {
-      setSuccess(t('admin.terraformMirror.msgUpdated', { name: editConfig?.name }))
+      status.setSuccess(t('admin.terraformMirror.msgUpdated', { name: editConfig?.name }))
       setEditConfig(null)
       queryClient.invalidateQueries({ queryKey: queryKeys.terraformMirrors._def })
     },
     onError: (err: unknown) => {
-      setError(getErrorMessage(err, t('admin.terraformMirror.errUpdate')))
+      status.setError(getErrorMessage(err, t('admin.terraformMirror.errUpdate')))
     },
   })
 
@@ -679,12 +680,12 @@ const TerraformMirrorPage: React.FC = () => {
       await api.deleteTerraformMirrorConfig(deleteConfig.id)
     },
     onSuccess: () => {
-      setSuccess(t('admin.terraformMirror.msgDeleted', { name: deleteConfig?.name }))
+      status.setSuccess(t('admin.terraformMirror.msgDeleted', { name: deleteConfig?.name }))
       setDeleteConfig(null)
       queryClient.invalidateQueries({ queryKey: queryKeys.terraformMirrors._def })
     },
     onError: (err: unknown) => {
-      setError(getErrorMessage(err, t('admin.terraformMirror.errDelete')))
+      status.setError(getErrorMessage(err, t('admin.terraformMirror.errDelete')))
     },
   })
 
@@ -700,9 +701,9 @@ const TerraformMirrorPage: React.FC = () => {
     setSyncingIds((prev) => new Set([...prev, config.id]))
     try {
       await api.triggerTerraformMirrorSync(config.id)
-      setSuccess(t('admin.terraformMirror.syncTriggered', { name: config.name }))
+      status.setSuccess(t('admin.terraformMirror.syncTriggered', { name: config.name }))
     } catch (err: unknown) {
-      setError(getErrorMessage(err, t('admin.terraformMirror.errTriggerSync')))
+      status.setError(getErrorMessage(err, t('admin.terraformMirror.errTriggerSync')))
     } finally {
       setSyncingIds((prev) => {
         const next = new Set(prev)
@@ -740,11 +741,13 @@ const TerraformMirrorPage: React.FC = () => {
     setDeletingVersion(true)
     try {
       await api.deleteTerraformVersion(versionsConfig.id, deleteVersion.version)
-      setSuccess(t('admin.terraformMirror.versionDeleted', { version: deleteVersion.version }))
+      status.setSuccess(
+        t('admin.terraformMirror.versionDeleted', { version: deleteVersion.version }),
+      )
       setDeleteVersion(null)
       openVersions(versionsConfig)
     } catch (err: unknown) {
-      setError(getErrorMessage(err, t('admin.terraformMirror.errDeleteVersion')))
+      status.setError(getErrorMessage(err, t('admin.terraformMirror.errDeleteVersion')))
       setDeleteVersion(null)
     } finally {
       setDeletingVersion(false)
@@ -830,16 +833,7 @@ const TerraformMirrorPage: React.FC = () => {
             </Typography>
           </Alert>
 
-          {error && (
-            <Alert severity="error" onClose={() => setError(null)} sx={{ mb: 2 }}>
-              {error}
-            </Alert>
-          )}
-          {success && (
-            <Alert severity="success" onClose={() => setSuccess(null)} sx={{ mb: 2 }}>
-              {success}
-            </Alert>
-          )}
+          <StatusAlerts status={status} mb={2} />
 
           {/* Release signing key status panel */}
           <ReleasesGPGKeyStatus />

--- a/frontend/src/pages/admin/UsersPage.tsx
+++ b/frontend/src/pages/admin/UsersPage.tsx
@@ -43,8 +43,10 @@ import PrivacyTipIcon from '@mui/icons-material/PrivacyTip'
 import EmptyState from '../../components/EmptyState'
 import Page from '../../components/Page'
 import PageHeader from '../../components/PageHeader'
+import StatusAlerts from '../../components/StatusAlerts'
 import PageTitleIcon from '@mui/icons-material/People'
 import api from '../../services/api'
+import { useStatusMessage } from '../../hooks/useStatusMessage'
 import { useAuth } from '../../contexts/AuthContext'
 import { User, UserMembership, Organization } from '../../types'
 import { RoleTemplate } from '../../types/rbac'
@@ -70,8 +72,7 @@ const UsersPage: React.FC = () => {
   // (#609): a users:read-only viewer would otherwise see actionable buttons
   // that only fail once clicked, relying entirely on the server to say no.
   const canManageUsers = isAdmin || allowedScopes.includes('users:write')
-  const [error, setError] = useState<string | null>(null)
-  const [info, setInfo] = useState<string | null>(null)
+  const status = useStatusMessage()
   const [searchQuery, setSearchQuery] = useState('')
   const { page, rowsPerPage, setPage, handleChangePage, handleChangeRowsPerPage } =
     usePagination(10)
@@ -140,8 +141,8 @@ const UsersPage: React.FC = () => {
     membershipsLoading: userMemberships[u.id]?.loading ?? true,
   }))
 
-  if (queryError && !error) {
-    setError(t('admin.users.errLoad'))
+  if (queryError && !status.error) {
+    status.setError(t('admin.users.errLoad'))
   }
 
   // Load memberships whenever rawUsers changes
@@ -238,7 +239,7 @@ const UsersPage: React.FC = () => {
   const handleCloseDialog = () => {
     setOpenDialog(false)
     setEditingUser(null)
-    setError(null)
+    status.setError(null)
     setEditMemberships([])
   }
 
@@ -272,7 +273,7 @@ const UsersPage: React.FC = () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.users._def })
     },
     onError: (err: unknown) => {
-      setError(getErrorMessage(err, t('admin.users.errSave')))
+      status.setError(getErrorMessage(err, t('admin.users.errSave')))
     },
   })
 
@@ -281,12 +282,12 @@ const UsersPage: React.FC = () => {
     onSuccess: () => {
       setDeleteDialogOpen(false)
       setUserToDelete(null)
-      setError(null)
+      status.setError(null)
       setUserMemberships({})
       queryClient.invalidateQueries({ queryKey: queryKeys.users._def })
     },
     onError: (err: unknown) => {
-      setError(getErrorMessage(err, t('admin.users.errDelete')))
+      status.setError(getErrorMessage(err, t('admin.users.errDelete')))
     },
   })
 
@@ -297,21 +298,19 @@ const UsersPage: React.FC = () => {
       setEraseDialogOpen(false)
       setUserToErase(null)
       setEraseConfirmText('')
-      setError(null)
-      setInfo(data.message || t('admin.users.userErased'))
+      status.showSuccess(data.message || t('admin.users.userErased'))
       setUserMemberships({})
       queryClient.invalidateQueries({ queryKey: queryKeys.users._def })
     },
     onError: (err: unknown) => {
-      setError(getErrorMessage(err, t('admin.users.errErase')))
+      status.setError(getErrorMessage(err, t('admin.users.errErase')))
     },
   })
 
   // GDPR Articles 15/20 — full data export. Triggers a browser download
   // by creating a temporary blob URL; cleaned up after the click is dispatched.
   const handleExportClick = async (user: User) => {
-    setError(null)
-    setInfo(null)
+    status.clear()
     setExportingUserId(user.id)
     try {
       const { blob, filename } = await api.exportUserData(user.id)
@@ -323,9 +322,9 @@ const UsersPage: React.FC = () => {
       a.click()
       document.body.removeChild(a)
       URL.revokeObjectURL(url)
-      setInfo(t('admin.users.exportedData', { email: user.email }))
+      status.setSuccess(t('admin.users.exportedData', { email: user.email }))
     } catch (err) {
-      setError(getErrorMessage(err, t('admin.users.errExport')))
+      status.setError(getErrorMessage(err, t('admin.users.errExport')))
     } finally {
       setExportingUserId(null)
     }
@@ -344,7 +343,7 @@ const UsersPage: React.FC = () => {
   }
 
   const handleSaveUser = () => {
-    setError(null)
+    status.setError(null)
     saveUserMutation.mutate()
   }
 
@@ -352,7 +351,7 @@ const UsersPage: React.FC = () => {
     if (!editingUser || !formData.organizationId) return
 
     try {
-      setError(null)
+      status.setError(null)
       await api.addOrganizationMember(formData.organizationId, {
         user_id: editingUser.id,
         role_template_id: formData.roleTemplateId || undefined,
@@ -366,7 +365,7 @@ const UsersPage: React.FC = () => {
       setFormData((prev) => ({ ...prev, organizationId: '', roleTemplateId: '' }))
     } catch (err: unknown) {
       console.error('Failed to add membership:', err)
-      setError(getErrorMessage(err, t('admin.users.errAddMembership')))
+      status.setError(getErrorMessage(err, t('admin.users.errAddMembership')))
     }
   }
 
@@ -374,7 +373,7 @@ const UsersPage: React.FC = () => {
     if (!editingUser) return
 
     try {
-      setError(null)
+      status.setError(null)
       await api.updateOrganizationMember(orgId, editingUser.id, {
         role_template_id: newRoleTemplateId || undefined,
       })
@@ -384,7 +383,7 @@ const UsersPage: React.FC = () => {
       setEditMemberships(memberships)
     } catch (err: unknown) {
       console.error('Failed to update membership role:', err)
-      setError(getErrorMessage(err, t('admin.users.errUpdateRole')))
+      status.setError(getErrorMessage(err, t('admin.users.errUpdateRole')))
     }
   }
 
@@ -392,14 +391,14 @@ const UsersPage: React.FC = () => {
     if (!editingUser) return
 
     try {
-      setError(null)
+      status.setError(null)
       await api.removeOrganizationMember(orgId, editingUser.id)
 
       // Update local state
       setEditMemberships((prev) => prev.filter((m) => m.organization_id !== orgId))
     } catch (err: unknown) {
       console.error('Failed to remove membership:', err)
-      setError(getErrorMessage(err, t('admin.users.errRemoveMembership')))
+      status.setError(getErrorMessage(err, t('admin.users.errRemoveMembership')))
     }
   }
 
@@ -410,7 +409,7 @@ const UsersPage: React.FC = () => {
 
   const handleDeleteConfirm = () => {
     if (!userToDelete) return
-    setError(null)
+    status.setError(null)
     deleteUserMutation.mutate(userToDelete.id)
   }
 
@@ -453,16 +452,7 @@ const UsersPage: React.FC = () => {
           ) : undefined
         }
       />
-      {error && (
-        <Alert severity="error" sx={{ mb: 3 }} onClose={() => setError(null)}>
-          {error}
-        </Alert>
-      )}
-      {info && (
-        <Alert severity="success" sx={{ mb: 3 }} onClose={() => setInfo(null)}>
-          {info}
-        </Alert>
-      )}
+      <StatusAlerts status={status} mb={3} />
       {/* Search Bar */}
       <TextField
         fullWidth

--- a/frontend/src/pages/admin/VersionApprovalsPage.tsx
+++ b/frontend/src/pages/admin/VersionApprovalsPage.tsx
@@ -21,7 +21,6 @@ import {
   TextField,
   Tooltip,
   Typography,
-  Alert,
   Tabs,
   Tab,
   ToggleButton,
@@ -36,8 +35,10 @@ import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown'
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp'
 import Page from '../../components/Page'
 import PageHeader from '../../components/PageHeader'
+import StatusAlerts from '../../components/StatusAlerts'
 import PageTitleIcon from '@mui/icons-material/HourglassEmpty'
 import api from '../../services/api'
+import { useStatusMessage } from '../../hooks/useStatusMessage'
 import { queryKeys } from '../../services/queryKeys'
 import { getErrorMessage } from '../../utils/errors'
 import { formatDate } from '../../utils'
@@ -267,8 +268,7 @@ const VersionApprovalsPage: React.FC = () => {
   const [statusTab, setStatusTab] = useState<VersionApprovalStatus | ''>('pending_approval')
   const [typeFilter, setTypeFilter] = useState<'provider' | 'terraform' | 'scanner' | ''>('')
   const [selected, setSelected] = useState<Set<string>>(new Set())
-  const [error, setError] = useState<string | null>(null)
-  const [success, setSuccess] = useState<string | null>(null)
+  const status = useStatusMessage()
 
   // Single approve/reject dialog
   const [actionDialog, setActionDialog] = useState<{
@@ -301,8 +301,8 @@ const VersionApprovalsPage: React.FC = () => {
 
   const items: VersionApproval[] = data?.items ?? []
 
-  if (queryError && !error) {
-    setError(getErrorMessage(queryError, t('admin.versionApprovals.errLoad')))
+  if (queryError && !status.error) {
+    status.setError(getErrorMessage(queryError, t('admin.versionApprovals.errLoad')))
   }
 
   const invalidate = () => {
@@ -314,14 +314,13 @@ const VersionApprovalsPage: React.FC = () => {
     mutationFn: ({ id, notes }: { id: string; notes?: string }) =>
       api.approveVersion(id, notes ? { notes } : undefined),
     onSuccess: () => {
-      setSuccess(t('admin.versionApprovals.approveSuccess'))
-      setError(null)
+      status.showSuccess(t('admin.versionApprovals.approveSuccess'))
       setActionDialog((d) => ({ ...d, open: false }))
       invalidate()
     },
     onError: (err: unknown) => {
       setActionDialog((d) => ({ ...d, open: false }))
-      setError(getErrorMessage(err, t('admin.versionApprovals.errApprove')))
+      status.setError(getErrorMessage(err, t('admin.versionApprovals.errApprove')))
     },
   })
 
@@ -329,14 +328,13 @@ const VersionApprovalsPage: React.FC = () => {
     mutationFn: ({ id, notes }: { id: string; notes?: string }) =>
       api.rejectVersion(id, notes ? { notes } : undefined),
     onSuccess: () => {
-      setSuccess(t('admin.versionApprovals.rejectSuccess'))
-      setError(null)
+      status.showSuccess(t('admin.versionApprovals.rejectSuccess'))
       setActionDialog((d) => ({ ...d, open: false }))
       invalidate()
     },
     onError: (err: unknown) => {
       setActionDialog((d) => ({ ...d, open: false }))
-      setError(getErrorMessage(err, t('admin.versionApprovals.errReject')))
+      status.setError(getErrorMessage(err, t('admin.versionApprovals.errReject')))
     },
   })
 
@@ -344,26 +342,28 @@ const VersionApprovalsPage: React.FC = () => {
     mutationFn: ({ ids, notes }: { ids: string[]; notes?: string }) =>
       api.bulkApproveVersions(ids, notes),
     onSuccess: (res) => {
-      setSuccess(t('admin.versionApprovals.bulkApproveSuccess', { count: res.approved ?? 0 }))
-      setError(null)
+      status.showSuccess(
+        t('admin.versionApprovals.bulkApproveSuccess', { count: res.approved ?? 0 }),
+      )
       setBulkDialog((d) => ({ ...d, open: false }))
       invalidate()
     },
     onError: (err: unknown) =>
-      setError(getErrorMessage(err, t('admin.versionApprovals.errBulkApprove'))),
+      status.setError(getErrorMessage(err, t('admin.versionApprovals.errBulkApprove'))),
   })
 
   const bulkRejectMutation = useMutation({
     mutationFn: ({ ids, notes }: { ids: string[]; notes?: string }) =>
       api.bulkRejectVersions(ids, notes),
     onSuccess: (res) => {
-      setSuccess(t('admin.versionApprovals.bulkRejectSuccess', { count: res.rejected ?? 0 }))
-      setError(null)
+      status.showSuccess(
+        t('admin.versionApprovals.bulkRejectSuccess', { count: res.rejected ?? 0 }),
+      )
       setBulkDialog((d) => ({ ...d, open: false }))
       invalidate()
     },
     onError: (err: unknown) =>
-      setError(getErrorMessage(err, t('admin.versionApprovals.errBulkReject'))),
+      status.setError(getErrorMessage(err, t('admin.versionApprovals.errBulkReject'))),
   })
 
   const allSelected = items.length > 0 && selected.size === items.length
@@ -421,16 +421,7 @@ const VersionApprovalsPage: React.FC = () => {
         description={t('admin.versionApprovals.pageSubtitle')}
       />
 
-      {error && (
-        <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
-          {error}
-        </Alert>
-      )}
-      {success && (
-        <Alert severity="success" sx={{ mb: 2 }} onClose={() => setSuccess(null)}>
-          {success}
-        </Alert>
-      )}
+      <StatusAlerts status={status} mb={2} />
 
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
         <Tabs

--- a/frontend/src/pages/admin/__tests__/MirrorPoliciesPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/MirrorPoliciesPage.test.tsx
@@ -212,6 +212,23 @@ describe('MirrorPoliciesPage', () => {
     await waitFor(() => expect(deleteMirrorPolicyMock).toHaveBeenCalledWith('pol-1'))
   })
 
+  // Covers the page -> useStatusMessage -> StatusAlerts chain for the success
+  // banner; the "shows error state when API fails" case above covers the error
+  // banner. Between them the shared wiring is exercised end to end.
+  it('shows the success banner after a policy is deleted', async () => {
+    listMirrorPoliciesMock.mockResolvedValue(fakePolicies)
+    deleteMirrorPolicyMock.mockResolvedValue({})
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Allow HashiCorp')).toBeInTheDocument())
+    await userEvent.click(screen.getAllByRole('button', { name: /delete policy/i })[0])
+    await waitFor(() => expect(screen.getByText('Confirm Delete')).toBeInTheDocument())
+    const confirmBtns = screen.getAllByRole('button', { name: /^delete$/i })
+    await userEvent.click(confirmBtns[confirmBtns.length - 1])
+    await waitFor(() => {
+      expect(screen.getByText('Policy deleted successfully')).toBeInTheDocument()
+    })
+  })
+
   it('cancels create dialog', async () => {
     listMirrorPoliciesMock.mockResolvedValue([])
     renderPage()


### PR DESCRIPTION
Closes #690.

## What the finding actually is

I counted before converting. The `error` / `success` `useState<string | null>(null)` pair (or the error-only half) appears in **16 files** under `src/pages/admin/`, across **17 render sites** — the issue listed 15 files, missing `SecurityScanningPage` (which spells the state `scannerError` / `scannerSuccess`), and `StoragePage` renders the pair **twice**. The alert JSX was byte-identical almost everywhere; the only variations were the bottom margin (`mb: 2` vs `mb: 3`) and one page writing the same attributes in a different order.

## The shape

- `useStatusMessage()` — owns the state and the `setSuccess(msg); setError(null)` clear-on-success wiring that each page repeated by hand (now `showSuccess`), plus `clear()` for the pages that wiped both.
- `<StatusAlerts status={status} mb={n} />` — owns the markup.

`StatusAlerts` takes the **whole hook result** instead of four separate props. That is the main design decision and it is deliberate: with `error` / `success` / `onDismissError` / `onDismissSuccess` as separate props, swapping two same-typed callbacks is a mistake TypeScript cannot see, and it would be repeated at 12 call sites. Passing the object makes the dismiss handlers unforgeable. `mb` is **required** rather than defaulted so that every call site has to restate the spacing its page already used — omitting it is a compile error rather than a silent visual change.

## Behaviour preservation

Same MUI `<Alert>`, so the same default `role="alert"` announcement; same error-above-success order; same dismiss buttons; same per-page margin. No page auto-dismissed a banner before and none does now. `setError` deliberately does **not** clear a success, because none of the pages did that.

**Converted (11):** ApprovalsPage, MirrorPoliciesPage, MirrorsPage, OIDCSettingsPage, StoragePage (both sites), TerraformMirrorPage, VersionApprovalsPage, UsersPage, APIKeysPage, AuditLogPage, SCMProvidersPage.

`UsersPage` named its success channel `info` while rendering it with `severity="success"`; that is the same channel, so it was renamed as part of the conversion.

`TerraformMirrorPage` is converted but keeps plain `setSuccess` — unlike its siblings it **never** cleared the error banner on success, so giving it `showSuccess` would change what the user sees.

**Left alone on purpose (5)** — these differ in ways the abstraction would have flattened:

| Page | Why |
|---|---|
| `NotificationsPage` | renders success **above** error, and keeps a separate load-error branch. A failure after a success does not clear the success, so both can be on screen and the order is user-visible. |
| `SecurityScanningPage` | also success-above-error, prefixed state names, nested inside a `Collapse`. |
| `OrganizationsPage` | error is **not** dismissible and is gated on `!import.meta.env.DEV`. |
| `ModuleUploadPage`, `ProviderUploadPage` | bare non-dismissible alerts with no margin — and both are being edited concurrently for the upload size cap. |

Supporting the success-first order or a non-dismissible mode would mean adding configuration to the component for pages whose difference is probably accidental. I would rather leave five honest outliers than encode their quirks as options.

## Verification, given deps cannot be installed here

`npm ci` fails in this environment (private package needs a `read:packages` token), so **vitest never ran locally — CI is the first execution.** Compensating for that drove the design and the checks:

1. **The change shape is compiler-checked.** A typo in a `status.*` member, a missing `mb`, or a stale `error` reference is a type error, not a runtime surprise on one page.
2. **Scripted, assertion-guarded edits.** Every JSX block was replaced by exact string match with an expected-match-count assertion, so a block that differed from my reconstruction would abort rather than be silently skipped. All 12 matched their expected counts first time.
3. **Real syntax check.** Installed `typescript` standalone and parsed all 16 changed files through the compiler API: 0 syntax errors.
4. **Real format check.** Installed `prettier@3.9.6` standalone and ran it over every changed file. Four files still report deviations — I verified those files report the **byte-identical** deviation set on unmodified `main`, so they are pre-existing (my standalone resolve differs slightly from the lockfile's) and I did not touch them. Every file I created or edited passes cleanly.
5. **Tests that fail if the wiring is wrong.** New `useStatusMessage` and `StatusAlerts` suites cover what the pages used to do by hand — including that error renders above success, that dismissing one banner leaves the other alone, that `showSuccess` drops the error, and that `setError` does *not* drop a success. A new `MirrorPoliciesPage` case drives a real delete through page → hook → component and asserts the success banner appears; the existing "shows error state when API fails" case covers the error channel. Being a refactor, these pass before and after — the point is that they fail if the extraction is mis-wired.

I could not run eslint. The one risk I checked by hand is `react-hooks/exhaustive-deps` (CI runs `--max-warnings 0`): setters from a custom hook are not treated as stable the way `useState` setters are, but exactly one hook-with-deps in the converted set touches this state (`APIKeysPage`) and it already carries a disable comment.

## Not done

No adjacent cleanups. The five unconverted pages are listed above rather than filed as follow-ups — happy to open one if you want the remainder tracked.
