### PR TITLE
fix(e2e): enable identity migrations in the E2E stack

### DIFF
--- a/deployments/docker-compose.test.yml
+++ b/deployments/docker-compose.test.yml
@@ -29,6 +29,9 @@ services:
       - TFR_DATABASE_USER=registry
       - TFR_DATABASE_PASSWORD=registry
       - TFR_DATABASE_SSL_MODE=disable
+      # The backend writes identity.audit_logs.actor_email, which only exists once
+      # identity migration 000007 runs — and that migration is gated on this flag.
+      - TFR_IDENTITY_MIGRATIONS_ENABLED=true
       # DEV_MODE enables /api/v1/dev/login for Playwright fixtures — test/CI only, never production
       - DEV_MODE=true
       # This stack runs at the default logging.level ("info"), which


### PR DESCRIPTION
`E2E (gated/manual)` has been failing on `main`. The Playwright failures are a symptom — the cause is a missing database column.

Every audit write in the run returns:

```
pq: column "actor_email" of relation "audit_logs" does not exist at position 2:127 (42703)
```

so the admin sidebar never renders, and the `Approvals` / `Mirror Policies` / admin-policies-navigation specs time out looking for links that were never drawn.

### Why the column is missing

`actor_email` is added by **identity migration `000007`**, which lives in `terraform-suite-identity` — not in the backend's own migration set:

```sql
-- identity/migrations/000007_delete_does_not_rehome_rows.up.sql:160
ALTER TABLE identity.audit_logs ADD COLUMN IF NOT EXISTS actor_email VARCHAR(255);
```

The backend applies that chain only behind a flag:

```go
func identityMigrationsEnabled() bool {
return os.Getenv("TFR_IDENTITY_MIGRATIONS_ENABLED") == "true"
}
```

**No compose file in either repo set it** — the backend's own `docker-compose.yml` has it commented out.

That explains the confusing part of the failing log. It reported success:

```
"Running database migrations..."
"Database migrations completed successfully"
"Database schema version: 50 (dirty: false)"
```

Schema 50 is the backend's own chain, fully applied and clean. The identity chain never ran at all — there is no `"Running identity schema migrations..."` line anywhere in that run — so `identity.audit_logs` sat one migration short of what the image expects.

### Verified, not assumed

Reproduced locally against the same image the job pulls. With the flag, two lines appear that are absent from the failing run:

```
"Running identity schema migrations..."
"Identity schema migrations completed successfully"
```

and `information_schema` confirms the column:

```sql
SELECT count(*) FROM information_schema.columns
 WHERE table_schema='identity' AND table_name='audit_logs' AND column_name='actor_email';
-- 1
```

### Scope

Only `docker-compose.test.yml`, which backs both `e2e-gated` and `e2e-security`.

`docker-compose.contract-check.yml` is **deliberately left alone** — it pins backend `3.5.2`, which predates the `actor_email` write, and Contract Check is green. It will need the same flag whenever that pin moves forward.

### Worth a separate look

`docker-compose.test.yml` runs the backend at **`:latest`** while contract-check pins `3.5.2`. That is why `main` went red with no change in this repo — an upstream backend publish is enough to break it. Pinning E2E to a known-good tag would make this class of failure impossible; out of scope here.
