### PR TITLE
fix(api): confirm a 401 ended the session before clearing tfr_csrf

### DIFF
--- a/frontend/src/services/__tests__/api.test.ts
+++ b/frontend/src/services/__tests__/api.test.ts
@@ -401,6 +401,19 @@ describe('ApiClient', () => {
   // ─── 401 Interceptor ──────────────────────────────────────────────────
 
   describe('response interceptor – 401 handling', () => {
+    // The teardown of a live-looking session is now gated on a /auth/me
+    // confirmation (#677), so it lands a few microtasks after the interceptor
+    // has already rejected. A macrotask turn drains that chain.
+    const flushProbe = () => new Promise((resolve) => setTimeout(resolve, 0))
+
+    /** Make the /auth/me confirmation probe answer with `status` (or a network error). */
+    const answerProbe = (response?: { status: number }) =>
+      (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockImplementation(() =>
+        response && response.status < 400
+          ? Promise.resolve({ status: response.status, data: { user: { id: '1' } } })
+          : Promise.reject({ response, isAxiosError: true }),
+      )
+
     it('does not treat stray legacy localStorage keys as a session (clears them, no redirect)', async () => {
       // Pre-migration sessions left auth_token/user in localStorage. Those keys
       // are no longer a session signal — only the tfr_csrf cookie is. A 401
@@ -448,6 +461,9 @@ describe('ApiClient', () => {
       // HttpOnly auth cookie + the readable tfr_csrf double-submit cookie.
       document.cookie = 'tfr_csrf=some-csrf-token'
       await getApiClient()
+      // /modules/search is not the session check, so the session is confirmed
+      // dead against /auth/me before the teardown runs (#677).
+      answerProbe({ status: 401 })
 
       const error = {
         response: { status: 401 },
@@ -457,6 +473,7 @@ describe('ApiClient', () => {
 
       const authRejectedHandler = capturedResRejectedHandlers[0]
       await expect(authRejectedHandler(error)).rejects.toBe(error)
+      await flushProbe()
       expect(window.location.href).toContain('/login')
 
       // Clean up so this cookie doesn't leak into later tests.
@@ -471,6 +488,7 @@ describe('ApiClient', () => {
       window.history.pushState({}, '', '/modules/hashicorp/consul/aws?tab=inputs')
       document.cookie = 'tfr_csrf=some-csrf-token'
       await getApiClient()
+      answerProbe({ status: 401 })
 
       const error = {
         response: { status: 401 },
@@ -479,6 +497,7 @@ describe('ApiClient', () => {
       } as AxiosError
 
       await expect(capturedResRejectedHandlers[0](error)).rejects.toBe(error)
+      await flushProbe()
       expect(sessionStorage.getItem('returnUrl')).toBe('/modules/hashicorp/consul/aws?tab=inputs')
 
       document.cookie = 'tfr_csrf=; Max-Age=0'
@@ -639,6 +658,226 @@ describe('ApiClient', () => {
         document.cookie = 'tfr_csrf=; Max-Age=0; path=/'
       }
     })
+
+    // ─── A 401 is not automatically session death (#677) ──────────────────
+    // tfr_csrf is the client half of the double-submit pair. Deleting it while
+    // the HttpOnly auth cookie is still valid — which JS can neither read nor
+    // clear — leaves the session alive but every subsequent mutation shipping
+    // no X-CSRF-Token, i.e. a silent, fail-closed write outage until reload.
+    // So the teardown is confirmed against /auth/me first.
+    describe('401s that are not session failures', () => {
+      const liveSessionCookie = 'tfr_csrf=live-session-csrf'
+
+      afterEach(() => {
+        document.cookie = 'tfr_csrf=; Max-Age=0; path=/'
+        localStorage.clear()
+      })
+
+      it.each([
+        [
+          'module SCM sync — backend 401s "not connected to this SCM provider"',
+          '/api/v1/admin/modules/m1/scm/sync',
+        ],
+        ['an authorization failure the backend returns as 401 not 403', '/api/v1/admin/users'],
+        [
+          'an external-SCM endpoint no URL heuristic knows about',
+          '/api/v1/scm-providers/1/pull-requests',
+        ],
+      ])(
+        'keeps the tfr_csrf half of the double-submit pair when /auth/me proves the session is alive: %s',
+        async (_label, url) => {
+          document.cookie = `${liveSessionCookie}; path=/`
+          localStorage.setItem('user', '{"id":"1"}')
+          window.history.pushState({}, '', '/admin/modules')
+          await getApiClient()
+          answerProbe({ status: 200 })
+
+          const error = {
+            response: { status: 401 },
+            config: { url, method: 'post' },
+            isAxiosError: true,
+          } as AxiosError
+
+          await expect(capturedResRejectedHandlers[0](error)).rejects.toBe(error)
+          await flushProbe()
+
+          expect(mockAxiosInstance.get).toHaveBeenCalledWith(
+            '/api/v1/auth/me',
+            expect.objectContaining({ _sessionProbe: true }),
+          )
+          // The pair survives, so the next POST still carries X-CSRF-Token.
+          expect(document.cookie).toContain(liveSessionCookie)
+          expect(localStorage.getItem('user')).toBe('{"id":"1"}')
+          expect(window.location.href).toContain('/admin/modules')
+        },
+      )
+
+      it('tears the session down once /auth/me confirms it really is gone', async () => {
+        document.cookie = `${liveSessionCookie}; path=/`
+        window.history.pushState({}, '', '/admin/modules')
+        await getApiClient()
+        answerProbe({ status: 401 })
+
+        const error = {
+          response: { status: 401 },
+          config: { url: '/api/v1/admin/users' },
+          isAxiosError: true,
+        } as AxiosError
+
+        await expect(capturedResRejectedHandlers[0](error)).rejects.toBe(error)
+        await flushProbe()
+
+        expect(document.cookie).not.toContain('live-session-csrf')
+        expect(window.location.href).toContain('/login')
+      })
+
+      it.each([
+        ['a 5xx from the auth service', { status: 503 }],
+        ['no response at all (network blip)', undefined],
+      ])(
+        'leaves the session intact when the confirmation cannot answer: %s',
+        async (_label, probeResponse) => {
+          document.cookie = `${liveSessionCookie}; path=/`
+          window.history.pushState({}, '', '/admin/modules')
+          await getApiClient()
+          answerProbe(probeResponse)
+
+          const error = {
+            response: { status: 401 },
+            config: { url: '/api/v1/admin/users' },
+            isAxiosError: true,
+          } as AxiosError
+
+          await expect(capturedResRejectedHandlers[0](error)).rejects.toBe(error)
+          await flushProbe()
+
+          expect(document.cookie).toContain(liveSessionCookie)
+          expect(window.location.href).toContain('/admin/modules')
+        },
+      )
+
+      it.each([
+        ['Setup Wizard SetupToken', '/api/v1/setup/admin', 'SetupToken setup-abc123'],
+        ['an explicit Bearer token', '/api/v1/modules', 'Bearer some-jwt'],
+      ])(
+        'never touches the cookie session for a request carrying its own credential (%s)',
+        async (_label, url, authorization) => {
+          document.cookie = `${liveSessionCookie}; path=/`
+          window.history.pushState({}, '', '/setup')
+          await getApiClient()
+          answerProbe({ status: 401 })
+
+          const error = {
+            response: { status: 401 },
+            config: { url, headers: { Authorization: authorization } },
+            isAxiosError: true,
+          } as AxiosError
+
+          await expect(capturedResRejectedHandlers[0](error)).rejects.toBe(error)
+          await flushProbe()
+
+          // A 401 on someone else's credential is not evidence about this one:
+          // no probe, no teardown, no redirect.
+          expect(mockAxiosInstance.get).not.toHaveBeenCalled()
+          expect(document.cookie).toContain(liveSessionCookie)
+          expect(window.location.href).toContain('/setup')
+        },
+      )
+
+      it('confirms once for a burst of concurrent 401s', async () => {
+        // A page that fans out six requests must not fan out six probes.
+        document.cookie = `${liveSessionCookie}; path=/`
+        window.history.pushState({}, '', '/admin/modules')
+        await getApiClient()
+        answerProbe({ status: 200 })
+
+        const error = {
+          response: { status: 401 },
+          config: { url: '/api/v1/admin/users' },
+          isAxiosError: true,
+        } as AxiosError
+
+        await Promise.all(
+          Array.from({ length: 6 }, () =>
+            expect(capturedResRejectedHandlers[0](error)).rejects.toBe(error),
+          ),
+        )
+        await flushProbe()
+
+        expect(mockAxiosInstance.get).toHaveBeenCalledTimes(1)
+
+        // The latch releases, so a later 401 is confirmed again rather than
+        // being trusted from a stale answer.
+        await expect(capturedResRejectedHandlers[0](error)).rejects.toBe(error)
+        await flushProbe()
+        expect(mockAxiosInstance.get).toHaveBeenCalledTimes(2)
+      })
+
+      it('does not re-enter the 401 handler for the confirmation probe itself', async () => {
+        // Without the marker the probe's own 401 would look like a fresh
+        // session-death event and recurse into another probe.
+        document.cookie = `${liveSessionCookie}; path=/`
+        window.history.pushState({}, '', '/admin/modules')
+        await getApiClient()
+        answerProbe({ status: 401 })
+
+        const probeError = {
+          response: { status: 401 },
+          config: { url: '/api/v1/auth/me', _sessionProbe: true },
+          isAxiosError: true,
+        } as unknown as AxiosError
+
+        await expect(capturedResRejectedHandlers[0](probeError)).rejects.toBe(probeError)
+        await flushProbe()
+
+        expect(mockAxiosInstance.get).not.toHaveBeenCalled()
+        expect(document.cookie).toContain(liveSessionCookie)
+        expect(window.location.href).toContain('/admin/modules')
+      })
+
+      it('needs no confirmation when /auth/me is the request that 401d', async () => {
+        // /auth/me IS the session check — asking it again would only re-ask the
+        // question it just answered.
+        document.cookie = `${liveSessionCookie}; path=/`
+        window.history.pushState({}, '', '/admin/modules')
+        await getApiClient()
+        answerProbe({ status: 200 })
+
+        const error = {
+          response: { status: 401 },
+          config: { url: '/api/v1/auth/me' },
+          isAxiosError: true,
+        } as AxiosError
+
+        await expect(capturedResRejectedHandlers[0](error)).rejects.toBe(error)
+
+        expect(mockAxiosInstance.get).not.toHaveBeenCalled()
+        expect(document.cookie).not.toContain('live-session-csrf')
+        expect(window.location.href).toContain('/login')
+      })
+
+      it('does not probe for an anonymous visitor with no session signal', async () => {
+        // No tfr_csrf means there is nothing to protect and nothing to redirect;
+        // the legacy localStorage sweep still runs.
+        localStorage.setItem('auth_token', 'stale-legacy-jwt')
+        window.history.pushState({}, '', '/public-page')
+        await getApiClient()
+        answerProbe({ status: 401 })
+
+        const error = {
+          response: { status: 401 },
+          config: { url: '/api/v1/admin/users' },
+          isAxiosError: true,
+        } as AxiosError
+
+        await expect(capturedResRejectedHandlers[0](error)).rejects.toBe(error)
+        await flushProbe()
+
+        expect(mockAxiosInstance.get).not.toHaveBeenCalled()
+        expect(localStorage.getItem('auth_token')).toBeNull()
+        expect(window.location.href).toContain('/public-page')
+      })
+    })
   })
 
   // ─── Mock-data safety (#615) ───────────────────────────────────────────────
@@ -655,6 +894,11 @@ describe('ApiClient', () => {
       vi.stubEnv('VITE_USE_MOCK_DATA', 'true')
       document.cookie = 'tfr_csrf=sess; path=/'
       await getApiClient()
+      // The /auth/me confirmation (#677) answers 401 too — the session is dead.
+      ;(mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockRejectedValue({
+        response: { status: 401 },
+        isAxiosError: true,
+      })
 
       const error = {
         response: { status: 401 },
@@ -665,6 +909,7 @@ describe('ApiClient', () => {
       const authRejectedHandler = capturedResRejectedHandlers[0]
       // Must reach the real 401 handler (reject + redirect), not resolve as mock.
       await expect(authRejectedHandler(error)).rejects.toBe(error)
+      await new Promise((resolve) => setTimeout(resolve, 0))
       expect(window.location.href).toContain('/login')
     })
 

--- a/frontend/src/services/__tests__/http.test.ts
+++ b/frontend/src/services/__tests__/http.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect } from 'vitest'
-import { isSCMOAuthFailureUrl, checkCsrfOriginConfig } from '../api/http'
+import { isSCMOAuthFailureUrl, checkCsrfOriginConfig, classifySession401 } from '../api/http'
 
 // ─── SCM OAuth vs session 401 classification (#617) ─────────────────────────
 // A 401 on an endpoint that proxies the external SCM API (using the stored OAuth
 // token) means "reconnect your SCM token" and must NOT wipe the app session.
 // Everything else — including the provider record and the OAuth-linkage
-// endpoints — is a real session failure that redirects to /login.
+// endpoints — may be a real session failure, and is confirmed against /auth/me
+// before anything is torn down (see classifySession401 below).
 
 describe('isSCMOAuthFailureUrl', () => {
   it.each([
@@ -27,6 +28,63 @@ describe('isSCMOAuthFailureUrl', () => {
     ['empty', ''],
   ])('classifies %s as a session failure (not OAuth)', (_label, url) => {
     expect(isSCMOAuthFailureUrl(url)).toBe(false)
+  })
+})
+
+// ─── 401 → session-death classification (#677) ──────────────────────────────
+// Only a request the *cookie session* authenticated can report that session's
+// death. Everything else either carries its own credential or has to be
+// confirmed against /auth/me before the tfr_csrf half of the double-submit pair
+// is destroyed.
+
+describe('classifySession401', () => {
+  it.each([
+    ['setup-wizard SetupToken', '/api/v1/setup/admin', { Authorization: 'SetupToken abc123' }],
+    ['lowercase header name', '/api/v1/setup/complete', { authorization: 'SetupToken abc123' }],
+    ['explicit Bearer', '/api/v1/modules', { Authorization: 'Bearer some-jwt' }],
+  ])('treats %s as another credential, never session death', (_label, url, headers) => {
+    expect(classifySession401({ url, headers })).toBe('other-credential')
+  })
+
+  it('reads an Authorization header off an AxiosHeaders-style object', () => {
+    // Axios normalises headers into an AxiosHeaders instance whose values are
+    // only reachable via .get() — a plain property read returns undefined and
+    // would misclassify a SetupToken request as a dead session.
+    const headers = { get: (name: string) => (name === 'Authorization' ? 'SetupToken abc' : null) }
+    expect(classifySession401({ url: '/api/v1/setup/admin', headers })).toBe('other-credential')
+    expect(classifySession401({ url: '/api/v1/setup/admin', headers: { get: () => null } })).toBe(
+      'unconfirmed',
+    )
+  })
+
+  it.each([
+    '/api/v1/scm-providers/123/repositories',
+    '/api/v1/scm-providers/456/repositories/owner/repo/tags',
+  ])('treats an external-SCM proxy call as another credential: %s', (url) => {
+    expect(classifySession401({ url })).toBe('other-credential')
+  })
+
+  it.each([
+    ['bare path', '/api/v1/auth/me'],
+    ['with a query string', '/api/v1/auth/me?fresh=1'],
+  ])('treats the /auth/me session check itself as authoritative (%s)', (_label, url) => {
+    expect(classifySession401({ url })).toBe('session-dead')
+  })
+
+  it.each([
+    [
+      'module SCM sync (backend 401s "not connected to this SCM provider")',
+      '/api/v1/admin/modules/m1/scm/sync',
+    ],
+    ['an authorization failure returned as 401', '/api/v1/admin/users'],
+    ['an SCM endpoint no URL heuristic knows about', '/api/v1/scm-providers/1/pull-requests'],
+    ['no config url at all', ''],
+  ])('leaves a cookie-authenticated 401 unconfirmed: %s', (_label, url) => {
+    expect(classifySession401({ url })).toBe('unconfirmed')
+  })
+
+  it('leaves a missing config unconfirmed rather than assuming session death', () => {
+    expect(classifySession401(undefined)).toBe('unconfirmed')
   })
 })
 

--- a/frontend/src/services/api/http.ts
+++ b/frontend/src/services/api/http.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosError, InternalAxiosRequestConfig } from 'axios'
+import axios, { AxiosError, AxiosRequestConfig, InternalAxiosRequestConfig } from 'axios'
 import { addApiBreadcrumb } from '../errorReporting'
 import { clearAuthStorage } from '../../utils/authStorage'
 import { captureReturnUrl } from '../../utils/returnUrl'
@@ -129,26 +129,93 @@ function getMockResponse(url: string): { data: unknown; status: number } {
  * expired or was revoked (show a reconnect prompt) — NOT that the user's app
  * session died. Endpoints that operate on the local provider record or the OAuth
  * linkage itself (list/get/update/delete, /oauth/*, /token, /verify) are
- * deliberately excluded: a 401 there is a real session failure and must redirect
- * to /login.
+ * deliberately excluded: a 401 there may be a real session failure.
  *
- * This is a URL-shape heuristic. The robust fix is a structured backend signal
- * (a dedicated error code) so new external-SCM endpoints need not be enumerated
- * here — see audit issue #617 (backend change, out of tree). Until then, any new
- * endpoint that calls the external SCM API on the user's behalf must be added to
- * this list.
+ * This is a URL-shape heuristic, and it is no longer load-bearing: an
+ * external-SCM endpoint missing from this list is merely `unconfirmed` (see
+ * classifySession401 below), so it costs a /auth/me round-trip instead of
+ * destroying a live session's CSRF cookie (#677). Listing one here just skips
+ * that round-trip. A structured backend error code would remove the heuristic
+ * entirely — see audit issue #617 (backend change, out of tree).
  */
 const SCM_OAUTH_SUBRESOURCES = ['/repositories', '/tags', '/branches'] as const
 
 /**
  * Classifies a 401 on an SCM-provider request as an OAuth-token failure (true,
- * keep the session) vs a user-session failure (false, wipe + redirect), from the
- * request URL shape.
+ * definitely keep the session) from the request URL shape.
  */
 export function isSCMOAuthFailureUrl(url: string): boolean {
   return (
     url.includes('/scm-providers/') && SCM_OAUTH_SUBRESOURCES.some((suffix) => url.includes(suffix))
   )
+}
+
+/**
+ * GET /api/v1/auth/me is the one endpoint whose entire job is to answer "is this
+ * browser's cookie session still alive?", and it is authenticated by nothing but
+ * that session. A 401 from it is therefore the authoritative session-death
+ * signal, and a 2xx is proof the session is alive.
+ */
+const SESSION_PROBE_URL = '/api/v1/auth/me'
+
+/**
+ * Marks the confirmation request issued by confirmSessionDead() so the 401
+ * handler ignores it: the probe asks the handler's own question, and letting its
+ * 401 back in would both recurse and look like a fresh session-death event.
+ */
+type SessionProbeConfig = { _sessionProbe?: boolean }
+
+/** Is this request itself the authoritative session check? */
+function isSessionProbeUrl(url: string): boolean {
+  return url.split('?')[0].endsWith(SESSION_PROBE_URL)
+}
+
+/**
+ * True when the request carried its own Authorization credential. Axios
+ * normalizes headers into an AxiosHeaders instance whose values are only
+ * reachable through .get(), but callers (and tests) hand in plain objects too,
+ * so both shapes are read.
+ */
+function hasExplicitAuthorization(headers: unknown): boolean {
+  if (!headers || typeof headers !== 'object') return false
+  const bag = headers as {
+    Authorization?: unknown
+    authorization?: unknown
+    get?: (name: string) => unknown
+  }
+  const viaGetter = typeof bag.get === 'function' ? bag.get('Authorization') : undefined
+  return !!(bag.Authorization ?? bag.authorization ?? viaGetter)
+}
+
+/**
+ * How a 401 relates to *this browser's cookie session* (#677). Only a request
+ * that the session cookie authenticated can report that session's death:
+ *
+ * - `other-credential` — the request authenticated with something else: an
+ *   explicit Authorization header (the Setup Wizard's SetupToken, or a Bearer
+ *   token) or an SCM-provider call the backend proxies with the stored OAuth
+ *   token. The 401 is about *that* credential and is evidence of nothing here.
+ * - `session-dead` — the request IS the session check, so its 401 is the answer.
+ * - `unconfirmed` — a cookie-authenticated request that could equally have 401d
+ *   for an authorization failure returned as 401 rather than 403, a handler-level
+ *   "not connected to this SCM provider", or a transient auth blip. The session
+ *   may well be alive, so nothing may be torn down until /auth/me says otherwise.
+ *
+ * Note the direction of the residual risk: an endpoint nobody anticipated lands
+ * in `unconfirmed`, which costs one extra GET and never destroys a live session
+ * — the opposite of a URL-shape allowlist, where the unanticipated endpoint is
+ * the one that breaks.
+ */
+export type Session401Verdict = 'other-credential' | 'session-dead' | 'unconfirmed'
+
+export function classifySession401(
+  config: { url?: string; headers?: unknown } | undefined,
+): Session401Verdict {
+  const url = config?.url || ''
+  if (isSCMOAuthFailureUrl(url) || hasExplicitAuthorization(config?.headers)) {
+    return 'other-credential'
+  }
+  return isSessionProbeUrl(url) ? 'session-dead' : 'unconfirmed'
 }
 
 /**
@@ -231,9 +298,9 @@ http.interceptors.request.use(
 // never fire it again for this page's lifetime — independent of whether the
 // tfr_csrf cookie deletion below actually took effect. Browser cookie deletion
 // silently no-ops when the cookie was set with a Domain attribute this code
-// doesn't mirror; without this guard that would keep hadSession=true forever and
-// reintroduce the /login <-> 401 redirect loop the cookie expiry is meant to
-// prevent. This module-scope flag only covers concurrent/same-tick 401s within a
+// doesn't mirror; without this guard the cookie would read as a live session
+// forever and reintroduce the /login <-> 401 redirect loop the cookie expiry is
+// meant to prevent. This module-scope flag only covers concurrent/same-tick 401s within a
 // single page instance — a real redirect is a full-page navigation that reloads
 // the module and resets it. The attribute-independent, navigation-surviving half
 // of the guard is the "already on /login" check at the redirect site below:
@@ -244,6 +311,74 @@ let hasRedirectedToLogin = false
 // The redirect target. Refusing to navigate here when we are already on this path
 // is what makes the loop guard survive a real page reload (see #621 above).
 const LOGIN_PATH = '/login'
+
+/**
+ * Consume the session: drop the client-side remnants and send the user to
+ * /login. Only called once the session is known to be dead, because the CSRF
+ * cookie expiry below is destructive in a way JS cannot undo — the HttpOnly auth
+ * cookie is not clearable from here, so a session that outlives its tfr_csrf
+ * half keeps authenticating while every mutation fails the double-submit check
+ * (#677).
+ */
+function endSession(): void {
+  clearAuthStorage()
+  // Expire the CSRF cookie so the session signal is ONE-SHOT, exactly like
+  // the localStorage keys clearAuthStorage() just removed. Without this, a
+  // session invalidated server-side (revocation, secret rotation, clock
+  // skew) redirects in a loop: /login mounts AuthProvider, which probes
+  // /auth/me, 401s, and re-triggers this handler with the cookie still set.
+  // Safe to clear from JS -- the cookie is non-HttpOnly by design and a dead
+  // session's CSRF token has no value.
+  document.cookie = 'tfr_csrf=; Max-Age=0; path=/'
+  // Two independent loop guards close the Domain-scoped-cookie case where the
+  // deletion above no-ops and the cookie session signal stays true forever: (1)
+  // the module-scope flag stops concurrent 401s in this page instance; (2) the
+  // "already on /login" check survives a real page reload (which resets that
+  // flag) — redirecting to /login while already on /login is the loop itself.
+  const alreadyOnLoginPage = window.location.pathname === LOGIN_PATH
+  if (!hasRedirectedToLogin && !alreadyOnLoginPage) {
+    hasRedirectedToLogin = true
+    // Capture INSIDE the redirect branch, not on every 401 (#695). A 401
+    // that does not navigate is an SCM-OAuth failure, an anonymous probe,
+    // or a suppressed loop-guard case -- recording a destination for any of
+    // those would leave a stale entry that hijacks the next real login.
+    captureReturnUrl()
+    window.location.href = LOGIN_PATH
+  }
+}
+
+// One confirmation at a time: a page that fans out six requests answers six
+// 401s in the same tick, and six identical /auth/me probes would answer one
+// question. Cleared when the probe settles rather than cached — a session can
+// die at any moment, so the next 401 deserves a fresh answer.
+let sessionProbeInFlight = false
+
+/**
+ * Ask /auth/me whether the session is actually dead, and only then tear it down.
+ * A probe that cannot answer (5xx, network failure, rate limit) deliberately
+ * leaves everything in place: a live session keeping a usable CSRF pair is
+ * recoverable, a live session that lost it is a silent write outage.
+ */
+function confirmSessionDead(): void {
+  if (sessionProbeInFlight) return
+  sessionProbeInFlight = true
+  http
+    // Path spelled out rather than passed as SESSION_PROBE_URL because
+    // scripts/contract-check.ts only resolves literal path arguments — inlining
+    // keeps this call under the frontend/backend route contract check.
+    .get('/api/v1/auth/me', { _sessionProbe: true } as AxiosRequestConfig & SessionProbeConfig)
+    .then(
+      () => {
+        // 2xx: the session is alive, so that 401 meant something else entirely.
+      },
+      (probeError: AxiosError) => {
+        if (probeError?.response?.status === 401) endSession()
+      },
+    )
+    .finally(() => {
+      sessionProbeInFlight = false
+    })
+}
 
 // Response interceptor for error handling
 http.interceptors.response.use(
@@ -259,47 +394,30 @@ http.interceptors.response.use(
       return getMockResponse(error.config?.url || '')
     }
 
-    if (error.response?.status === 401) {
-      // SCM provider endpoints return 401 when the SCM OAuth token has expired or
-      // been revoked — this is not a user session failure. Let the error propagate
-      // so the calling component (e.g. RepositoryBrowser) can show the reconnect
-      // prompt rather than wiping the user's session and redirecting to /login.
-      const url = error.config?.url || ''
-      const isSCMOAuthFailure = isSCMOAuthFailureUrl(url)
-
-      if (!isSCMOAuthFailure) {
-        // Only redirect when the user previously had an active cookie session.
-        // Fresh anonymous visitors receive 401 on probing endpoints like
-        // /auth/me — this is expected and should NOT trigger a redirect so
-        // public pages remain accessible. The "tfr_csrf" cookie is set only
-        // when the backend issues or refreshes the auth cookie (see
-        // middleware/csrf.go) and cleared on logout, so its presence is a
-        // reliable session signal even though the HttpOnly auth cookie itself
-        // isn't readable from JS.
-        const hadSession = !!getCookie('tfr_csrf')
-        clearAuthStorage()
-        // Expire the CSRF cookie so the session signal is ONE-SHOT, exactly like
-        // the localStorage keys clearAuthStorage() just removed. Without this, a
-        // session invalidated server-side (revocation, secret rotation, clock
-        // skew) redirects in a loop: /login mounts AuthProvider, which probes
-        // /auth/me, 401s, and re-triggers this handler with the cookie still set.
-        // Safe to clear from JS -- the cookie is non-HttpOnly by design and a dead
-        // session's CSRF token has no value.
-        document.cookie = 'tfr_csrf=; Max-Age=0; path=/'
-        // Two independent loop guards close the Domain-scoped-cookie case where the
-        // deletion above no-ops and hadSession stays true forever: (1) the
-        // module-scope flag stops concurrent 401s in this page instance; (2) the
-        // "already on /login" check survives a real page reload (which resets that
-        // flag) — redirecting to /login while already on /login is the loop itself.
-        const alreadyOnLoginPage = window.location.pathname === LOGIN_PATH
-        if (hadSession && !hasRedirectedToLogin && !alreadyOnLoginPage) {
-          hasRedirectedToLogin = true
-          // Capture INSIDE the redirect branch, not on every 401 (#695). A 401
-          // that does not navigate is an SCM-OAuth failure, an anonymous probe,
-          // or a suppressed loop-guard case -- recording a destination for any of
-          // those would leave a stale entry that hijacks the next real login.
-          captureReturnUrl()
-          window.location.href = LOGIN_PATH
+    const config = error.config as (InternalAxiosRequestConfig & SessionProbeConfig) | undefined
+    // The confirmation probe's own 401 is handled by confirmSessionDead(), which
+    // asked the question; re-entering here would recurse.
+    if (error.response?.status === 401 && !config?._sessionProbe) {
+      // Not every 401 means the session died: an SCM-provider call proxied with
+      // the stored OAuth token 401s when THAT token expired (the calling
+      // component, e.g. RepositoryBrowser, shows a reconnect prompt), and a
+      // request carrying its own Authorization credential 401s about that
+      // credential. Neither is evidence about the cookie session (#677).
+      const verdict = classifySession401(config)
+      if (verdict !== 'other-credential') {
+        // The "tfr_csrf" cookie is set only when the backend issues or refreshes
+        // the auth cookie (see middleware/csrf.go) and cleared on logout, so its
+        // presence is a reliable session signal even though the HttpOnly auth
+        // cookie itself isn't readable from JS. Without it there is no session to
+        // end and no reason to probe: fresh anonymous visitors receive 401 on
+        // endpoints like /auth/me, which must leave public pages accessible. The
+        // pre-cookie-migration localStorage keys are still swept.
+        if (!getCookie('tfr_csrf')) {
+          clearAuthStorage()
+        } else if (verdict === 'session-dead') {
+          endSession()
+        } else {
+          confirmSessionDead()
         }
       }
     }


### PR DESCRIPTION
## The defect

`http.ts`'s 401 interceptor treated every non-SCM 401 as session death: `clearAuthStorage()`, `document.cookie = 'tfr_csrf=; Max-Age=0; path=/'`, redirect to `/login`.

`tfr_csrf` is the **client half of the double-submit pair**, and the HttpOnly `tfr_auth_token` can neither be read nor cleared from JS. So a 401 that did *not* end the session left the user authenticated with no CSRF token: the request interceptor only sets `X-CSRF-Token` `if (csrfToken)`, so every subsequent POST/PUT/PATCH/DELETE went out bare and was rejected server-side until a reload. Fail-closed, but a silent write outage.

## Premise verified — these 401s exist today

| 401 source | Reaches the interceptor as | Session |
|---|---|---|
| `POST /api/v1/admin/modules/{id}/scm/sync` → `"not connected to this SCM provider"` (handler-level, backend `internal/api/modules/scm_linking.go`) | no `/scm-providers/` + subresource match → "session dead" | **alive** |
| an authorization failure the backend answers 401 instead of 403 | same | **alive** |
| a new external-SCM endpoint not yet listed in `SCM_OAUTH_SUBRESOURCES` (its own comment concedes the list is "a URL-shape heuristic") | same | **alive** |
| `GET /api/v1/auth/me` 401 (AuthProvider probe) | session dead | dead — correct |

The backend has no structured 401 error code to key off (every 401 is a free-form `{"error": "..."}` string), so #617's "dedicated error code" is still out of tree.

## The fix

`classifySession401(config)` replaces the single "is this SCM?" question:

- **`other-credential`** — the request carried its own `Authorization` header (Setup Wizard `SetupToken`, an explicit `Bearer`) or is an SCM call the backend proxies with the stored OAuth token. A 401 is about *that* credential; nothing is touched.
- **`session-dead`** — the request **is** `GET /auth/me`, the one endpoint whose job is to answer "is this session alive?". Its 401 is the answer: teardown runs immediately, exactly as before.
- **`unconfirmed`** — everything else cookie-authenticated. The teardown is gated on a single `GET /auth/me` confirmation and runs only if that 401s too.

Properties:

- a probe that **cannot** answer (5xx, network failure, rate limit) changes nothing — a live session that keeps a usable CSRF pair is recoverable; one that lost it is not;
- **one probe at a time** serves a whole burst of 401s, and the latch releases on settle so the next 401 gets a fresh answer;
- the probe is marked `_sessionProbe` so it cannot re-enter the handler (and if the marker were ever dropped, its `/auth/me` URL classifies as `session-dead`, so it still cannot recurse);
- no probe at all when there is no `tfr_csrf` cookie — anonymous visitors on public pages behave exactly as before (legacy localStorage sweep, no redirect);
- the residual risk is **inverted**: an endpoint nobody anticipated now costs one extra GET instead of destroying a live session's CSRF cookie. The `SCM_OAUTH_SUBRESOURCES` list is no longer load-bearing, only an optimisation.

Clearing the cookie on a genuinely dead session, both #621 loop guards (module flag + "already on /login") and the #695 return-URL capture are unchanged and still covered.

## Mutation table

Each mutation was applied to the fixed `http.ts`, the two suites re-run, then the file restored from a `cp` backup.

| # | Mutation | Result |
|---|---|---|
| M1 | teardown unconditionally on every non-`other-credential` 401 (pre-fix behaviour) | **6 fail** |
| M2 | drop the `_sessionProbe` re-entry check | **1 fail** (probe recursion test) |
| M3 | tear down regardless of what the probe answered | **6 fail** |
| M4 | stop recognising a request's own `Authorization` credential | **6 fail** (2 interceptor + 4 classifier) |
| M5 | remove the single-probe latch | **1 fail** (burst test) |
| M6 | never probe — blanket-suppress the deletion | **11 fail** (session-death coverage collapses, which is the point: the deletion must keep working) |
| M7 | `/auth/me` no longer authoritative | **6 fail** (incl. both #621 loop-guard tests) |

Unmutated: 293/293 in the two suites, 2238/2238 across the full local suite.

## Checks

`npm run lint` clean · `tsc --noEmit` clean · full `vitest run` 150 files / 2238 tests green · `vitest run --coverage` exit 0 with `http.ts` at **99.09 / 98.14 / 100 / 99.03** against its 95/90/95/95 per-file floor.

`prettier --check` fails repo-wide on 64 files **on pristine `main`** (it is not a CI gate); every line this PR adds or edits is prettier-clean — the first violation in `api.test.ts` is at line 1071, past the end of this diff.

## Deliberately not done

- **LoginPage "already signed in" redirect** (the issue's "at minimum"): the cause is removed — a live session is no longer bounced to `/login` by the interceptor — and that change belongs to the routing layer, not the API client. Worth a separate issue if wanted as defence in depth.
- **Backend structured 401 error code (#617)**: out of tree, and no longer needed for correctness here — it would only let the client skip the confirmation round-trip.

Closes #677