### PR TITLE
refactor(hooks): port useProviderDetail to React Query (#674)

### DIFF
--- a/frontend/src/hooks/__tests__/useProviderDetail.test.tsx
+++ b/frontend/src/hooks/__tests__/useProviderDetail.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
-import { renderHook, act, waitFor } from '@testing-library/react'
+import { renderHook, act, waitFor, screen } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 const mockApi = vi.hoisted(() => ({
@@ -47,14 +48,32 @@ function version(v: string, extra: Record<string, unknown> = {}) {
   }
 }
 
-/** Renders the hook under the real router so ?tab=/?doc= behave as in the app. */
-function renderProviderDetail(initialPath = '/providers/hashicorp/aws') {
+function createQueryClient(queryOverrides: Record<string, unknown> = {}) {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0, ...queryOverrides } },
+  })
+}
+
+/**
+ * Renders the hook under the real router so ?tab=/?doc= behave as in the app,
+ * and under a React Query client so the hook's queries/mutations behave as in
+ * the app. A fresh client per render unless the caller supplies one, so cached
+ * provider data never leaks between tests.
+ */
+function renderProviderDetail(
+  initialPath = '/providers/hashicorp/aws',
+  queryClient: QueryClient = createQueryClient(),
+) {
   const wrapper = ({ children }: { children: React.ReactNode }) => (
-    <MemoryRouter initialEntries={[initialPath]}>
-      <Routes>
-        <Route path="/providers/:namespace/:type" element={<>{children}</>} />
-      </Routes>
-    </MemoryRouter>
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[initialPath]}>
+        <Routes>
+          <Route path="/providers/:namespace/:type" element={<>{children}</>} />
+          {/* Landing route for handleDeleteProvider's navigate('/providers') */}
+          <Route path="/providers" element={<div data-testid="providers-list" />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
   )
   return renderHook(() => useProviderDetail(), { wrapper })
 }
@@ -248,11 +267,68 @@ describe('useProviderDetail', () => {
     expect(result.current.deleteVersionDialogOpen).toBe(true)
 
     await act(async () => {
-      await result.current.handleDeleteVersion()
+      result.current.handleDeleteVersion()
     })
-    expect(mockApi.deleteProviderVersion).toHaveBeenCalledWith('hashicorp', 'aws', '5.0.0')
-    expect(mockApi.searchProviders).toHaveBeenCalledTimes(2)
+    await waitFor(() =>
+      expect(mockApi.deleteProviderVersion).toHaveBeenCalledWith('hashicorp', 'aws', '5.0.0'),
+    )
+    // The delete invalidates the provider detail query, which refetches it
+    await waitFor(() => expect(mockApi.searchProviders).toHaveBeenCalledTimes(2))
     expect(result.current.deleteVersionDialogOpen).toBe(false)
+    expect(result.current.versionToDelete).toBeNull()
+  })
+
+  it('reloads the provider after deprecating a version', async () => {
+    mockApi.deprecateProviderVersion.mockResolvedValue({})
+    const { result } = renderProviderDetail()
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    act(() => result.current.setDeprecationMessage('use 6.x'))
+    await act(async () => {
+      result.current.handleDeprecateVersion()
+    })
+
+    await waitFor(() =>
+      expect(mockApi.deprecateProviderVersion).toHaveBeenCalledWith(
+        'hashicorp',
+        'aws',
+        '5.0.0',
+        'use 6.x',
+      ),
+    )
+    await waitFor(() => expect(mockApi.searchProviders).toHaveBeenCalledTimes(2))
+    expect(result.current.deprecationMessage).toBe('')
+    expect(result.current.deprecateDialogOpen).toBe(false)
+  })
+
+  it('reloads the provider after removing a deprecation', async () => {
+    mockApi.undeprecateProviderVersion.mockResolvedValue({})
+    const { result } = renderProviderDetail()
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    await act(async () => {
+      result.current.handleUndeprecateVersion()
+    })
+
+    await waitFor(() =>
+      expect(mockApi.undeprecateProviderVersion).toHaveBeenCalledWith('hashicorp', 'aws', '5.0.0'),
+    )
+    await waitFor(() => expect(mockApi.searchProviders).toHaveBeenCalledTimes(2))
+  })
+
+  it('deletes the provider and navigates away', async () => {
+    mockApi.deleteProvider.mockResolvedValue({})
+    const { result } = renderProviderDetail()
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    await act(async () => {
+      result.current.handleDeleteProvider()
+    })
+
+    await waitFor(() => expect(mockApi.deleteProvider).toHaveBeenCalledWith('hashicorp', 'aws'))
+    // Deleting the provider leaves the detail route for the provider list
+    await waitFor(() => expect(screen.getByTestId('providers-list')).toBeInTheDocument())
+    expect(result.current.deleteProviderDialogOpen).toBe(false)
   })
 
   it('reports a failure to deprecate without leaving the dialog open', async () => {
@@ -262,10 +338,140 @@ describe('useProviderDetail', () => {
 
     await waitFor(() => expect(result.current.loading).toBe(false))
     await act(async () => {
-      await result.current.handleDeprecateVersion()
+      result.current.handleDeprecateVersion()
     })
-    expect(result.current.error).toMatch(/failed to deprecate version/i)
+    await waitFor(() => expect(result.current.error).toMatch(/failed to deprecate version/i))
     expect(result.current.deprecateDialogOpen).toBe(false)
     expect(result.current.deprecating).toBe(false)
+    // A failed write must not refetch — the cache is still correct
+    expect(mockApi.searchProviders).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports a failure to delete a version and keeps the queued version', async () => {
+    mockApi.deleteProviderVersion.mockRejectedValue({ status: 500 })
+    const { result } = renderProviderDetail()
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    act(() => result.current.openDeleteVersionDialog('5.0.0'))
+    await act(async () => {
+      result.current.handleDeleteVersion()
+    })
+
+    await waitFor(() => expect(result.current.error).toMatch(/failed to delete version/i))
+    expect(result.current.deleteVersionDialogOpen).toBe(false)
+    expect(result.current.versionToDelete).toBe('5.0.0')
+    expect(result.current.deleting).toBe(false)
+  })
+
+  it('keeps the version the user picked when a mutation refetches the provider', async () => {
+    // Bug fix shipped with the React Query port (#674): the hand-rolled reload
+    // reset the selection to versions[0] on every refetch, so deprecating any
+    // version other than the newest snapped the detail panel back to the newest
+    // one and the user never saw the change they had just made. useModuleDetail
+    // already preserved the selection; this asserts the provider page does too.
+    // The refetch has to return *changed* rows, or React Query's structural
+    // sharing hands back the identical array, the selection effect never re-runs
+    // and the assertion would hold even for a hook that resets the selection.
+    mockApi.getProviderVersions
+      .mockResolvedValueOnce({
+        versions: [version('5.0.0'), version('4.0.0', { deprecated: true })],
+      })
+      .mockResolvedValueOnce({
+        versions: [version('5.0.0'), version('4.0.0', { deprecated: false })],
+      })
+    mockApi.undeprecateProviderVersion.mockResolvedValue({})
+    const { result } = renderProviderDetail()
+
+    await waitFor(() => expect(result.current.selectedVersion?.version).toBe('5.0.0'))
+    act(() => result.current.setSelectedVersion(result.current.versions[1]))
+    expect(result.current.selectedVersion?.version).toBe('4.0.0')
+    expect(result.current.selectedVersion?.deprecated).toBe(true)
+
+    await act(async () => {
+      result.current.handleUndeprecateVersion()
+    })
+    await waitFor(() => expect(mockApi.searchProviders).toHaveBeenCalledTimes(2))
+    // The refetched rows have landed (4.0.0 is no longer deprecated)
+    await waitFor(() => expect(result.current.selectedVersion?.deprecated).toBe(false))
+
+    expect(result.current.selectedVersion?.version).toBe('4.0.0')
+  })
+
+  it('picks up the refetched version row rather than the stale one', async () => {
+    // The selection is preserved by version string, but it must point at the
+    // freshly fetched row -- otherwise the panel would keep rendering the
+    // pre-mutation `deprecated: false` copy of the same version.
+    mockApi.getProviderVersions
+      .mockResolvedValueOnce({ versions: [version('5.0.0')] })
+      .mockResolvedValueOnce({
+        versions: [version('5.0.0', { deprecated: true, deprecation_message: 'use 6.x' })],
+      })
+    mockApi.deprecateProviderVersion.mockResolvedValue({})
+    const { result } = renderProviderDetail()
+
+    await waitFor(() => expect(result.current.selectedVersion?.version).toBe('5.0.0'))
+    expect(result.current.selectedVersion?.deprecated).toBe(false)
+
+    await act(async () => {
+      result.current.handleDeprecateVersion()
+    })
+    await waitFor(() => expect(result.current.selectedVersion?.deprecated).toBe(true))
+    expect(result.current.selectedVersion?.deprecation_message).toBe('use 6.x')
+  })
+
+  it('dedupes concurrent readers of the same provider into one request', async () => {
+    // Two mounted consumers of the hook share one cache entry, so the API is hit
+    // once. The hand-rolled version fetched once per consumer (#674).
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={createQueryClient()}>
+        <MemoryRouter initialEntries={['/providers/hashicorp/aws']}>
+          <Routes>
+            <Route path="/providers/:namespace/:type" element={<>{children}</>} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    )
+    const { result } = renderHook(
+      () => ({ first: useProviderDetail(), second: useProviderDetail() }),
+      { wrapper },
+    )
+
+    await waitFor(() => expect(result.current.first.loading).toBe(false))
+    await waitFor(() => expect(result.current.second.loading).toBe(false))
+    expect(mockApi.searchProviders).toHaveBeenCalledTimes(1)
+    expect(mockApi.getProviderVersions).toHaveBeenCalledTimes(1)
+    expect(result.current.second.provider?.type).toBe('aws')
+  })
+
+  it('caches the doc index per version instead of refetching on every switch', async () => {
+    mockApi.searchProviders.mockResolvedValue({
+      providers: [{ ...provider, source: 'hashicorp/aws' }],
+    })
+    mockApi.getProviderVersions.mockResolvedValue({
+      versions: [version('5.0.0'), version('4.0.0')],
+    })
+    mockApi.getProviderDocs.mockResolvedValue({
+      docs: [{ id: 'd1', title: 'Overview', slug: 'index', category: 'overview', language: 'hcl' }],
+      total: 1,
+    })
+    // Mirrors the app's real client (src/queryClient.ts): a 30s stale window and
+    // a live cache. With the test default of gcTime: 0 nothing is retained, so
+    // there would be no caching claim left to make.
+    const { result } = renderProviderDetail(
+      '/providers/hashicorp/aws',
+      createQueryClient({ gcTime: 5 * 60 * 1000, staleTime: 30_000 }),
+    )
+
+    await waitFor(() => expect(result.current.docs).toHaveLength(1))
+    expect(mockApi.getProviderDocs).toHaveBeenCalledTimes(1)
+
+    act(() => result.current.setSelectedVersion(result.current.versions[1]))
+    await waitFor(() => expect(mockApi.getProviderDocs).toHaveBeenCalledTimes(2))
+    expect(mockApi.getProviderDocs.mock.calls[1][2]).toBe('4.0.0')
+
+    // Switching back is served from the cache for that version
+    act(() => result.current.setSelectedVersion(result.current.versions[0]))
+    await waitFor(() => expect(result.current.docs).toHaveLength(1))
+    expect(mockApi.getProviderDocs).toHaveBeenCalledTimes(2)
   })
 })

--- a/frontend/src/hooks/useProviderDetail.ts
+++ b/frontend/src/hooks/useProviderDetail.ts
@@ -1,22 +1,44 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useMemo } from 'react'
 import type { SyntheticEvent } from 'react'
 import { useParams, useNavigate, useSearchParams } from 'react-router-dom'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import api from '../services/api'
 import { getErrorMessage } from '../utils/errors'
 import { captureError } from '../services/errorReporting'
 import { Provider, ProviderVersion, ProviderDocEntry } from '../types'
 import { useAuth } from '../contexts/AuthContext'
 import { REGISTRY_HOST } from '../config'
+import { queryKeys } from '../services/queryKeys'
 import { sortByVersionDesc } from '../utils/semver'
 
 /** Page size used when walking the paginated provider doc index. */
 const DOCS_PAGE_SIZE = 1000
 
 /**
+ * Stable empty list for the docs query's default, so the auto-select effect
+ * below doesn't see a new array identity on every render.
+ */
+const NO_DOCS: ProviderDocEntry[] = []
+
+// Route params, narrowed once from possibly-undefined useParams() values. Query
+// and mutation functions take this instead of asserting namespace!/type!
+// individually, so a query's `enabled` flag and its queryFn can't drift out of
+// sync -- the same narrowed object gates both. Mirrors ModuleRouteParams in
+// useModuleDetail.
+interface ProviderRouteParams {
+  namespace: string
+  type: string
+}
+
+/**
  * Data fetching, mutation and UI state for ProviderDetailPage.
  *
  * Keeps the page component presentational: everything that touches the API,
  * the route params or the `?tab=`/`?doc=` query state lives here.
+ *
+ * Reads go through React Query and writes through useMutation with cache
+ * invalidation, matching useModuleDetail (#674) -- the two hooks serve the same
+ * page shape and had diverged into two different data-fetching architectures.
  */
 export function useProviderDetail() {
   const { namespace, type } = useParams<{
@@ -24,6 +46,7 @@ export function useProviderDetail() {
     type: string
   }>()
   const navigate = useNavigate()
+  const queryClient = useQueryClient()
   const [searchParams, setSearchParams] = useSearchParams()
   const { isAuthenticated, allowedScopes } = useAuth()
   const canManage =
@@ -39,87 +62,104 @@ export function useProviderDetail() {
   // Use 'type' as the name for display
   const name = type
 
-  const [provider, setProvider] = useState<Provider | null>(null)
-  const [versions, setVersions] = useState<ProviderVersion[]>([])
+  // UI-only state (not server data)
   const [selectedVersion, setSelectedVersion] = useState<ProviderVersion | null>(null)
-  const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [copiedSource, setCopiedSource] = useState(false)
   const [copiedChecksum, setCopiedChecksum] = useState<string | null>(null)
   const [deleteProviderDialogOpen, setDeleteProviderDialogOpen] = useState(false)
   const [deleteVersionDialogOpen, setDeleteVersionDialogOpen] = useState(false)
   const [versionToDelete, setVersionToDelete] = useState<string | null>(null)
-  const [deleting, setDeleting] = useState(false)
   const [deprecateDialogOpen, setDeprecateDialogOpen] = useState(false)
   const [deprecationMessage, setDeprecationMessage] = useState('')
-  const [deprecating, setDeprecating] = useState(false)
 
-  const [docs, setDocs] = useState<ProviderDocEntry[]>([])
-  const [docsLoading, setDocsLoading] = useState(false)
+  // =========================================================================
+  // 1. Provider + versions query (primary)
+  // =========================================================================
+  const routeParams: ProviderRouteParams | null = useMemo(
+    () => (namespace && type ? { namespace, type } : null),
+    [namespace, type],
+  )
+  const providerQueryEnabled = !!routeParams
 
-  const loadProviderDetails = useCallback(async () => {
-    if (!namespace || !type) return
+  const {
+    data: providerData,
+    isLoading: loading,
+    error: providerQueryError,
+  } = useQuery({
+    queryKey: queryKeys.providers.detail(namespace ?? '', type ?? ''),
+    queryFn: async () => {
+      if (!routeParams) throw new Error('Provider route params missing')
 
-    try {
-      setLoading(true)
-      setError(null)
-
-      // Use searchProviders with namespace filter and then find by type
-      const [providerData, versionsData] = await Promise.all([
-        api.searchProviders({ query: type, limit: 100 }), // Search with type as query
-        api.getProviderVersions(namespace, type),
+      // Use searchProviders with the type as the query, then find the exact
+      // namespace/type match in the results.
+      const [providerResults, versionsData] = await Promise.all([
+        api.searchProviders({ query: routeParams.type, limit: 100 }),
+        api.getProviderVersions(routeParams.namespace, routeParams.type),
       ])
 
-      // Filter results to find exact match for namespace/type
-      const matchingProvider = providerData.providers.find(
-        (p: Provider) => p.namespace === namespace && p.type === type,
-      )
+      const matchingProvider =
+        providerResults.providers.find(
+          (p: Provider) => p.namespace === routeParams.namespace && p.type === routeParams.type,
+        ) ?? null
 
-      if (!matchingProvider) {
-        setError('Provider not found')
-        return
-      }
+      // A miss is a cacheable answer, not a transport failure: returning it as
+      // data (rather than throwing) keeps it off the retry path and out of the
+      // telemetry report below, exactly as the previous hand-rolled early
+      // return did.
+      if (!matchingProvider) return { provider: null, versions: [] as ProviderVersion[] }
 
-      setProvider(matchingProvider)
+      // Backend returns { versions: [...] } directly -- sort by semver descending
+      return { provider: matchingProvider, versions: sortByVersionDesc(versionsData.versions || []) }
+    },
+    enabled: providerQueryEnabled,
+  })
 
-      // Backend returns { versions: [...] } directly — sort by semver descending
-      const sortedVersions = sortByVersionDesc(versionsData.versions || [])
-      setVersions(sortedVersions)
+  const provider = providerData?.provider ?? null
+  const versions = useMemo(() => providerData?.versions ?? [], [providerData?.versions])
 
-      if (sortedVersions.length > 0) {
-        setSelectedVersion(sortedVersions[0])
-      }
-    } catch (err) {
-      console.error('Failed to load provider details:', err)
+  // Derive the page-level error string from the query
+  useEffect(() => {
+    if (providerQueryError) {
+      console.error('Failed to load provider details:', providerQueryError)
       // setError() here uses a plain hardcoded string, not getErrorMessage(), so
       // it doesn't get telemetry reporting for free -- report explicitly (#623).
-      captureError(err instanceof Error ? err : new Error(String(err)), {
-        context: 'Failed to load provider details',
-      })
+      captureError(providerQueryError, { context: 'Failed to load provider details' })
       setError('Failed to load provider details. Please try again.')
-    } finally {
-      setLoading(false)
+      return
     }
-  }, [namespace, type])
+    if (!providerData) return
+    setError(providerData.provider ? null : 'Provider not found')
+  }, [providerQueryError, providerData])
 
+  // Auto-select latest version (or preserve current selection on refetch)
   useEffect(() => {
-    loadProviderDetails()
-  }, [loadProviderDetails])
+    if (versions.length === 0) return
+    setSelectedVersion((prev) => {
+      const current = prev?.version
+      const match = current ? versions.find((v) => v.version === current) : null
+      return match || versions[0]
+    })
+  }, [versions])
 
-  // Fetch doc index for mirrored providers when version is selected
-  useEffect(() => {
-    if (!provider?.source || !selectedVersion || !namespace || !type) return
-    let cancelled = false
-    const fetchAllDocs = async () => {
+  // =========================================================================
+  // 2. Doc index for mirrored providers (depends on selectedVersion)
+  // =========================================================================
+  const docsVersion = selectedVersion?.version ?? ''
+
+  const { data: docs = NO_DOCS, isLoading: docsLoading } = useQuery<ProviderDocEntry[]>({
+    queryKey: queryKeys.providers.docs(namespace ?? '', type ?? '', docsVersion),
+    queryFn: async () => {
+      if (!routeParams) return []
       let allDocs: ProviderDocEntry[] = []
       let offset = 0
       let total = Infinity
 
       while (offset < total) {
         const data = await api.getProviderDocs(
-          namespace,
-          type,
-          selectedVersion.version,
+          routeParams.namespace,
+          routeParams.type,
+          docsVersion,
           undefined,
           'hcl',
           DOCS_PAGE_SIZE,
@@ -131,23 +171,9 @@ export function useProviderDetail() {
         if (data.docs.length === 0) break
       }
       return allDocs
-    }
-
-    setDocsLoading(true)
-    fetchAllDocs()
-      .then((allDocs) => {
-        if (!cancelled) setDocs(allDocs)
-      })
-      .catch(() => {
-        /* non-fatal */
-      })
-      .finally(() => {
-        if (!cancelled) setDocsLoading(false)
-      })
-    return () => {
-      cancelled = true
-    }
-  }, [provider?.source, selectedVersion, namespace, type])
+    },
+    enabled: providerQueryEnabled && !!provider?.source && !!docsVersion,
+  })
 
   // Auto-select first doc when Documentation tab is opened with no selection
   useEffect(() => {
@@ -164,6 +190,78 @@ export function useProviderDetail() {
     )
   }, [activeTab, docParam, docs, setSearchParams])
 
+  // =========================================================================
+  // Mutations
+  // =========================================================================
+
+  const deleteProviderMutation = useMutation({
+    mutationFn: (params: ProviderRouteParams) => api.deleteProvider(params.namespace, params.type),
+    onSuccess: () => {
+      navigate('/providers')
+    },
+    onError: (err: unknown) => {
+      console.error('Failed to delete provider:', err)
+      setError(getErrorMessage(err, 'Failed to delete provider. Please try again.'))
+    },
+    onSettled: () => {
+      setDeleteProviderDialogOpen(false)
+    },
+  })
+
+  const deleteVersionMutation = useMutation({
+    mutationFn: (args: ProviderRouteParams & { version: string }) =>
+      api.deleteProviderVersion(args.namespace, args.type, args.version),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.providers.detail(namespace ?? '', type ?? ''),
+      })
+      setVersionToDelete(null)
+    },
+    onError: (err: unknown) => {
+      console.error('Failed to delete version:', err)
+      setError(getErrorMessage(err, 'Failed to delete version. Please try again.'))
+    },
+    onSettled: () => {
+      setDeleteVersionDialogOpen(false)
+    },
+  })
+
+  const deprecateVersionMutation = useMutation({
+    mutationFn: (args: ProviderRouteParams & { version: string; message?: string }) =>
+      api.deprecateProviderVersion(args.namespace, args.type, args.version, args.message),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.providers.detail(namespace ?? '', type ?? ''),
+      })
+      setDeprecationMessage('')
+    },
+    onError: (err: unknown) => {
+      console.error('Failed to deprecate version:', err)
+      setError(getErrorMessage(err, 'Failed to deprecate version. Please try again.'))
+    },
+    onSettled: () => {
+      setDeprecateDialogOpen(false)
+    },
+  })
+
+  const undeprecateVersionMutation = useMutation({
+    mutationFn: (args: ProviderRouteParams & { version: string }) =>
+      api.undeprecateProviderVersion(args.namespace, args.type, args.version),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.providers.detail(namespace ?? '', type ?? ''),
+      })
+    },
+    onError: (err: unknown) => {
+      console.error('Failed to remove deprecation:', err)
+      setError(getErrorMessage(err, 'Failed to remove deprecation. Please try again.'))
+    },
+  })
+
+  // =========================================================================
+  // Handler wrappers (preserve existing call signatures for the page)
+  // =========================================================================
+
   const handleCopySource = () => {
     if (!provider || !selectedVersion) return
 
@@ -179,38 +277,14 @@ export function useProviderDetail() {
     setTimeout(() => setCopiedChecksum(null), 2000)
   }
 
-  const handleDeleteProvider = async () => {
-    if (!namespace || !type) return
-
-    try {
-      setDeleting(true)
-      await api.deleteProvider(namespace, type)
-      navigate('/providers')
-    } catch (err: unknown) {
-      console.error('Failed to delete provider:', err)
-      setError(getErrorMessage(err, 'Failed to delete provider. Please try again.'))
-    } finally {
-      setDeleting(false)
-      setDeleteProviderDialogOpen(false)
-    }
+  const handleDeleteProvider = () => {
+    if (!routeParams) return
+    deleteProviderMutation.mutate(routeParams)
   }
 
-  const handleDeleteVersion = async () => {
-    if (!namespace || !type || !versionToDelete) return
-
-    try {
-      setDeleting(true)
-      await api.deleteProviderVersion(namespace, type, versionToDelete)
-      // Reload the provider details
-      await loadProviderDetails()
-      setVersionToDelete(null)
-    } catch (err: unknown) {
-      console.error('Failed to delete version:', err)
-      setError(getErrorMessage(err, 'Failed to delete version. Please try again.'))
-    } finally {
-      setDeleting(false)
-      setDeleteVersionDialogOpen(false)
-    }
+  const handleDeleteVersion = () => {
+    if (!routeParams || !versionToDelete) return
+    deleteVersionMutation.mutate({ ...routeParams, version: versionToDelete })
   }
 
   const openDeleteVersionDialog = (version: string) => {
@@ -218,27 +292,13 @@ export function useProviderDetail() {
     setDeleteVersionDialogOpen(true)
   }
 
-  const handleDeprecateVersion = async () => {
-    if (!namespace || !type || !selectedVersion) return
-
-    try {
-      setDeprecating(true)
-      await api.deprecateProviderVersion(
-        namespace,
-        type,
-        selectedVersion.version,
-        deprecationMessage || undefined,
-      )
-      // Reload the provider details
-      await loadProviderDetails()
-      setDeprecationMessage('')
-    } catch (err: unknown) {
-      console.error('Failed to deprecate version:', err)
-      setError(getErrorMessage(err, 'Failed to deprecate version. Please try again.'))
-    } finally {
-      setDeprecating(false)
-      setDeprecateDialogOpen(false)
-    }
+  const handleDeprecateVersion = () => {
+    if (!routeParams || !selectedVersion) return
+    deprecateVersionMutation.mutate({
+      ...routeParams,
+      version: selectedVersion.version,
+      message: deprecationMessage || undefined,
+    })
   }
 
   const handlePublishNewVersion = () => {
@@ -250,20 +310,9 @@ export function useProviderDetail() {
     })
   }
 
-  const handleUndeprecateVersion = async () => {
-    if (!namespace || !type || !selectedVersion) return
-
-    try {
-      setDeprecating(true)
-      await api.undeprecateProviderVersion(namespace, type, selectedVersion.version)
-      // Reload the provider details
-      await loadProviderDetails()
-    } catch (err: unknown) {
-      console.error('Failed to remove deprecation:', err)
-      setError(getErrorMessage(err, 'Failed to remove deprecation. Please try again.'))
-    } finally {
-      setDeprecating(false)
-    }
+  const handleUndeprecateVersion = () => {
+    if (!routeParams || !selectedVersion) return
+    undeprecateVersionMutation.mutate({ ...routeParams, version: selectedVersion.version })
   }
 
   const handleTabChange = (_: SyntheticEvent, newValue: number) => {
@@ -357,7 +406,7 @@ provider "${name}" {
     // Delete provider dialog
     deleteProviderDialogOpen,
     setDeleteProviderDialogOpen,
-    deleting,
+    deleting: deleteProviderMutation.isPending || deleteVersionMutation.isPending,
     // Delete version dialog
     deleteVersionDialogOpen,
     setDeleteVersionDialogOpen,
@@ -368,7 +417,7 @@ provider "${name}" {
     setDeprecateDialogOpen,
     deprecationMessage,
     setDeprecationMessage,
-    deprecating,
+    deprecating: deprecateVersionMutation.isPending || undeprecateVersionMutation.isPending,
     // Documentation tab
     activeTab,
     hasDocs,

--- a/frontend/src/pages/__tests__/ProviderDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/ProviderDetailPage.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
 // Mock api
 const searchProvidersMock = vi.fn()
@@ -50,13 +51,23 @@ vi.mock('../../services/errorReporting', () => ({
 import ProviderDetailPage from '../ProviderDetailPage'
 import { captureError } from '../../services/errorReporting'
 
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  })
+}
+
 function renderPage(path = '/providers/hashicorp/aws') {
+  // A fresh client per render, so provider data cached by one test can never
+  // satisfy the next one's query and hide a missing fetch.
   return render(
-    <MemoryRouter initialEntries={[path]}>
-      <Routes>
-        <Route path="/providers/:namespace/:type" element={<ProviderDetailPage />} />
-      </Routes>
-    </MemoryRouter>,
+    <QueryClientProvider client={createQueryClient()}>
+      <MemoryRouter initialEntries={[path]}>
+        <Routes>
+          <Route path="/providers/:namespace/:type" element={<ProviderDetailPage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
   )
 }
 
@@ -131,6 +142,16 @@ describe('ProviderDetailPage', () => {
         context: 'Failed to load provider details',
       }),
     )
+  })
+
+  // A namespace/type that matches nothing is a cacheable answer, not a transport
+  // failure: it must not be retried and must not be reported as an app error.
+  it('does not report a not-found provider to telemetry', async () => {
+    searchProvidersMock.mockResolvedValue({ providers: [] })
+    getProviderVersionsMock.mockResolvedValue({ versions: [] })
+    renderPage()
+    await waitFor(() => expect(screen.getByText(/provider not found/i)).toBeInTheDocument())
+    expect(captureError).not.toHaveBeenCalled()
   })
 
   it('renders provider details after loading', async () => {

--- a/frontend/src/services/__tests__/queryKeys.test.ts
+++ b/frontend/src/services/__tests__/queryKeys.test.ts
@@ -84,6 +84,24 @@ describe('queryKeys', () => {
       const key = queryKeys.providers.versions('hashicorp', 'aws')
       expect(key).toEqual(['providers', 'versions', 'hashicorp', 'aws'])
     })
+
+    it('docs key includes namespace/type/version', () => {
+      const key = queryKeys.providers.docs('hashicorp', 'aws', '5.0.0')
+      expect(key).toEqual(['providers', 'docs', 'hashicorp', 'aws', '5.0.0'])
+    })
+
+    it('docs key changes with the version, so one version cannot serve another', () => {
+      expect(queryKeys.providers.docs('hashicorp', 'aws', '5.0.0')).not.toEqual(
+        queryKeys.providers.docs('hashicorp', 'aws', '4.0.0'),
+      )
+    })
+
+    it('docs key is not a prefix collision with the detail key', () => {
+      // invalidateQueries(detail) must not sweep the doc index away with it.
+      expect(queryKeys.providers.docs('hashicorp', 'aws', '5.0.0').slice(0, 2)).not.toEqual(
+        queryKeys.providers.detail('hashicorp', 'aws').slice(0, 2),
+      )
+    })
   })
 
   describe('dashboard', () => {

--- a/frontend/src/services/queryKeys.ts
+++ b/frontend/src/services/queryKeys.ts
@@ -36,6 +36,8 @@ export const queryKeys = {
       [...queryKeys.providers._def, 'detail', namespace, type] as const,
     versions: (namespace: string, type: string) =>
       [...queryKeys.providers._def, 'versions', namespace, type] as const,
+    docs: (namespace: string, type: string, version: string) =>
+      [...queryKeys.providers._def, 'docs', namespace, type, version] as const,
   },
   dashboard: {
     _def: ['dashboard'] as const,


### PR DESCRIPTION
Closes #674

## What the issue claimed, and what is actually there

Verified against `main`. The issue is accurate, and its line reference (`useProviderDetail.ts:1-90`) is stale — the hook is 394 lines, not 90 — but every claim holds:

| Concern | `useProviderDetail` (before) | `useModuleDetail` |
| --- | --- | --- |
| Read | `useEffect` → `loadProviderDetails()` `useCallback` | `useQuery` |
| Loading | `useState(true)` + `finally { setLoading(false) }` | `isLoading` |
| Error | `useState<string\|null>` + `try/catch` | `useState` derived from the query's `error` |
| Refetch after write | `await loadProviderDetails()` inline in 3 handlers | `queryClient.invalidateQueries` in `onSuccess` |
| Pending flags | `deleting` / `deprecating` `useState` pairs | `mutation.isPending` |
| Caching / dedup | none — every mount refetches, every consumer fetches its own copy | one cache entry per key |
| Retry | none | `retryQuery` from the shared client (once, 5xx only) |
| Doc index | `useEffect` + a `cancelled` flag + `docsLoading` `useState` | n/a (module docs already a `useQuery`) |

Two things worth adding to the issue's account:

1. **The stale-response race is real, not theoretical.** `loadProviderDetails` had no cancellation at all — only the doc-index effect did. Changing route params while a request was in flight let the older response call `setProvider`/`setVersions` last and win.
2. **The doc index leaked across versions.** The fetch was keyed by nothing; `docs` kept whatever the previous provider/version had loaded until the next fetch resolved.

## Behavioural bug found, fixed deliberately (not smuggled in as "refactor")

**The version the user selected was discarded on every refetch.** `loadProviderDetails` ended with `setSelectedVersion(sortedVersions[0])` unconditionally, and it ran after every mutation. So: select 4.0.0 → deprecate it → the reload snaps the detail panel back to 5.0.0, and the user never sees the deprecation they just made. `useModuleDetail` already guarded this ("or preserve current selection on refetch"); the provider page now uses the same effect. Covered by `keeps the version the user picked when a mutation refetches the provider`, mutation-verified (M4).

The companion test `picks up the refetched version row rather than the stale one` (M5) pins the other half: the selection is preserved *by version string* and re-points at the freshly fetched row, so the panel does not keep rendering the pre-mutation copy.

## Other intended consequences of the port

- A mutation-triggered refetch is now a background refetch. Previously each write set the shared `loading` flag, so the whole page was replaced by a spinner after every delete/deprecate. It no longer is — same as the module page.
- Load failures now go through the shared client's retry policy (once for 5xx/network, never for 4xx — `src/queryClient.ts`). Telemetry still reports once per settled error, because `captureError` moved to the error-derivation effect rather than sitting inside the query function.
- The doc index is no longer refetched when an unrelated version is deleted or deprecated. Doc content is per-version immutable mirror data, and the key is `(namespace, type, version)`.

Explicitly held constant: the error copy (`Provider not found`, `Failed to load provider details. Please try again.`, and the three mutation fallbacks), the `console.error` calls, `captureError`'s exact argument and `context`, dialog open/close timing (`onSettled`), `versionToDelete` surviving a failed delete, `deprecationMessage` clearing only on success, and every derived value (`hasDocs`, `githubUrl`, `changelogUrl`, `getTerraformExample`).

A provider that matches nothing is returned as **data** (`{ provider: null, versions: [] }`) rather than thrown, which is what keeps it off the retry path and out of telemetry — matching the old early-`return`.

## Scope

No hook factory, no shared abstraction. `useModuleDetail` is untouched. The only shared change is one new query key (`queryKeys.providers.docs`); `queryKeys.providers.detail` already existed and was unused.

## Mutation table

Every guard was broken, watched fail, and restored from a `cp` backup.

| # | Mutation applied to the fix | Test that must go red | Result |
| --- | --- | --- | --- |
| M1 | drop `invalidateQueries` from `deleteVersionMutation.onSuccess` | `reloads the provider after deleting a version` | failed ✅ |
| M2 | drop `invalidateQueries` from `deprecateVersionMutation.onSuccess` | `reloads the provider after deprecating a version` | failed ✅ |
| M3 | drop `invalidateQueries` from `undeprecateVersionMutation.onSuccess` | `reloads the provider after removing a deprecation` | failed ✅ |
| M4 | `setSelectedVersion(versions[0])` (the old reset) | `keeps the version the user picked when a mutation refetches the provider` | failed ✅ |
| M5 | `setSelectedVersion((prev) => prev ?? versions[0])` (keep the stale row) | `picks up the refetched version row rather than the stale one` | failed ✅ |
| M6 | drop the version from the docs query key | `caches the doc index per version instead of refetching on every switch` | failed ✅ |
| M7 | append `Math.random()` to the detail query key | `dedupes concurrent readers of the same provider into one request` | failed ✅ |
| M8 | move `invalidateQueries` to `onSettled` (so a failed write refetches) | `reports a failure to deprecate without leaving the dialog open` | failed ✅ |
| M9 | clear `versionToDelete` in `onSettled` | `reports a failure to delete a version and keeps the queued version` | failed ✅ |
| M10 | delete the `captureError` call | `reports a failed provider details load to telemetry` | failed ✅ |
| M11 | `setError(null)` instead of `'Provider not found'` | `surfaces a not-found error when no provider matches the route` | failed ✅ |
| M12 | `throw` on not-found instead of returning it as data | `does not report a not-found provider to telemetry` | failed ✅ |
| M13 | drop `navigate('/providers')` from `deleteProviderMutation.onSuccess` | `deletes the provider and navigates away` | failed ✅ |
| M14 | give the docs key the `detail` prefix | `docs key is not a prefix collision with the detail key` | failed ✅ |

M4 is the reason the test fixture returns *changed* rows across the two fetches: with identical responses React Query's structural sharing hands back the same array, the selection effect never re-runs, and the assertion held even for a hook that resets the selection. It passed for the wrong reason until the fixture was fixed — caught by M4 reporting STILL PASSED on the first run.

## Verification

Baseline before any edit — `useProviderDetail` + `useModuleDetail` + `semver` + `ProviderDetailPage`: 100 passed. After: the same files are 140 passed (22 hook tests, up from 14).

- `npx tsc --noEmit` — clean
- `npm run lint` (`eslint . --max-warnings 0`) — clean
- `npm run test:coverage` — **150 files, 2250 tests passed**, thresholds met. `useProviderDetail.ts` at 92.5% lines / 88.5% statements / 78.8% branches.

## Left undone

- `queryKeys.providers.versions` is still unused (it was unused before; the detail query fetches provider and versions together under one key, as the module hook does). Not removed — out of scope.
- The provider read still goes through `searchProviders({ query: type, limit: 100 })` and filters client-side rather than hitting `getProvider(namespace, type)`. That is a pre-existing backend-shaped oddity, unchanged here; changing it would alter what the UI shows.
- No `useProviderDetail`/`useModuleDetail` shared factory. The duplication is idiom-level, not code-level, and the two hooks' queries differ enough that a factory would cost more than it saves.
