### PR TITLE
ci: comment the remaining action pins with their exact tags

### DIFF
--- a/.github/workflows/signature-replay.yml
+++ b/.github/workflows/signature-replay.yml
@@ -253,7 +253,7 @@ jobs:
       # report for the run someone will actually want to read.
       - name: Upload report
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: signature-replay-report
           path: replay-report.json


### PR DESCRIPTION
A bare `# v7` / `# v9` comment names a **moving** tag. It is true only until the upstream cuts a release and GitHub advances that tag past the pinned SHA — at which point zizmor's `ref-version-mismatch` fails **every PR in the repo**, with no change on our side.

That is not hypothetical. It is exactly how the `codeql-action` pins broke earlier today: `v4.37.7` shipped, the `v4` tag moved off our pinned `v4.37.6`, and green PRs went red on their own across several repos.

### What this does

Replaces each bare-major comment with the precise tag its pinned SHA **already resolves to**, so the comment cannot expire.

**No SHA changes.** No action upgrades ride along — bumping a pin stays Dependabot's job, and keeping the two separate means a lint fix never quietly ships a new action version.

### How the tags were chosen

Each pinned SHA was resolved against the upstream tag list, and the precise `vX.Y.Z` tag pointing at that exact commit was used. Any pin whose SHA could not be matched to a precise tag would have been left untouched and reported rather than guessed — there were none.

### Scope

Part of a suite-wide sweep: **53 pins across 8 repos**. `terraform-state-manager-frontend` and `pipeline-task-core` were already clean and needed no change.

Verification is zizmor itself — it runs this audit online on this PR. Note that a *local* zizmor run without a token silently skips it and reports a false clean, so the CI result here is the meaningful one.
