### PR TITLE
fix(upload): cap provider archives at the backend's 500MB, not the module 100MB

### DIFF
--- a/frontend/src/components/FileDropZone.tsx
+++ b/frontend/src/components/FileDropZone.tsx
@@ -3,7 +3,26 @@ import { Box, Button, Stack, Typography, Alert } from '@mui/material'
 import CloudUpload from '@mui/icons-material/CloudUpload'
 import InsertDriveFileIcon from '@mui/icons-material/InsertDriveFile'
 
-export const HARD_MAX_BYTES = 100 * 1024 * 1024 // 100MB (backend limit)
+/**
+ * Default cap, and the real limit for module archives: the backend rejects a
+ * module tar.gz above `archivelimits.MaxBytes` (100MB) in
+ * `internal/validation/archive.go`.
+ *
+ * This is NOT the limit for every upload — provider archives are allowed five
+ * times as much (see PROVIDER_MAX_BYTES). Reusing this one constant for both
+ * was #672: legitimate multi-platform provider releases were refused in the
+ * browser, before the request the backend would have accepted was even sent.
+ */
+export const HARD_MAX_BYTES = 100 * 1024 * 1024 // 100MB
+
+/**
+ * Cap for provider archives, mirroring `MaxProviderBinarySize` in the backend's
+ * `internal/api/providers/upload.go`, which rejects anything larger with
+ * "provider binary too large". The edge proxy is provisioned to match
+ * (`client_max_body_size 500m` in nginx.conf and nginx-ecs.conf.template).
+ */
+export const PROVIDER_MAX_BYTES = 500 * 1024 * 1024 // 500MB
+
 export const SOFT_WARN_BYTES = 50 * 1024 * 1024 // 50MB
 
 export interface FileDropZoneProps {
@@ -13,6 +32,13 @@ export interface FileDropZoneProps {
   onFileSelected: (file: File) => void
   /** Allowed extensions, leading dot required (e.g. ['.tar.gz', '.tgz']). */
   acceptedExtensions: string[]
+  /**
+   * Largest accepted file, in bytes. Defaults to HARD_MAX_BYTES, the module
+   * archive limit. Callers whose endpoint enforces something else must pass it
+   * — a client-side cap below the backend's is a false rejection the user
+   * cannot work around, not extra safety.
+   */
+  maxBytes?: number
   /** Optional callback fired on clear. */
   onClear?: () => void
   /** Disables interaction (e.g., during upload). */
@@ -39,6 +65,7 @@ const FileDropZone: React.FC<FileDropZoneProps> = ({
   onFileSelected,
   onClear,
   acceptedExtensions,
+  maxBytes = HARD_MAX_BYTES,
   disabled,
   idlePrompt,
   'data-testid': testId = 'file-drop-zone',
@@ -56,9 +83,9 @@ const FileDropZone: React.FC<FileDropZoneProps> = ({
         setError(`Invalid file type. Expected ${acceptedExtensions.join(' or ')}.`)
         return
       }
-      if (candidate.size > HARD_MAX_BYTES) {
+      if (candidate.size > maxBytes) {
         setError(
-          `File is too large (${formatBytes(candidate.size)}). Maximum allowed size is ${formatBytes(HARD_MAX_BYTES)}.`,
+          `File is too large (${formatBytes(candidate.size)}). Maximum allowed size is ${formatBytes(maxBytes)}.`,
         )
         return
       }
@@ -67,7 +94,7 @@ const FileDropZone: React.FC<FileDropZoneProps> = ({
       }
       onFileSelected(candidate)
     },
-    [acceptedExtensions, onFileSelected],
+    [acceptedExtensions, maxBytes, onFileSelected],
   )
 
   const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
@@ -207,7 +234,7 @@ const FileDropZone: React.FC<FileDropZoneProps> = ({
                 color: 'text.secondary',
               }}
             >
-              Maximum {formatBytes(HARD_MAX_BYTES)}
+              Maximum {formatBytes(maxBytes)}
             </Typography>
           </Stack>
         )}

--- a/frontend/src/components/__tests__/FileDropZone.test.tsx
+++ b/frontend/src/components/__tests__/FileDropZone.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, it, expect, vi } from 'vitest'
-import FileDropZone, { HARD_MAX_BYTES, SOFT_WARN_BYTES } from '../FileDropZone'
+import FileDropZone, { HARD_MAX_BYTES, PROVIDER_MAX_BYTES, SOFT_WARN_BYTES } from '../FileDropZone'
 
 function makeFile(name: string, sizeBytes: number, type = 'application/gzip'): File {
   const f = new File(['x'], name, { type })
@@ -71,6 +71,64 @@ describe('FileDropZone', () => {
     fireEvent.drop(zone, { dataTransfer: makeDataTransfer([huge]) })
     expect(onFileSelected).not.toHaveBeenCalled()
     expect(screen.getByTestId('file-drop-zone-error')).toHaveTextContent(/too large/i)
+  })
+
+  it('accepts a file above the default cap when maxBytes raises it (#672)', () => {
+    // The provider case. A 150MB archive is well inside what the backend
+    // accepts for providers (MaxProviderBinarySize, 500MB) but was refused in
+    // the browser because the component's single constant was the module limit.
+    const onFileSelected = vi.fn()
+    render(
+      <FileDropZone
+        file={null}
+        onFileSelected={onFileSelected}
+        acceptedExtensions={['.zip']}
+        maxBytes={PROVIDER_MAX_BYTES}
+      />,
+    )
+    const zone = screen.getByTestId('file-drop-zone')
+    const big = makeFile('terraform-provider-widget_1.0.0.zip', 150 * 1024 * 1024)
+    fireEvent.drop(zone, { dataTransfer: makeDataTransfer([big]) })
+    expect(onFileSelected).toHaveBeenCalledWith(big)
+    expect(screen.queryByTestId('file-drop-zone-error')).not.toBeInTheDocument()
+  })
+
+  it('still blocks a file above the raised cap', () => {
+    // maxBytes moves the limit, it does not remove it.
+    const onFileSelected = vi.fn()
+    render(
+      <FileDropZone
+        file={null}
+        onFileSelected={onFileSelected}
+        acceptedExtensions={['.zip']}
+        maxBytes={PROVIDER_MAX_BYTES}
+      />,
+    )
+    const zone = screen.getByTestId('file-drop-zone')
+    const huge = makeFile('enormous.zip', PROVIDER_MAX_BYTES + 1)
+    fireEvent.drop(zone, { dataTransfer: makeDataTransfer([huge]) })
+    expect(onFileSelected).not.toHaveBeenCalled()
+    expect(screen.getByTestId('file-drop-zone-error')).toHaveTextContent(/500\.0 MB/)
+  })
+
+  it('reports the effective cap, not the default, in the idle hint and the error', () => {
+    // The advertised maximum and the rejection message both have to follow
+    // maxBytes; a zone that accepts 500MB while telling the user "Maximum
+    // 100.0 MB" is the same false rejection moved into the copy.
+    const { rerender } = render(
+      <FileDropZone file={null} onFileSelected={vi.fn()} acceptedExtensions={['.zip']} />,
+    )
+    expect(screen.getByText(/Maximum 100\.0 MB/)).toBeInTheDocument()
+
+    rerender(
+      <FileDropZone
+        file={null}
+        onFileSelected={vi.fn()}
+        acceptedExtensions={['.zip']}
+        maxBytes={PROVIDER_MAX_BYTES}
+      />,
+    )
+    expect(screen.getByText(/Maximum 500\.0 MB/)).toBeInTheDocument()
   })
 
   it('warns but accepts files between soft and hard limits', () => {

--- a/frontend/src/components/__tests__/FileDropZone.test.tsx
+++ b/frontend/src/components/__tests__/FileDropZone.test.tsx
@@ -129,6 +129,14 @@ describe('FileDropZone', () => {
       />,
     )
     expect(screen.getByText(/Maximum 500\.0 MB/)).toBeInTheDocument()
+
+    const zone = screen.getByTestId('file-drop-zone')
+    fireEvent.drop(zone, {
+      dataTransfer: makeDataTransfer([makeFile('over.zip', PROVIDER_MAX_BYTES + 1)]),
+    })
+    expect(screen.getByTestId('file-drop-zone-error')).toHaveTextContent(
+      'Maximum allowed size is 500.0 MB.',
+    )
   })
 
   it('warns but accepts files between soft and hard limits', () => {

--- a/frontend/src/pages/admin/ProviderUploadPage.tsx
+++ b/frontend/src/pages/admin/ProviderUploadPage.tsx
@@ -28,7 +28,7 @@ import { getErrorMessage, isCanceledError } from '../../utils/errors'
 import Page from '../../components/Page'
 import PageHeader from '../../components/PageHeader'
 import PageTitleIcon from '@mui/icons-material/Extension'
-import FileDropZone from '../../components/FileDropZone'
+import FileDropZone, { PROVIDER_MAX_BYTES } from '../../components/FileDropZone'
 
 type ProviderMethod = 'choose' | 'upload' | 'mirror'
 
@@ -324,6 +324,10 @@ const ProviderUploadPage: React.FC = () => {
           onFileSelected={handleProviderFileSelected}
           onClear={() => setProviderFile(null)}
           acceptedExtensions={['.zip']}
+          // Provider archives are capped at 500MB by the backend, not at the
+          // 100MB module limit FileDropZone defaults to (#672). A release zip
+          // carrying several platform binaries routinely passes 100MB.
+          maxBytes={PROVIDER_MAX_BYTES}
           disabled={uploading}
           data-testid="provider-upload-dropzone"
         />

--- a/frontend/src/pages/admin/__tests__/ModuleUploadPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/ModuleUploadPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
@@ -173,6 +173,25 @@ describe('ModuleUploadPage — upload form (roadmap 2.5)', () => {
     const file = new File(['x'], 'mod.tar.gz', { type: 'application/gzip' })
     await user.upload(input, file)
     expect(screen.getByText('mod.tar.gz')).toBeInTheDocument()
+  })
+
+  it('still refuses a 150MB module archive — the provider cap is not shared (#672)', async () => {
+    // Companion to the provider-side test. #672 is fixed by making the cap
+    // per-caller, NOT by raising one shared constant: the backend rejects a
+    // module tar.gz over archivelimits.MaxBytes (100MB), so accepting 150MB
+    // here would only move the failure to the server. This test passes against
+    // today's code by design — it exists so that "simplifying" the two limits
+    // back into one 500MB constant fails instead of quietly regressing.
+    const user = userEvent.setup()
+    await openUploadForm(user)
+    const input = screen.getByTestId('module-upload-dropzone-input') as HTMLInputElement
+    const big = new File(['x'], 'huge.tar.gz', { type: 'application/gzip' })
+    Object.defineProperty(big, 'size', { value: 150 * 1024 * 1024 })
+    fireEvent.change(input, { target: { files: [big] } })
+
+    const error = await screen.findByTestId('module-upload-dropzone-error')
+    expect(error).toHaveTextContent(/too large/i)
+    expect(error).toHaveTextContent(/100\.0 MB/)
   })
 
   it('disables Upload Module when a registry segment is invalid', async () => {

--- a/frontend/src/pages/admin/__tests__/ProviderUploadPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/ProviderUploadPage.test.tsx
@@ -128,6 +128,29 @@ describe('ProviderUploadPage', () => {
     await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/providers/myorg/widget'))
   })
 
+  it('accepts a 150MB provider archive the backend would have taken (#672)', async () => {
+    // FileDropZone's default cap is the module archive limit (100MB). The
+    // provider endpoint enforces MaxProviderBinarySize (500MB), and a release
+    // zip carrying several platform binaries routinely lands between the two,
+    // so before #672 this file was refused in the browser and the request the
+    // backend would have accepted was never sent.
+    //
+    // Asserted through the page rather than by rendering FileDropZone with a
+    // prop: the component test cannot tell whether *this page* passes it.
+    const user = userEvent.setup()
+    renderPage()
+    await user.click(screen.getByText('Manual Upload'))
+
+    const input = screen.getByTestId('provider-upload-dropzone-input') as HTMLInputElement
+    const name = 'terraform-provider-widget_1.0.0_linux_amd64.zip'
+    const big = new File(['zipdata'], name, { type: 'application/zip' })
+    Object.defineProperty(big, 'size', { value: 150 * 1024 * 1024 })
+    fireEvent.change(input, { target: { files: [big] } })
+
+    expect(await screen.findByText(name)).toBeInTheDocument()
+    expect(screen.queryByTestId('provider-upload-dropzone-error')).not.toBeInTheDocument()
+  })
+
   it('shows error alert when upload fails', async () => {
     const user = userEvent.setup()
     uploadProviderMock.mockRejectedValue(new Error('upload blew up'))


### PR DESCRIPTION
Closes #672.

## Verified against the backend, not inferred

The issue's premise and its recommended 500MB both check out. The two endpoints genuinely enforce different limits:

| upload | backend constant | value |
|---|---|---|
| module `.tar.gz` | `validation.MaxArchiveSize` = `archivelimits.MaxBytes` (`internal/validation/archive.go`) | `100 << 20` |
| provider `.zip` | `MaxProviderBinarySize` (`internal/api/providers/upload.go`), checked against the uploaded size at line 197 | `500 << 20` |

So `HARD_MAX_BYTES`'s `// 100MB (backend limit)` comment was right for modules and wrong for providers, and `FileDropZone` exposed no way to say so. A multi-platform provider release zip lands between the two often enough to matter, and the browser refused it with *"Maximum allowed size is 100.0 MB"* before the request the backend would have accepted was ever sent — a false rejection with no user workaround. `nginx.conf` and `nginx-ecs.conf.template` already carry `client_max_body_size 500m`, so the edge was provisioned for it all along.

One correction to the issue's reading, worth recording: the backend's `ParseMultipartForm(100 << 20)` in `modules/upload.go` is Go's *maxMemory* argument, not a size cap — it does not limit the request. The module cap really is `ValidateArchive`, which is why 100MB is still the right number for modules.

## What changed

`FileDropZone` takes an optional `maxBytes`, defaulting to `HARD_MAX_BYTES` so the module page is untouched; `ProviderUploadPage` passes the new `PROVIDER_MAX_BYTES`. Both constants now name the backend symbol they mirror, so the next person can check them.

The advertised maximum in the idle hint and the text of the rejection both follow the effective cap. A zone that accepts 500MB while printing "Maximum 100.0 MB" would just relocate the false rejection into the copy.

**Fixed per-caller rather than by raising the single constant.** Modules really are capped at 100MB, so one shared 500MB would only move the module failure from the browser to the server, with a worse error and a wasted upload.

## Scope of the defect class

`FileDropZone` is the only file-input surface in `src/` — `grep 'type="file"'` returns that component and nothing else — so its two callers are the entire class. Both are now correct.

## Would these tests fail if the change were reverted?

- **`ProviderUploadPage.test.tsx` — 150MB `.zip` is accepted.** The load-bearing one. Fails on `main`: the file is rejected and the filename never renders. Asserted through the page, not by rendering `FileDropZone` with a prop directly, because a component-level test cannot tell whether *this page* passes it.
- **`FileDropZone.test.tsx` — accepts above the default when `maxBytes` raises it.** Fails on `main` (and does not even compile there — no such prop).
- **`FileDropZone.test.tsx` — the idle hint and error report the effective cap.** The `Maximum 500.0 MB` half fails on `main`.
- **`FileDropZone.test.tsx` — still blocks above the raised cap**, and **`ModuleUploadPage.test.tsx` — 150MB `.tar.gz` still refused.** These two pass against today's code by design, and I have said so in their comments rather than letting them look like bug repros. They are the guard on the *shape* of the fix: they fail if someone later "simplifies" the two limits back into a single 500MB constant, which is the regression this fix is one edit away from.

No existing test asserted the buggy behaviour, so nothing had to be inverted. The pre-existing `blocks files larger than the hard maximum` case still covers the default.

## CI is the first execution of these tests

`npm ci` cannot run in the environment this was written in — `frontend/package.json` depends on a private package needing a `read:packages` token that isn't available there — so vitest could not be run locally. In place of guessing:

- The two backend limits were read out of the backend repo rather than taken from the issue, including the `ParseMultipartForm` correction above.
- `formatBytes` was evaluated by hand for every boundary the tests assert (`100.0 MB`, `150.0 MB`, `500.0 MB`) so the string matchers are not guesses.
- All changed files were run through standalone prettier **3.9.6** — the exact version this repo pins — with the repo's `.prettierrc`. For the record: no workflow in `.github/workflows/` actually runs prettier, and several pre-existing lines in the touched test files already do not conform; those were left alone rather than reformatted, to keep the diff to the fix.

## Not done, deliberately

- **nginx.** `client_max_body_size 500m` bounds the *body*, so a provider archive within a few hundred bytes of exactly 500MB still 413s once multipart framing is added. That is a far narrower edge than the one fixed here, and `nginx.conf` is being changed concurrently on another branch — widening it here would have bought a merge conflict for a case nobody has hit.
- **`SOFT_WARN_BYTES` was left at 50MB** for both. It is advisory copy ("uploads may take a while"), which is if anything more true for a provider archive, so scaling it with `maxBytes` would have been change for its own sake.