### PR TITLE
refactor(terraform-mirror): split TerraformMirrorPage into its five dialog flows

### DIFF
--- a/frontend/src/pages/admin/TerraformMirrorPage.tsx
+++ b/frontend/src/pages/admin/TerraformMirrorPage.tsx
@@ -10,12 +10,8 @@ import {
   Alert,
   Box,
   Button,
-  Card,
-  CardActions,
-  CardContent,
   Chip,
   CircularProgress,
-  Collapse,
   Container,
   Dialog,
   DialogActions,
@@ -23,7 +19,6 @@ import {
   DialogTitle,
   FormControlLabel,
   Grid,
-  IconButton,
   MenuItem,
   Paper,
   Switch,
@@ -34,35 +29,10 @@ import {
   TableHead,
   TableRow,
   TextField,
-  Tooltip,
   Typography,
 } from '@mui/material'
-
-/** Known Terraform binary platform combinations (os/arch). */
-const KNOWN_PLATFORMS = [
-  'linux/amd64',
-  'linux/arm64',
-  'linux/386',
-  'linux/arm',
-  'darwin/amd64',
-  'darwin/arm64',
-  'windows/amd64',
-  'windows/386',
-  'windows/arm64',
-  'freebsd/amd64',
-  'freebsd/386',
-  'freebsd/arm',
-] as const
 import AddIcon from '@mui/icons-material/Add'
-import CheckCircleIcon from '@mui/icons-material/CheckCircle'
-import DeleteIcon from '@mui/icons-material/Delete'
-import EditIcon from '@mui/icons-material/Edit'
-import ErrorIcon from '@mui/icons-material/Error'
-import ExpandLessIcon from '@mui/icons-material/ExpandLess'
-import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
-import HistoryIcon from '@mui/icons-material/History'
 import RefreshIcon from '@mui/icons-material/Refresh'
-import SyncIcon from '@mui/icons-material/Sync'
 
 import api from '../../services/api'
 import { useStatusMessage } from '../../hooks/useStatusMessage'
@@ -73,450 +43,20 @@ import {
   type TerraformMirrorConfig,
   type TerraformMirrorStatusResponse,
   type TerraformVersion,
-  type TerraformVersionPlatform,
   type TerraformSyncHistory,
   type CreateTerraformMirrorConfigRequest,
   type UpdateTerraformMirrorConfigRequest,
-  syncStatusColor,
   parsePlatformFilter,
 } from '../../types/terraform_mirror'
-
-// ---------------------------------------------------------------------------
-// Helper chip components
-// ---------------------------------------------------------------------------
-
-const SyncStatusChip: React.FC<{ status: string; size?: 'small' | 'medium' }> = ({
-  status,
-  size = 'small',
-}) => (
-  <Chip
-    label={status}
-    color={syncStatusColor(status)}
-    size={size}
-    icon={
-      status === 'synced' || status === 'success' ? (
-        <CheckCircleIcon />
-      ) : status === 'failed' ? (
-        <ErrorIcon />
-      ) : undefined
-    }
-  />
-)
-
-const ToolChip: React.FC<{ tool: string }> = ({ tool }) => {
-  const color = tool === 'terraform' ? 'primary' : tool === 'opentofu' ? 'secondary' : 'default'
-  return <Chip label={tool} size="small" color={color} variant="outlined" />
-}
-
-// ---------------------------------------------------------------------------
-// Version row with expandable platform list
-// ---------------------------------------------------------------------------
-
-const VersionRow: React.FC<{
-  version: TerraformVersion
-  configId: string
-  onDelete: (v: TerraformVersion) => void
-  canManage: boolean
-}> = ({ version, configId, onDelete, canManage }) => {
-  const { t } = useTranslation()
-  const [open, setOpen] = useState(false)
-  const [platforms, setPlatforms] = useState<TerraformVersionPlatform[] | null>(null)
-  const [loadingPlatforms, setLoadingPlatforms] = useState(false)
-
-  const handleExpand = async () => {
-    if (!open && platforms === null) {
-      setLoadingPlatforms(true)
-      try {
-        const data = await api.listTerraformVersionPlatforms(configId, version.version)
-        setPlatforms(data)
-      } catch {
-        setPlatforms([])
-      } finally {
-        setLoadingPlatforms(false)
-      }
-    }
-    setOpen((prev) => !prev)
-  }
-
-  return (
-    <>
-      <TableRow hover sx={{ '& > *': { borderBottom: 'unset' } }}>
-        <TableCell>
-          <IconButton
-            size="small"
-            aria-label={t('admin.terraformMirror.ariaToggleVersionDetails')}
-            onClick={handleExpand}
-          >
-            {open ? <ExpandLessIcon /> : <ExpandMoreIcon />}
-          </IconButton>
-        </TableCell>
-        <TableCell>
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-            <Typography
-              variant="body2"
-              sx={{
-                fontFamily: 'monospace',
-              }}
-            >
-              {version.version}
-            </Typography>
-            {version.is_latest && (
-              <Chip label={t('admin.terraformMirror.chipLatest')} color="primary" size="small" />
-            )}
-            {version.is_deprecated && (
-              <Chip
-                label={t('admin.terraformMirror.chipDeprecated')}
-                color="warning"
-                size="small"
-              />
-            )}
-          </Box>
-        </TableCell>
-        <TableCell>
-          <SyncStatusChip status={version.sync_status} />
-        </TableCell>
-        <TableCell>
-          {version.approval_status && (
-            <Chip
-              label={t(`admin.versionApprovals.status.${version.approval_status}`)}
-              size="small"
-              color={
-                version.approval_status === 'approved'
-                  ? 'success'
-                  : version.approval_status === 'rejected'
-                    ? 'error'
-                    : 'warning'
-              }
-            />
-          )}
-        </TableCell>
-        <TableCell>
-          {version.synced_at ? new Date(version.synced_at).toLocaleString() : '—'}
-        </TableCell>
-        <TableCell align="right">
-          {canManage && (
-            <Tooltip title={t('admin.terraformMirror.tooltipDeleteVersion')}>
-              <span>
-                <IconButton
-                  size="small"
-                  aria-label={t('admin.terraformMirror.ariaDeleteVersion')}
-                  color="error"
-                  onClick={() => onDelete(version)}
-                  disabled={version.sync_status === 'syncing'}
-                >
-                  <DeleteIcon fontSize="small" />
-                </IconButton>
-              </span>
-            </Tooltip>
-          )}
-        </TableCell>
-      </TableRow>
-      <TableRow>
-        <TableCell colSpan={6} sx={{ pb: 0, pt: 0 }}>
-          <Collapse in={open} unmountOnExit>
-            <Box sx={{ m: 1, mb: 2 }}>
-              {loadingPlatforms ? (
-                <CircularProgress size={20} />
-              ) : platforms && platforms.length > 0 ? (
-                <Table size="small">
-                  <TableHead>
-                    <TableRow>
-                      <TableCell>OS</TableCell>
-                      <TableCell>{t('admin.terraformMirror.thArch')}</TableCell>
-                      <TableCell>{t('admin.terraformMirror.thFilename')}</TableCell>
-                      <TableCell>{t('admin.terraformMirror.thStatus')}</TableCell>
-                      <TableCell>SHA256</TableCell>
-                      <TableCell>GPG</TableCell>
-                    </TableRow>
-                  </TableHead>
-                  <TableBody>
-                    {platforms.map((p) => (
-                      <TableRow key={p.id}>
-                        <TableCell>{p.os}</TableCell>
-                        <TableCell>{p.arch}</TableCell>
-                        <TableCell>
-                          <Typography
-                            variant="caption"
-                            sx={{
-                              fontFamily: 'monospace',
-                              wordBreak: 'break-all',
-                            }}
-                          >
-                            {p.filename}
-                          </Typography>
-                        </TableCell>
-                        <TableCell>
-                          <SyncStatusChip status={p.sync_status} />
-                        </TableCell>
-                        <TableCell>
-                          {p.sha256_verified ? (
-                            <CheckCircleIcon color="success" fontSize="small" />
-                          ) : (
-                            <ErrorIcon color="disabled" fontSize="small" />
-                          )}
-                        </TableCell>
-                        <TableCell>
-                          {p.gpg_verified ? (
-                            <CheckCircleIcon color="success" fontSize="small" />
-                          ) : (
-                            <ErrorIcon color="disabled" fontSize="small" />
-                          )}
-                        </TableCell>
-                      </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
-              ) : (
-                <Typography
-                  variant="body2"
-                  sx={{
-                    color: 'text.secondary',
-                  }}
-                >
-                  {t('admin.terraformMirror.noPlatformsSynced')}
-                </Typography>
-              )}
-            </Box>
-          </Collapse>
-        </TableCell>
-      </TableRow>
-    </>
-  )
-}
-
-// ---------------------------------------------------------------------------
-// Config card
-// ---------------------------------------------------------------------------
-
-const ConfigCard: React.FC<{
-  config: TerraformMirrorConfig
-  status?: TerraformMirrorStatusResponse
-  onEdit: (c: TerraformMirrorConfig) => void
-  onDelete: (c: TerraformMirrorConfig) => void
-  onSync: (c: TerraformMirrorConfig) => void
-  onViewVersions: (c: TerraformMirrorConfig) => void
-  onViewHistory: (c: TerraformMirrorConfig) => void
-  syncing: boolean
-  canManage: boolean
-}> = ({
-  config,
-  status,
-  onEdit,
-  onDelete,
-  onSync,
-  onViewVersions,
-  onViewHistory,
-  syncing,
-  canManage,
-}) => {
-  const { t } = useTranslation()
-  return (
-    <Card variant="outlined">
-      <CardContent>
-        <Box
-          sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', mb: 1 }}
-        >
-          <Typography variant="h6" sx={{ wordBreak: 'break-word' }}>
-            {config.name}
-          </Typography>
-          <Box sx={{ display: 'flex', gap: 0.5, ml: 1, flexShrink: 0 }}>
-            <ToolChip tool={config.tool} />
-            <Chip
-              label={
-                config.enabled
-                  ? t('admin.terraformMirror.chipEnabled')
-                  : t('admin.terraformMirror.chipDisabled')
-              }
-              color={config.enabled ? 'success' : 'default'}
-              size="small"
-            />
-          </Box>
-        </Box>
-
-        {config.description && (
-          <Typography
-            variant="body2"
-            sx={{
-              color: 'text.secondary',
-              mb: 1,
-            }}
-          >
-            {config.description}
-          </Typography>
-        )}
-
-        <Typography
-          variant="body2"
-          noWrap
-          sx={{
-            color: 'text.secondary',
-          }}
-        >
-          {config.upstream_url}
-        </Typography>
-
-        {status && (
-          <Box
-            sx={{
-              display: 'flex',
-              gap: 1,
-              flexWrap: 'wrap',
-              mt: 1,
-            }}
-          >
-            <Chip
-              size="small"
-              label={t('admin.terraformMirror.chipVersionCount', { count: status.version_count })}
-              variant="outlined"
-            />
-            <Chip
-              size="small"
-              label={t('admin.terraformMirror.chipPlatformCount', { count: status.platform_count })}
-              variant="outlined"
-            />
-            {status.pending_count > 0 && (
-              <Chip
-                size="small"
-                label={t('admin.terraformMirror.chipPendingCount', { count: status.pending_count })}
-                variant="outlined"
-                color="warning"
-              />
-            )}
-          </Box>
-        )}
-
-        <Box sx={{ mt: 1.5 }}>
-          {config.last_sync_status ? (
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-              <SyncStatusChip status={config.last_sync_status} />
-              {config.last_sync_at && (
-                <Typography
-                  variant="caption"
-                  sx={{
-                    color: 'text.secondary',
-                  }}
-                >
-                  {new Date(config.last_sync_at).toLocaleString()}
-                </Typography>
-              )}
-            </Box>
-          ) : (
-            <Typography
-              variant="caption"
-              sx={{
-                color: 'text.secondary',
-              }}
-            >
-              {t('admin.terraformMirror.neverSynced')}
-            </Typography>
-          )}
-        </Box>
-      </CardContent>
-
-      <CardActions sx={{ justifyContent: 'space-between', flexWrap: 'wrap', gap: 0.5 }}>
-        <Box>
-          <Tooltip title={t('admin.terraformMirror.tooltipViewDetails')}>
-            <Button size="small" onClick={() => onViewVersions(config)}>
-              {t('admin.terraformMirror.viewDetails')}
-            </Button>
-          </Tooltip>
-          <Tooltip title={t('admin.terraformMirror.tooltipViewHistory')}>
-            <IconButton
-              size="small"
-              aria-label={t('admin.terraformMirror.ariaViewHistory')}
-              onClick={() => onViewHistory(config)}
-            >
-              <HistoryIcon fontSize="small" />
-            </IconButton>
-          </Tooltip>
-        </Box>
-        {canManage && (
-          <Box>
-            <Tooltip title={t('admin.terraformMirror.tooltipTriggerSync')}>
-              <span>
-                <IconButton
-                  size="small"
-                  aria-label={t('admin.terraformMirror.ariaSyncMirror')}
-                  onClick={() => onSync(config)}
-                  disabled={syncing || !config.enabled}
-                >
-                  <SyncIcon fontSize="small" />
-                </IconButton>
-              </span>
-            </Tooltip>
-            <Tooltip title={t('admin.terraformMirror.tooltipEditConfig')}>
-              <IconButton
-                size="small"
-                aria-label={t('admin.terraformMirror.ariaEditMirror')}
-                onClick={() => onEdit(config)}
-              >
-                <EditIcon fontSize="small" />
-              </IconButton>
-            </Tooltip>
-            <Tooltip title={t('admin.terraformMirror.tooltipDeleteMirror')}>
-              <IconButton
-                size="small"
-                aria-label={t('admin.terraformMirror.ariaDeleteMirror')}
-                color="error"
-                onClick={() => onDelete(config)}
-              >
-                <DeleteIcon fontSize="small" />
-              </IconButton>
-            </Tooltip>
-          </Box>
-        )}
-      </CardActions>
-    </Card>
-  )
-}
-
-// ---------------------------------------------------------------------------
-// Tool defaults
-// ---------------------------------------------------------------------------
-
-const TOOL_DEFAULT_URLS: Record<string, string> = {
-  terraform: 'https://releases.hashicorp.com',
-  opentofu: 'https://github.com/opentofu/opentofu',
-  packer: 'https://releases.hashicorp.com',
-  sentinel: 'https://releases.hashicorp.com',
-  opa: 'https://github.com/open-policy-agent/opa',
-  'terraform-docs': 'https://github.com/terraform-docs/terraform-docs',
-}
-
-/** Returns the canonical upstream URL for a known tool, or '' for custom. */
-function toolDefaultUrl(tool: string): string {
-  return TOOL_DEFAULT_URLS[tool] ?? ''
-}
-
-/**
- * SUPPORTED_TOOLS is the single source of truth for the selectable upstream
- * tools in both the create and edit dialogs, so a new tool is added in exactly
- * one place. "custom" is rendered separately because its label is translated.
- */
-const SUPPORTED_TOOLS: readonly { value: string; label: string }[] = [
-  { value: 'terraform', label: 'Terraform (HashiCorp)' },
-  { value: 'opentofu', label: 'OpenTofu' },
-  { value: 'packer', label: 'Packer (HashiCorp)' },
-  { value: 'sentinel', label: 'Sentinel (HashiCorp)' },
-  { value: 'opa', label: 'OPA (Open Policy Agent)' },
-  { value: 'terraform-docs', label: 'terraform-docs' },
-]
-
-// ---------------------------------------------------------------------------
-// Empty config form helpers
-// ---------------------------------------------------------------------------
-
-const emptyCreate = (): CreateTerraformMirrorConfigRequest => ({
-  name: '',
-  description: '',
-  tool: 'terraform',
-  upstream_url: toolDefaultUrl('terraform'),
-  gpg_verify: true,
-  stable_only: true,
-  enabled: true,
-  sync_interval_hours: 24,
-  requires_approval: true,
-})
+import { SyncStatusChip, ToolChip } from './terraformMirror/StatusChips'
+import MirrorConfigCard from './terraformMirror/MirrorConfigCard'
+import MirrorVersionRow from './terraformMirror/MirrorVersionRow'
+import {
+  KNOWN_PLATFORMS,
+  SUPPORTED_TOOLS,
+  emptyCreate,
+  toolDefaultUrl,
+} from './terraformMirror/constants'
 
 // ---------------------------------------------------------------------------
 // Main page
@@ -847,7 +387,7 @@ const TerraformMirrorPage: React.FC = () => {
                 const status = statusMap[cfg.id]
                 return (
                   <Grid size={{ xs: 12, md: 6 }} key={cfg.id}>
-                    <ConfigCard
+                    <MirrorConfigCard
                       config={cfg}
                       status={status}
                       onEdit={openEdit}
@@ -1282,7 +822,7 @@ const TerraformMirrorPage: React.FC = () => {
                       </TableHead>
                       <TableBody>
                         {versions.map((v) => (
-                          <VersionRow
+                          <MirrorVersionRow
                             key={v.id}
                             version={v}
                             configId={versionsConfig.id}

--- a/frontend/src/pages/admin/TerraformMirrorPage.tsx
+++ b/frontend/src/pages/admin/TerraformMirrorPage.tsx
@@ -5,27 +5,7 @@ import { queryKeys } from '../../services/queryKeys'
 import PageHeader from '../../components/PageHeader'
 import StatusAlerts from '../../components/StatusAlerts'
 import PageTitleIcon from '@mui/icons-material/GetApp'
-import {
-  Alert,
-  Box,
-  Button,
-  Chip,
-  CircularProgress,
-  Container,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
-  Grid,
-  Paper,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Typography,
-} from '@mui/material'
+import { Alert, Box, Button, CircularProgress, Container, Grid, Typography } from '@mui/material'
 import AddIcon from '@mui/icons-material/Add'
 import RefreshIcon from '@mui/icons-material/Refresh'
 
@@ -37,15 +17,17 @@ import ReleasesGPGKeyStatus from '../../components/ReleasesGPGKeyStatus'
 import {
   type TerraformMirrorConfig,
   type TerraformMirrorStatusResponse,
-  type TerraformVersion,
-  type TerraformSyncHistory,
 } from '../../types/terraform_mirror'
-import { SyncStatusChip, ToolChip } from './terraformMirror/StatusChips'
 import MirrorConfigCard from './terraformMirror/MirrorConfigCard'
-import MirrorVersionRow from './terraformMirror/MirrorVersionRow'
 import CreateMirrorDialog, { useCreateMirrorFlow } from './terraformMirror/CreateMirrorDialog'
 import EditMirrorDialog, { useEditMirrorFlow } from './terraformMirror/EditMirrorDialog'
 import DeleteMirrorDialog, { useDeleteMirrorFlow } from './terraformMirror/DeleteMirrorDialog'
+import {
+  DeleteVersionDialog,
+  MirrorVersionsDialog,
+  useMirrorVersionsFlow,
+} from './terraformMirror/MirrorVersionsDialog'
+import MirrorHistoryDialog, { useMirrorHistoryFlow } from './terraformMirror/MirrorHistoryDialog'
 
 // ---------------------------------------------------------------------------
 // Main page
@@ -64,25 +46,19 @@ const TerraformMirrorPage: React.FC = () => {
   const canManage = allowedScopes.includes('admin') || allowedScopes.includes('mirrors:manage')
   const status = useStatusMessage()
 
+  // The five dialog flows. Each hook owns its own dialog's state and requests;
+  // the page only holds the flow object so a card's button can open it and the
+  // matching dialog can render against it. The versions flow also owns the
+  // delete-version confirmation nested inside it, because confirming a delete
+  // reloads the version list behind it.
   const create = useCreateMirrorFlow(status)
-
   const edit = useEditMirrorFlow(status)
   const deleteMirror = useDeleteMirrorFlow(status)
-
-  // ---- versions dialog ----
-  const [versionsConfig, setVersionsConfig] = useState<TerraformMirrorConfig | null>(null)
-  const [versions, setVersions] = useState<TerraformVersion[]>([])
-  const [versionsLoading, setVersionsLoading] = useState(false)
-  const [deleteVersion, setDeleteVersion] = useState<TerraformVersion | null>(null)
-  const [deletingVersion, setDeletingVersion] = useState(false)
+  const versions = useMirrorVersionsFlow(status)
+  const history = useMirrorHistoryFlow()
 
   // ---- status overlay (per-card) ----
   const [statusMap, setStatusMap] = useState<Record<string, TerraformMirrorStatusResponse>>({})
-
-  // ---- history dialog ----
-  const [historyConfig, setHistoryConfig] = useState<TerraformMirrorConfig | null>(null)
-  const [history, setHistory] = useState<TerraformSyncHistory[]>([])
-  const [historyLoading, setHistoryLoading] = useState(false)
 
   // ---- sync in-progress ----
   const [syncingIds, setSyncingIds] = useState<Set<string>>(new Set())
@@ -134,64 +110,6 @@ const TerraformMirrorPage: React.FC = () => {
         next.delete(config.id)
         return next
       })
-    }
-  }
-
-  // ---------------------------------------------------------------------------
-  // Versions dialog
-  // ---------------------------------------------------------------------------
-  const openVersions = async (config: TerraformMirrorConfig) => {
-    setVersionsConfig(config)
-    setVersionsLoading(true)
-    setVersions([])
-    try {
-      const data = await api.listTerraformVersions(config.id, { synced: false })
-      const rows = data.versions ?? []
-      // Sort: latest first, then by version descending
-      const sorted = [...rows].sort((a, b) => {
-        if (a.is_latest !== b.is_latest) return a.is_latest ? -1 : 1
-        return b.version.localeCompare(a.version, undefined, { numeric: true })
-      })
-      setVersions(sorted)
-    } catch {
-      setVersions([])
-    } finally {
-      setVersionsLoading(false)
-    }
-  }
-
-  const handleDeleteVersion = async () => {
-    if (!deleteVersion || !versionsConfig) return
-    setDeletingVersion(true)
-    try {
-      await api.deleteTerraformVersion(versionsConfig.id, deleteVersion.version)
-      status.setSuccess(
-        t('admin.terraformMirror.versionDeleted', { version: deleteVersion.version }),
-      )
-      setDeleteVersion(null)
-      openVersions(versionsConfig)
-    } catch (err: unknown) {
-      status.setError(getErrorMessage(err, t('admin.terraformMirror.errDeleteVersion')))
-      setDeleteVersion(null)
-    } finally {
-      setDeletingVersion(false)
-    }
-  }
-
-  // ---------------------------------------------------------------------------
-  // History dialog
-  // ---------------------------------------------------------------------------
-  const openHistory = async (config: TerraformMirrorConfig) => {
-    setHistoryConfig(config)
-    setHistoryLoading(true)
-    setHistory([])
-    try {
-      const data = await api.getTerraformMirrorHistory(config.id, 20)
-      setHistory(data.history ?? [])
-    } catch {
-      setHistory([])
-    } finally {
-      setHistoryLoading(false)
     }
   }
 
@@ -268,8 +186,8 @@ const TerraformMirrorPage: React.FC = () => {
                       onEdit={edit.openDialog}
                       onDelete={deleteMirror.openDialog}
                       onSync={handleSync}
-                      onViewVersions={openVersions}
-                      onViewHistory={openHistory}
+                      onViewVersions={versions.openDialog}
+                      onViewHistory={history.openDialog}
                       syncing={syncingIds.has(cfg.id)}
                       canManage={canManage}
                     />
@@ -285,152 +203,11 @@ const TerraformMirrorPage: React.FC = () => {
 
           <DeleteMirrorDialog flow={deleteMirror} />
 
-          {/* ==================================================================
-          Versions Dialog
-      ================================================================== */}
-          {versionsConfig && (
-            <Dialog open onClose={() => setVersionsConfig(null)} maxWidth="lg" fullWidth>
-              <DialogTitle>
-                {t('admin.terraformMirror.versionsTitle', { name: versionsConfig.name })}
-                <Box component="span" sx={{ ml: 1 }}>
-                  <ToolChip tool={versionsConfig.tool} />
-                </Box>
-              </DialogTitle>
-              <DialogContent>
-                {versionsLoading ? (
-                  <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
-                    <CircularProgress />
-                  </Box>
-                ) : versions.length === 0 ? (
-                  <Alert severity="info">{t('admin.terraformMirror.noVersionsSynced')}</Alert>
-                ) : (
-                  <TableContainer component={Paper} variant="outlined">
-                    <Table size="small">
-                      <TableHead>
-                        <TableRow>
-                          <TableCell width={48} />
-                          <TableCell>{t('admin.terraformMirror.thVersion')}</TableCell>
-                          <TableCell>{t('admin.terraformMirror.thStatus')}</TableCell>
-                          <TableCell>{t('admin.terraformMirror.thApproval')}</TableCell>
-                          <TableCell>{t('admin.terraformMirror.thSyncedAt')}</TableCell>
-                          <TableCell align="right">
-                            {t('admin.terraformMirror.thActions')}
-                          </TableCell>
-                        </TableRow>
-                      </TableHead>
-                      <TableBody>
-                        {versions.map((v) => (
-                          <MirrorVersionRow
-                            key={v.id}
-                            version={v}
-                            configId={versionsConfig.id}
-                            onDelete={setDeleteVersion}
-                            canManage={canManage}
-                          />
-                        ))}
-                      </TableBody>
-                    </Table>
-                  </TableContainer>
-                )}
-              </DialogContent>
-              <DialogActions>
-                <Button onClick={() => setVersionsConfig(null)}>
-                  {t('admin.terraformMirror.close')}
-                </Button>
-              </DialogActions>
-            </Dialog>
-          )}
+          <MirrorVersionsDialog flow={versions} canManage={canManage} />
 
-          {/* ---- Delete Version Confirmation ---- */}
-          <Dialog open={!!deleteVersion} onClose={() => setDeleteVersion(null)}>
-            <DialogTitle>{t('admin.terraformMirror.deleteVersionTitle')}</DialogTitle>
-            <DialogContent>
-              <Typography>
-                {t('admin.terraformMirror.deleteVersionTextBefore')}
-                <strong>{deleteVersion?.version}</strong>
-                {t('admin.terraformMirror.deleteVersionTextAfter')}
-              </Typography>
-            </DialogContent>
-            <DialogActions>
-              <Button onClick={() => setDeleteVersion(null)}>
-                {t('admin.terraformMirror.cancel')}
-              </Button>
-              <Button color="error" onClick={handleDeleteVersion} disabled={deletingVersion}>
-                {deletingVersion ? (
-                  <CircularProgress size={18} />
-                ) : (
-                  t('admin.terraformMirror.delete')
-                )}
-              </Button>
-            </DialogActions>
-          </Dialog>
+          <DeleteVersionDialog flow={versions} />
 
-          {/* ==================================================================
-          History Dialog
-      ================================================================== */}
-          <Dialog
-            open={!!historyConfig}
-            onClose={() => setHistoryConfig(null)}
-            maxWidth="lg"
-            fullWidth
-          >
-            <DialogTitle>
-              {t('admin.terraformMirror.historyTitle', { name: historyConfig?.name })}
-            </DialogTitle>
-            <DialogContent>
-              {historyLoading ? (
-                <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
-                  <CircularProgress />
-                </Box>
-              ) : history.length === 0 ? (
-                <Alert severity="info">{t('admin.terraformMirror.noHistory')}</Alert>
-              ) : (
-                <TableContainer component={Paper} variant="outlined">
-                  <Table size="small">
-                    <TableHead>
-                      <TableRow>
-                        <TableCell>{t('admin.terraformMirror.thStarted')}</TableCell>
-                        <TableCell>{t('admin.terraformMirror.thCompleted')}</TableCell>
-                        <TableCell>{t('admin.terraformMirror.thTriggeredBy')}</TableCell>
-                        <TableCell>{t('admin.terraformMirror.thStatus')}</TableCell>
-                        <TableCell>{t('admin.terraformMirror.thVersions')}</TableCell>
-                        <TableCell>{t('admin.terraformMirror.thPlatforms')}</TableCell>
-                        <TableCell>{t('admin.terraformMirror.thFailures')}</TableCell>
-                      </TableRow>
-                    </TableHead>
-                    <TableBody>
-                      {history.map((h) => (
-                        <TableRow key={h.id} hover>
-                          <TableCell>{new Date(h.started_at).toLocaleString()}</TableCell>
-                          <TableCell>
-                            {h.completed_at ? new Date(h.completed_at).toLocaleString() : '—'}
-                          </TableCell>
-                          <TableCell>{h.triggered_by}</TableCell>
-                          <TableCell>
-                            <SyncStatusChip status={h.status} />
-                          </TableCell>
-                          <TableCell>{h.versions_synced}</TableCell>
-                          <TableCell>{h.platforms_synced}</TableCell>
-                          <TableCell>
-                            {h.versions_failed > 0 ? (
-                              <Chip label={h.versions_failed} color="error" size="small" />
-                            ) : (
-                              '0'
-                            )}
-                          </TableCell>
-                        </TableRow>
-                      ))}
-                    </TableBody>
-                  </Table>
-                </TableContainer>
-              )}
-            </DialogContent>
-            <DialogActions>
-              <Button onClick={() => setHistoryConfig(null)}>
-                {t('admin.terraformMirror.close')}
-              </Button>
-            </DialogActions>
-          </Dialog>
+          <MirrorHistoryDialog flow={history} />
         </Container>
       )}
     </Box>

--- a/frontend/src/pages/admin/TerraformMirrorPage.tsx
+++ b/frontend/src/pages/admin/TerraformMirrorPage.tsx
@@ -44,19 +44,14 @@ import {
   type TerraformMirrorStatusResponse,
   type TerraformVersion,
   type TerraformSyncHistory,
-  type CreateTerraformMirrorConfigRequest,
   type UpdateTerraformMirrorConfigRequest,
   parsePlatformFilter,
 } from '../../types/terraform_mirror'
 import { SyncStatusChip, ToolChip } from './terraformMirror/StatusChips'
 import MirrorConfigCard from './terraformMirror/MirrorConfigCard'
 import MirrorVersionRow from './terraformMirror/MirrorVersionRow'
-import {
-  KNOWN_PLATFORMS,
-  SUPPORTED_TOOLS,
-  emptyCreate,
-  toolDefaultUrl,
-} from './terraformMirror/constants'
+import CreateMirrorDialog, { useCreateMirrorFlow } from './terraformMirror/CreateMirrorDialog'
+import { KNOWN_PLATFORMS, SUPPORTED_TOOLS, toolDefaultUrl } from './terraformMirror/constants'
 
 // ---------------------------------------------------------------------------
 // Main page
@@ -75,11 +70,7 @@ const TerraformMirrorPage: React.FC = () => {
   const canManage = allowedScopes.includes('admin') || allowedScopes.includes('mirrors:manage')
   const status = useStatusMessage()
 
-  // ---- create dialog ----
-  const [createOpen, setCreateOpen] = useState(false)
-  const [createForm, setCreateForm] = useState<CreateTerraformMirrorConfigRequest>(emptyCreate())
-  const [createVersionFilter, setCreateVersionFilter] = useState('')
-  const [createPlatformFilter, setCreatePlatformFilter] = useState<string[]>([])
+  const create = useCreateMirrorFlow(status)
 
   // ---- edit dialog ----
   const [editConfig, setEditConfig] = useState<TerraformMirrorConfig | null>(null)
@@ -138,34 +129,6 @@ const TerraformMirrorPage: React.FC = () => {
       }
     })
   }, [configs])
-
-  // ---------------------------------------------------------------------------
-  // Create
-  // ---------------------------------------------------------------------------
-  const createMutation = useMutation({
-    mutationFn: async () => {
-      await api.createTerraformMirrorConfig({
-        ...createForm,
-        platform_filter: createPlatformFilter.length > 0 ? createPlatformFilter : undefined,
-        version_filter: createVersionFilter.trim() || undefined,
-      })
-    },
-    onSuccess: () => {
-      status.setSuccess(t('admin.terraformMirror.msgCreated', { name: createForm.name }))
-      setCreateOpen(false)
-      setCreateForm(emptyCreate())
-      setCreateVersionFilter('')
-      setCreatePlatformFilter([])
-      queryClient.invalidateQueries({ queryKey: queryKeys.terraformMirrors._def })
-    },
-    onError: (err: unknown) => {
-      status.setError(getErrorMessage(err, t('admin.terraformMirror.errCreate')))
-    },
-  })
-
-  const handleCreate = () => {
-    createMutation.mutate()
-  }
 
   // ---------------------------------------------------------------------------
   // Edit
@@ -345,16 +308,7 @@ const TerraformMirrorPage: React.FC = () => {
                   {t('admin.terraformMirror.refresh')}
                 </Button>
                 {canManage && (
-                  <Button
-                    variant="contained"
-                    startIcon={<AddIcon />}
-                    onClick={() => {
-                      setCreateForm(emptyCreate())
-                      setCreateVersionFilter('')
-                      setCreatePlatformFilter([])
-                      setCreateOpen(true)
-                    }}
-                  >
+                  <Button variant="contained" startIcon={<AddIcon />} onClick={create.openDialog}>
                     {t('admin.terraformMirror.addMirror')}
                   </Button>
                 )}
@@ -404,186 +358,7 @@ const TerraformMirrorPage: React.FC = () => {
             </Grid>
           )}
 
-          {/* ==================================================================
-          Create Dialog
-      ================================================================== */}
-          <Dialog open={createOpen} onClose={() => setCreateOpen(false)} maxWidth="sm" fullWidth>
-            <DialogTitle>{t('admin.terraformMirror.dialogTitleCreate')}</DialogTitle>
-            <DialogContent>
-              <Box sx={{ pt: 1, display: 'flex', flexDirection: 'column', gap: 2 }}>
-                <TextField
-                  label={t('admin.terraformMirror.labelName')}
-                  value={createForm.name}
-                  onChange={(e) => setCreateForm((prev) => ({ ...prev, name: e.target.value }))}
-                  helperText={t('admin.terraformMirror.helpName')}
-                  required
-                  fullWidth
-                />
-                <TextField
-                  label={t('admin.terraformMirror.labelDescription')}
-                  value={createForm.description ?? ''}
-                  onChange={(e) =>
-                    setCreateForm((prev) => ({ ...prev, description: e.target.value }))
-                  }
-                  fullWidth
-                />
-                <TextField
-                  select
-                  label={t('admin.terraformMirror.labelTool')}
-                  value={createForm.tool}
-                  onChange={(e) => {
-                    const newTool = e.target.value
-                    setCreateForm((prev) => {
-                      // Auto-update upstream URL only if it still matches the previous tool's default
-                      const prevDefault = toolDefaultUrl(prev.tool)
-                      const shouldUpdate =
-                        prev.upstream_url === prevDefault || prev.upstream_url === ''
-                      return {
-                        ...prev,
-                        tool: newTool,
-                        upstream_url: shouldUpdate ? toolDefaultUrl(newTool) : prev.upstream_url,
-                      }
-                    })
-                  }}
-                  fullWidth
-                >
-                  {SUPPORTED_TOOLS.map((toolOption) => (
-                    <MenuItem key={toolOption.value} value={toolOption.value}>
-                      {toolOption.label}
-                    </MenuItem>
-                  ))}
-                  <MenuItem value="custom">{t('admin.terraformMirror.menuCustom')}</MenuItem>
-                </TextField>
-                <TextField
-                  label={t('admin.terraformMirror.labelUpstreamUrl')}
-                  value={createForm.upstream_url}
-                  onChange={(e) =>
-                    setCreateForm((prev) => ({ ...prev, upstream_url: e.target.value }))
-                  }
-                  helperText={
-                    createForm.tool === 'opentofu'
-                      ? t('admin.terraformMirror.helpUrlOpentofu')
-                      : createForm.tool === 'terraform'
-                        ? t('admin.terraformMirror.helpUrlTerraform')
-                        : t('admin.terraformMirror.helpUrlCustom')
-                  }
-                  required
-                  fullWidth
-                />
-                <TextField
-                  label={t('admin.terraformMirror.labelSyncInterval')}
-                  type="number"
-                  value={createForm.sync_interval_hours ?? 24}
-                  onChange={(e) =>
-                    setCreateForm((prev) => ({
-                      ...prev,
-                      sync_interval_hours: parseInt(e.target.value, 10),
-                    }))
-                  }
-                  fullWidth
-                  slotProps={{
-                    htmlInput: { min: 1 },
-                  }}
-                />
-                <Box sx={{ display: 'flex', gap: 2 }}>
-                  <FormControlLabel
-                    control={
-                      <Switch
-                        checked={createForm.enabled ?? true}
-                        onChange={(e) =>
-                          setCreateForm((prev) => ({ ...prev, enabled: e.target.checked }))
-                        }
-                      />
-                    }
-                    label={t('admin.terraformMirror.labelEnabled')}
-                  />
-                  <FormControlLabel
-                    control={
-                      <Switch
-                        checked={createForm.gpg_verify ?? true}
-                        onChange={(e) =>
-                          setCreateForm((prev) => ({ ...prev, gpg_verify: e.target.checked }))
-                        }
-                      />
-                    }
-                    label={t('admin.terraformMirror.labelGpgVerify')}
-                  />
-                  <FormControlLabel
-                    control={
-                      <Switch
-                        checked={createForm.stable_only ?? false}
-                        onChange={(e) =>
-                          setCreateForm((prev) => ({ ...prev, stable_only: e.target.checked }))
-                        }
-                      />
-                    }
-                    label={t('admin.terraformMirror.labelStableOnly')}
-                  />
-                  <FormControlLabel
-                    control={
-                      <Switch
-                        checked={createForm.requires_approval ?? false}
-                        onChange={(e) =>
-                          setCreateForm((prev) => ({
-                            ...prev,
-                            requires_approval: e.target.checked,
-                          }))
-                        }
-                      />
-                    }
-                    label={t('admin.terraformMirror.labelRequiresApproval')}
-                  />
-                </Box>
-                <TextField
-                  label={t('admin.terraformMirror.labelVersionFilter')}
-                  value={createVersionFilter}
-                  onChange={(e) => setCreateVersionFilter(e.target.value)}
-                  helperText={t('admin.terraformMirror.helpVersionFilter')}
-                  fullWidth
-                />
-                <Autocomplete
-                  multiple
-                  options={KNOWN_PLATFORMS}
-                  value={createPlatformFilter}
-                  onChange={(_event, newValue) => setCreatePlatformFilter(newValue)}
-                  renderInput={(params) => (
-                    <TextField
-                      {...params}
-                      label={t('admin.terraformMirror.labelPlatformFilter')}
-                      placeholder={
-                        createPlatformFilter.length === 0
-                          ? t('admin.terraformMirror.placeholderAllPlatforms')
-                          : ''
-                      }
-                      helperText={t('admin.terraformMirror.helpPlatformFilter')}
-                      fullWidth
-                    />
-                  )}
-                  renderValue={(value, getItemProps) =>
-                    value.map((option, index) => (
-                      <Chip label={option} size="small" {...getItemProps({ index })} key={option} />
-                    ))
-                  }
-                />
-              </Box>
-            </DialogContent>
-            <DialogActions>
-              <Button onClick={() => setCreateOpen(false)}>
-                {t('admin.terraformMirror.cancel')}
-              </Button>
-              <Button
-                onClick={handleCreate}
-                variant="contained"
-                disabled={createMutation.isPending || !createForm.name || !createForm.upstream_url}
-              >
-                {createMutation.isPending ? (
-                  <CircularProgress size={18} />
-                ) : (
-                  t('admin.terraformMirror.create')
-                )}
-              </Button>
-            </DialogActions>
-          </Dialog>
+          <CreateMirrorDialog flow={create} />
 
           {/* ==================================================================
           Edit Dialog

--- a/frontend/src/pages/admin/TerraformMirrorPage.tsx
+++ b/frontend/src/pages/admin/TerraformMirrorPage.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { queryKeys } from '../../services/queryKeys'
 import PageHeader from '../../components/PageHeader'
 import StatusAlerts from '../../components/StatusAlerts'
@@ -45,6 +45,7 @@ import MirrorConfigCard from './terraformMirror/MirrorConfigCard'
 import MirrorVersionRow from './terraformMirror/MirrorVersionRow'
 import CreateMirrorDialog, { useCreateMirrorFlow } from './terraformMirror/CreateMirrorDialog'
 import EditMirrorDialog, { useEditMirrorFlow } from './terraformMirror/EditMirrorDialog'
+import DeleteMirrorDialog, { useDeleteMirrorFlow } from './terraformMirror/DeleteMirrorDialog'
 
 // ---------------------------------------------------------------------------
 // Main page
@@ -66,8 +67,7 @@ const TerraformMirrorPage: React.FC = () => {
   const create = useCreateMirrorFlow(status)
 
   const edit = useEditMirrorFlow(status)
-  // ---- delete dialog ----
-  const [deleteConfig, setDeleteConfig] = useState<TerraformMirrorConfig | null>(null)
+  const deleteMirror = useDeleteMirrorFlow(status)
 
   // ---- versions dialog ----
   const [versionsConfig, setVersionsConfig] = useState<TerraformMirrorConfig | null>(null)
@@ -117,29 +117,6 @@ const TerraformMirrorPage: React.FC = () => {
       }
     })
   }, [configs])
-
-  // ---------------------------------------------------------------------------
-  // Delete
-  // ---------------------------------------------------------------------------
-  const deleteMutation = useMutation({
-    mutationFn: async () => {
-      if (!deleteConfig) throw new Error('No config to delete')
-      await api.deleteTerraformMirrorConfig(deleteConfig.id)
-    },
-    onSuccess: () => {
-      status.setSuccess(t('admin.terraformMirror.msgDeleted', { name: deleteConfig?.name }))
-      setDeleteConfig(null)
-      queryClient.invalidateQueries({ queryKey: queryKeys.terraformMirrors._def })
-    },
-    onError: (err: unknown) => {
-      status.setError(getErrorMessage(err, t('admin.terraformMirror.errDelete')))
-    },
-  })
-
-  const handleDelete = () => {
-    if (!deleteConfig) return
-    deleteMutation.mutate()
-  }
 
   // ---------------------------------------------------------------------------
   // Sync
@@ -289,7 +266,7 @@ const TerraformMirrorPage: React.FC = () => {
                       config={cfg}
                       status={status}
                       onEdit={edit.openDialog}
-                      onDelete={setDeleteConfig}
+                      onDelete={deleteMirror.openDialog}
                       onSync={handleSync}
                       onViewVersions={openVersions}
                       onViewHistory={openHistory}
@@ -306,31 +283,7 @@ const TerraformMirrorPage: React.FC = () => {
 
           <EditMirrorDialog flow={edit} />
 
-          {/* ==================================================================
-          Delete Config Dialog
-      ================================================================== */}
-          <Dialog open={!!deleteConfig} onClose={() => setDeleteConfig(null)}>
-            <DialogTitle>{t('admin.terraformMirror.deleteConfigTitle')}</DialogTitle>
-            <DialogContent>
-              <Typography>
-                {t('admin.terraformMirror.deleteConfigTextBefore')}
-                <strong>{deleteConfig?.name}</strong>
-                {t('admin.terraformMirror.deleteConfigTextAfter')}
-              </Typography>
-            </DialogContent>
-            <DialogActions>
-              <Button onClick={() => setDeleteConfig(null)}>
-                {t('admin.terraformMirror.cancel')}
-              </Button>
-              <Button color="error" onClick={handleDelete} disabled={deleteMutation.isPending}>
-                {deleteMutation.isPending ? (
-                  <CircularProgress size={18} />
-                ) : (
-                  t('admin.terraformMirror.delete')
-                )}
-              </Button>
-            </DialogActions>
-          </Dialog>
+          <DeleteMirrorDialog flow={deleteMirror} />
 
           {/* ==================================================================
           Versions Dialog

--- a/frontend/src/pages/admin/TerraformMirrorPage.tsx
+++ b/frontend/src/pages/admin/TerraformMirrorPage.tsx
@@ -6,7 +6,6 @@ import PageHeader from '../../components/PageHeader'
 import StatusAlerts from '../../components/StatusAlerts'
 import PageTitleIcon from '@mui/icons-material/GetApp'
 import {
-  Autocomplete,
   Alert,
   Box,
   Button,
@@ -17,18 +16,14 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
-  FormControlLabel,
   Grid,
-  MenuItem,
   Paper,
-  Switch,
   Table,
   TableBody,
   TableCell,
   TableContainer,
   TableHead,
   TableRow,
-  TextField,
   Typography,
 } from '@mui/material'
 import AddIcon from '@mui/icons-material/Add'
@@ -44,14 +39,12 @@ import {
   type TerraformMirrorStatusResponse,
   type TerraformVersion,
   type TerraformSyncHistory,
-  type UpdateTerraformMirrorConfigRequest,
-  parsePlatformFilter,
 } from '../../types/terraform_mirror'
 import { SyncStatusChip, ToolChip } from './terraformMirror/StatusChips'
 import MirrorConfigCard from './terraformMirror/MirrorConfigCard'
 import MirrorVersionRow from './terraformMirror/MirrorVersionRow'
 import CreateMirrorDialog, { useCreateMirrorFlow } from './terraformMirror/CreateMirrorDialog'
-import { KNOWN_PLATFORMS, SUPPORTED_TOOLS, toolDefaultUrl } from './terraformMirror/constants'
+import EditMirrorDialog, { useEditMirrorFlow } from './terraformMirror/EditMirrorDialog'
 
 // ---------------------------------------------------------------------------
 // Main page
@@ -72,12 +65,7 @@ const TerraformMirrorPage: React.FC = () => {
 
   const create = useCreateMirrorFlow(status)
 
-  // ---- edit dialog ----
-  const [editConfig, setEditConfig] = useState<TerraformMirrorConfig | null>(null)
-  const [editForm, setEditForm] = useState<UpdateTerraformMirrorConfigRequest>({})
-  const [editVersionFilter, setEditVersionFilter] = useState('')
-  const [editPlatformFilter, setEditPlatformFilter] = useState<string[]>([])
-
+  const edit = useEditMirrorFlow(status)
   // ---- delete dialog ----
   const [deleteConfig, setDeleteConfig] = useState<TerraformMirrorConfig | null>(null)
 
@@ -129,50 +117,6 @@ const TerraformMirrorPage: React.FC = () => {
       }
     })
   }, [configs])
-
-  // ---------------------------------------------------------------------------
-  // Edit
-  // ---------------------------------------------------------------------------
-  const openEdit = (config: TerraformMirrorConfig) => {
-    setEditConfig(config)
-    setEditVersionFilter(config.version_filter ?? '')
-    setEditPlatformFilter(parsePlatformFilter(config.platform_filter))
-    setEditForm({
-      name: config.name,
-      description: config.description ?? '',
-      tool: config.tool,
-      enabled: config.enabled,
-      upstream_url: config.upstream_url,
-      gpg_verify: config.gpg_verify,
-      stable_only: config.stable_only,
-      sync_interval_hours: config.sync_interval_hours,
-      requires_approval: config.requires_approval ?? false,
-    })
-  }
-
-  const editMutation = useMutation({
-    mutationFn: async () => {
-      if (!editConfig) throw new Error('No config to edit')
-      await api.updateTerraformMirrorConfig(editConfig.id, {
-        ...editForm,
-        platform_filter: editPlatformFilter.length > 0 ? editPlatformFilter : [],
-        version_filter: editVersionFilter.trim() || '',
-      })
-    },
-    onSuccess: () => {
-      status.setSuccess(t('admin.terraformMirror.msgUpdated', { name: editConfig?.name }))
-      setEditConfig(null)
-      queryClient.invalidateQueries({ queryKey: queryKeys.terraformMirrors._def })
-    },
-    onError: (err: unknown) => {
-      status.setError(getErrorMessage(err, t('admin.terraformMirror.errUpdate')))
-    },
-  })
-
-  const handleEdit = () => {
-    if (!editConfig) return
-    editMutation.mutate()
-  }
 
   // ---------------------------------------------------------------------------
   // Delete
@@ -344,7 +288,7 @@ const TerraformMirrorPage: React.FC = () => {
                     <MirrorConfigCard
                       config={cfg}
                       status={status}
-                      onEdit={openEdit}
+                      onEdit={edit.openDialog}
                       onDelete={setDeleteConfig}
                       onSync={handleSync}
                       onViewVersions={openVersions}
@@ -360,181 +304,7 @@ const TerraformMirrorPage: React.FC = () => {
 
           <CreateMirrorDialog flow={create} />
 
-          {/* ==================================================================
-          Edit Dialog
-      ================================================================== */}
-          <Dialog open={!!editConfig} onClose={() => setEditConfig(null)} maxWidth="sm" fullWidth>
-            <DialogTitle>
-              {t('admin.terraformMirror.dialogTitleEdit', { name: editConfig?.name })}
-            </DialogTitle>
-            <DialogContent>
-              <Box sx={{ pt: 1, display: 'flex', flexDirection: 'column', gap: 2 }}>
-                <TextField
-                  label={t('admin.terraformMirror.labelName')}
-                  value={editForm.name ?? ''}
-                  onChange={(e) => setEditForm((prev) => ({ ...prev, name: e.target.value }))}
-                  fullWidth
-                />
-                <TextField
-                  label={t('admin.terraformMirror.labelDescription')}
-                  value={editForm.description ?? ''}
-                  onChange={(e) =>
-                    setEditForm((prev) => ({ ...prev, description: e.target.value }))
-                  }
-                  fullWidth
-                />
-                <TextField
-                  select
-                  label={t('admin.terraformMirror.labelTool')}
-                  value={editForm.tool ?? 'terraform'}
-                  onChange={(e) => {
-                    const newTool = e.target.value
-                    setEditForm((prev) => {
-                      const prevDefault = toolDefaultUrl(prev.tool ?? 'terraform')
-                      const shouldUpdate =
-                        (prev.upstream_url ?? '') === prevDefault ||
-                        (prev.upstream_url ?? '') === ''
-                      return {
-                        ...prev,
-                        tool: newTool,
-                        upstream_url: shouldUpdate ? toolDefaultUrl(newTool) : prev.upstream_url,
-                      }
-                    })
-                  }}
-                  fullWidth
-                >
-                  {SUPPORTED_TOOLS.map((toolOption) => (
-                    <MenuItem key={toolOption.value} value={toolOption.value}>
-                      {toolOption.label}
-                    </MenuItem>
-                  ))}
-                  <MenuItem value="custom">{t('admin.terraformMirror.menuCustom')}</MenuItem>
-                </TextField>
-                <TextField
-                  label={t('admin.terraformMirror.labelUpstreamUrl')}
-                  value={editForm.upstream_url ?? ''}
-                  onChange={(e) =>
-                    setEditForm((prev) => ({ ...prev, upstream_url: e.target.value }))
-                  }
-                  helperText={
-                    editForm.tool === 'opentofu'
-                      ? t('admin.terraformMirror.helpUrlOpentofu')
-                      : editForm.tool === 'terraform'
-                        ? t('admin.terraformMirror.helpUrlTerraform')
-                        : t('admin.terraformMirror.helpUrlCustom')
-                  }
-                  fullWidth
-                />
-                <TextField
-                  label={t('admin.terraformMirror.labelSyncInterval')}
-                  type="number"
-                  value={editForm.sync_interval_hours ?? 24}
-                  onChange={(e) =>
-                    setEditForm((prev) => ({
-                      ...prev,
-                      sync_interval_hours: parseInt(e.target.value, 10),
-                    }))
-                  }
-                  fullWidth
-                  slotProps={{
-                    htmlInput: { min: 1 },
-                  }}
-                />
-                <Box sx={{ display: 'flex', gap: 2 }}>
-                  <FormControlLabel
-                    control={
-                      <Switch
-                        checked={editForm.enabled ?? true}
-                        onChange={(e) =>
-                          setEditForm((prev) => ({ ...prev, enabled: e.target.checked }))
-                        }
-                      />
-                    }
-                    label={t('admin.terraformMirror.labelEnabled')}
-                  />
-                  <FormControlLabel
-                    control={
-                      <Switch
-                        checked={editForm.gpg_verify ?? true}
-                        onChange={(e) =>
-                          setEditForm((prev) => ({ ...prev, gpg_verify: e.target.checked }))
-                        }
-                      />
-                    }
-                    label={t('admin.terraformMirror.labelGpgVerify')}
-                  />
-                  <FormControlLabel
-                    control={
-                      <Switch
-                        checked={editForm.stable_only ?? false}
-                        onChange={(e) =>
-                          setEditForm((prev) => ({ ...prev, stable_only: e.target.checked }))
-                        }
-                      />
-                    }
-                    label={t('admin.terraformMirror.labelStableOnly')}
-                  />
-                  <FormControlLabel
-                    control={
-                      <Switch
-                        checked={editForm.requires_approval ?? false}
-                        onChange={(e) =>
-                          setEditForm((prev) => ({
-                            ...prev,
-                            requires_approval: e.target.checked,
-                          }))
-                        }
-                      />
-                    }
-                    label={t('admin.terraformMirror.labelRequiresApproval')}
-                  />
-                </Box>
-                <TextField
-                  label={t('admin.terraformMirror.labelVersionFilter')}
-                  value={editVersionFilter}
-                  onChange={(e) => setEditVersionFilter(e.target.value)}
-                  helperText={t('admin.terraformMirror.helpVersionFilter')}
-                  fullWidth
-                />
-                <Autocomplete
-                  multiple
-                  options={KNOWN_PLATFORMS}
-                  value={editPlatformFilter}
-                  onChange={(_event, newValue) => setEditPlatformFilter(newValue)}
-                  renderInput={(params) => (
-                    <TextField
-                      {...params}
-                      label={t('admin.terraformMirror.labelPlatformFilter')}
-                      placeholder={
-                        editPlatformFilter.length === 0
-                          ? t('admin.terraformMirror.placeholderAllPlatforms')
-                          : ''
-                      }
-                      helperText={t('admin.terraformMirror.helpPlatformFilter')}
-                      fullWidth
-                    />
-                  )}
-                  renderValue={(value, getItemProps) =>
-                    value.map((option, index) => (
-                      <Chip label={option} size="small" {...getItemProps({ index })} key={option} />
-                    ))
-                  }
-                />
-              </Box>
-            </DialogContent>
-            <DialogActions>
-              <Button onClick={() => setEditConfig(null)}>
-                {t('admin.terraformMirror.cancel')}
-              </Button>
-              <Button onClick={handleEdit} variant="contained" disabled={editMutation.isPending}>
-                {editMutation.isPending ? (
-                  <CircularProgress size={18} />
-                ) : (
-                  t('admin.terraformMirror.save')
-                )}
-              </Button>
-            </DialogActions>
-          </Dialog>
+          <EditMirrorDialog flow={edit} />
 
           {/* ==================================================================
           Delete Config Dialog

--- a/frontend/src/pages/admin/__tests__/TerraformMirrorPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/TerraformMirrorPage.test.tsx
@@ -94,7 +94,7 @@ describe('TerraformMirrorPage', () => {
   })
 
   it('shows loading spinner initially', () => {
-    listTerraformMirrorConfigsMock.mockReturnValue(new Promise(() => { }))
+    listTerraformMirrorConfigsMock.mockReturnValue(new Promise(() => {}))
     renderPage()
     expect(screen.getByRole('progressbar')).toBeInTheDocument()
   })
@@ -761,5 +761,112 @@ describe('TerraformMirrorPage', () => {
     await userEvent.click(screen.getByRole('button', { name: /view details/i }))
     await waitFor(() => expect(screen.getByText('1.5.0')).toBeInTheDocument())
     expect(screen.getByRole('button', { name: /delete version/i })).toBeInTheDocument()
+  })
+
+  // ── behaviour the #675 dialog-flow extraction had to carry across ─────────
+  //
+  // Each of these locks a specific transition that moving a flow into its own
+  // hook could have silently dropped. They assert on the exact banner/field
+  // text, never on a loose /error|failed/ — the GPG panel renders its own
+  // failure alert in every test in this file.
+
+  it('leaves an earlier error banner on screen when a later action succeeds', async () => {
+    // Divergence, preserved deliberately: every flow on this page reports
+    // success with status.setSuccess, where six sibling admin pages use
+    // showSuccess (which also clears the error). Swapping this page to
+    // showSuccess would remove the "sync failed" banner below.
+    listTerraformMirrorConfigsMock.mockResolvedValue({ configs: fakeConfigs })
+    triggerSyncMock.mockRejectedValue(new Error('sync failed'))
+    createMirrorMock.mockResolvedValue({ id: 'new-id' })
+    renderPage()
+    await waitFor(() => expect(screen.getAllByText('terraform').length).toBeGreaterThan(0))
+
+    await userEvent.click(screen.getByRole('button', { name: /^sync mirror$/i }))
+    await waitFor(() => expect(screen.getByText('sync failed')).toBeInTheDocument())
+
+    await userEvent.click(screen.getByRole('button', { name: /add mirror/i }))
+    await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument())
+    await userEvent.type(screen.getByLabelText(/^Name/i), 'later-tf')
+    await userEvent.click(screen.getByRole('button', { name: /^create$/i }))
+
+    await waitFor(() => expect(screen.getByText('Mirror "later-tf" created')).toBeInTheDocument())
+    expect(screen.getByText('sync failed')).toBeInTheDocument()
+  })
+
+  it('blanks a cancelled draft when the create dialog is reopened', async () => {
+    listTerraformMirrorConfigsMock.mockResolvedValue({ configs: [] })
+    renderPage()
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /add mirror/i })).toBeInTheDocument(),
+    )
+
+    await userEvent.click(screen.getByRole('button', { name: /add mirror/i }))
+    await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument())
+    await userEvent.type(screen.getByLabelText(/^Name/i), 'abandoned-draft')
+    await userEvent.type(screen.getByLabelText(/version filter/i), '~> 1.5')
+    expect(screen.getByLabelText(/^Name/i)).toHaveValue('abandoned-draft')
+    await userEvent.click(screen.getByRole('button', { name: /^cancel$/i }))
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())
+
+    await userEvent.click(screen.getByRole('button', { name: /add mirror/i }))
+    await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument())
+    expect(screen.getByLabelText(/^Name/i)).toHaveValue('')
+    expect(screen.getByLabelText(/version filter/i)).toHaveValue('')
+  })
+
+  it('reloads the versions list after a version is deleted', async () => {
+    listTerraformMirrorConfigsMock.mockResolvedValue({ configs: fakeConfigs })
+    listVersionsMock.mockResolvedValue({
+      versions: [
+        {
+          id: 'v1',
+          version: '1.5.0',
+          sync_status: 'synced',
+          is_latest: true,
+          is_deprecated: false,
+          synced_at: '2025-06-01T00:00:00Z',
+        },
+      ],
+    })
+    deleteVersionMock.mockResolvedValue({})
+    renderPage()
+    await waitFor(() => expect(screen.getAllByText('terraform').length).toBeGreaterThan(0))
+    await userEvent.click(screen.getByRole('button', { name: /view details/i }))
+    await waitFor(() => expect(listVersionsMock).toHaveBeenCalledTimes(1))
+
+    await userEvent.click(screen.getByRole('button', { name: /delete version/i }))
+    await waitFor(() => expect(screen.getByText(/Delete Terraform Version/i)).toBeInTheDocument())
+    const dialogs = screen.getAllByRole('dialog')
+    const deleteBtn = dialogs[dialogs.length - 1].querySelector(
+      'button[class*="MuiButton-colorError"]',
+    ) as HTMLButtonElement
+    await userEvent.click(deleteBtn)
+
+    await waitFor(() => expect(screen.getByText('Version 1.5.0 deleted')).toBeInTheDocument())
+    // The browser behind the confirmation refetches so the deleted row goes away.
+    await waitFor(() => expect(listVersionsMock).toHaveBeenCalledTimes(2))
+    expect(listVersionsMock).toHaveBeenLastCalledWith('tm-1', { synced: false })
+  })
+
+  it('shows an empty versions table, and no banner, when the versions load fails', async () => {
+    listTerraformMirrorConfigsMock.mockResolvedValue({ configs: fakeConfigs })
+    listVersionsMock.mockRejectedValue(new Error('versions boom'))
+    renderPage()
+    await waitFor(() => expect(screen.getAllByText('terraform').length).toBeGreaterThan(0))
+    await userEvent.click(screen.getByRole('button', { name: /view details/i }))
+    await waitFor(() =>
+      expect(screen.getByText('No versions have been synced yet.')).toBeInTheDocument(),
+    )
+    expect(screen.queryByText('versions boom')).not.toBeInTheDocument()
+  })
+
+  it('shows an empty history table, and no banner, when the history load fails', async () => {
+    listTerraformMirrorConfigsMock.mockResolvedValue({ configs: fakeConfigs })
+    getHistoryMock.mockRejectedValue(new Error('history boom'))
+    renderPage()
+    await waitFor(() => expect(screen.getAllByText('terraform').length).toBeGreaterThan(0))
+    await userEvent.click(screen.getByRole('button', { name: /view sync history/i }))
+    await waitFor(() => expect(screen.getByText('No sync history yet.')).toBeInTheDocument())
+    expect(screen.queryByText('history boom')).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/pages/admin/terraformMirror/CreateMirrorDialog.tsx
+++ b/frontend/src/pages/admin/terraformMirror/CreateMirrorDialog.tsx
@@ -1,0 +1,278 @@
+import React, { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import {
+  Autocomplete,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControlLabel,
+  MenuItem,
+  Switch,
+  TextField,
+} from '@mui/material'
+import api from '../../../services/api'
+import { queryKeys } from '../../../services/queryKeys'
+import { getErrorMessage } from '../../../utils/errors'
+import type { StatusMessage } from '../../../hooks/useStatusMessage'
+import type { CreateTerraformMirrorConfigRequest } from '../../../types/terraform_mirror'
+import { KNOWN_PLATFORMS, SUPPORTED_TOOLS, emptyCreate, toolDefaultUrl } from './constants'
+
+/** Everything the create-mirror dialog needs; produced by `useCreateMirrorFlow`. */
+export interface CreateMirrorFlow {
+  open: boolean
+  form: CreateTerraformMirrorConfigRequest
+  setForm: React.Dispatch<React.SetStateAction<CreateTerraformMirrorConfigRequest>>
+  versionFilter: string
+  setVersionFilter: (value: string) => void
+  platformFilter: string[]
+  setPlatformFilter: (value: string[]) => void
+  isPending: boolean
+  /** Opens the dialog on a blank form, discarding anything a cancelled run left behind. */
+  openDialog: () => void
+  close: () => void
+  submit: () => void
+}
+
+/**
+ * Owns the create-mirror flow: the draft form, its version/platform filters and
+ * the POST that turns them into a config.
+ *
+ * On success the page's success banner is set with `setSuccess`, not
+ * `showSuccess` — this page deliberately leaves a previous error banner on
+ * screen (see TerraformMirrorPage).
+ */
+export function useCreateMirrorFlow(status: StatusMessage): CreateMirrorFlow {
+  const { t } = useTranslation()
+  const queryClient = useQueryClient()
+  const [open, setOpen] = useState(false)
+  const [form, setForm] = useState<CreateTerraformMirrorConfigRequest>(emptyCreate())
+  const [versionFilter, setVersionFilter] = useState('')
+  const [platformFilter, setPlatformFilter] = useState<string[]>([])
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      await api.createTerraformMirrorConfig({
+        ...form,
+        platform_filter: platformFilter.length > 0 ? platformFilter : undefined,
+        version_filter: versionFilter.trim() || undefined,
+      })
+    },
+    onSuccess: () => {
+      status.setSuccess(t('admin.terraformMirror.msgCreated', { name: form.name }))
+      setOpen(false)
+      setForm(emptyCreate())
+      setVersionFilter('')
+      setPlatformFilter([])
+      queryClient.invalidateQueries({ queryKey: queryKeys.terraformMirrors._def })
+    },
+    onError: (err: unknown) => {
+      status.setError(getErrorMessage(err, t('admin.terraformMirror.errCreate')))
+    },
+  })
+
+  return {
+    open,
+    form,
+    setForm,
+    versionFilter,
+    setVersionFilter,
+    platformFilter,
+    setPlatformFilter,
+    isPending: mutation.isPending,
+    openDialog: () => {
+      setForm(emptyCreate())
+      setVersionFilter('')
+      setPlatformFilter([])
+      setOpen(true)
+    },
+    close: () => setOpen(false),
+    submit: () => {
+      mutation.mutate()
+    },
+  }
+}
+
+/** The "Add mirror" form dialog. */
+const CreateMirrorDialog: React.FC<{ flow: CreateMirrorFlow }> = ({ flow }) => {
+  const { t } = useTranslation()
+  const {
+    form,
+    setForm,
+    versionFilter,
+    setVersionFilter,
+    platformFilter,
+    setPlatformFilter,
+    isPending,
+  } = flow
+
+  return (
+    <Dialog open={flow.open} onClose={flow.close} maxWidth="sm" fullWidth>
+      <DialogTitle>{t('admin.terraformMirror.dialogTitleCreate')}</DialogTitle>
+      <DialogContent>
+        <Box sx={{ pt: 1, display: 'flex', flexDirection: 'column', gap: 2 }}>
+          <TextField
+            label={t('admin.terraformMirror.labelName')}
+            value={form.name}
+            onChange={(e) => setForm((prev) => ({ ...prev, name: e.target.value }))}
+            helperText={t('admin.terraformMirror.helpName')}
+            required
+            fullWidth
+          />
+          <TextField
+            label={t('admin.terraformMirror.labelDescription')}
+            value={form.description ?? ''}
+            onChange={(e) => setForm((prev) => ({ ...prev, description: e.target.value }))}
+            fullWidth
+          />
+          <TextField
+            select
+            label={t('admin.terraformMirror.labelTool')}
+            value={form.tool}
+            onChange={(e) => {
+              const newTool = e.target.value
+              setForm((prev) => {
+                // Auto-update upstream URL only if it still matches the previous tool's default
+                const prevDefault = toolDefaultUrl(prev.tool)
+                const shouldUpdate = prev.upstream_url === prevDefault || prev.upstream_url === ''
+                return {
+                  ...prev,
+                  tool: newTool,
+                  upstream_url: shouldUpdate ? toolDefaultUrl(newTool) : prev.upstream_url,
+                }
+              })
+            }}
+            fullWidth
+          >
+            {SUPPORTED_TOOLS.map((toolOption) => (
+              <MenuItem key={toolOption.value} value={toolOption.value}>
+                {toolOption.label}
+              </MenuItem>
+            ))}
+            <MenuItem value="custom">{t('admin.terraformMirror.menuCustom')}</MenuItem>
+          </TextField>
+          <TextField
+            label={t('admin.terraformMirror.labelUpstreamUrl')}
+            value={form.upstream_url}
+            onChange={(e) => setForm((prev) => ({ ...prev, upstream_url: e.target.value }))}
+            helperText={
+              form.tool === 'opentofu'
+                ? t('admin.terraformMirror.helpUrlOpentofu')
+                : form.tool === 'terraform'
+                  ? t('admin.terraformMirror.helpUrlTerraform')
+                  : t('admin.terraformMirror.helpUrlCustom')
+            }
+            required
+            fullWidth
+          />
+          <TextField
+            label={t('admin.terraformMirror.labelSyncInterval')}
+            type="number"
+            value={form.sync_interval_hours ?? 24}
+            onChange={(e) =>
+              setForm((prev) => ({
+                ...prev,
+                sync_interval_hours: parseInt(e.target.value, 10),
+              }))
+            }
+            fullWidth
+            slotProps={{
+              htmlInput: { min: 1 },
+            }}
+          />
+          <Box sx={{ display: 'flex', gap: 2 }}>
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={form.enabled ?? true}
+                  onChange={(e) => setForm((prev) => ({ ...prev, enabled: e.target.checked }))}
+                />
+              }
+              label={t('admin.terraformMirror.labelEnabled')}
+            />
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={form.gpg_verify ?? true}
+                  onChange={(e) => setForm((prev) => ({ ...prev, gpg_verify: e.target.checked }))}
+                />
+              }
+              label={t('admin.terraformMirror.labelGpgVerify')}
+            />
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={form.stable_only ?? false}
+                  onChange={(e) => setForm((prev) => ({ ...prev, stable_only: e.target.checked }))}
+                />
+              }
+              label={t('admin.terraformMirror.labelStableOnly')}
+            />
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={form.requires_approval ?? false}
+                  onChange={(e) =>
+                    setForm((prev) => ({
+                      ...prev,
+                      requires_approval: e.target.checked,
+                    }))
+                  }
+                />
+              }
+              label={t('admin.terraformMirror.labelRequiresApproval')}
+            />
+          </Box>
+          <TextField
+            label={t('admin.terraformMirror.labelVersionFilter')}
+            value={versionFilter}
+            onChange={(e) => setVersionFilter(e.target.value)}
+            helperText={t('admin.terraformMirror.helpVersionFilter')}
+            fullWidth
+          />
+          <Autocomplete
+            multiple
+            options={KNOWN_PLATFORMS}
+            value={platformFilter}
+            onChange={(_event, newValue) => setPlatformFilter(newValue)}
+            renderInput={(params) => (
+              <TextField
+                {...params}
+                label={t('admin.terraformMirror.labelPlatformFilter')}
+                placeholder={
+                  platformFilter.length === 0
+                    ? t('admin.terraformMirror.placeholderAllPlatforms')
+                    : ''
+                }
+                helperText={t('admin.terraformMirror.helpPlatformFilter')}
+                fullWidth
+              />
+            )}
+            renderValue={(value, getItemProps) =>
+              value.map((option, index) => (
+                <Chip label={option} size="small" {...getItemProps({ index })} key={option} />
+              ))
+            }
+          />
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={flow.close}>{t('admin.terraformMirror.cancel')}</Button>
+        <Button
+          onClick={flow.submit}
+          variant="contained"
+          disabled={isPending || !form.name || !form.upstream_url}
+        >
+          {isPending ? <CircularProgress size={18} /> : t('admin.terraformMirror.create')}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}
+
+export default CreateMirrorDialog

--- a/frontend/src/pages/admin/terraformMirror/DeleteMirrorDialog.tsx
+++ b/frontend/src/pages/admin/terraformMirror/DeleteMirrorDialog.tsx
@@ -1,0 +1,92 @@
+import React, { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import {
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Typography,
+} from '@mui/material'
+import api from '../../../services/api'
+import { queryKeys } from '../../../services/queryKeys'
+import { getErrorMessage } from '../../../utils/errors'
+import type { StatusMessage } from '../../../hooks/useStatusMessage'
+import type { TerraformMirrorConfig } from '../../../types/terraform_mirror'
+
+/** Everything the delete-mirror confirmation needs; produced by `useDeleteMirrorFlow`. */
+export interface DeleteMirrorFlow {
+  /** The config awaiting confirmation, or null when the dialog is closed. */
+  config: TerraformMirrorConfig | null
+  isPending: boolean
+  openDialog: (config: TerraformMirrorConfig) => void
+  close: () => void
+  submit: () => void
+}
+
+/**
+ * Owns the delete-mirror confirmation: which config is pending deletion and the
+ * DELETE that removes it.
+ *
+ * On success the page's success banner is set with `setSuccess`, not
+ * `showSuccess` — this page deliberately leaves a previous error banner on
+ * screen (see TerraformMirrorPage).
+ */
+export function useDeleteMirrorFlow(status: StatusMessage): DeleteMirrorFlow {
+  const { t } = useTranslation()
+  const queryClient = useQueryClient()
+  const [config, setConfig] = useState<TerraformMirrorConfig | null>(null)
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      if (!config) throw new Error('No config to delete')
+      await api.deleteTerraformMirrorConfig(config.id)
+    },
+    onSuccess: () => {
+      status.setSuccess(t('admin.terraformMirror.msgDeleted', { name: config?.name }))
+      setConfig(null)
+      queryClient.invalidateQueries({ queryKey: queryKeys.terraformMirrors._def })
+    },
+    onError: (err: unknown) => {
+      status.setError(getErrorMessage(err, t('admin.terraformMirror.errDelete')))
+    },
+  })
+
+  return {
+    config,
+    isPending: mutation.isPending,
+    openDialog: setConfig,
+    close: () => setConfig(null),
+    submit: () => {
+      if (!config) return
+      mutation.mutate()
+    },
+  }
+}
+
+/** The "delete this mirror configuration?" confirmation. */
+const DeleteMirrorDialog: React.FC<{ flow: DeleteMirrorFlow }> = ({ flow }) => {
+  const { t } = useTranslation()
+  return (
+    <Dialog open={!!flow.config} onClose={flow.close}>
+      <DialogTitle>{t('admin.terraformMirror.deleteConfigTitle')}</DialogTitle>
+      <DialogContent>
+        <Typography>
+          {t('admin.terraformMirror.deleteConfigTextBefore')}
+          <strong>{flow.config?.name}</strong>
+          {t('admin.terraformMirror.deleteConfigTextAfter')}
+        </Typography>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={flow.close}>{t('admin.terraformMirror.cancel')}</Button>
+        <Button color="error" onClick={flow.submit} disabled={flow.isPending}>
+          {flow.isPending ? <CircularProgress size={18} /> : t('admin.terraformMirror.delete')}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}
+
+export default DeleteMirrorDialog

--- a/frontend/src/pages/admin/terraformMirror/EditMirrorDialog.tsx
+++ b/frontend/src/pages/admin/terraformMirror/EditMirrorDialog.tsx
@@ -1,0 +1,293 @@
+import React, { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import {
+  Autocomplete,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControlLabel,
+  MenuItem,
+  Switch,
+  TextField,
+} from '@mui/material'
+import api from '../../../services/api'
+import { queryKeys } from '../../../services/queryKeys'
+import { getErrorMessage } from '../../../utils/errors'
+import type { StatusMessage } from '../../../hooks/useStatusMessage'
+import {
+  type TerraformMirrorConfig,
+  type UpdateTerraformMirrorConfigRequest,
+  parsePlatformFilter,
+} from '../../../types/terraform_mirror'
+import { KNOWN_PLATFORMS, SUPPORTED_TOOLS, toolDefaultUrl } from './constants'
+
+/** Everything the edit-mirror dialog needs; produced by `useEditMirrorFlow`. */
+export interface EditMirrorFlow {
+  /** The config being edited, or null when the dialog is closed. */
+  config: TerraformMirrorConfig | null
+  form: UpdateTerraformMirrorConfigRequest
+  setForm: React.Dispatch<React.SetStateAction<UpdateTerraformMirrorConfigRequest>>
+  versionFilter: string
+  setVersionFilter: (value: string) => void
+  platformFilter: string[]
+  setPlatformFilter: (value: string[]) => void
+  isPending: boolean
+  /** Opens the dialog seeded from the given config's current values. */
+  openDialog: (config: TerraformMirrorConfig) => void
+  close: () => void
+  submit: () => void
+}
+
+/**
+ * Owns the edit-mirror flow: which config is open, the form seeded from it and
+ * the PUT that saves it back.
+ *
+ * On success the page's success banner is set with `setSuccess`, not
+ * `showSuccess` — this page deliberately leaves a previous error banner on
+ * screen (see TerraformMirrorPage).
+ */
+export function useEditMirrorFlow(status: StatusMessage): EditMirrorFlow {
+  const { t } = useTranslation()
+  const queryClient = useQueryClient()
+  const [config, setConfig] = useState<TerraformMirrorConfig | null>(null)
+  const [form, setForm] = useState<UpdateTerraformMirrorConfigRequest>({})
+  const [versionFilter, setVersionFilter] = useState('')
+  const [platformFilter, setPlatformFilter] = useState<string[]>([])
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      if (!config) throw new Error('No config to edit')
+      await api.updateTerraformMirrorConfig(config.id, {
+        ...form,
+        platform_filter: platformFilter.length > 0 ? platformFilter : [],
+        version_filter: versionFilter.trim() || '',
+      })
+    },
+    onSuccess: () => {
+      status.setSuccess(t('admin.terraformMirror.msgUpdated', { name: config?.name }))
+      setConfig(null)
+      queryClient.invalidateQueries({ queryKey: queryKeys.terraformMirrors._def })
+    },
+    onError: (err: unknown) => {
+      status.setError(getErrorMessage(err, t('admin.terraformMirror.errUpdate')))
+    },
+  })
+
+  return {
+    config,
+    form,
+    setForm,
+    versionFilter,
+    setVersionFilter,
+    platformFilter,
+    setPlatformFilter,
+    isPending: mutation.isPending,
+    openDialog: (next: TerraformMirrorConfig) => {
+      setConfig(next)
+      setVersionFilter(next.version_filter ?? '')
+      setPlatformFilter(parsePlatformFilter(next.platform_filter))
+      setForm({
+        name: next.name,
+        description: next.description ?? '',
+        tool: next.tool,
+        enabled: next.enabled,
+        upstream_url: next.upstream_url,
+        gpg_verify: next.gpg_verify,
+        stable_only: next.stable_only,
+        sync_interval_hours: next.sync_interval_hours,
+        requires_approval: next.requires_approval ?? false,
+      })
+    },
+    close: () => setConfig(null),
+    submit: () => {
+      if (!config) return
+      mutation.mutate()
+    },
+  }
+}
+
+/**
+ * The "Edit mirror" form dialog. Deliberately not merged with
+ * CreateMirrorDialog: create marks Name and Upstream URL as required and
+ * explains Name in helper text, edit does neither, and the two forms are typed
+ * against different request shapes.
+ */
+const EditMirrorDialog: React.FC<{ flow: EditMirrorFlow }> = ({ flow }) => {
+  const { t } = useTranslation()
+  const {
+    config,
+    form,
+    setForm,
+    versionFilter,
+    setVersionFilter,
+    platformFilter,
+    setPlatformFilter,
+    isPending,
+  } = flow
+
+  return (
+    <Dialog open={!!config} onClose={flow.close} maxWidth="sm" fullWidth>
+      <DialogTitle>
+        {t('admin.terraformMirror.dialogTitleEdit', { name: config?.name })}
+      </DialogTitle>
+      <DialogContent>
+        <Box sx={{ pt: 1, display: 'flex', flexDirection: 'column', gap: 2 }}>
+          <TextField
+            label={t('admin.terraformMirror.labelName')}
+            value={form.name ?? ''}
+            onChange={(e) => setForm((prev) => ({ ...prev, name: e.target.value }))}
+            fullWidth
+          />
+          <TextField
+            label={t('admin.terraformMirror.labelDescription')}
+            value={form.description ?? ''}
+            onChange={(e) => setForm((prev) => ({ ...prev, description: e.target.value }))}
+            fullWidth
+          />
+          <TextField
+            select
+            label={t('admin.terraformMirror.labelTool')}
+            value={form.tool ?? 'terraform'}
+            onChange={(e) => {
+              const newTool = e.target.value
+              setForm((prev) => {
+                const prevDefault = toolDefaultUrl(prev.tool ?? 'terraform')
+                const shouldUpdate =
+                  (prev.upstream_url ?? '') === prevDefault || (prev.upstream_url ?? '') === ''
+                return {
+                  ...prev,
+                  tool: newTool,
+                  upstream_url: shouldUpdate ? toolDefaultUrl(newTool) : prev.upstream_url,
+                }
+              })
+            }}
+            fullWidth
+          >
+            {SUPPORTED_TOOLS.map((toolOption) => (
+              <MenuItem key={toolOption.value} value={toolOption.value}>
+                {toolOption.label}
+              </MenuItem>
+            ))}
+            <MenuItem value="custom">{t('admin.terraformMirror.menuCustom')}</MenuItem>
+          </TextField>
+          <TextField
+            label={t('admin.terraformMirror.labelUpstreamUrl')}
+            value={form.upstream_url ?? ''}
+            onChange={(e) => setForm((prev) => ({ ...prev, upstream_url: e.target.value }))}
+            helperText={
+              form.tool === 'opentofu'
+                ? t('admin.terraformMirror.helpUrlOpentofu')
+                : form.tool === 'terraform'
+                  ? t('admin.terraformMirror.helpUrlTerraform')
+                  : t('admin.terraformMirror.helpUrlCustom')
+            }
+            fullWidth
+          />
+          <TextField
+            label={t('admin.terraformMirror.labelSyncInterval')}
+            type="number"
+            value={form.sync_interval_hours ?? 24}
+            onChange={(e) =>
+              setForm((prev) => ({
+                ...prev,
+                sync_interval_hours: parseInt(e.target.value, 10),
+              }))
+            }
+            fullWidth
+            slotProps={{
+              htmlInput: { min: 1 },
+            }}
+          />
+          <Box sx={{ display: 'flex', gap: 2 }}>
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={form.enabled ?? true}
+                  onChange={(e) => setForm((prev) => ({ ...prev, enabled: e.target.checked }))}
+                />
+              }
+              label={t('admin.terraformMirror.labelEnabled')}
+            />
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={form.gpg_verify ?? true}
+                  onChange={(e) => setForm((prev) => ({ ...prev, gpg_verify: e.target.checked }))}
+                />
+              }
+              label={t('admin.terraformMirror.labelGpgVerify')}
+            />
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={form.stable_only ?? false}
+                  onChange={(e) => setForm((prev) => ({ ...prev, stable_only: e.target.checked }))}
+                />
+              }
+              label={t('admin.terraformMirror.labelStableOnly')}
+            />
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={form.requires_approval ?? false}
+                  onChange={(e) =>
+                    setForm((prev) => ({
+                      ...prev,
+                      requires_approval: e.target.checked,
+                    }))
+                  }
+                />
+              }
+              label={t('admin.terraformMirror.labelRequiresApproval')}
+            />
+          </Box>
+          <TextField
+            label={t('admin.terraformMirror.labelVersionFilter')}
+            value={versionFilter}
+            onChange={(e) => setVersionFilter(e.target.value)}
+            helperText={t('admin.terraformMirror.helpVersionFilter')}
+            fullWidth
+          />
+          <Autocomplete
+            multiple
+            options={KNOWN_PLATFORMS}
+            value={platformFilter}
+            onChange={(_event, newValue) => setPlatformFilter(newValue)}
+            renderInput={(params) => (
+              <TextField
+                {...params}
+                label={t('admin.terraformMirror.labelPlatformFilter')}
+                placeholder={
+                  platformFilter.length === 0
+                    ? t('admin.terraformMirror.placeholderAllPlatforms')
+                    : ''
+                }
+                helperText={t('admin.terraformMirror.helpPlatformFilter')}
+                fullWidth
+              />
+            )}
+            renderValue={(value, getItemProps) =>
+              value.map((option, index) => (
+                <Chip label={option} size="small" {...getItemProps({ index })} key={option} />
+              ))
+            }
+          />
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={flow.close}>{t('admin.terraformMirror.cancel')}</Button>
+        <Button onClick={flow.submit} variant="contained" disabled={isPending}>
+          {isPending ? <CircularProgress size={18} /> : t('admin.terraformMirror.save')}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}
+
+export default EditMirrorDialog

--- a/frontend/src/pages/admin/terraformMirror/MirrorConfigCard.tsx
+++ b/frontend/src/pages/admin/terraformMirror/MirrorConfigCard.tsx
@@ -1,0 +1,210 @@
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+import {
+  Box,
+  Button,
+  Card,
+  CardActions,
+  CardContent,
+  Chip,
+  IconButton,
+  Tooltip,
+  Typography,
+} from '@mui/material'
+import DeleteIcon from '@mui/icons-material/Delete'
+import EditIcon from '@mui/icons-material/Edit'
+import HistoryIcon from '@mui/icons-material/History'
+import SyncIcon from '@mui/icons-material/Sync'
+import type {
+  TerraformMirrorConfig,
+  TerraformMirrorStatusResponse,
+} from '../../../types/terraform_mirror'
+import { SyncStatusChip, ToolChip } from './StatusChips'
+
+/**
+ * One mirror configuration's summary tile plus the buttons that open each of the
+ * page's dialog flows; `canManage` hides the mutating controls (#609).
+ */
+const MirrorConfigCard: React.FC<{
+  config: TerraformMirrorConfig
+  status?: TerraformMirrorStatusResponse
+  onEdit: (c: TerraformMirrorConfig) => void
+  onDelete: (c: TerraformMirrorConfig) => void
+  onSync: (c: TerraformMirrorConfig) => void
+  onViewVersions: (c: TerraformMirrorConfig) => void
+  onViewHistory: (c: TerraformMirrorConfig) => void
+  syncing: boolean
+  canManage: boolean
+}> = ({
+  config,
+  status,
+  onEdit,
+  onDelete,
+  onSync,
+  onViewVersions,
+  onViewHistory,
+  syncing,
+  canManage,
+}) => {
+  const { t } = useTranslation()
+  return (
+    <Card variant="outlined">
+      <CardContent>
+        <Box
+          sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', mb: 1 }}
+        >
+          <Typography variant="h6" sx={{ wordBreak: 'break-word' }}>
+            {config.name}
+          </Typography>
+          <Box sx={{ display: 'flex', gap: 0.5, ml: 1, flexShrink: 0 }}>
+            <ToolChip tool={config.tool} />
+            <Chip
+              label={
+                config.enabled
+                  ? t('admin.terraformMirror.chipEnabled')
+                  : t('admin.terraformMirror.chipDisabled')
+              }
+              color={config.enabled ? 'success' : 'default'}
+              size="small"
+            />
+          </Box>
+        </Box>
+
+        {config.description && (
+          <Typography
+            variant="body2"
+            sx={{
+              color: 'text.secondary',
+              mb: 1,
+            }}
+          >
+            {config.description}
+          </Typography>
+        )}
+
+        <Typography
+          variant="body2"
+          noWrap
+          sx={{
+            color: 'text.secondary',
+          }}
+        >
+          {config.upstream_url}
+        </Typography>
+
+        {status && (
+          <Box
+            sx={{
+              display: 'flex',
+              gap: 1,
+              flexWrap: 'wrap',
+              mt: 1,
+            }}
+          >
+            <Chip
+              size="small"
+              label={t('admin.terraformMirror.chipVersionCount', { count: status.version_count })}
+              variant="outlined"
+            />
+            <Chip
+              size="small"
+              label={t('admin.terraformMirror.chipPlatformCount', { count: status.platform_count })}
+              variant="outlined"
+            />
+            {status.pending_count > 0 && (
+              <Chip
+                size="small"
+                label={t('admin.terraformMirror.chipPendingCount', { count: status.pending_count })}
+                variant="outlined"
+                color="warning"
+              />
+            )}
+          </Box>
+        )}
+
+        <Box sx={{ mt: 1.5 }}>
+          {config.last_sync_status ? (
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+              <SyncStatusChip status={config.last_sync_status} />
+              {config.last_sync_at && (
+                <Typography
+                  variant="caption"
+                  sx={{
+                    color: 'text.secondary',
+                  }}
+                >
+                  {new Date(config.last_sync_at).toLocaleString()}
+                </Typography>
+              )}
+            </Box>
+          ) : (
+            <Typography
+              variant="caption"
+              sx={{
+                color: 'text.secondary',
+              }}
+            >
+              {t('admin.terraformMirror.neverSynced')}
+            </Typography>
+          )}
+        </Box>
+      </CardContent>
+
+      <CardActions sx={{ justifyContent: 'space-between', flexWrap: 'wrap', gap: 0.5 }}>
+        <Box>
+          <Tooltip title={t('admin.terraformMirror.tooltipViewDetails')}>
+            <Button size="small" onClick={() => onViewVersions(config)}>
+              {t('admin.terraformMirror.viewDetails')}
+            </Button>
+          </Tooltip>
+          <Tooltip title={t('admin.terraformMirror.tooltipViewHistory')}>
+            <IconButton
+              size="small"
+              aria-label={t('admin.terraformMirror.ariaViewHistory')}
+              onClick={() => onViewHistory(config)}
+            >
+              <HistoryIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+        </Box>
+        {canManage && (
+          <Box>
+            <Tooltip title={t('admin.terraformMirror.tooltipTriggerSync')}>
+              <span>
+                <IconButton
+                  size="small"
+                  aria-label={t('admin.terraformMirror.ariaSyncMirror')}
+                  onClick={() => onSync(config)}
+                  disabled={syncing || !config.enabled}
+                >
+                  <SyncIcon fontSize="small" />
+                </IconButton>
+              </span>
+            </Tooltip>
+            <Tooltip title={t('admin.terraformMirror.tooltipEditConfig')}>
+              <IconButton
+                size="small"
+                aria-label={t('admin.terraformMirror.ariaEditMirror')}
+                onClick={() => onEdit(config)}
+              >
+                <EditIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
+            <Tooltip title={t('admin.terraformMirror.tooltipDeleteMirror')}>
+              <IconButton
+                size="small"
+                aria-label={t('admin.terraformMirror.ariaDeleteMirror')}
+                color="error"
+                onClick={() => onDelete(config)}
+              >
+                <DeleteIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
+          </Box>
+        )}
+      </CardActions>
+    </Card>
+  )
+}
+
+export default MirrorConfigCard

--- a/frontend/src/pages/admin/terraformMirror/MirrorHistoryDialog.tsx
+++ b/frontend/src/pages/admin/terraformMirror/MirrorHistoryDialog.tsx
@@ -1,0 +1,127 @@
+import React, { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+} from '@mui/material'
+import api from '../../../services/api'
+import type { TerraformMirrorConfig, TerraformSyncHistory } from '../../../types/terraform_mirror'
+import { SyncStatusChip } from './StatusChips'
+
+/** Everything the sync-history browser needs; produced by `useMirrorHistoryFlow`. */
+export interface MirrorHistoryFlow {
+  /** The config whose history is being browsed, or null when the dialog is closed. */
+  config: TerraformMirrorConfig | null
+  history: TerraformSyncHistory[]
+  loading: boolean
+  /** Opens the browser and loads that config's 20 most recent sync runs. */
+  openDialog: (config: TerraformMirrorConfig) => void
+  close: () => void
+}
+
+/**
+ * Owns the sync-history browser: which config is open and its last 20 runs.
+ *
+ * Fetched imperatively rather than through react-query, and a failed load is
+ * shown as an empty history with no banner, exactly as before.
+ */
+export function useMirrorHistoryFlow(): MirrorHistoryFlow {
+  const [config, setConfig] = useState<TerraformMirrorConfig | null>(null)
+  const [history, setHistory] = useState<TerraformSyncHistory[]>([])
+  const [loading, setLoading] = useState(false)
+
+  const openDialog = async (next: TerraformMirrorConfig) => {
+    setConfig(next)
+    setLoading(true)
+    setHistory([])
+    try {
+      const data = await api.getTerraformMirrorHistory(next.id, 20)
+      setHistory(data.history ?? [])
+    } catch {
+      setHistory([])
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return { config, history, loading, openDialog, close: () => setConfig(null) }
+}
+
+/** The read-only table of a mirror's recent sync runs. */
+const MirrorHistoryDialog: React.FC<{ flow: MirrorHistoryFlow }> = ({ flow }) => {
+  const { t } = useTranslation()
+  const { config, history, loading } = flow
+
+  return (
+    <Dialog open={!!config} onClose={flow.close} maxWidth="lg" fullWidth>
+      <DialogTitle>{t('admin.terraformMirror.historyTitle', { name: config?.name })}</DialogTitle>
+      <DialogContent>
+        {loading ? (
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+            <CircularProgress />
+          </Box>
+        ) : history.length === 0 ? (
+          <Alert severity="info">{t('admin.terraformMirror.noHistory')}</Alert>
+        ) : (
+          <TableContainer component={Paper} variant="outlined">
+            <Table size="small">
+              <TableHead>
+                <TableRow>
+                  <TableCell>{t('admin.terraformMirror.thStarted')}</TableCell>
+                  <TableCell>{t('admin.terraformMirror.thCompleted')}</TableCell>
+                  <TableCell>{t('admin.terraformMirror.thTriggeredBy')}</TableCell>
+                  <TableCell>{t('admin.terraformMirror.thStatus')}</TableCell>
+                  <TableCell>{t('admin.terraformMirror.thVersions')}</TableCell>
+                  <TableCell>{t('admin.terraformMirror.thPlatforms')}</TableCell>
+                  <TableCell>{t('admin.terraformMirror.thFailures')}</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {history.map((h) => (
+                  <TableRow key={h.id} hover>
+                    <TableCell>{new Date(h.started_at).toLocaleString()}</TableCell>
+                    <TableCell>
+                      {h.completed_at ? new Date(h.completed_at).toLocaleString() : '—'}
+                    </TableCell>
+                    <TableCell>{h.triggered_by}</TableCell>
+                    <TableCell>
+                      <SyncStatusChip status={h.status} />
+                    </TableCell>
+                    <TableCell>{h.versions_synced}</TableCell>
+                    <TableCell>{h.platforms_synced}</TableCell>
+                    <TableCell>
+                      {h.versions_failed > 0 ? (
+                        <Chip label={h.versions_failed} color="error" size="small" />
+                      ) : (
+                        '0'
+                      )}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={flow.close}>{t('admin.terraformMirror.close')}</Button>
+      </DialogActions>
+    </Dialog>
+  )
+}
+
+export default MirrorHistoryDialog

--- a/frontend/src/pages/admin/terraformMirror/MirrorVersionRow.tsx
+++ b/frontend/src/pages/admin/terraformMirror/MirrorVersionRow.tsx
@@ -1,0 +1,202 @@
+import React, { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import {
+  Box,
+  Chip,
+  CircularProgress,
+  Collapse,
+  IconButton,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Tooltip,
+  Typography,
+} from '@mui/material'
+import CheckCircleIcon from '@mui/icons-material/CheckCircle'
+import DeleteIcon from '@mui/icons-material/Delete'
+import ErrorIcon from '@mui/icons-material/Error'
+import ExpandLessIcon from '@mui/icons-material/ExpandLess'
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
+import api from '../../../services/api'
+import type { TerraformVersion, TerraformVersionPlatform } from '../../../types/terraform_mirror'
+import { SyncStatusChip } from './StatusChips'
+
+/**
+ * One row of the versions dialog, owning the lazy per-row platform fetch that
+ * fires the first time the row is expanded and is cached for the row's lifetime.
+ */
+const MirrorVersionRow: React.FC<{
+  version: TerraformVersion
+  configId: string
+  onDelete: (v: TerraformVersion) => void
+  canManage: boolean
+}> = ({ version, configId, onDelete, canManage }) => {
+  const { t } = useTranslation()
+  const [open, setOpen] = useState(false)
+  const [platforms, setPlatforms] = useState<TerraformVersionPlatform[] | null>(null)
+  const [loadingPlatforms, setLoadingPlatforms] = useState(false)
+
+  const handleExpand = async () => {
+    if (!open && platforms === null) {
+      setLoadingPlatforms(true)
+      try {
+        const data = await api.listTerraformVersionPlatforms(configId, version.version)
+        setPlatforms(data)
+      } catch {
+        setPlatforms([])
+      } finally {
+        setLoadingPlatforms(false)
+      }
+    }
+    setOpen((prev) => !prev)
+  }
+
+  return (
+    <>
+      <TableRow hover sx={{ '& > *': { borderBottom: 'unset' } }}>
+        <TableCell>
+          <IconButton
+            size="small"
+            aria-label={t('admin.terraformMirror.ariaToggleVersionDetails')}
+            onClick={handleExpand}
+          >
+            {open ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+          </IconButton>
+        </TableCell>
+        <TableCell>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <Typography
+              variant="body2"
+              sx={{
+                fontFamily: 'monospace',
+              }}
+            >
+              {version.version}
+            </Typography>
+            {version.is_latest && (
+              <Chip label={t('admin.terraformMirror.chipLatest')} color="primary" size="small" />
+            )}
+            {version.is_deprecated && (
+              <Chip
+                label={t('admin.terraformMirror.chipDeprecated')}
+                color="warning"
+                size="small"
+              />
+            )}
+          </Box>
+        </TableCell>
+        <TableCell>
+          <SyncStatusChip status={version.sync_status} />
+        </TableCell>
+        <TableCell>
+          {version.approval_status && (
+            <Chip
+              label={t(`admin.versionApprovals.status.${version.approval_status}`)}
+              size="small"
+              color={
+                version.approval_status === 'approved'
+                  ? 'success'
+                  : version.approval_status === 'rejected'
+                    ? 'error'
+                    : 'warning'
+              }
+            />
+          )}
+        </TableCell>
+        <TableCell>
+          {version.synced_at ? new Date(version.synced_at).toLocaleString() : '—'}
+        </TableCell>
+        <TableCell align="right">
+          {canManage && (
+            <Tooltip title={t('admin.terraformMirror.tooltipDeleteVersion')}>
+              <span>
+                <IconButton
+                  size="small"
+                  aria-label={t('admin.terraformMirror.ariaDeleteVersion')}
+                  color="error"
+                  onClick={() => onDelete(version)}
+                  disabled={version.sync_status === 'syncing'}
+                >
+                  <DeleteIcon fontSize="small" />
+                </IconButton>
+              </span>
+            </Tooltip>
+          )}
+        </TableCell>
+      </TableRow>
+      <TableRow>
+        <TableCell colSpan={6} sx={{ pb: 0, pt: 0 }}>
+          <Collapse in={open} unmountOnExit>
+            <Box sx={{ m: 1, mb: 2 }}>
+              {loadingPlatforms ? (
+                <CircularProgress size={20} />
+              ) : platforms && platforms.length > 0 ? (
+                <Table size="small">
+                  <TableHead>
+                    <TableRow>
+                      <TableCell>OS</TableCell>
+                      <TableCell>{t('admin.terraformMirror.thArch')}</TableCell>
+                      <TableCell>{t('admin.terraformMirror.thFilename')}</TableCell>
+                      <TableCell>{t('admin.terraformMirror.thStatus')}</TableCell>
+                      <TableCell>SHA256</TableCell>
+                      <TableCell>GPG</TableCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {platforms.map((p) => (
+                      <TableRow key={p.id}>
+                        <TableCell>{p.os}</TableCell>
+                        <TableCell>{p.arch}</TableCell>
+                        <TableCell>
+                          <Typography
+                            variant="caption"
+                            sx={{
+                              fontFamily: 'monospace',
+                              wordBreak: 'break-all',
+                            }}
+                          >
+                            {p.filename}
+                          </Typography>
+                        </TableCell>
+                        <TableCell>
+                          <SyncStatusChip status={p.sync_status} />
+                        </TableCell>
+                        <TableCell>
+                          {p.sha256_verified ? (
+                            <CheckCircleIcon color="success" fontSize="small" />
+                          ) : (
+                            <ErrorIcon color="disabled" fontSize="small" />
+                          )}
+                        </TableCell>
+                        <TableCell>
+                          {p.gpg_verified ? (
+                            <CheckCircleIcon color="success" fontSize="small" />
+                          ) : (
+                            <ErrorIcon color="disabled" fontSize="small" />
+                          )}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              ) : (
+                <Typography
+                  variant="body2"
+                  sx={{
+                    color: 'text.secondary',
+                  }}
+                >
+                  {t('admin.terraformMirror.noPlatformsSynced')}
+                </Typography>
+              )}
+            </Box>
+          </Collapse>
+        </TableCell>
+      </TableRow>
+    </>
+  )
+}
+
+export default MirrorVersionRow

--- a/frontend/src/pages/admin/terraformMirror/MirrorVersionsDialog.tsx
+++ b/frontend/src/pages/admin/terraformMirror/MirrorVersionsDialog.tsx
@@ -86,7 +86,9 @@ export function useMirrorVersionsFlow(status: StatusMessage): MirrorVersionsFlow
     setDeleting(true)
     try {
       await api.deleteTerraformVersion(config.id, pendingDelete.version)
-      status.setSuccess(t('admin.terraformMirror.versionDeleted', { version: pendingDelete.version }))
+      status.setSuccess(
+        t('admin.terraformMirror.versionDeleted', { version: pendingDelete.version }),
+      )
       setPendingDelete(null)
       openDialog(config)
     } catch (err: unknown) {

--- a/frontend/src/pages/admin/terraformMirror/MirrorVersionsDialog.tsx
+++ b/frontend/src/pages/admin/terraformMirror/MirrorVersionsDialog.tsx
@@ -1,0 +1,197 @@
+import React, { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+} from '@mui/material'
+import api from '../../../services/api'
+import { getErrorMessage } from '../../../utils/errors'
+import type { StatusMessage } from '../../../hooks/useStatusMessage'
+import type { TerraformMirrorConfig, TerraformVersion } from '../../../types/terraform_mirror'
+import { ToolChip } from './StatusChips'
+import MirrorVersionRow from './MirrorVersionRow'
+
+/**
+ * Everything the versions browser and its delete confirmation need; produced by
+ * `useMirrorVersionsFlow`.
+ */
+export interface MirrorVersionsFlow {
+  /** The config whose versions are being browsed, or null when closed. */
+  config: TerraformMirrorConfig | null
+  versions: TerraformVersion[]
+  loading: boolean
+  /** Opens the browser and loads that config's versions. */
+  openDialog: (config: TerraformMirrorConfig) => void
+  close: () => void
+  /** The version awaiting delete confirmation, or null when that dialog is closed. */
+  pendingDelete: TerraformVersion | null
+  requestDelete: (version: TerraformVersion) => void
+  cancelDelete: () => void
+  confirmDelete: () => void
+  deleting: boolean
+}
+
+/**
+ * Owns the versions browser and the delete-version confirmation nested inside
+ * it — one hook rather than two because confirming a delete reloads the list
+ * behind it, so the two dialogs cannot own their state independently.
+ *
+ * The list is fetched imperatively rather than through react-query, and a
+ * failed load is shown as an empty list with no banner, exactly as before.
+ */
+export function useMirrorVersionsFlow(status: StatusMessage): MirrorVersionsFlow {
+  const { t } = useTranslation()
+  const [config, setConfig] = useState<TerraformMirrorConfig | null>(null)
+  const [versions, setVersions] = useState<TerraformVersion[]>([])
+  const [loading, setLoading] = useState(false)
+  const [pendingDelete, setPendingDelete] = useState<TerraformVersion | null>(null)
+  const [deleting, setDeleting] = useState(false)
+
+  const openDialog = async (next: TerraformMirrorConfig) => {
+    setConfig(next)
+    setLoading(true)
+    setVersions([])
+    try {
+      const data = await api.listTerraformVersions(next.id, { synced: false })
+      const rows = data.versions ?? []
+      // Sort: latest first, then by version descending
+      const sorted = [...rows].sort((a, b) => {
+        if (a.is_latest !== b.is_latest) return a.is_latest ? -1 : 1
+        return b.version.localeCompare(a.version, undefined, { numeric: true })
+      })
+      setVersions(sorted)
+    } catch {
+      setVersions([])
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const confirmDelete = async () => {
+    if (!pendingDelete || !config) return
+    setDeleting(true)
+    try {
+      await api.deleteTerraformVersion(config.id, pendingDelete.version)
+      status.setSuccess(t('admin.terraformMirror.versionDeleted', { version: pendingDelete.version }))
+      setPendingDelete(null)
+      openDialog(config)
+    } catch (err: unknown) {
+      status.setError(getErrorMessage(err, t('admin.terraformMirror.errDeleteVersion')))
+      setPendingDelete(null)
+    } finally {
+      setDeleting(false)
+    }
+  }
+
+  return {
+    config,
+    versions,
+    loading,
+    openDialog,
+    close: () => setConfig(null),
+    pendingDelete,
+    requestDelete: setPendingDelete,
+    cancelDelete: () => setPendingDelete(null),
+    confirmDelete,
+    deleting,
+  }
+}
+
+/**
+ * The versions browser. Mounted only while a config is selected (unlike the
+ * other dialogs on this page, which stay mounted and toggle `open`).
+ */
+export const MirrorVersionsDialog: React.FC<{
+  flow: MirrorVersionsFlow
+  canManage: boolean
+}> = ({ flow, canManage }) => {
+  const { t } = useTranslation()
+  const { config, versions, loading } = flow
+  if (!config) return null
+
+  return (
+    <Dialog open onClose={flow.close} maxWidth="lg" fullWidth>
+      <DialogTitle>
+        {t('admin.terraformMirror.versionsTitle', { name: config.name })}
+        <Box component="span" sx={{ ml: 1 }}>
+          <ToolChip tool={config.tool} />
+        </Box>
+      </DialogTitle>
+      <DialogContent>
+        {loading ? (
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+            <CircularProgress />
+          </Box>
+        ) : versions.length === 0 ? (
+          <Alert severity="info">{t('admin.terraformMirror.noVersionsSynced')}</Alert>
+        ) : (
+          <TableContainer component={Paper} variant="outlined">
+            <Table size="small">
+              <TableHead>
+                <TableRow>
+                  <TableCell width={48} />
+                  <TableCell>{t('admin.terraformMirror.thVersion')}</TableCell>
+                  <TableCell>{t('admin.terraformMirror.thStatus')}</TableCell>
+                  <TableCell>{t('admin.terraformMirror.thApproval')}</TableCell>
+                  <TableCell>{t('admin.terraformMirror.thSyncedAt')}</TableCell>
+                  <TableCell align="right">{t('admin.terraformMirror.thActions')}</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {versions.map((v) => (
+                  <MirrorVersionRow
+                    key={v.id}
+                    version={v}
+                    configId={config.id}
+                    onDelete={flow.requestDelete}
+                    canManage={canManage}
+                  />
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={flow.close}>{t('admin.terraformMirror.close')}</Button>
+      </DialogActions>
+    </Dialog>
+  )
+}
+
+/** The "delete this version?" confirmation raised from a row of the browser. */
+export const DeleteVersionDialog: React.FC<{ flow: MirrorVersionsFlow }> = ({ flow }) => {
+  const { t } = useTranslation()
+  return (
+    <Dialog open={!!flow.pendingDelete} onClose={flow.cancelDelete}>
+      <DialogTitle>{t('admin.terraformMirror.deleteVersionTitle')}</DialogTitle>
+      <DialogContent>
+        <Typography>
+          {t('admin.terraformMirror.deleteVersionTextBefore')}
+          <strong>{flow.pendingDelete?.version}</strong>
+          {t('admin.terraformMirror.deleteVersionTextAfter')}
+        </Typography>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={flow.cancelDelete}>{t('admin.terraformMirror.cancel')}</Button>
+        <Button color="error" onClick={flow.confirmDelete} disabled={flow.deleting}>
+          {flow.deleting ? <CircularProgress size={18} /> : t('admin.terraformMirror.delete')}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}

--- a/frontend/src/pages/admin/terraformMirror/StatusChips.tsx
+++ b/frontend/src/pages/admin/terraformMirror/StatusChips.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import { Chip } from '@mui/material'
+import CheckCircleIcon from '@mui/icons-material/CheckCircle'
+import ErrorIcon from '@mui/icons-material/Error'
+import { syncStatusColor } from '../../../types/terraform_mirror'
+
+/**
+ * The two one-line chips the mirror admin UI repeats: a sync-status chip used by
+ * the config card, the versions table and the history table, and a tool chip
+ * used by the config card and the versions dialog title.
+ */
+
+export const SyncStatusChip: React.FC<{ status: string; size?: 'small' | 'medium' }> = ({
+  status,
+  size = 'small',
+}) => (
+  <Chip
+    label={status}
+    color={syncStatusColor(status)}
+    size={size}
+    icon={
+      status === 'synced' || status === 'success' ? (
+        <CheckCircleIcon />
+      ) : status === 'failed' ? (
+        <ErrorIcon />
+      ) : undefined
+    }
+  />
+)
+
+export const ToolChip: React.FC<{ tool: string }> = ({ tool }) => {
+  const color = tool === 'terraform' ? 'primary' : tool === 'opentofu' ? 'secondary' : 'default'
+  return <Chip label={tool} size="small" color={color} variant="outlined" />
+}

--- a/frontend/src/pages/admin/terraformMirror/constants.ts
+++ b/frontend/src/pages/admin/terraformMirror/constants.ts
@@ -1,0 +1,63 @@
+import type { CreateTerraformMirrorConfigRequest } from '../../../types/terraform_mirror'
+
+/**
+ * The upstream-tool vocabulary shared by the create and edit mirror dialogs, so
+ * a new tool is added in exactly one place rather than in two dialog bodies.
+ */
+
+/** Known Terraform binary platform combinations (os/arch). */
+export const KNOWN_PLATFORMS = [
+  'linux/amd64',
+  'linux/arm64',
+  'linux/386',
+  'linux/arm',
+  'darwin/amd64',
+  'darwin/arm64',
+  'windows/amd64',
+  'windows/386',
+  'windows/arm64',
+  'freebsd/amd64',
+  'freebsd/386',
+  'freebsd/arm',
+] as const
+
+const TOOL_DEFAULT_URLS: Record<string, string> = {
+  terraform: 'https://releases.hashicorp.com',
+  opentofu: 'https://github.com/opentofu/opentofu',
+  packer: 'https://releases.hashicorp.com',
+  sentinel: 'https://releases.hashicorp.com',
+  opa: 'https://github.com/open-policy-agent/opa',
+  'terraform-docs': 'https://github.com/terraform-docs/terraform-docs',
+}
+
+/** Returns the canonical upstream URL for a known tool, or '' for custom. */
+export function toolDefaultUrl(tool: string): string {
+  return TOOL_DEFAULT_URLS[tool] ?? ''
+}
+
+/**
+ * SUPPORTED_TOOLS is the single source of truth for the selectable upstream
+ * tools in both the create and edit dialogs, so a new tool is added in exactly
+ * one place. "custom" is rendered separately because its label is translated.
+ */
+export const SUPPORTED_TOOLS: readonly { value: string; label: string }[] = [
+  { value: 'terraform', label: 'Terraform (HashiCorp)' },
+  { value: 'opentofu', label: 'OpenTofu' },
+  { value: 'packer', label: 'Packer (HashiCorp)' },
+  { value: 'sentinel', label: 'Sentinel (HashiCorp)' },
+  { value: 'opa', label: 'OPA (Open Policy Agent)' },
+  { value: 'terraform-docs', label: 'terraform-docs' },
+]
+
+/** The blank create-dialog form: a fresh mirror is stable-only and gated on approval. */
+export const emptyCreate = (): CreateTerraformMirrorConfigRequest => ({
+  name: '',
+  description: '',
+  tool: 'terraform',
+  upstream_url: toolDefaultUrl('terraform'),
+  gpg_verify: true,
+  stable_only: true,
+  enabled: true,
+  sync_interval_hours: 24,
+  requires_approval: true,
+})


### PR DESCRIPTION
Closes #675

Splits `TerraformMirrorPage.tsx` along the seams the issue names — the dialog
flows — rather than by line count. The page goes from **1402 lines to 214**, and
now holds only the config-list query, the per-card status overlay, the
trigger-sync handler, and five flow objects.

## What the file actually contained

Verified before touching anything. The issue says 1408 lines; `main` is at 1402
(minor drift). It rendered **six** dialogs across **five** flows:

| flow | dialogs | state it owned |
|---|---|---|
| create | Create | `createOpen`, `createForm`, `createVersionFilter`, `createPlatformFilter` |
| edit | Edit | `editConfig`, `editForm`, `editVersionFilter`, `editPlatformFilter` |
| delete config | Delete Config | `deleteConfig` |
| versions browser | Versions **+ Delete Version** | `versionsConfig`, `versions`, `versionsLoading`, `deleteVersion`, `deletingVersion` |
| history browser | History | `historyConfig`, `history`, `historyLoading` |

Delete-version is a sixth dialog but not a sixth flow: confirming a delete
reloads the version list behind it, so the two cannot own their state
independently. They stay in one module and one hook.

## Extraction

`src/pages/admin/terraformMirror/`, one reason to exist each:

| file | why it exists |
|---|---|
| `constants.ts` | the tool list, default upstream URLs and platform options shared by the create and edit dialogs — one place to add a new tool |
| `StatusChips.tsx` | the two one-line chips the card, versions table and history table all repeat |
| `MirrorConfigCard.tsx` | one config's summary tile plus the buttons that open each flow |
| `MirrorVersionRow.tsx` | one versions-table row plus its lazy per-row platform fetch |
| `CreateMirrorDialog.tsx` | the create flow: draft form, its filters, the POST |
| `EditMirrorDialog.tsx` | the edit flow: which config is open, the form seeded from it, the PUT |
| `DeleteMirrorDialog.tsx` | the delete-config confirmation and its DELETE |
| `MirrorVersionsDialog.tsx` | the versions browser and the delete-version confirmation nested in it |
| `MirrorHistoryDialog.tsx` | the sync-history browser |

Each flow file exports a `use*Flow` hook (state + requests) and the dialog that
renders against it. The page calls the five hooks and passes each flow object to
its dialog. **No generic dialog framework and no shared `useCrudDialogs`** — the
issue suggests one, but the five flows differ enough (two carry forms, one
carries a nested confirmation, two are read-only browsers) that a common
abstraction would be parameterised back into five special cases.

## Behaviour deliberately preserved

- **The success banner does not clear an earlier error.** Every flow here calls
  `status.setSuccess`, where six sibling admin pages call `showSuccess` (which
  also clears the error). `StoragePage.tsx` is the only other page that does
  this. **Left exactly as it was and now covered by a test** — this looked like a
  divergence worth flagging rather than silently "fixing". If it turns out to be
  an oversight, it should be a separate, deliberate change across both pages.
- **The versions and history browsers still fetch imperatively on open**, not
  through react-query, and both still swallow a failed load into an empty table
  with no banner. Moving them onto react-query would change when they refetch.
- **The create and edit forms are still two separate components.** They look like
  ~170 duplicated lines, but create marks Name and Upstream URL `required` and
  carries helper text under Name, edit does neither, and the two are typed
  against different request shapes. Merging them would reintroduce all three
  differences as props.
- Mount semantics per dialog are unchanged: the versions browser is still the
  only one that unmounts rather than toggling `open`.
- Order of operations inside every handler is unchanged, including
  create-on-success (banner → close → blank form → blank filters → invalidate)
  and edit sending `platform_filter: []` / `version_filter: ''` to clear, where
  create sends `undefined`.

## Verification

Real toolchain in a clean worktree (`npm ci`, 283 packages) — no substitutes.

- Baseline before touching anything: **43 tests pass**, `tsc --noEmit` clean,
  `eslint --max-warnings 0` clean. Coverage for this page was *not* thin, which
  is why the full extraction was safe to do rather than partial.
- After each of the five commits: page tests re-run green.
- Final: **2243 tests / 150 files pass**, lint clean, typecheck clean.
- Coverage moved up on all four metrics (thresholds 80/70/70/80):

  | | statements | branches | functions | lines |
  |---|---|---|---|---|
  | before | 84.69 | 77.76 | 78.73 | 86.67 |
  | after | **85.38** | **78.61** | **79.71** | **87.37** |

### Mutation table

Five new tests, each verified by breaking what it protects and watching that one
test fail, then restoring from a `cp` backup.

| # | mutation | file | result |
|---|---|---|---|
| M1 | `status.setSuccess` → `status.showSuccess` | `CreateMirrorDialog.tsx` | ✗ *leaves an earlier error banner on screen* |
| M2 | drop `setForm(emptyCreate())` from `openDialog` | `CreateMirrorDialog.tsx` | ✗ *blanks a cancelled draft* |
| M3 | drop `setVersionFilter('')` from `openDialog` | `CreateMirrorDialog.tsx` | ✗ *blanks a cancelled draft* |
| M4 | drop the `openDialog(config)` refetch from `confirmDelete` | `MirrorVersionsDialog.tsx` | ✗ *reloads the versions list* |
| M5 | surface the versions load failure as a banner | `MirrorVersionsDialog.tsx` | ✗ *empty versions table, and no banner* |
| M6 | surface the history load failure as a banner | `MirrorHistoryDialog.tsx` | ✗ *empty history table, and no banner* |
| M7 | drop `setLoading(false)` from the history `finally` | `MirrorHistoryDialog.tsx` | ✗ *empty history table, and no banner* |

A first attempt at M6 (`throw` inside the `catch`) was **inert** — the rejection
is swallowed by the fire-and-forget call site and the table still renders empty,
so the test passed. It was replaced with the mutation above, which is what
"harmonise this flow with the CRUD flows" would actually look like.

All assertions name exact banner and field text. This test file already renders
a second `Failed to load GPG key status.` alert in every test, so a loose
`/error|failed/` regex matches two elements and stops testing anything.

## Left undone, on purpose

- **`MirrorsPage.tsx` (1286 lines, 13 `useState`)** — the issue's Explanation
  calls out that it has the same shape. It is a different page with its own
  tests and is out of this PR's scope; worth its own issue so it gets its own
  baseline and its own mutation pass.
- **The create/edit form duplication** — see above. Worth revisiting only as a
  deliberate decision about the three behavioural differences, not as a
  drive-by.
- **`EditMirrorDialog.tsx` reads 48% statements / 28% functions in the per-file
  report.** That is not a regression — the aggregate went up, and those
  `onChange` handlers were equally untested when they were inline in the god
  component. The split just makes the thin spot visible, and it is now
  attributable to one file.
- **Flaky test noted, not touched:** `cancels edit mirror dialog without action`
  failed once on a heavily loaded box and passed on every other run (including
  twice immediately after). It races MUI's dialog exit transition against
  `waitFor`'s 1s default. The pattern is pre-existing and unchanged by this PR.
