### PR TITLE
fix(ci): file OSV findings as a deduplicated tracking issue

### DIFF
--- a/.github/workflows/weekly-security.yml
+++ b/.github/workflows/weekly-security.yml
@@ -74,7 +74,13 @@ jobs:
     name: OSV Scan
     runs-on: ubuntu-latest
     permissions:
-      security-events: write
+      # `security-events: write` used to be requested here and was never used:
+      # nothing in this job uploads SARIF (the scan writes JSON for the triage
+      # gate below). Findings surfaced nowhere as a result -- no alert, no
+      # issue, no notification (#780). It is replaced by the permission the job
+      # actually needs to reach a human.
+      contents: read # checkout
+      issues: write # the tracking issue maintained by "Report OSV findings"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -93,6 +99,28 @@ jobs:
             --output=osv-results.json
             --lockfile=frontend/package-lock.json
             --lockfile=e2e/package-lock.json
+
+      # Maintains ONE tracking issue naming the advisories, found by the
+      # `osv-report` label rather than by title. Runs BEFORE the gate below so a
+      # blocking finding is filed as well as failing the job, and with
+      # `always()` so it still files when the scan step itself failed.
+      #
+      # The logic lives in a repo script rather than inline YAML so it is
+      # covered by the unit suite (frontend/scripts/__tests__/osv-report.test.ts)
+      # against real scanner output, instead of only ever running in production.
+      - name: Report OSV findings
+        if: always() && steps.osv.outcome != 'skipped'
+        # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        env:
+          # Passed through env, not `${{ }}` inside `script:`, which would be a
+          # template-injection sink. A non-zero scanner exit with no findings at
+          # all is a scan that did not happen; the filer refuses to report clean.
+          OSV_SCAN_OUTCOME: ${{ steps.osv.outcome }}
+        with:
+          script: |
+            const { run } = await import(`${process.env.GITHUB_WORKSPACE}/frontend/scripts/osv-report.mjs`);
+            await run({ github, context, core });
 
       # Triaged through the same gate the npm-audit jobs use, against the same
       # exceptions file, so the two scanners cannot reach opposite conclusions

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -123,6 +123,7 @@ matching `v*.*.*` with a "Restrict deletions" rule.
 - `npm audit --audit-level=high` in Dockerfile, on every pull request, and in the scheduled security workflow
 - `rehype-sanitize` for Markdown rendering (XSS mitigation)
 - Scheduled weekly security workflow with auto-issue on failure
+- **OSV-Scanner findings are filed, not just logged**: the weekly `OSV Scan` job maintains a single tracking issue carrying the `osv-report` label, naming every high/critical advisory (id, severity, package, installed version, minimal fix, lockfile). It is rewritten in place while the findings persist, comments what changed when the set changes, and closes itself once a scan reports none. An unreadable or absent scan report fails the job rather than reading as clean. Logic and tests: `frontend/scripts/osv-report.mjs`
 - **SLSA provenance attestation** on Docker images via `actions/attest-build-provenance`
 - **SBOM (SPDX) generation and attestation** on Docker images via Syft (`anchore/sbom-action`) and `actions/attest-sbom`
 - **Cosign keyless signing** on Docker images via Sigstore (verify with `cosign verify`)

--- a/frontend/scripts/__tests__/audit-gate.test.ts
+++ b/frontend/scripts/__tests__/audit-gate.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 // @ts-expect-error -- plain ESM script, no type declarations by design
-import { triage, triageOsv, triageReport, render, loadExceptions } from '../audit-gate.mjs'
+import { triage, triageOsv, triageReport, render, loadExceptions, compareVersions } from '../audit-gate.mjs'
 
 type Fix = boolean | { name: string; version: string; isSemVerMajor: boolean }
 
@@ -184,6 +184,84 @@ describe('audit-gate OSV mode', () => {
     r.results[0].packages[0].vulnerabilities[0].database_specific.severity = 'MODERATE'
     const { blocking, advisory, accepted } = triageOsv(r, NONE)
     expect([blocking, advisory, accepted].every((l) => l.length === 0)).toBe(true)
+  })
+
+  // An advisory that spans several release lines publishes one fix per line.
+  // Taking whichever OSV listed first named a fix from an unrelated major and
+  // the gate then wrote the finding off as "breaking only" — silently NOT
+  // blocking on a high with a patch-level fix. Real ranges, from this repo's
+  // own frontend/package-lock.json at e52794c~1.
+  describe('minimal upgrade selection', () => {
+    const multiLine = (installed: string, fixes: string[]) => ({
+      results: [
+        {
+          source: { path: 'frontend/package-lock.json' },
+          packages: [
+            {
+              package: { name: 'brace-expansion', version: installed, ecosystem: 'npm' },
+              vulnerabilities: [
+                {
+                  id: 'GHSA-mh99-v99m-4gvg',
+                  summary: 'Example advisory',
+                  database_specific: { severity: 'HIGH' },
+                  affected: [
+                    {
+                      package: { name: 'brace-expansion' },
+                      ranges: fixes.map((fixed) => ({ type: 'SEMVER', events: [{ introduced: '0' }, { fixed }] })),
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })
+
+    it.each([
+      ['1.1.16', '1.1.17'],
+      ['5.0.7', '5.0.8'],
+      ['3.0.1', '3.0.3'],
+    ])('picks the lowest fix above %s, not the first listed', (installed, expected) => {
+      const { blocking } = triageOsv(multiLine(installed, ['5.0.8', '3.0.3', '2.1.3', '1.1.17']), NONE)
+      expect(blocking).toHaveLength(1)
+      expect(blocking[0].fix.version).toBe(expected)
+    })
+
+    it('still reports a breaking-only fix as breaking', () => {
+      const { blocking, advisory } = triageOsv(multiLine('3.8.3', ['4.3.9']), NONE)
+      expect(blocking).toHaveLength(0)
+      expect(advisory[0].fix.version).toBe('4.3.9')
+      expect(advisory[0].why).toBe('only a semver-major (breaking) fix is available')
+    })
+
+    it('falls back to the first published fix when none is an upgrade', () => {
+      const { advisory } = triageOsv(multiLine('9.9.9', ['1.1.17']), NONE)
+      expect(advisory[0].fix.version).toBe('1.1.17')
+    })
+
+    it.each([
+      ['1.1.16', '1.1.17', -1],
+      ['1.1.17', '1.1.16', 1],
+      ['1.1.17', '1.1.17', 0],
+      ['2.1.3', '10.0.0', -1],
+      ['1.2', '1.2.0', 0],
+    ])('compareVersions(%s, %s) sorts numerically', (a, b, sign) => {
+      expect(Math.sign(compareVersions(a, b))).toBe(sign)
+    })
+  })
+
+  it('carries the installed version and CVSS score for the issue filer', () => {
+    const r = osvReport('nanoid', '3.3.16', '3.3.18', 'GHSA-2v37-7h3g-55p8')
+    r.results[0].packages[0].groups = [{ ids: ['GHSA-2v37-7h3g-55p8'], aliases: [], max_severity: '8.2' }]
+    const { blocking } = triageOsv(r, NONE)
+    expect(blocking[0].installed).toBe('3.3.16')
+    expect(blocking[0].cvss).toBe('8.2')
+  })
+
+  it('leaves cvss empty when the scanner published no score', () => {
+    const { blocking } = triageOsv(osvReport('lib', '1.0.0', '1.0.1'), NONE)
+    expect(blocking[0].cvss).toBe('')
   })
 
   it('auto-detects report format so callers need not declare the scanner', () => {

--- a/frontend/scripts/__tests__/fixtures/osv-clean.json
+++ b/frontend/scripts/__tests__/fixtures/osv-clean.json
@@ -1,0 +1,9 @@
+{
+  "results": [],
+  "experimental_config": {
+    "licenses": {
+      "summary": false,
+      "allowlist": null
+    }
+  }
+}

--- a/frontend/scripts/__tests__/fixtures/osv-findings.json
+++ b/frontend/scripts/__tests__/fixtures/osv-findings.json
@@ -1,0 +1,2270 @@
+{
+  "results": [
+    {
+      "source": {
+        "path": "/home/runner/work/terraform-registry-frontend/terraform-registry-frontend/frontend/package-lock.json",
+        "type": "lockfile"
+      },
+      "packages": [
+        {
+          "package": {
+            "name": "brace-expansion",
+            "version": "1.1.16",
+            "ecosystem": "npm"
+          },
+          "dependency_groups": [
+            "dev"
+          ],
+          "groups": [
+            {
+              "ids": [
+                "GHSA-mh99-v99m-4gvg"
+              ],
+              "aliases": [
+                "CVE-2026-14257",
+                "GHSA-mh99-v99m-4gvg"
+              ],
+              "max_severity": "7.5"
+            },
+            {
+              "ids": [
+                "GHSA-rgw5-rvv9-x895"
+              ],
+              "aliases": [
+                "CVE-2026-69152",
+                "GHSA-rgw5-rvv9-x895"
+              ],
+              "max_severity": "7.5"
+            }
+          ],
+          "vulnerabilities": [
+            {
+              "affected": [
+                {
+                  "database_specific": {
+                    "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2026/07/GHSA-mh99-v99m-4gvg/GHSA-mh99-v99m-4gvg.json"
+                  },
+                  "package": {
+                    "ecosystem": "npm",
+                    "name": "brace-expansion",
+                    "purl": "pkg:npm/brace-expansion"
+                  },
+                  "ranges": [
+                    {
+                      "events": [
+                        {
+                          "introduced": "4.0.0"
+                        },
+                        {
+                          "fixed": "5.0.8"
+                        }
+                      ],
+                      "type": "SEMVER"
+                    }
+                  ]
+                },
+                {
+                  "database_specific": {
+                    "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2026/07/GHSA-mh99-v99m-4gvg/GHSA-mh99-v99m-4gvg.json"
+                  },
+                  "package": {
+                    "ecosystem": "npm",
+                    "name": "brace-expansion",
+                    "purl": "pkg:npm/brace-expansion"
+                  },
+                  "ranges": [
+                    {
+                      "events": [
+                        {
+                          "introduced": "3.0.0"
+                        },
+                        {
+                          "fixed": "3.0.3"
+                        }
+                      ],
+                      "type": "SEMVER"
+                    }
+                  ]
+                },
+                {
+                  "database_specific": {
+                    "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2026/07/GHSA-mh99-v99m-4gvg/GHSA-mh99-v99m-4gvg.json"
+                  },
+                  "package": {
+                    "ecosystem": "npm",
+                    "name": "brace-expansion",
+                    "purl": "pkg:npm/brace-expansion"
+                  },
+                  "ranges": [
+                    {
+                      "events": [
+                        {
+                          "introduced": "2.0.0"
+                        },
+                        {
+                          "fixed": "2.1.3"
+                        }
+                      ],
+                      "type": "SEMVER"
+                    }
+                  ]
+                },
+                {
+                  "database_specific": {
+                    "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2026/07/GHSA-mh99-v99m-4gvg/GHSA-mh99-v99m-4gvg.json"
+                  },
+                  "package": {
+                    "ecosystem": "npm",
+                    "name": "brace-expansion",
+                    "purl": "pkg:npm/brace-expansion"
+                  },
+                  "ranges": [
+                    {
+                      "events": [
+                        {
+                          "introduced": "0"
+                        },
+                        {
+                          "fixed": "1.1.17"
+                        }
+                      ],
+                      "type": "SEMVER"
+                    }
+                  ]
+                }
+              ],
+              "aliases": [
+                "CVE-2026-14257"
+              ],
+              "database_specific": {
+                "cwe_ids": [
+                  "CWE-400",
+                  "CWE-770"
+                ],
+                "github_reviewed": true,
+                "github_reviewed_at": "2026-07-24T21:53:14Z",
+                "nvd_published_at": "2026-07-23T14:17:00Z",
+                "severity": "HIGH"
+              },
+              "details": "### Summary\n\n`expand()` bounds the *number* of results it produces (the `max` option,\n`100_000` by default) but not their *length*. By chaining many brace groups,\nan attacker keeps the result count under `max` while making every result grow\nwith the number of groups. Building `max` long results — plus the intermediate\narrays combined at each brace group — exhausts memory and crashes the Node\nprocess with an **uncatchable** out-of-memory error. `try/catch` around\n`expand()` does not help: the fatal error terminates the process.\n\nA ~7.5 KB input (`'{a,b}'.repeat(1500)`) is enough to crash a default Node\nprocess.\n\n### Details\n\nFor `N` chained brace groups such as `'{a,b}'.repeat(N)`:\n\n- the result count is `2^N`, immediately capped at `max` (`100_000`), so the\n  `max` protection appears to hold, but\n- each result is `N` characters long, so the total output size is\n  `max × N` characters, which grows without bound in `N`.\n\n`expand_` combines each brace set with the fully-expanded tail:\n\n```js\nconst post = m.post.length ? expand_(m.post, max, false) : ['']\n...\nfor (let j = 0; j \u003c N.length; j++) {\n  for (let k = 0; k \u003c post.length \u0026\u0026 expansions.length \u003c max; k++) {\n    const expansion = pre + N[j] + post[k]   // grows one group longer per level\n    ...\n    expansions.push(expansion)\n  }\n}\n```\n\nThe loop guard `expansions.length \u003c max` limits how many strings are built, but\nnothing limits how long they get. Each recursion level materializes another\narray of up to `max` strings, one character longer than the level below, and —\nbecause V8 represents `pre + N[j] + post[k]` as a cons-string (rope) that\nreferences `post[k]` — those intermediate strings stay reachable through the\nwhole chain. Memory therefore scales with `max × N`.\n\nMeasured on `5.0.7` (`'{a,b}'.repeat(N)`, default `max`):\n\n| groups (N) | input bytes | result count | peak RSS |\n|---|---|---|---|\n| 20 | 100 | 100,000 | ~80 MB |\n| 50 | 250 | 100,000 | ~214 MB |\n| 100 | 500 | 100,000 | ~409 MB |\n| 300 | 1,500 | 100,000 | ~1,148 MB |\n| 1500 | 7,500 | — | **OOM crash** |\n\n### Proof of concept\n\n```js\nconst { expand } = require('brace-expansion')\n\n// ~7.5 KB input — crashes the process with a fatal, uncatchable OOM:\n//   FATAL ERROR: ... JavaScript heap out of memory\ntry {\n  expand('{a,b}'.repeat(1500))\n} catch (e) {\n  // never reached — the process is already dead\n}\n```\n\n### Impact\n\nAny application that passes attacker-influenced strings to\n`brace-expansion.expand()` — directly, or transitively via `minimatch` / `glob`\nbrace patterns — can be crashed by a small request. Because the failure is a\nfatal V8 out-of-memory error rather than a thrown exception, it cannot be caught\nand it takes down the whole worker/process, denying service.\n\n### Remediation\n\nUpgrade to a patched release. The fix bounds the total number of characters a\nsingle `expand()` call may accumulate (`EXPANSION_MAX_LENGTH`, default\n`4_000_000`, configurable via a new `maxLength` option), applied inside the\noutput-building loops so intermediate arrays are bounded too. Once the limit is\nreached, output is truncated — consistent with how `max` already truncates —\ninstead of growing without bound. The limit sits well above any realistic\nexpansion (100,000 results hitting `max` measure ~1M characters), so legitimate\ninput is unaffected.\n\nAfter the fix, `'{a,b}'.repeat(1500)` returns a bounded, truncated result in\n~0.7 s using ~340 MB and never crashes, including under a constrained 512 MB\nheap.\n\nThe fix bounds memory but the algorithm still rebuilds intermediate arrays at\neach level (roughly `O(N × maxLength)` work on this input class). A streaming\nrewrite that produces output in `O(total output size)` can be a non-urgent\nfollow-up.\n\nIf immediate upgrade isn't possible, avoid passing untrusted input to\n`expand()` / glob brace patterns, or pass a small explicit `max` **and**\n`maxLength`.",
+              "id": "GHSA-mh99-v99m-4gvg",
+              "modified": "2026-07-31T19:45:20.213748264Z",
+              "published": "2026-07-24T21:53:14Z",
+              "references": [
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/juliangruber/brace-expansion/security/advisories/GHSA-mh99-v99m-4gvg"
+                },
+                {
+                  "type": "ADVISORY",
+                  "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-14257"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/juliangruber/brace-expansion/pull/129"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/juliangruber/brace-expansion/pull/130"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/juliangruber/brace-expansion/pull/136"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/juliangruber/brace-expansion/commit/139d015104e71433ad52a41d19467c48ecbb2c7d"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/juliangruber/brace-expansion/commit/a1bd33999ea75262c4749fff3bbb0d1372bd07b5"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/juliangruber/brace-expansion/commit/cb4b9e47cc2ec777c14b2b4492fb431a56f6a031"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/juliangruber/brace-expansion/commit/d13ff455a58b0d56704f0111e3c2a0b16ceb06eb"
+                },
+                {
+                  "type": "PACKAGE",
+                  "url": "https://github.com/juliangruber/brace-expansion"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://www.npmjs.com/package/brace-expansion"
+                }
+              ],
+              "related": [
+                "CGA-369p-jq5q-2j43"
+              ],
+              "schema_version": "1.7.5",
+              "severity": [
+                {
+                  "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+                  "type": "CVSS_V3"
+                }
+              ],
+              "summary": "brace-expansion: DoS via unbounded expansion length causing an out-of-memory process crash"
+            },
+            {
+              "affected": [
+                {
+                  "database_specific": {
+                    "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2026/08/GHSA-rgw5-rvv9-x895/GHSA-rgw5-rvv9-x895.json"
+                  },
+                  "package": {
+                    "ecosystem": "npm",
+                    "name": "brace-expansion",
+                    "purl": "pkg:npm/brace-expansion"
+                  },
+                  "ranges": [
+                    {
+                      "events": [
+                        {
+                          "introduced": "0"
+                        },
+                        {
+                          "fixed": "1.1.18"
+                        }
+                      ],
+                      "type": "SEMVER"
+                    }
+                  ]
+                },
+                {
+                  "database_specific": {
+                    "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2026/08/GHSA-rgw5-rvv9-x895/GHSA-rgw5-rvv9-x895.json"
+                  },
+                  "package": {
+                    "ecosystem": "npm",
+                    "name": "brace-expansion",
+                    "purl": "pkg:npm/brace-expansion"
+                  },
+                  "ranges": [
+                    {
+                      "events": [
+                        {
+                          "introduced": "2.0.0"
+                        },
+                        {
+                          "fixed": "2.1.4"
+                        }
+                      ],
+                      "type": "SEMVER"
+                    }
+                  ]
+                },
+                {
+                  "database_specific": {
+                    "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2026/08/GHSA-rgw5-rvv9-x895/GHSA-rgw5-rvv9-x895.json"
+                  },
+                  "package": {
+                    "ecosystem": "npm",
+                    "name": "brace-expansion",
+                    "purl": "pkg:npm/brace-expansion"
+                  },
+                  "ranges": [
+                    {
+                      "events": [
+                        {
+                          "introduced": "3.0.0"
+                        },
+                        {
+                          "fixed": "3.0.6"
+                        }
+                      ],
+                      "type": "SEMVER"
+                    }
+                  ]
+                },
+                {
+                  "database_specific": {
+                    "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2026/08/GHSA-rgw5-rvv9-x895/GHSA-rgw5-rvv9-x895.json"
+                  },
+                  "package": {
+                    "ecosystem": "npm",
+                    "name": "brace-expansion",
+                    "purl": "pkg:npm/brace-expansion"
+                  },
+                  "ranges": [
+                    {
+                      "events": [
+                        {
+                          "introduced": "4.0.0"
+                        },
+                        {
+                          "fixed": "5.0.9"
+                        }
+                      ],
+                      "type": "SEMVER"
+                    }
+                  ]
+                }
+              ],
+              "aliases": [
+                "CVE-2026-69152"
+              ],
+              "database_specific": {
+                "cwe_ids": [
+                  "CWE-400",
+                  "CWE-770"
+                ],
+                "github_reviewed": true,
+                "github_reviewed_at": "2026-08-03T16:35:32Z",
+                "nvd_published_at": "2026-08-03T17:16:45Z",
+                "severity": "HIGH"
+              },
+              "details": "### Summary\n\nThe `maxLength` mitigation added in `5.0.8` for GHSA-mh99-v99m-4gvg / CVE-2026-14257 is incomplete. It bounds the accumulator where results are *combined*, but not the intermediate arrays that feed it. A ~25 KB input still crashes the Node process with an **uncatchable** out-of-memory error, so `try/catch` around `expand()` does not help.\n\nA second, related path in the same function lets a ~400 KB input block the event loop for over two minutes without ever exceeding the memory bound.\n\n### Details\n\n`maxLength` was enforced in `combine()`, the single place output grows. Two arrays are built *before* `combine()` runs, and neither was bounded.\n\n**1. Comma alternatives accumulate without a running total (memory exhaustion)**\n\nEach alternative in `{a,b,c,...}` is expanded by its own recursive `expand_()` call, so each receives a full, independent `maxLength` allowance. The results were then concatenated into a single `values` array with no cumulative limit:\n\n```js\nvalues = []\nfor (let j = 0; j \u003c n.length; j++) {\n  values.push.apply(values, expand_(n[j], max, maxLength, false))\n}\n\nacc = combine(acc, pre, values, max, maxLength, ...)\n```\n\nWith `A` alternatives, `values` can reach `A * maxLength` characters before `combine()` gets a chance to truncate it. At the default `maxLength` of 4,000,000 and 400 alternatives, that is well past any default heap.\n\n**2. Padded sequences ignore `maxLength` while generating (CPU exhaustion)**\n\n`expandSequence()` was bounded by `max` (the result *count*) but never consulted `maxLength`. A padded sequence's element width follows the input, so `{0...01..100000}` with a wide pad generates `max` elements, each as wide as the input, only for `combine()` to discard all but a handful.\n\nMemory stays flat here, because V8 represents the padded strings as cons-strings, which is likely why this path was not caught alongside the original issue. The cost is time: work proportional to `max * width`.\n\n| pad width | input bytes | results kept | time (5.0.8) | time (patched) |\n|---|---|---|---|---|\n| 20,000 | 20 KB | 199 | ~7.3 s | ~20 ms |\n| 100,000 | 100 KB | 39 | ~32 s | ~20 ms |\n| 400,000 | 400 KB | 9 | ~124 s | ~18 ms |\n\nOutput is byte-identical before and after the fix; only the wasted work is removed.\n\n### Proof of concept\n\nMemory exhaustion, against `5.0.8`:\n\n```js\nimport { expand } from 'brace-expansion'\n\nconst part = '{' + '0'.repeat(50) + '1..100000}'\nconst input = '{' + Array(400).fill(part).join(',') + '}'  // ~25 KB\n\ntry {\n  expand(input)\n} catch (e) {\n  // never reached - the process is already dead\n}\n```\n\n```\nFATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory\nAborted\n```\n\nEvent-loop stall, against `5.0.8`:\n\n```js\nimport { expand } from 'brace-expansion'\n\n// ~400 KB input, returns 9 results after roughly two minutes of blocking CPU\nexpand('{' + '0'.repeat(400_000) + '1..100000}')\n```\n\n### Impact\n\nDenial of service. Any application that passes attacker-controlled input to `expand()`, directly or transitively through a glob or pattern-matching library, can be remotely crashed or stalled. The out-of-memory variant terminates the process and cannot be handled with `try/catch`.\n\nApplications already on `5.0.8` are affected: the `5.0.8` mitigation does not cover these paths.\n\n### Patches\n\nBoth intermediate arrays are now bounded as they are built, using the same `max` and `maxLength` limits already applied in `combine()`:\n\n- `values` tracks a running result count and character length while alternatives are appended, and stops once either bound is reached.\n- `expandSequence()` accepts `maxLength` and stops generating once the sequence's own characters reach it.\n\nAs with the existing limits, output is truncated rather than allowed to grow without bound, which matches how `max` already behaves. The defaults sit well above any realistic expansion, so legitimate input is unaffected.\n\n### Workarounds\n\nIf upgrading is not immediately possible, avoid passing untrusted input to `expand()` or to glob brace patterns, or pass an explicitly small `max` **and** `maxLength`.\n\nNote that a small `maxLength` alone was not sufficient on affected versions: it was applied per alternative rather than cumulatively, which is the root of the first issue above.\n\n### Credits\n\nThe memory-exhaustion bypass was reported by Alessio Della Libera, CEO \u0026 Co-founder at [Numyra](https://numyra.ai/).\n\nThe sequence-generation issue was found while verifying that report.",
+              "id": "GHSA-rgw5-rvv9-x895",
+              "modified": "2026-08-04T21:27:00.495135395Z",
+              "published": "2026-08-03T16:35:32Z",
+              "references": [
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/juliangruber/brace-expansion/security/advisories/GHSA-rgw5-rvv9-x895"
+                },
+                {
+                  "type": "ADVISORY",
+                  "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-69152"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/juliangruber/brace-expansion/commit/139d015104e71433ad52a41d19467c48ecbb2c7d"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/juliangruber/brace-expansion/commit/1e30c930238d7162802d88a94189182def178dac"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/juliangruber/brace-expansion/commit/688a99eeaab02627c2b89ba8ba4821fecfa659cf"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/juliangruber/brace-expansion/commit/cb4b9e47cc2ec777c14b2b4492fb431a56f6a031"
+                },
+                {
+                  "type": "PACKAGE",
+                  "url": "https://github.com/juliangruber/brace-expansion"
+                }
+              ],
+              "related": [
+                "CGA-7234-5hj8-j5q9"
+              ],
+              "schema_version": "1.7.5",
+              "severity": [
+                {
+                  "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+                  "type": "CVSS_V3"
+                }
+              ],
+              "summary": "brace-expansion: DoS via unbounded intermediate arrays, bypassing the CVE-2026-14257 mitigation"
+            }
+          ]
+        },
+        {
+          "package": {
+            "name": "brace-expansion",
+            "version": "5.0.7",
+            "ecosystem": "npm"
+          },
+          "groups": [
+            {
+              "ids": [
+                "GHSA-mh99-v99m-4gvg"
+              ],
+              "aliases": [
+                "CVE-2026-14257",
+                "GHSA-mh99-v99m-4gvg"
+              ],
+              "max_severity": "7.5"
+            },
+            {
+              "ids": [
+                "GHSA-rgw5-rvv9-x895"
+              ],
+              "aliases": [
+                "CVE-2026-69152",
+                "GHSA-rgw5-rvv9-x895"
+              ],
+              "max_severity": "7.5"
+            }
+          ],
+          "vulnerabilities": [
+            {
+              "affected": [
+                {
+                  "database_specific": {
+                    "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2026/07/GHSA-mh99-v99m-4gvg/GHSA-mh99-v99m-4gvg.json"
+                  },
+                  "package": {
+                    "ecosystem": "npm",
+                    "name": "brace-expansion",
+                    "purl": "pkg:npm/brace-expansion"
+                  },
+                  "ranges": [
+                    {
+                      "events": [
+                        {
+                          "introduced": "4.0.0"
+                        },
+                        {
+                          "fixed": "5.0.8"
+                        }
+                      ],
+                      "type": "SEMVER"
+                    }
+                  ]
+                },
+                {
+                  "database_specific": {
+                    "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2026/07/GHSA-mh99-v99m-4gvg/GHSA-mh99-v99m-4gvg.json"
+                  },
+                  "package": {
+                    "ecosystem": "npm",
+                    "name": "brace-expansion",
+                    "purl": "pkg:npm/brace-expansion"
+                  },
+                  "ranges": [
+                    {
+                      "events": [
+                        {
+                          "introduced": "3.0.0"
+                        },
+                        {
+                          "fixed": "3.0.3"
+                        }
+                      ],
+                      "type": "SEMVER"
+                    }
+                  ]
+                },
+                {
+                  "database_specific": {
+                    "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2026/07/GHSA-mh99-v99m-4gvg/GHSA-mh99-v99m-4gvg.json"
+                  },
+                  "package": {
+                    "ecosystem": "npm",
+                    "name": "brace-expansion",
+                    "purl": "pkg:npm/brace-expansion"
+                  },
+                  "ranges": [
+                    {
+                      "events": [
+                        {
+                          "introduced": "2.0.0"
+                        },
+                        {
+                          "fixed": "2.1.3"
+                        }
+                      ],
+                      "type": "SEMVER"
+                    }
+                  ]
+                },
+                {
+                  "database_specific": {
+                    "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2026/07/GHSA-mh99-v99m-4gvg/GHSA-mh99-v99m-4gvg.json"
+                  },
+                  "package": {
+                    "ecosystem": "npm",
+                    "name": "brace-expansion",
+                    "purl": "pkg:npm/brace-expansion"
+                  },
+                  "ranges": [
+                    {
+                      "events": [
+                        {
+                          "introduced": "0"
+                        },
+                        {
+                          "fixed": "1.1.17"
+                        }
+                      ],
+                      "type": "SEMVER"
+                    }
+                  ]
+                }
+              ],
+              "aliases": [
+                "CVE-2026-14257"
+              ],
+              "database_specific": {
+                "cwe_ids": [
+                  "CWE-400",
+                  "CWE-770"
+                ],
+                "github_reviewed": true,
+                "github_reviewed_at": "2026-07-24T21:53:14Z",
+                "nvd_published_at": "2026-07-23T14:17:00Z",
+                "severity": "HIGH"
+              },
+              "details": "### Summary\n\n`expand()` bounds the *number* of results it produces (the `max` option,\n`100_000` by default) but not their *length*. By chaining many brace groups,\nan attacker keeps the result count under `max` while making every result grow\nwith the number of groups. Building `max` long results — plus the intermediate\narrays combined at each brace group — exhausts memory and crashes the Node\nprocess with an **uncatchable** out-of-memory error. `try/catch` around\n`expand()` does not help: the fatal error terminates the process.\n\nA ~7.5 KB input (`'{a,b}'.repeat(1500)`) is enough to crash a default Node\nprocess.\n\n### Details\n\nFor `N` chained brace groups such as `'{a,b}'.repeat(N)`:\n\n- the result count is `2^N`, immediately capped at `max` (`100_000`), so the\n  `max` protection appears to hold, but\n- each result is `N` characters long, so the total output size is\n  `max × N` characters, which grows without bound in `N`.\n\n`expand_` combines each brace set with the fully-expanded tail:\n\n```js\nconst post = m.post.length ? expand_(m.post, max, false) : ['']\n...\nfor (let j = 0; j \u003c N.length; j++) {\n  for (let k = 0; k \u003c post.length \u0026\u0026 expansions.length \u003c max; k++) {\n    const expansion = pre + N[j] + post[k]   // grows one group longer per level\n    ...\n    expansions.push(expansion)\n  }\n}\n```\n\nThe loop guard `expansions.length \u003c max` limits how many strings are built, but\nnothing limits how long they get. Each recursion level materializes another\narray of up to `max` strings, one character longer than the level below, and —\nbecause V8 represents `pre + N[j] + post[k]` as a cons-string (rope) that\nreferences `post[k]` — those intermediate strings stay reachable through the\nwhole chain. Memory therefore scales with `max × N`.\n\nMeasured on `5.0.7` (`'{a,b}'.repeat(N)`, default `max`):\n\n| groups (N) | input bytes | result count | peak RSS |\n|---|---|---|---|\n| 20 | 100 | 100,000 | ~80 MB |\n| 50 | 250 | 100,000 | ~214 MB |\n| 100 | 500 | 100,000 | ~409 MB |\n| 300 | 1,500 | 100,000 | ~1,148 MB |\n| 1500 | 7,500 | — | **OOM crash** |\n\n### Proof of concept\n\n```js\nconst { expand } = require('brace-expansion')\n\n// ~7.5 KB input — crashes the process with a fatal, uncatchable OOM:\n//   FATAL ERROR: ... JavaScript heap out of memory\ntry {\n  expand('{a,b}'.repeat(1500))\n} catch (e) {\n  // never reached — the process is already dead\n}\n```\n\n### Impact\n\nAny application that passes attacker-influenced strings to\n`brace-expansion.expand()` — directly, or transitively via `minimatch` / `glob`\nbrace patterns — can be crashed by a small request. Because the failure is a\nfatal V8 out-of-memory error rather than a thrown exception, it cannot be caught\nand it takes down the whole worker/process, denying service.\n\n### Remediation\n\nUpgrade to a patched release. The fix bounds the total number of characters a\nsingle `expand()` call may accumulate (`EXPANSION_MAX_LENGTH`, default\n`4_000_000`, configurable via a new `maxLength` option), applied inside the\noutput-building loops so intermediate arrays are bounded too. Once the limit is\nreached, output is truncated — consistent with how `max` already truncates —\ninstead of growing without bound. The limit sits well above any realistic\nexpansion (100,000 results hitting `max` measure ~1M characters), so legitimate\ninput is unaffected.\n\nAfter the fix, `'{a,b}'.repeat(1500)` returns a bounded, truncated result in\n~0.7 s using ~340 MB and never crashes, including under a constrained 512 MB\nheap.\n\nThe fix bounds memory but the algorithm still rebuilds intermediate arrays at\neach level (roughly `O(N × maxLength)` work on this input class). A streaming\nrewrite that produces output in `O(total output size)` can be a non-urgent\nfollow-up.\n\nIf immediate upgrade isn't possible, avoid passing untrusted input to\n`expand()` / glob brace patterns, or pass a small explicit `max` **and**\n`maxLength`.",
+              "id": "GHSA-mh99-v99m-4gvg",
+              "modified": "2026-07-31T19:45:20.213748264Z",
+              "published": "2026-07-24T21:53:14Z",
+              "references": [
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/juliangruber/brace-expansion/security/advisories/GHSA-mh99-v99m-4gvg"
+                },
+                {
+                  "type": "ADVISORY",
+                  "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-14257"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/juliangruber/brace-expansion/pull/129"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/juliangruber/brace-expansion/pull/130"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/juliangruber/brace-expansion/pull/136"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/juliangruber/brace-expansion/commit/139d015104e71433ad52a41d19467c48ecbb2c7d"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/juliangruber/brace-expansion/commit/a1bd33999ea75262c4749fff3bbb0d1372bd07b5"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/juliangruber/brace-expansion/commit/cb4b9e47cc2ec777c14b2b4492fb431a56f6a031"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/juliangruber/brace-expansion/commit/d13ff455a58b0d56704f0111e3c2a0b16ceb06eb"
+                },
+                {
+                  "type": "PACKAGE",
+                  "url": "https://github.com/juliangruber/brace-expansion"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://www.npmjs.com/package/brace-expansion"
+                }
+              ],
+              "related": [
+                "CGA-369p-jq5q-2j43"
+              ],
+              "schema_version": "1.7.5",
+              "severity": [
+                {
+                  "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+                  "type": "CVSS_V3"
+                }
+              ],
+              "summary": "brace-expansion: DoS via unbounded expansion length causing an out-of-memory process crash"
+            },
+            {
+              "affected": [
+                {
+                  "database_specific": {
+                    "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2026/08/GHSA-rgw5-rvv9-x895/GHSA-rgw5-rvv9-x895.json"
+                  },
+                  "package": {
+                    "ecosystem": "npm",
+                    "name": "brace-expansion",
+                    "purl": "pkg:npm/brace-expansion"
+                  },
+                  "ranges": [
+                    {
+                      "events": [
+                        {
+                          "introduced": "0"
+                        },
+                        {
+                          "fixed": "1.1.18"
+                        }
+                      ],
+                      "type": "SEMVER"
+                    }
+                  ]
+                },
+                {
+                  "database_specific": {
+                    "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2026/08/GHSA-rgw5-rvv9-x895/GHSA-rgw5-rvv9-x895.json"
+                  },
+                  "package": {
+                    "ecosystem": "npm",
+                    "name": "brace-expansion",
+                    "purl": "pkg:npm/brace-expansion"
+                  },
+                  "ranges": [
+                    {
+                      "events": [
+                        {
+                          "introduced": "2.0.0"
+                        },
+                        {
+                          "fixed": "2.1.4"
+                        }
+                      ],
+                      "type": "SEMVER"
+                    }
+                  ]
+                },
+                {
+                  "database_specific": {
+                    "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2026/08/GHSA-rgw5-rvv9-x895/GHSA-rgw5-rvv9-x895.json"
+                  },
+                  "package": {
+                    "ecosystem": "npm",
+                    "name": "brace-expansion",
+                    "purl": "pkg:npm/brace-expansion"
+                  },
+                  "ranges": [
+                    {
+                      "events": [
+                        {
+                          "introduced": "3.0.0"
+                        },
+                        {
+                          "fixed": "3.0.6"
+                        }
+                      ],
+                      "type": "SEMVER"
+                    }
+                  ]
+                },
+                {
+                  "database_specific": {
+                    "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2026/08/GHSA-rgw5-rvv9-x895/GHSA-rgw5-rvv9-x895.json"
+                  },
+                  "package": {
+                    "ecosystem": "npm",
+                    "name": "brace-expansion",
+                    "purl": "pkg:npm/brace-expansion"
+                  },
+                  "ranges": [
+                    {
+                      "events": [
+                        {
+                          "introduced": "4.0.0"
+                        },
+                        {
+                          "fixed": "5.0.9"
+                        }
+                      ],
+                      "type": "SEMVER"
+                    }
+                  ]
+                }
+              ],
+              "aliases": [
+                "CVE-2026-69152"
+              ],
+              "database_specific": {
+                "cwe_ids": [
+                  "CWE-400",
+                  "CWE-770"
+                ],
+                "github_reviewed": true,
+                "github_reviewed_at": "2026-08-03T16:35:32Z",
+                "nvd_published_at": "2026-08-03T17:16:45Z",
+                "severity": "HIGH"
+              },
+              "details": "### Summary\n\nThe `maxLength` mitigation added in `5.0.8` for GHSA-mh99-v99m-4gvg / CVE-2026-14257 is incomplete. It bounds the accumulator where results are *combined*, but not the intermediate arrays that feed it. A ~25 KB input still crashes the Node process with an **uncatchable** out-of-memory error, so `try/catch` around `expand()` does not help.\n\nA second, related path in the same function lets a ~400 KB input block the event loop for over two minutes without ever exceeding the memory bound.\n\n### Details\n\n`maxLength` was enforced in `combine()`, the single place output grows. Two arrays are built *before* `combine()` runs, and neither was bounded.\n\n**1. Comma alternatives accumulate without a running total (memory exhaustion)**\n\nEach alternative in `{a,b,c,...}` is expanded by its own recursive `expand_()` call, so each receives a full, independent `maxLength` allowance. The results were then concatenated into a single `values` array with no cumulative limit:\n\n```js\nvalues = []\nfor (let j = 0; j \u003c n.length; j++) {\n  values.push.apply(values, expand_(n[j], max, maxLength, false))\n}\n\nacc = combine(acc, pre, values, max, maxLength, ...)\n```\n\nWith `A` alternatives, `values` can reach `A * maxLength` characters before `combine()` gets a chance to truncate it. At the default `maxLength` of 4,000,000 and 400 alternatives, that is well past any default heap.\n\n**2. Padded sequences ignore `maxLength` while generating (CPU exhaustion)**\n\n`expandSequence()` was bounded by `max` (the result *count*) but never consulted `maxLength`. A padded sequence's element width follows the input, so `{0...01..100000}` with a wide pad generates `max` elements, each as wide as the input, only for `combine()` to discard all but a handful.\n\nMemory stays flat here, because V8 represents the padded strings as cons-strings, which is likely why this path was not caught alongside the original issue. The cost is time: work proportional to `max * width`.\n\n| pad width | input bytes | results kept | time (5.0.8) | time (patched) |\n|---|---|---|---|---|\n| 20,000 | 20 KB | 199 | ~7.3 s | ~20 ms |\n| 100,000 | 100 KB | 39 | ~32 s | ~20 ms |\n| 400,000 | 400 KB | 9 | ~124 s | ~18 ms |\n\nOutput is byte-identical before and after the fix; only the wasted work is removed.\n\n### Proof of concept\n\nMemory exhaustion, against `5.0.8`:\n\n```js\nimport { expand } from 'brace-expansion'\n\nconst part = '{' + '0'.repeat(50) + '1..100000}'\nconst input = '{' + Array(400).fill(part).join(',') + '}'  // ~25 KB\n\ntry {\n  expand(input)\n} catch (e) {\n  // never reached - the process is already dead\n}\n```\n\n```\nFATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory\nAborted\n```\n\nEvent-loop stall, against `5.0.8`:\n\n```js\nimport { expand } from 'brace-expansion'\n\n// ~400 KB input, returns 9 results after roughly two minutes of blocking CPU\nexpand('{' + '0'.repeat(400_000) + '1..100000}')\n```\n\n### Impact\n\nDenial of service. Any application that passes attacker-controlled input to `expand()`, directly or transitively through a glob or pattern-matching library, can be remotely crashed or stalled. The out-of-memory variant terminates the process and cannot be handled with `try/catch`.\n\nApplications already on `5.0.8` are affected: the `5.0.8` mitigation does not cover these paths.\n\n### Patches\n\nBoth intermediate arrays are now bounded as they are built, using the same `max` and `maxLength` limits already applied in `combine()`:\n\n- `values` tracks a running result count and character length while alternatives are appended, and stops once either bound is reached.\n- `expandSequence()` accepts `maxLength` and stops generating once the sequence's own characters reach it.\n\nAs with the existing limits, output is truncated rather than allowed to grow without bound, which matches how `max` already behaves. The defaults sit well above any realistic expansion, so legitimate input is unaffected.\n\n### Workarounds\n\nIf upgrading is not immediately possible, avoid passing untrusted input to `expand()` or to glob brace patterns, or pass an explicitly small `max` **and** `maxLength`.\n\nNote that a small `maxLength` alone was not sufficient on affected versions: it was applied per alternative rather than cumulatively, which is the root of the first issue above.\n\n### Credits\n\nThe memory-exhaustion bypass was reported by Alessio Della Libera, CEO \u0026 Co-founder at [Numyra](https://numyra.ai/).\n\nThe sequence-generation issue was found while verifying that report.",
+              "id": "GHSA-rgw5-rvv9-x895",
+              "modified": "2026-08-04T21:27:00.495135395Z",
+              "published": "2026-08-03T16:35:32Z",
+              "references": [
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/juliangruber/brace-expansion/security/advisories/GHSA-rgw5-rvv9-x895"
+                },
+                {
+                  "type": "ADVISORY",
+                  "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-69152"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/juliangruber/brace-expansion/commit/139d015104e71433ad52a41d19467c48ecbb2c7d"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/juliangruber/brace-expansion/commit/1e30c930238d7162802d88a94189182def178dac"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/juliangruber/brace-expansion/commit/688a99eeaab02627c2b89ba8ba4821fecfa659cf"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/juliangruber/brace-expansion/commit/cb4b9e47cc2ec777c14b2b4492fb431a56f6a031"
+                },
+                {
+                  "type": "PACKAGE",
+                  "url": "https://github.com/juliangruber/brace-expansion"
+                }
+              ],
+              "related": [
+                "CGA-7234-5hj8-j5q9"
+              ],
+              "schema_version": "1.7.5",
+              "severity": [
+                {
+                  "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+                  "type": "CVSS_V3"
+                }
+              ],
+              "summary": "brace-expansion: DoS via unbounded intermediate arrays, bypassing the CVE-2026-14257 mitigation"
+            }
+          ]
+        },
+        {
+          "package": {
+            "name": "dompurify",
+            "version": "3.4.12",
+            "ecosystem": "npm"
+          },
+          "groups": [
+            {
+              "ids": [
+                "GHSA-55q2-fjhq-7xh7"
+              ],
+              "aliases": [
+                "GHSA-55q2-fjhq-7xh7"
+              ],
+              "max_severity": "5.1"
+            }
+          ],
+          "vulnerabilities": [
+            {
+              "affected": [
+                {
+                  "database_specific": {
+                    "last_known_affected_version_range": "\u003c= 3.4.12",
+                    "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2026/08/GHSA-55q2-fjhq-7xh7/GHSA-55q2-fjhq-7xh7.json"
+                  },
+                  "package": {
+                    "ecosystem": "npm",
+                    "name": "dompurify",
+                    "purl": "pkg:npm/dompurify"
+                  },
+                  "ranges": [
+                    {
+                      "events": [
+                        {
+                          "introduced": "0"
+                        },
+                        {
+                          "fixed": "3.4.13"
+                        }
+                      ],
+                      "type": "SEMVER"
+                    }
+                  ]
+                }
+              ],
+              "database_specific": {
+                "cwe_ids": [
+                  "CWE-79"
+                ],
+                "github_reviewed": true,
+                "github_reviewed_at": "2026-08-07T15:30:47Z",
+                "nvd_published_at": null,
+                "severity": "MODERATE"
+              },
+              "details": "### Summary\n\nDuring `IN_PLACE` sanitization, a hook that removes an element can leave that element's detached descendants executable. A descendant image can retain its attacker-provided `onload` handler and fire after `sanitize()` returns, even though the returned root is clean and the image remains disconnected from the document.\n\n### Details\n\nIn DOMPurify 3.4.12, `_sanitizeElements()` in `src/purify.ts:1862-1904` runs the `beforeSanitizeElements` or `uponSanitizeElement` hook and returns immediately when the hook detached the current node. The return does not call `_neutralizeSubtree(currentNode)`.\n\nThe detached subtree is not added to `DOMPurify.removed`, so the post-walk `IN_PLACE` neutralization cannot reach it. If the browser queued a resource event while the application constructed the detached dirty root, a descendant can therefore retain its handler and execute after sanitization.\n\nThe hook only rejects the containing element and does not add or approve the event handler. DOMPurify's ordinary removal path de-arms the same queued event; only the hook-detachment early return skips the existing subtree neutralization.\n\n### PoC\n\nLoad the published `dompurify@3.4.12` `dist/purify.js` before this script in Chromium:\n\n```html\n\u003cdiv id=\"result\"\u003enot fired\u003c/div\u003e\n\u003cscript\u003e\nconst root = document.createElement('div');\nroot.innerHTML = `\n  \u003cfooter\u003e\n    \u003cimg src=\"data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7\"\n         onload=\"result.textContent = 'XSS after sanitize'\"\u003e\n  \u003c/footer\u003e\n  \u003cdiv\u003esafe\u003c/div\u003e`;\n\nDOMPurify.setConfig({\n  ALLOWED_TAGS: ['div', '#text', 'footer'],\n  IN_PLACE: true\n});\nDOMPurify.addHook('uponSanitizeElement', node =\u003e {\n  if (node.tagName === 'FOOTER') node.remove();\n});\n\nDOMPurify.sanitize(root);\ndocument.body.append(root);\n\u003c/script\u003e\n```\n\n`sanitize()` returns with no handler execution and the returned root contains only the safe `div`. After the event loop advances, the original image remains disconnected but its retained `onload` changes the page to `XSS after sanitize`.\n\nAs the claim-matched control, use the same detached input with `ALLOWED_TAGS: ['div', '#text']` and no hook. DOMPurify's ordinary removal path removes the original image's handler, the returned root is still `\u003cdiv\u003esafe\u003c/div\u003e`, and the marker does not fire.\n\n### Impact\n\nIn an application that uses `IN_PLACE` with the documented element-removal hook pattern, an attacker who can supply HTML can execute JavaScript in the integrating application's origin after the application sanitizes and renders that content.\n\nThe required non-default configuration is `IN_PLACE` plus a hook that removes a containing element. The hook does not add or approve the event handler, and the dirty root never needs to be connected before sanitization.\n\n### Suggested fix\n\nReuse the existing `_neutralizeSubtree(currentNode)` helper before returning from both hook-detachment branches in `_sanitizeElements()`. Add regressions for `beforeSanitizeElements` and `uponSanitizeElement` that retain a reference to a descendant resource element and verify that its event handler is removed after the hook detaches its ancestor.",
+              "id": "GHSA-55q2-fjhq-7xh7",
+              "modified": "2026-08-10T15:39:09.674741038Z",
+              "published": "2026-08-07T15:30:47Z",
+              "references": [
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/cure53/DOMPurify/security/advisories/GHSA-55q2-fjhq-7xh7"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/cure53/DOMPurify/pull/1557"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/cure53/DOMPurify/commit/3067f7746769"
+                },
+                {
+                  "type": "PACKAGE",
+                  "url": "https://github.com/cure53/DOMPurify"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/cure53/DOMPurify/releases/tag/3.4.13"
+                }
+              ],
+              "related": [
+                "CGA-g648-m8cr-xq5c"
+              ],
+              "schema_version": "1.8.0",
+              "severity": [
+                {
+                  "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:P/VC:N/VI:N/VA:N/SC:L/SI:L/SA:N",
+                  "type": "CVSS_V4"
+                }
+              ],
+              "summary": "DOMPurify: IN_PLACE hook removal leaves a detached subtree executable, causing XSS"
+            }
+          ]
+        },
+        {
+          "package": {
+            "name": "immutable",
+            "version": "3.8.3",
+            "ecosystem": "npm"
+          },
+          "groups": [
+            {
+              "ids": [
+                "GHSA-v56q-mh7h-f735"
+              ],
+              "aliases": [
+                "CVE-2026-59879",
+                "GHSA-v56q-mh7h-f735"
+              ],
+              "max_severity": "8.7"
+            },
+            {
+              "ids": [
+                "GHSA-xvcm-6775-5m9r"
+              ],
+              "aliases": [
+                "CVE-2026-59880",
+                "GHSA-xvcm-6775-5m9r"
+              ],
+              "max_severity": "8.7"
+            }
+          ],
+          "vulnerabilities": [
+            {
+              "affected": [
+                {
+                  "database_specific": {
+                    "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2026/07/GHSA-v56q-mh7h-f735/GHSA-v56q-mh7h-f735.json"
+                  },
+                  "package": {
+                    "ecosystem": "npm",
+                    "name": "immutable",
+                    "purl": "pkg:npm/immutable"
+                  },
+                  "ranges": [
+                    {
+                      "events": [
+                        {
+                          "introduced": "0"
+                        },
+                        {
+                          "fixed": "4.3.9"
+                        }
+                      ],
+                      "type": "SEMVER"
+                    }
+                  ]
+                },
+                {
+                  "database_specific": {
+                    "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2026/07/GHSA-v56q-mh7h-f735/GHSA-v56q-mh7h-f735.json"
+                  },
+                  "package": {
+                    "ecosystem": "npm",
+                    "name": "immutable",
+                    "purl": "pkg:npm/immutable"
+                  },
+                  "ranges": [
+                    {
+                      "events": [
+                        {
+                          "introduced": "5.0.0-beta.1"
+                        },
+                        {
+                          "fixed": "5.1.8"
+                        }
+                      ],
+                      "type": "SEMVER"
+                    }
+                  ]
+                }
+              ],
+              "aliases": [
+                "CVE-2026-59879"
+              ],
+              "database_specific": {
+                "cwe_ids": [
+                  "CWE-1284",
+                  "CWE-190",
+                  "CWE-400",
+                  "CWE-835"
+                ],
+                "github_reviewed": true,
+                "github_reviewed_at": "2026-07-21T18:36:27Z",
+                "nvd_published_at": "2026-07-08T17:17:26Z",
+                "severity": "HIGH"
+              },
+              "details": "## Summary\n\n`List#set`, `List#setSize`, `List#setIn`, `List#updateIn` (and the functional `set` / `setIn` / `updateIn`) mishandle an index or size in the range `[2 ** 30, 2 ** 31)`:\n\n- On an **empty** `List` the operation enters an **uncatchable infinite loop** (a tight CPU spin; a surrounding `try/catch` never regains control). Only killing the worker recovers it.\n- On a **populated** `List` (≥ 32 elements — i.e. any array of ≥ 32 items turned into a `List` by `fromJS`) the loop allocates without bound → heap exhaustion → the **process aborts** (`SIGABRT`, exit `134`, or kernel OOM-kill `137`). A real crash, not a recoverable error.\n\nThe index may be a **numeric string**, so it can come straight from a request body, URL, or key-path. A single small unauthenticated request is enough.\n\nThere is also a companion **silent data-corruption** issue in `setSize`:\n\n```js\nList([1, 2, 3]).setSize(2 ** 31); // before fix =\u003e size 0  (silently cleared)\nList([1, 2, 3]).setSize(2 ** 32 + 5); // before fix =\u003e size 5  (huge value wraps to 5)\n```\n\n## Impact\n\nAvailability only. A reachable configuration is any endpoint that routes untrusted input into a `List` index or a `setIn`/`updateIn` key-path — which the extremely common `state = fromJS(body); state.setIn(userPath, value)` pattern does (config stores, document/collection editors, redux-immutable reducers, JSON-Patch endpoints, etc.).\n\nNo confidentiality or integrity impact, no RCE. The companion `setSize` bug can silently corrupt application state (wrong size) without crashing.\n\n## Reproduction (immutable 5.1.7)\n\n```ts\nimport { fromJS, List } from 'immutable';\n\n// 1) Populated List: OOM -\u003e process abort (SIGABRT, exit 134) within ~2s\nfromJS({ items: new Array(64).fill(0) }).setIn(['items', '1073741824'], 'x');\n\n// 2) Empty List: hangs forever, uncatchable\nList().set(2 ** 30, 'x');\n\n// 3) Silent truncation\nList([1, 2, 3]).setSize(2 ** 31); // =\u003e size 0\nList([1, 2, 3]).setSize(2 ** 32 + 5); // =\u003e size 5\n```\n\nA remote 43-byte HTTP request (`{\"path\":[\"items\",\"1073741824\"],\"value\":\"x\"}`) is sufficient to abort a worker that applies it via `state = state.setIn(path, value)`.\n\nAny index in `[2 ** 30, 2 ** 31)` works (`1073741824`, `2000000000`, …). An index in `[2 ** 31, 2 ** 32)` does not crash — it silently wraps (clearing the List) via the same root cause.\n\n## Root cause\n\n`List` stores its values in a 32-wide trie (`SHIFT = 5`, so each level addresses 5 more bits) and uses **signed 32-bit bitwise arithmetic** throughout `setListBounds()` (`src/List.js`):\n\n1. **Infinite loop (the hang / OOM).** The level-raising loop\n\n```js\nwhile (newTailOffset \u003e= 1 \u003c\u003c (newLevel + SHIFT)) {\n  newRoot = new VNode(\n    newRoot \u0026\u0026 newRoot.array.length ? [newRoot] : [],\n    owner\n  );\n  newLevel += SHIFT;\n}\n```\n\nrelies on `1 \u003c\u003c (newLevel + SHIFT)`. A JavaScript shift count is taken **mod 32**, so once `newLevel + SHIFT` reaches `31` the term goes **negative** (`1 \u003c\u003c 31 === -2147483648`) and at `32` wraps to `1` (`1 \u003c\u003c 35 === 8`). The comparison then stays `true` forever and the loop never terminates. On a populated `List`, each iteration retains a new `VNode` (`[newRoot]`), so the heap fills and V8 aborts; on an empty `List` it spins on CPU without allocating.\n\n2. **Silent wraparound (the `setSize` corruption).** The `begin |= 0` / `end |= 0` coercion (`ToInt32`) silently wraps large finite values (`(2 ** 31) | 0 === -2147483648`, `(2 ** 32 + 5) | 0 === 5`), producing a wrong resulting size instead of an error.\n\nThe threshold is `2 ** 30`: that is the largest size for which `1 \u003c\u003c (newLevel + SHIFT)` stays a valid positive 32-bit integer throughout the loops (`newLevel + SHIFT` stays ≤ 30).\n\n## Remediation\n\nThe fix is contained to `setListBounds()` in `src/List.js`:\n\n1. **Validate up front, before the lossy `| 0` coercion.** Compute the intended origin and capacity in full precision and throw a clear, catchable `RangeError` when they exceed the addressable range (`MAX_LIST_SIZE = 2 ** 30`). `Infinity`/`NaN` are left to the existing `| 0 → 0` behaviour (so `setSize(Infinity)` stays `0` and `slice(0, Infinity)` still means \"to the end\").\n\n2. **Stop the shift from wrapping.** Replace `1 \u003c\u003c exp` in the level-raising loops with a helper that uses the cheap bitwise shift while it is exact (`exp ≤ 30`, the common path including every `push`/`setSize`/`slice`) and falls back to the non-wrapping `2 ** exp` only for the rare deep trees reached when a negative origin (`unshift` / negative index) is normalized to a large positive capacity (`exp` can reach 35 there, where `1 \u003c\u003c 35` would wrap to 8).\n\nThis turns every hang, the misleading `\"Maximum call stack size exceeded\"`, the OOM/`SIGABRT`, and the silent `setSize` truncation into one descriptive `RangeError`, preserves all behaviour for sizes `\u003c 2 ** 30`, and keeps the hot `push` path on the fast bitwise shift (the `2 ** exp` branch is never reached by non-negative operations).\n\n### Is the new limit a breaking change?\n\nNo working code is affected. A `List` could never actually hold `≥ 2 ** 30` values before — the attempt hung, crashed, or silently corrupted the size. The limit was already implicit in the 32-bit trie; the fix only makes it explicit and catchable, mirroring native JS arrays (`new Array(2 ** 32)` → `RangeError: Invalid array length`). The single observable behaviour change is that `setSize(hugeValue)`, which used to return a silently wrong size, now throws. `2 ** 30` ≈ 1.07 billion entries (~8 GB of pointers alone), far beyond any practical use.\n\n## Mitigations (for users who cannot upgrade immediately)\n\n- Validate/clamp any externally supplied `List` index or `setIn`/`updateIn` key-path segment against a sane maximum before passing it to immutable.\n- Reject numeric path segments `≥ 2 ** 30`.\n- Run request handling in a worker that can be restarted, and cap the heap (`--max-old-space-size`) so an abort is contained.",
+              "id": "GHSA-v56q-mh7h-f735",
+              "modified": "2026-07-23T09:29:38.743021553Z",
+              "published": "2026-07-21T18:36:27Z",
+              "references": [
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/immutable-js/immutable-js/security/advisories/GHSA-v56q-mh7h-f735"
+                },
+                {
+                  "type": "ADVISORY",
+                  "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-59879"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/immutable-js/immutable-js/commit/a1a1ee412dcaa380ab325196283d06594ffe4b84"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/immutable-js/immutable-js/commit/f0bc997d8eb9886aff2236635aa210a95a04304a"
+                },
+                {
+                  "type": "PACKAGE",
+                  "url": "https://github.com/immutable-js/immutable-js"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/immutable-js/immutable-js/releases/tag/v4.3.9"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/immutable-js/immutable-js/releases/tag/v5.1.8"
+                }
+              ],
+              "related": [
+                "CGA-7vjc-336f-72j3"
+              ],
+              "schema_version": "1.7.5",
+              "severity": [
+                {
+                  "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+                  "type": "CVSS_V3"
+                },
+                {
+                  "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:H/SC:N/SI:N/SA:N",
+                  "type": "CVSS_V4"
+                }
+              ],
+              "summary": "Immutable.js `List` 32-bit trie overflow → unrecoverable DoS"
+            },
+            {
+              "affected": [
+                {
+                  "database_specific": {
+                    "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2026/07/GHSA-xvcm-6775-5m9r/GHSA-xvcm-6775-5m9r.json"
+                  },
+                  "package": {
+                    "ecosystem": "npm",
+                    "name": "immutable",
+                    "purl": "pkg:npm/immutable"
+                  },
+                  "ranges": [
+                    {
+                      "events": [
+                        {
+                          "introduced": "0"
+                        },
+                        {
+                          "fixed": "4.3.9"
+                        }
+                      ],
+                      "type": "SEMVER"
+                    }
+                  ]
+                },
+                {
+                  "database_specific": {
+                    "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2026/07/GHSA-xvcm-6775-5m9r/GHSA-xvcm-6775-5m9r.json"
+                  },
+                  "package": {
+                    "ecosystem": "npm",
+                    "name": "immutable",
+                    "purl": "pkg:npm/immutable"
+                  },
+                  "ranges": [
+                    {
+                      "events": [
+                        {
+                          "introduced": "5.0.0-beta.1"
+                        },
+                        {
+                          "fixed": "5.1.8"
+                        }
+                      ],
+                      "type": "SEMVER"
+                    }
+                  ]
+                }
+              ],
+              "aliases": [
+                "CVE-2026-59880"
+              ],
+              "database_specific": {
+                "cwe_ids": [
+                  "CWE-400",
+                  "CWE-407"
+                ],
+                "github_reviewed": true,
+                "github_reviewed_at": "2026-07-21T19:02:33Z",
+                "nvd_published_at": "2026-07-08T16:16:34Z",
+                "severity": "HIGH"
+              },
+              "details": "## Summary\n\n`Immutable.Map` and `Immutable.Set` keep keys that share the same 32-bit hash in a collision bucket that is scanned linearly. The string hash is public and deterministic, so an attacker who controls the **keys** inserted into a Map can craft many keys that all collide, degrading insertion and lookup from amortized O(1) to O(n) per operation — and O(n²) to build or read the whole set. A small, attacker-shaped payload can therefore consume disproportionate CPU and, on a single-threaded runtime such as Node.js, stall the event loop and deny service.\n\n## Details\n\nThe string hash uses the JVM-style polynomial `hashed = (31 * hashed + charCode) | 0`. Strings such as `\"Aa\"` and `\"BB\"` hash to the same value (`65*31+97 == 66*31+66 == 2112`), and concatenating such blocks yields `2^n` distinct strings sharing one hash (40 characters ⇒ \u003e1,000,000 colliding keys). \nAll such keys route to a single `HashCollisionNode`, whose `get`/`update` walk the entire bucket testing `is()`. There is no per-process salt, so the colliding set is fully precomputable from the open-source algorithm.\n\n## Proof of concept\n\nInserting N colliding keys (e.g. via `Immutable.Map(obj)` / `Immutable.fromJS(obj)`) is O(N²). Measured on one machine, ~8,000 colliding\nkeys take ~0.7 s to build and ~0.6 s to read, scaling ×4 per doubling; ~16,000 keys exceed several seconds.\n\n## Impact\n\nCPU-bound denial of service in applications that ingest attacker-controlled object **keys** into Immutable structures, e.g. `Immutable.Map(req.body)`, `Immutable.fromJS(req.body)`, `state.merge(userObject)` / `mergeDeep(...)`. Applications that only store attacker input as **values** under fixed keys are not affected.\n\n## Affected versions\n\nAll versions through `5.1.7` (the deterministic string hash and linear collision bucket have existed since the 4.x line).\n\n## Patches\n\nFixed in `5.1.8` _(adjust to the actual release)_: large collision buckets are indexed by a per-process **seeded** secondary hash, restoring near-linear behavior for the affected paths. The public `hash()` is unchanged (no breaking change), and `is()` remains the sole authority on key equality.\n\n## Workarounds\n\nBefore passing untrusted data to Immutable.js: cap request body size, limit object key count/length, and reject high-cardinality payloads; avoid building Maps directly from untrusted object keys.\n\n## References\n\n- CWE-407 (Inefficient Algorithmic Complexity), CWE-400 (Uncontrolled Resource Consumption)\n- OWASP API4:2023 (Unrestricted Resource Consumption)",
+              "id": "GHSA-xvcm-6775-5m9r",
+              "modified": "2026-07-23T09:29:38.648870910Z",
+              "published": "2026-07-21T19:02:33Z",
+              "references": [
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/immutable-js/immutable-js/security/advisories/GHSA-xvcm-6775-5m9r"
+                },
+                {
+                  "type": "ADVISORY",
+                  "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-59880"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/immutable-js/immutable-js/commit/3dd7e5655012597a41873e328bf9142a8901527b"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/immutable-js/immutable-js/commit/e51d49fc612ded5ec4dfb94ff294d22074269b0f"
+                },
+                {
+                  "type": "PACKAGE",
+                  "url": "https://github.com/immutable-js/immutable-js"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/immutable-js/immutable-js/releases/tag/v4.3.9"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/immutable-js/immutable-js/releases/tag/v5.1.8"
+                }
+              ],
+              "related": [
+                "CGA-36jv-9g92-vq8v"
+              ],
+              "schema_version": "1.7.5",
+              "severity": [
+                {
+                  "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:H/SC:N/SI:N/SA:N",
+                  "type": "CVSS_V4"
+                }
+              ],
+              "summary": "Immutabl: Hash-collision algorithmic complexity denial of service in Immutable.Map/Set"
+            }
+          ]
+        },
+        {
+          "package": {
+            "name": "js-yaml",
+            "version": "4.3.0",
+            "ecosystem": "npm"
+          },
+          "groups": [
+            {
+              "ids": [
+                "GHSA-5p4m-2wfm-xmqj"
+              ],
+              "aliases": [
+                "GHSA-5p4m-2wfm-xmqj"
+              ],
+              "max_severity": "7.5"
+            }
+          ],
+          "vulnerabilities": [
+            {
+              "affected": [
+                {
+                  "database_specific": {
+                    "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2026/08/GHSA-5p4m-2wfm-xmqj/GHSA-5p4m-2wfm-xmqj.json"
+                  },
+                  "package": {
+                    "ecosystem": "npm",
+                    "name": "js-yaml",
+                    "purl": "pkg:npm/js-yaml"
+                  },
+                  "ranges": [
+                    {
+                      "events": [
+                        {
+                          "introduced": "4.0.0"
+                        },
+                        {
+                          "fixed": "4.3.1"
+                        }
+                      ],
+                      "type": "SEMVER"
+                    }
+                  ]
+                },
+                {
+                  "database_specific": {
+                    "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2026/08/GHSA-5p4m-2wfm-xmqj/GHSA-5p4m-2wfm-xmqj.json"
+                  },
+                  "package": {
+                    "ecosystem": "npm",
+                    "name": "js-yaml",
+                    "purl": "pkg:npm/js-yaml"
+                  },
+                  "ranges": [
+                    {
+                      "events": [
+                        {
+                          "introduced": "3.0.0"
+                        },
+                        {
+                          "fixed": "3.15.1"
+                        }
+                      ],
+                      "type": "SEMVER"
+                    }
+                  ]
+                }
+              ],
+              "database_specific": {
+                "cwe_ids": [
+                  "CWE-407"
+                ],
+                "github_reviewed": true,
+                "github_reviewed_at": "2026-08-06T20:27:32Z",
+                "nvd_published_at": null,
+                "severity": "HIGH"
+              },
+              "details": "# Quadratic CPU consumption in `!!omap` resolution (js-yaml 3.x and 4.x)\n\n## Summary\n\n`resolveYamlOmap()` enforces key uniqueness for `!!omap` sequences with a linear\nscan (`objectKeys.indexOf(...)`) inside the per-element loop, making resolution\n**O(n²)** in the number of entries. A modestly sized YAML document therefore\nconsumes disproportionate CPU inside `yaml.load()`, giving a denial of service\nagainst any consumer that parses untrusted YAML.\n\n`!!omap` is registered in the **default schema**\n(`lib/schema/default.js` → `require('../type/omap')`), so a plain\n`yaml.load(untrustedInput)` with no options is affected — no custom schema or\nnon-default configuration is required.\n\n**This is the same weakness as CVE-2026-59870 / GHSA-724g-mxrg-4qvm**, which was\nfixed in the 5.x line in 5.2.1. That fix was never backported: both currently\nmaintained legacy lines still carry the original implementation.\n\n## Affected versions\n\n| Line | Latest tested | Status |\n|---|---|---|\n| 3.x | **3.15.0** | Affected — `objectKeys.indexOf(pairKey)` at `lib/type/omap.js:29` |\n| 4.x | **4.3.0** | Affected — `objectKeys.indexOf(pairKey)` at `lib/type/omap.js:30` |\n| 5.x | 5.2.2 | **Not affected** — fixed in 5.2.1 (uses a `Set`) |\n\nBoth figures are the newest release of each line at the time of writing, so\nthis is not a \"you are on an old version\" issue.\n\n## Details\n\n`lib/type/omap.js` (js-yaml 4.3.0):\n\n```js\nif (objectKeys.indexOf(pairKey) === -1) objectKeys.push(pairKey)\nelse return false\n```\n\n`objectKeys` grows by one element per entry, and `Array.prototype.indexOf` is a\nlinear scan, so resolving an `n`-entry `!!omap` performs roughly\n`1 + 2 + … + n` comparisons — quadratic in `n`. The work happens synchronously\ninside `yaml.load()`, blocking the event loop for its whole duration.\n\nThe 5.x line already solves exactly this by tracking seen keys in a `Set`\n(`src/tag/sequence/omap.ts`):\n\n```ts\nif (carrier.seen.has(key)) return 'duplicate key in ordered map'\ncarrier.seen.add(key)\n```\n\n## Proof of concept\n\n```js\n// poc.js  —  node poc.js\nconst yaml = require('js-yaml');\nconst doc = n =\u003e '!!omap\\n' + Array.from({length: n}, (_, i) =\u003e `- k${i}: ${i}`).join('\\n') + '\\n';\n\nfor (const n of [10000, 20000, 40000, 80000]) {\n  const d = doc(n), t = Date.now();\n  yaml.load(d);                      // default schema, no options\n  console.log(`n=${n} bytes=${d.length} load=${Date.now() - t}ms`);\n}\n```\n\n### Measured (node v20.20.2, default heap, no flags)\n\n**js-yaml 4.3.0**\n\n```\nn=10000  bytes=137787   load=54ms\nn=20000  bytes=297787   load=169ms\nn=40000  bytes=617787   load=646ms\nn=80000  bytes=1257787  load=2607ms\n```\n\n**js-yaml 3.15.0**\n\n```\nn=10000  bytes=137787   load=53ms\nn=20000  bytes=297787   load=166ms\nn=40000  bytes=617787   load=641ms\nn=80000  bytes=1257787  load=2567ms\n```\n\nRuntime grows by a factor of ~4 for each doubling of `n`, which is the\nsignature of O(n²) (linear growth would be ~2×).\n\nScaling further: a **2.48 MB** document with 150,000 entries blocked\n`yaml.load()` for **10.8 seconds**.\n\n## Impact\n\nAny service that parses attacker-influenced YAML with js-yaml 3.x or 4.x can be\nstalled with a small input. Because the loop is synchronous, a single request\nblocks the Node.js event loop and stalls every other request in the process —\nso the amplification is per-process, not just per-request.\n\nSuggested severity: consistent with **CVE-2026-59870** (the same weakness in\n5.x), i.e. Availability-only impact, network attack vector, no privileges or\nuser interaction required.\n\n## Suggested fix\n\nMirror the 5.x fix — replace the linear scan with a `Set`:\n\n```js\n// lib/type/omap.js\nconst seen = new Set()\n// ...\nif (seen.has(pairKey)) return false\nseen.add(pairKey)\n```\n\nThis preserves the existing duplicate-key rejection semantics exactly while\nmaking resolution O(n). A `maxOmapLength`-style cap would also work, but the\n`Set` matches what 5.x already ships and requires no new option.\n\n## References\n\n- CVE-2026-59870 / GHSA-724g-mxrg-4qvm — same weakness in 5.0.0–5.2.0, fixed in 5.2.1\n- `lib/type/omap.js` (3.x, 4.x) — the affected resolver\n- `lib/schema/default.js` — registers `!!omap` in the default schema\n\n## Discovery\n\nFound by an automated static-analysis and executed-proof-of-concept scanner run\nagainst js-yaml 4.2.0, then manually verified against 3.15.0 and 4.3.0 by\nexecuting the proof of concept above. All timings in this report were measured\non the **current** releases of each line, not on the version originally scanned.",
+              "id": "GHSA-5p4m-2wfm-xmqj",
+              "modified": "2026-08-07T21:11:58.193703070Z",
+              "published": "2026-08-06T20:27:32Z",
+              "references": [
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/nodeca/js-yaml/security/advisories/GHSA-5p4m-2wfm-xmqj"
+                },
+                {
+                  "type": "PACKAGE",
+                  "url": "https://github.com/nodeca/js-yaml"
+                }
+              ],
+              "related": [
+                "CGA-8m7q-fpgq-mvw6"
+              ],
+              "schema_version": "1.8.0",
+              "severity": [
+                {
+                  "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+                  "type": "CVSS_V3"
+                }
+              ],
+              "summary": "JS-YAML: Quadratic CPU consumption in !!omap resolution (3.x and 4.x) — CVE-2026-59870 fix not backported"
+            }
+          ]
+        },
+        {
+          "package": {
+            "name": "nanoid",
+            "version": "3.3.16",
+            "ecosystem": "npm"
+          },
+          "dependency_groups": [
+            "dev"
+          ],
+          "groups": [
+            {
+              "ids": [
+                "GHSA-2v37-7h3g-55p8"
+              ],
+              "aliases": [
+                "CVE-2026-67213",
+                "GHSA-2v37-7h3g-55p8"
+              ],
+              "max_severity": "8.2"
+            }
+          ],
+          "vulnerabilities": [
+            {
+              "affected": [
+                {
+                  "database_specific": {
+                    "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2026/07/GHSA-2v37-7h3g-55p8/GHSA-2v37-7h3g-55p8.json"
+                  },
+                  "package": {
+                    "ecosystem": "npm",
+                    "name": "nanoid",
+                    "purl": "pkg:npm/nanoid"
+                  },
+                  "ranges": [
+                    {
+                      "events": [
+                        {
+                          "introduced": "0"
+                        },
+                        {
+                          "fixed": "3.3.18"
+                        }
+                      ],
+                      "type": "SEMVER"
+                    }
+                  ]
+                },
+                {
+                  "database_specific": {
+                    "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2026/07/GHSA-2v37-7h3g-55p8/GHSA-2v37-7h3g-55p8.json"
+                  },
+                  "package": {
+                    "ecosystem": "npm",
+                    "name": "nanoid",
+                    "purl": "pkg:npm/nanoid"
+                  },
+                  "ranges": [
+                    {
+                      "events": [
+                        {
+                          "introduced": "4.0.0"
+                        },
+                        {
+                          "fixed": "5.1.6"
+                        }
+                      ],
+                      "type": "SEMVER"
+                    }
+                  ]
+                }
+              ],
+              "aliases": [
+                "CVE-2026-67213"
+              ],
+              "database_specific": {
+                "cwe_ids": [
+                  "CWE-835"
+                ],
+                "github_reviewed": true,
+                "github_reviewed_at": "2026-08-07T20:50:34Z",
+                "nvd_published_at": "2026-07-29T14:16:34Z",
+                "severity": "HIGH"
+              },
+              "details": "nanoid (Nano ID) before 5.1.6 contains an infinite loop in the customAlphabet and customRandom functions. When these functions are configured with a size of 0, the internal generation loop never satisfies its exit condition and spins indefinitely, hanging the calling thread. An application that passes an unvalidated, attacker-controlled size of 0 to these functions is exposed to a denial-of-service condition.",
+              "id": "GHSA-2v37-7h3g-55p8",
+              "modified": "2026-08-13T16:00:06.912130638Z",
+              "published": "2026-07-29T15:31:12Z",
+              "references": [
+                {
+                  "type": "ADVISORY",
+                  "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-67213"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/ai/nanoid/commit/cb3626d0f3342fdf179cd425fd9c4fbb92c7d0e7"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/ai/nanoid/commit/e10f8d40ce9d1ab47f66d65a16b48086432730d0"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/ai/nanoid/commit/f9d13f150847d117877adee3460a46eceb0cf49b"
+                },
+                {
+                  "type": "PACKAGE",
+                  "url": "https://github.com/ai/nanoid"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/ai/nanoid/releases/tag/3.3.17"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/ai/nanoid/releases/tag/3.3.18"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/ai/nanoid/releases/tag/5.1.6"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://www.vulncheck.com/advisories/nanoid-before-infinite-loop-via-zero-size-in-customalphabet-and-customrandom"
+                }
+              ],
+              "related": [
+                "CGA-8qm5-vcm3-9xc3"
+              ],
+              "schema_version": "1.9.0",
+              "severity": [
+                {
+                  "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
+                  "type": "CVSS_V3"
+                },
+                {
+                  "score": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:N/VI:N/VA:H/SC:N/SI:N/SA:N",
+                  "type": "CVSS_V4"
+                }
+              ],
+              "summary": "nanoid: custom generators can loop indefinitely when size is zero"
+            }
+          ]
+        },
+        {
+          "package": {
+            "name": "postcss",
+            "version": "8.5.18",
+            "ecosystem": "npm"
+          },
+          "dependency_groups": [
+            "dev"
+          ],
+          "groups": [
+            {
+              "ids": [
+                "GHSA-fxqj-rqcc-2cmp"
+              ],
+              "aliases": [
+                "CVE-2026-69153",
+                "GHSA-fxqj-rqcc-2cmp"
+              ],
+              "max_severity": "6.3"
+            }
+          ],
+          "vulnerabilities": [
+            {
+              "affected": [
+                {
+                  "database_specific": {
+                    "last_known_affected_version_range": "\u003c= 8.5.22",
+                    "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2026/08/GHSA-fxqj-rqcc-2cmp/GHSA-fxqj-rqcc-2cmp.json"
+                  },
+                  "package": {
+                    "ecosystem": "npm",
+                    "name": "postcss",
+                    "purl": "pkg:npm/postcss"
+                  },
+                  "ranges": [
+                    {
+                      "events": [
+                        {
+                          "introduced": "0"
+                        },
+                        {
+                          "fixed": "8.5.23"
+                        }
+                      ],
+                      "type": "SEMVER"
+                    }
+                  ]
+                }
+              ],
+              "aliases": [
+                "CVE-2026-69153"
+              ],
+              "database_specific": {
+                "cwe_ids": [
+                  "CWE-22",
+                  "CWE-200"
+                ],
+                "github_reviewed": true,
+                "github_reviewed_at": "2026-08-03T17:11:39Z",
+                "nvd_published_at": null,
+                "severity": "MODERATE"
+              },
+              "details": "## Summary\n\nThe fix for GHSA-6g55-p6wh-862q added a guard in `lib/previous-map.js` `PreviousMap.loadFile()` that restricts an attacker-controlled `sourceMappingURL` (from a CSS comment) to a `.map` extension and, for untrusted maps, rejects `..` traversal and absolute paths. The traversal/absolute rejection is nested inside `if (cssFile) { ... }`. When PostCSS is invoked without the `from` option, `cssFile` is falsy and that branch is skipped, leaving only the `.map` extension check.\n\n`PreviousMap` is constructed by `lib/input.js` whenever `pathAvailable \u0026\u0026 sourceMapAvailable` (under Node with source-map available), independent of `opts.from`/`opts.map` (the constructor returns early only for `opts.map === false`). So `postcss([]).process(css)` on attacker CSS reaches `loadFile` with `cssFile` undefined, and an attacker `/*# sourceMappingURL=/abs/path/x.map */` (or `../`-traversing path) is read via `readFileSync`. When the file is valid JSON, its `sources` (filesystem paths) and `sourcesContent` (source contents) are disclosed in the generated source map.\n\n## Affected code (v8.5.22 — the release carrying the GHSA-6g55 fix)\n\n```js\n// lib/previous-map.js\nloadFile(path, cssFile, trusted) {\n  if (!trusted \u0026\u0026 !this.unsafeMap) {\n    if (!/\\.map$/i.test(path)) {\n      return undefined\n    }\n    if (cssFile) {                       // guard runs ONLY when `from` is set\n      let relativePath = relative(dirname(cssFile), path)\n      if (relativePath === '..' ||\n          relativePath.startsWith('..' + sep) ||\n          isAbsolute(relativePath)) {\n        return undefined\n      }\n    }\n  }\n  this.root = dirname(path)\n  if (existsSync(path)) {\n    this.mapFile = path\n    return readFileSync(path, 'utf-8').toString().trim()   // sink\n  }\n}\n\n// loadMap(): untrusted annotation path, trusted=false; file === opts.from\n} else if (this.annotation) {\n  let map = this.annotation\n  if (file) map = join(dirname(file), map)   // no `from` -\u003e map stays the raw URL\n  let unknown = this.loadFile(map, file, false)  // file undefined -\u003e cssFile falsy\n```\n\n## Proof of concept (verified on postcss 8.5.22)\n\n```js\nconst postcss = require('postcss')\nconst fs = require('fs')\n\n// a 'secret' sourcemap OUTSIDE any expected tree (stand-in for another project's .map)\nconst secret = '/tmp/pcpoc/secret_out_of_tree.map'\nfs.writeFileSync(secret, JSON.stringify({\n  version: 3, sources: ['/etc/REAL_PATH_LEAK'], mappings: '', names: [],\n  sourcesContent: ['TOP_SECRET_abcdef']\n}))\n\nconst css = 'a{color:red}\\n/*# sourceMappingURL=' + secret + ' */'\nconst leaks = m =\u003e m \u0026\u0026 JSON.stringify(m.toJSON ? m.toJSON() : m).includes('TOP_SECRET_abcdef')\n\n;(async () =\u003e {\n  // A) NO `from`  -\u003e guard skipped -\u003e arbitrary absolute .map read + disclosed\n  const a = await postcss([]).process(css, { map: true })\n  console.log('no from   -\u003e leaked:', !!leaks(a.map))   // true\n\n  // B) WITH `from` -\u003e guard active -\u003e blocked\n  const b = await postcss([]).process(css, { from: '/tmp/pcpoc/in.css', map: true })\n  console.log('with from -\u003e leaked:', !!leaks(b.map))    // false\n})()\n```\n\nObserved output on postcss 8.5.22:\n\n```\nno from   -\u003e leaked: true      # sourcesContent 'TOP_SECRET_abcdef' AND sources '/etc/REAL_PATH_LEAK' appear in result.map\nwith from -\u003e leaked: false     # guard rejects the absolute path\n```\n\n`../` traversal (no `from`) also succeeds; non-`.map` targets (`.txt`, `?x=.map`, `#.map`) are blocked by the `.map` check. The tested build contains the GHSA-6g55 fix (`this.json = JSON.parse(...)` in `loadMap`, `consumer()` uses `this.json || this.text`), so this is a residual of that fix.\n\n## Impact\n\nArbitrary `.map`-file read (absolute path or `../` traversal) and disclosure of the target map's `sources` (local filesystem paths) and `sourcesContent` (source) into the generated source map, for any consumer that runs PostCSS on attacker-influenced CSS without a `from` option and exposes `result.map` (online CSS playgrounds, minify/lint services, string-input build steps). Bounded to files ending in `.map` that parse as JSON.\n\n## Suggested fix\n\nApply the traversal/absolute-path rejection to the untrusted map path regardless of whether `cssFile` is present (resolve against `process.cwd()` when there is no `cssFile`, and reject absolute paths and `..` escape in all untrusted cases), or refuse to load an untrusted external map when no base file is known.",
+              "id": "GHSA-fxqj-rqcc-2cmp",
+              "modified": "2026-08-04T21:26:59.056562955Z",
+              "published": "2026-08-03T17:11:39Z",
+              "references": [
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/postcss/postcss/security/advisories/GHSA-fxqj-rqcc-2cmp"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/postcss/postcss/commit/7beca139e70f9075c6b19700fcb00dd8033e5da8"
+                },
+                {
+                  "type": "PACKAGE",
+                  "url": "https://github.com/postcss/postcss"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/postcss/postcss/releases/tag/8.5.19"
+                }
+              ],
+              "related": [
+                "CGA-97hc-47q4-9f8x"
+              ],
+              "schema_version": "1.7.5",
+              "severity": [
+                {
+                  "score": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:L/VI:N/VA:N/SC:N/SI:N/SA:N",
+                  "type": "CVSS_V4"
+                }
+              ],
+              "summary": "PostCSS: incomplete fix of GHSA-6g55-p6wh-862q — attacker-controlled sourceMappingURL reads arbitrary .map files when `from` is unset"
+            }
+          ]
+        },
+        {
+          "package": {
+            "name": "react-router",
+            "version": "7.18.1",
+            "ecosystem": "npm"
+          },
+          "groups": [
+            {
+              "ids": [
+                "GHSA-qwww-vcr4-c8h2"
+              ],
+              "aliases": [
+                "GHSA-qwww-vcr4-c8h2"
+              ],
+              "max_severity": "7.1"
+            }
+          ],
+          "vulnerabilities": [
+            {
+              "affected": [
+                {
+                  "database_specific": {
+                    "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2026/07/GHSA-qwww-vcr4-c8h2/GHSA-qwww-vcr4-c8h2.json"
+                  },
+                  "package": {
+                    "ecosystem": "npm",
+                    "name": "react-router",
+                    "purl": "pkg:npm/react-router"
+                  },
+                  "ranges": [
+                    {
+                      "events": [
+                        {
+                          "introduced": "7.12.0"
+                        },
+                        {
+                          "fixed": "7.18.2"
+                        }
+                      ],
+                      "type": "SEMVER"
+                    }
+                  ]
+                },
+                {
+                  "database_specific": {
+                    "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2026/07/GHSA-qwww-vcr4-c8h2/GHSA-qwww-vcr4-c8h2.json"
+                  },
+                  "package": {
+                    "ecosystem": "npm",
+                    "name": "react-router",
+                    "purl": "pkg:npm/react-router"
+                  },
+                  "ranges": [
+                    {
+                      "events": [
+                        {
+                          "introduced": "8.0.0"
+                        },
+                        {
+                          "fixed": "8.3.0"
+                        }
+                      ],
+                      "type": "SEMVER"
+                    }
+                  ]
+                }
+              ],
+              "database_specific": {
+                "cwe_ids": [
+                  "CWE-352"
+                ],
+                "github_reviewed": true,
+                "github_reviewed_at": "2026-07-24T16:44:43Z",
+                "nvd_published_at": null,
+                "severity": "HIGH"
+              },
+              "details": "This is a follow up to CVE-2026-22030 to address related CSRF flows in unstable RSC code paths.\n\n\u003e [!NOTE]\n\u003e This only affects your application if you are using the unstable RSC APIs",
+              "id": "GHSA-qwww-vcr4-c8h2",
+              "modified": "2026-08-07T18:31:29.677238853Z",
+              "published": "2026-07-24T16:44:43Z",
+              "references": [
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/remix-run/react-router/security/advisories/GHSA-qwww-vcr4-c8h2"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/remix-run/react-router/commit/7a71c728ad116bd78699a258b2014ce9585729f5"
+                },
+                {
+                  "type": "PACKAGE",
+                  "url": "https://github.com/remix-run/react-router"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/remix-run/react-router/blob/main/CHANGELOG.md#v830"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/remix-run/react-router/releases/tag/react-router@8.3.0"
+                },
+                {
+                  "type": "WEB",
+                  "url": "http://github.com/remix-run/react-router/pull/15311"
+                }
+              ],
+              "related": [
+                "CGA-pwxj-xcv7-qh2g"
+              ],
+              "schema_version": "1.8.0",
+              "severity": [
+                {
+                  "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:P/VC:N/VI:H/VA:N/SC:N/SI:N/SA:N",
+                  "type": "CVSS_V4"
+                }
+              ],
+              "summary": "React Router: RSC Mode CSRF Bypass Allows Action Execution Before 400 Response"
+            }
+          ]
+        },
+        {
+          "package": {
+            "name": "undici",
+            "version": "7.28.0",
+            "ecosystem": "npm"
+          },
+          "dependency_groups": [
+            "dev"
+          ],
+          "groups": [
+            {
+              "ids": [
+                "GHSA-4cwx-7wf7-3272"
+              ],
+              "aliases": [
+                "CVE-2026-13697",
+                "GHSA-4cwx-7wf7-3272"
+              ],
+              "max_severity": "7.4"
+            },
+            {
+              "ids": [
+                "GHSA-8xcm-r25x-g524"
+              ],
+              "aliases": [
+                "CVE-2026-16728",
+                "GHSA-8xcm-r25x-g524"
+              ],
+              "max_severity": "4.8"
+            },
+            {
+              "ids": [
+                "GHSA-jr45-8vmc-qm54"
+              ],
+              "aliases": [
+                "CVE-2026-14643",
+                "GHSA-jr45-8vmc-qm54"
+              ],
+              "max_severity": "5.9"
+            },
+            {
+              "ids": [
+                "GHSA-m8rv-5g2x-5cg5"
+              ],
+              "aliases": [
+                "CVE-2026-15157",
+                "GHSA-m8rv-5g2x-5cg5"
+              ],
+              "max_severity": "4.2"
+            },
+            {
+              "ids": [
+                "GHSA-v3r7-h72x-cjcm"
+              ],
+              "aliases": [
+                "CVE-2026-16729",
+                "GHSA-v3r7-h72x-cjcm"
+              ],
+              "max_severity": "4.8"
+            }
+          ],
+          "vulnerabilities": [
+            {
+              "affected": [
+                {
+                  "database_specific": {
+                    "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2026/08/GHSA-4cwx-7wf7-3272/GHSA-4cwx-7wf7-3272.json"
+                  },
+                  "package": {
+                    "ecosystem": "npm",
+                    "name": "undici",
+                    "purl": "pkg:npm/undici"
+                  },
+                  "ranges": [
+                    {
+                      "events": [
+                        {
+                          "introduced": "7.0.0"
+                        },
+                        {
+                          "fixed": "7.29.0"
+                        }
+                      ],
+                      "type": "SEMVER"
+                    }
+                  ]
+                },
+                {
+                  "database_specific": {
+                    "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2026/08/GHSA-4cwx-7wf7-3272/GHSA-4cwx-7wf7-3272.json"
+                  },
+                  "package": {
+                    "ecosystem": "npm",
+                    "name": "undici",
+                    "purl": "pkg:npm/undici"
+                  },
+                  "ranges": [
+                    {
+                      "events": [
+                        {
+                          "introduced": "8.0.0"
+                        },
+                        {
+                          "fixed": "8.9.0"
+                        }
+                      ],
+                      "type": "SEMVER"
+                    }
+                  ]
+                }
+              ],
+              "aliases": [
+                "CVE-2026-13697"
+              ],
+              "database_specific": {
+                "cwe_ids": [
+                  "CWE-200",
+                  "CWE-248",
+                  "CWE-525"
+                ],
+                "github_reviewed": true,
+                "github_reviewed_at": "2026-08-03T19:19:47Z",
+                "nvd_published_at": "2026-07-29T17:16:50Z",
+                "severity": "HIGH"
+              },
+              "details": "### Summary\n\nTwo issues in undici's cache interceptor, both fixed by the same patch on `lib/util/cache.js`:\n\n1. **Shared-cache disclosure:** Responses with malformed qualified `Cache-Control: private` directives such as `private=\"\"` or `private=\",\"` can be incorrectly stored in the default shared cache, then served to a later caller with the same cache key.\n2. **Parse-time crash:** Mixed unqualified-and-qualified `private` directives in the same header (such as `public, max-age=60, private, private=\"hdr\"`) cause an uncaught `TypeError` in the cache-control parser, terminating the request.\n\n### Impact\n\n#### Shared-cache disclosure\n\nApplications using `interceptors.cache()` in shared mode may cache a user-specific response and serve it to a later caller with the same cache key. This can disclose private response bodies and headers, including `Set-Cookie`.\n\nRequired conditions:\n\n- the cache interceptor is enabled in shared mode, including the default configuration;\n- an upstream returns a malformed directive such as `Cache-Control: public, max-age=300, private=\"\"`;\n- another request later matches the same cache key, without a separating `Vary` header.\n\n#### Parse-time crash\n\nApplications using `interceptors.cache()` against an upstream that returns a `Cache-Control` header combining unqualified `private` with qualified `private=\"...\"` see an uncaught `TypeError: output.private.concat is not a function` during response handling. The request rejects; depending on the consumer's error handling, the process may exit.\n\n### Details\n\n`private=\"\"` is parsed as `{ private: [''] }`. The shared-cache guard only rejects `private === true`, so the response can be stored. When served from cache, the previous user's body and headers may be returned to a different user.\n\nFor the crash variant, an unqualified `private` directive sets `output.private = true`, then a subsequent qualified `private=\"hdr\"` directive attempts `output.private.concat(['hdr'])`, which throws because boolean has no `concat` method.\n\nThe patch routes the qualified-directive path through a shared helper that normalizes empty-after-trim arrays to `true` and preserves existing `true` values, closing both vectors.\n\n### Patches\n\nUpgrade to `undici` 7.29.0 or 8.9.0. Both releases fix the qualified `private` directive handling that caused the shared-cache storage and the parser crash.\n\n### Workarounds\n\nUntil patched, avoid shared `interceptors.cache()` for user-specific responses, use `type: 'private'`, or disable caching for affected origins.\n\n### Credit\n\nDisclosure variant reported by @h0rk1p via HackerOne report [#3817497](https://hackerone.com/reports/3817497).",
+              "id": "GHSA-4cwx-7wf7-3272",
+              "modified": "2026-08-04T21:26:59.185592001Z",
+              "published": "2026-08-03T19:19:47Z",
+              "references": [
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/nodejs/undici/security/advisories/GHSA-4cwx-7wf7-3272"
+                },
+                {
+                  "type": "ADVISORY",
+                  "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-13697"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/nodejs/undici/commit/4fe5bc5fefe5ac81a200fc8e1cf84b8bf8464451"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://cna.openjsf.org/security-advisories.html"
+                },
+                {
+                  "type": "PACKAGE",
+                  "url": "https://github.com/nodejs/undici"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/nodejs/undici/releases/tag/v7.29.0"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/nodejs/undici/releases/tag/v8.9.0"
+                }
+              ],
+              "related": [
+                "CGA-8m4w-gqg6-g2w7"
+              ],
+              "schema_version": "1.7.5",
+              "severity": [
+                {
+                  "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:H",
+                  "type": "CVSS_V3"
+                }
+              ],
+              "summary": "undici vulnerable to cross-user information disclosure and parse-time crash via degenerate private cache directives"
+            },
+            {
+              "affected": [
+                {
+                  "database_specific": {
+                    "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2026/08/GHSA-8xcm-r25x-g524/GHSA-8xcm-r25x-g524.json"
+                  },
+                  "package": {
+                    "ecosystem": "npm",
+                    "name": "undici",
+                    "purl": "pkg:npm/undici"
+                  },
+                  "ranges": [
+                    {
+                      "events": [
+                        {
+                          "introduced": "0"
+                        },
+                        {
+                          "fixed": "6.28.0"
+                        }
+                      ],
+                      "type": "SEMVER"
+                    }
+                  ]
+                },
+                {
+                  "database_specific": {
+                    "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2026/08/GHSA-8xcm-r25x-g524/GHSA-8xcm-r25x-g524.json"
+                  },
+                  "package": {
+                    "ecosystem": "npm",
+                    "name": "undici",
+                    "purl": "pkg:npm/undici"
+                  },
+                  "ranges": [
+                    {
+                      "events": [
+                        {
+                          "introduced": "7.0.0"
+                        },
+                        {
+                          "fixed": "7.29.0"
+                        }
+                      ],
+                      "type": "SEMVER"
+                    }
+                  ]
+                },
+                {
+                  "database_specific": {
+                    "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2026/08/GHSA-8xcm-r25x-g524/GHSA-8xcm-r25x-g524.json"
+                  },
+                  "package": {
+                    "ecosystem": "npm",
+                    "name": "undici",
+                    "purl": "pkg:npm/undici"
+                  },
+                  "ranges": [
+                    {
+                      "events": [
+                        {
+                          "introduced": "8.0.0"
+                        },
+                        {
+                          "fixed": "8.9.0"
+                        }
+                      ],
+                      "type": "SEMVER"
+                    }
+                  ]
+                }
+              ],
+              "aliases": [
+                "CVE-2026-16728"
+              ],
+              "database_specific": {
+                "cwe_ids": [
+                  "CWE-444"
+                ],
+                "github_reviewed": true,
+                "github_reviewed_at": "2026-08-03T19:24:33Z",
+                "nvd_published_at": "2026-07-29T21:17:46Z",
+                "severity": "MODERATE"
+              },
+              "details": "### Impact\n\nUndici's `interceptors.retry()` can deliver a response whose body length does not match the `Content-Length` header exposed to the application after a retry or resume of a partial response. Applications that use `interceptors.retry()` and forward upstream response headers and bodies downstream, for example proxy or gateway applications, may emit an invalid HTTP response with a stale `Content-Length` header. This can lead to downstream response desynchronization, connection hangs, or response corruption in clients or intermediaries that rely on the forwarded framing metadata.\n\nA malicious or faulty upstream can respond to a range request with a `206 Partial Content` response such as:\n\n```http\nContent-Range: bytes 0-99/300\nContent-Length: 300\n```\n\nand then send only 99 bytes before closing the socket. `interceptors.retry()` can then retry with `Range: bytes=99-99`, receive the final byte, and deliver a 100-byte body to the application while the response headers still contain `Content-Length: 300` from the first response.\n\nThe bug requires `interceptors.retry()` to be enabled, an upstream that returns a partial response with a mismatched framing header, and a downstream forwarder that does not remove or recalculate `Content-Length`.\n\n### Patches\n\nPatched in undici v6.28.0, v7.29.0, and v8.9.0. Users should upgrade to one of these versions or later.\n\n### Workarounds\n\n- Disable `interceptors.retry()` for untrusted upstreams.\n- Remove or recalculate `Content-Length` before forwarding a response body assembled or transformed by Undici.",
+              "id": "GHSA-8xcm-r25x-g524",
+              "modified": "2026-08-04T21:26:58.366960979Z",
+              "published": "2026-08-03T19:24:33Z",
+              "references": [
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/nodejs/undici/security/advisories/GHSA-8xcm-r25x-g524"
+                },
+                {
+                  "type": "ADVISORY",
+                  "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-16728"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/nodejs/undici/commit/1b5a5312c3a7d7a30c31bf0d000b39a8a2531e1c"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/nodejs/undici/commit/2b3f749336d356bbbc50192f87f6cf7bc714721a"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/nodejs/undici/commit/4a9dafb16ff43880cf590e6d9c2aeee25fbff6d7"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/nodejs/undici/commit/4fd5a0c61e627f928b7003adc4ffe1e55ec63420"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/nodejs/undici/commit/cba3a52ac2e7abcc4e656d82af8579ea82c2bb9e"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/nodejs/undici/commit/e11a68ed4ff345c79402476f7a00d473443e318d"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://hackerone.com/reports/3828685"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://cna.openjsf.org/security-advisories.html"
+                },
+                {
+                  "type": "PACKAGE",
+                  "url": "https://github.com/nodejs/undici"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/nodejs/undici/releases/tag/v6.28.0"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/nodejs/undici/releases/tag/v7.29.0"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/nodejs/undici/releases/tag/v8.9.0"
+                }
+              ],
+              "related": [
+                "CGA-fgmh-44p5-9m5q"
+              ],
+              "schema_version": "1.7.5",
+              "severity": [
+                {
+                  "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N",
+                  "type": "CVSS_V3"
+                }
+              ],
+              "summary": "undici vulnerable to downstream response desynchronization via retry interceptor"
+            },
+            {
+              "affected": [
+                {
+                  "database_specific": {
+                    "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2026/08/GHSA-jr45-8vmc-qm54/GHSA-jr45-8vmc-qm54.json"
+                  },
+                  "package": {
+                    "ecosystem": "npm",
+                    "name": "undici",
+                    "purl": "pkg:npm/undici"
+                  },
+                  "ranges": [
+                    {
+                      "events": [
+                        {
+                          "introduced": "7.0.0"
+                        },
+                        {
+                          "fixed": "7.29.0"
+                        }
+                      ],
+                      "type": "SEMVER"
+                    }
+                  ]
+                },
+                {
+                  "database_specific": {
+                    "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2026/08/GHSA-jr45-8vmc-qm54/GHSA-jr45-8vmc-qm54.json"
+                  },
+                  "package": {
+                    "ecosystem": "npm",
+                    "name": "undici",
+                    "purl": "pkg:npm/undici"
+                  },
+                  "ranges": [
+                    {
+                      "events": [
+                        {
+                          "introduced": "8.0.0"
+                        },
+                        {
+                          "fixed": "8.9.0"
+                        }
+                      ],
+                      "type": "SEMVER"
+                    }
+                  ]
+                }
+              ],
+              "aliases": [
+                "CVE-2026-14643"
+              ],
+              "database_specific": {
+                "cwe_ids": [
+                  "CWE-436",
+                  "CWE-524"
+                ],
+                "github_reviewed": true,
+                "github_reviewed_at": "2026-08-03T19:32:12Z",
+                "nvd_published_at": "2026-07-29T22:16:52Z",
+                "severity": "MODERATE"
+              },
+              "details": "## Impact\n\nUndici's cache interceptor mishandles optional whitespace (OWS) placed around the `=` of a qualified `no-cache` or `private` Cache-Control directive, such as `no-cache =\"authorization\"` (OWS before `=`) or `no-cache= \"authorization\"` (OWS after `=`). The parser either drops the directive entirely or stores a field name with literal quote characters, so the downstream cache decisions do not recognize the qualification and the response is stored.\n\nIn shared-cache mode, this allows a response containing one user's authenticated data to be served from cache to a subsequent caller, including an unauthenticated caller, when both requests resolve to the same cache key. The impact class is identical to CVE-2026-9678 (GHSA-pr7r-676h-xcf6); this advisory covers the whitespace-around-`=` bypass that the earlier fix did not normalize.\n\nAffected applications are those that explicitly enable the cache interceptor (`interceptors.cache()`) in shared mode, forward `Authorization` headers upstream, and receive cacheable responses with qualified `private` or `no-cache` directives whose field-name list is padded with OWS around the `=`.\n\n## Patches\n\nUpgrade to undici v7.29.0 or v8.9.0.\n\n## Workarounds\n\nIf upgrade is not immediately possible, disable shared-cache mode for traffic that includes `Authorization` headers, avoid caching responses to authenticated requests, or add `Vary: Authorization` upstream.",
+              "id": "GHSA-jr45-8vmc-qm54",
+              "modified": "2026-08-04T21:26:57.490221001Z",
+              "published": "2026-08-03T19:32:12Z",
+              "references": [
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/nodejs/undici/security/advisories/GHSA-jr45-8vmc-qm54"
+                },
+                {
+                  "type": "ADVISORY",
+                  "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-14643"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/nodejs/undici/commit/85a240551c9feb8b8a0ecc56c84b2b3015add8a9"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/nodejs/undici/commit/cb105d7c79069150982fa11acada0dd94a60dbbc"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://cna.openjsf.org/security-advisories.html"
+                },
+                {
+                  "type": "PACKAGE",
+                  "url": "https://github.com/nodejs/undici"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/nodejs/undici/releases/tag/v7.29.0"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/nodejs/undici/releases/tag/v8.9.0"
+                }
+              ],
+              "related": [
+                "CGA-v8r2-g74j-hqgg"
+              ],
+              "schema_version": "1.7.5",
+              "severity": [
+                {
+                  "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N",
+                  "type": "CVSS_V3"
+                }
+              ],
+              "summary": "undici vulnerable to cross-user information disclosure via whitespace around equals in Cache-Control directives"
+            },
+            {
+              "affected": [
+                {
+                  "database_specific": {
+                    "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2026/08/GHSA-m8rv-5g2x-5cg5/GHSA-m8rv-5g2x-5cg5.json"
+                  },
+                  "package": {
+                    "ecosystem": "npm",
+                    "name": "undici",
+                    "purl": "pkg:npm/undici"
+                  },
+                  "ranges": [
+                    {
+                      "events": [
+                        {
+                          "introduced": "0"
+                        },
+                        {
+                          "fixed": "6.28.0"
+                        }
+                      ],
+                      "type": "SEMVER"
+                    }
+                  ]
+                },
+                {
+                  "database_specific": {
+                    "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2026/08/GHSA-m8rv-5g2x-5cg5/GHSA-m8rv-5g2x-5cg5.json"
+                  },
+                  "package": {
+                    "ecosystem": "npm",
+                    "name": "undici",
+                    "purl": "pkg:npm/undici"
+                  },
+                  "ranges": [
+                    {
+                      "events": [
+                        {
+                          "introduced": "7.0.0"
+                        },
+                        {
+                          "fixed": "7.29.0"
+                        }
+                      ],
+                      "type": "SEMVER"
+                    }
+                  ]
+                },
+                {
+                  "database_specific": {
+                    "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2026/08/GHSA-m8rv-5g2x-5cg5/GHSA-m8rv-5g2x-5cg5.json"
+                  },
+                  "package": {
+                    "ecosystem": "npm",
+                    "name": "undici",
+                    "purl": "pkg:npm/undici"
+                  },
+                  "ranges": [
+                    {
+                      "events": [
+                        {
+                          "introduced": "8.0.0"
+                        },
+                        {
+                          "fixed": "8.9.0"
+                        }
+                      ],
+                      "type": "SEMVER"
+                    }
+                  ]
+                }
+              ],
+              "aliases": [
+                "CVE-2026-15157"
+              ],
+              "database_specific": {
+                "cwe_ids": [
+                  "CWE-93"
+                ],
+                "github_reviewed": true,
+                "github_reviewed_at": "2026-08-03T19:33:53Z",
+                "nvd_published_at": "2026-07-29T22:16:52Z",
+                "severity": "MODERATE"
+              },
+              "details": "### Impact\n\nWhen an application passes a duck-typed blob-like body to undici's HTTP/1.1 dispatcher (via `request()`, `stream()`, `pipeline()`, or `dispatch()`) with a `.type` derived from untrusted input, an attacker can inject CRLF sequences (`\\r\\n`) to append arbitrary HTTP headers and potentially smuggle a second request past the upstream.\n\nThe vulnerable branch in `lib/dispatcher/client-h1.js` pushes `body.type` directly into the outgoing headers with no validation, while every other header path in undici goes through `isValidHeaderValue()`:\n\n```javascript\n} else if (util.isBlobLike(body) \u0026\u0026 request.contentType == null \u0026\u0026 body.type) {\n  headers.push('content-type', body.type)  // bypasses isValidHeaderValue()\n}\n```\n\nThe bug requires a hand-rolled duck-typed blob object or a Blob subclass with a controlled `.type`. Native `Blob` is safe because its constructor strips CRLF from `.type`. `fetch()` is unaffected because it validates via the `Headers` class. Ecosystem consumers that build duck-typed blob shapes from user input include `form-data-encoder`, `formdata-polyfill`, and `formdata-node`.\n\nSame defect class as `CVE-2022-35948` (explicit `content-type` sink, fixed in undici 5.8.2) and `CVE-2026-1527` (`upgrade` option sink, fixed in 6.24.0 / 7.24.0), both closed by adding `isValidHeaderValue()` on their respective sinks. This branch was missed.\n\n### Patches\n\nPatched in undici v6.28.0, v7.29.0, and v8.9.0. Users should upgrade to one of these versions or later.\n\n### Workarounds\n\n- Set an explicit, validated `content-type` header on the request options (skips the vulnerable branch).\n- Use a native `Blob` (or `fetch-blob`) instead of a hand-rolled duck-typed object.\n- Reject control characters in the MIME type before assigning it to `.type`.\n- Use `fetch()` instead of the non-`fetch` APIs.",
+              "id": "GHSA-m8rv-5g2x-5cg5",
+              "modified": "2026-08-04T21:26:57.967095860Z",
+              "published": "2026-08-03T19:33:53Z",
+              "references": [
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/nodejs/undici/security/advisories/GHSA-m8rv-5g2x-5cg5"
+                },
+                {
+                  "type": "ADVISORY",
+                  "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-15157"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/nodejs/undici/commit/33928bc24f742ea8422ed90d17f2e0cc83e4d09d"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/nodejs/undici/commit/740a0b7c173cb4a83a5b693e96e8f3a116cfc400"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/nodejs/undici/commit/7d3cf924c262c486bc77f951348f4e5c847b7b42"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://cna.openjsf.org/security-advisories.html"
+                },
+                {
+                  "type": "PACKAGE",
+                  "url": "https://github.com/nodejs/undici"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/nodejs/undici/releases/tag/v6.28.0"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/nodejs/undici/releases/tag/v7.29.0"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/nodejs/undici/releases/tag/v8.9.0"
+                }
+              ],
+              "related": [
+                "CGA-vpq3-h495-g2vc"
+              ],
+              "schema_version": "1.7.5",
+              "severity": [
+                {
+                  "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:L/A:N",
+                  "type": "CVSS_V3"
+                }
+              ],
+              "summary": "undici vulnerable to CRLF Injection via blob-like body 'type' property"
+            },
+            {
+              "affected": [
+                {
+                  "database_specific": {
+                    "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2026/08/GHSA-v3r7-h72x-cjcm/GHSA-v3r7-h72x-cjcm.json"
+                  },
+                  "package": {
+                    "ecosystem": "npm",
+                    "name": "undici",
+                    "purl": "pkg:npm/undici"
+                  },
+                  "ranges": [
+                    {
+                      "events": [
+                        {
+                          "introduced": "0"
+                        },
+                        {
+                          "fixed": "6.28.0"
+                        }
+                      ],
+                      "type": "SEMVER"
+                    }
+                  ]
+                },
+                {
+                  "database_specific": {
+                    "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2026/08/GHSA-v3r7-h72x-cjcm/GHSA-v3r7-h72x-cjcm.json"
+                  },
+                  "package": {
+                    "ecosystem": "npm",
+                    "name": "undici",
+                    "purl": "pkg:npm/undici"
+                  },
+                  "ranges": [
+                    {
+                      "events": [
+                        {
+                          "introduced": "7.0.0"
+                        },
+                        {
+                          "fixed": "7.29.0"
+                        }
+                      ],
+                      "type": "SEMVER"
+                    }
+                  ]
+                },
+                {
+                  "database_specific": {
+                    "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2026/08/GHSA-v3r7-h72x-cjcm/GHSA-v3r7-h72x-cjcm.json"
+                  },
+                  "package": {
+                    "ecosystem": "npm",
+                    "name": "undici",
+                    "purl": "pkg:npm/undici"
+                  },
+                  "ranges": [
+                    {
+                      "events": [
+                        {
+                          "introduced": "8.0.0"
+                        },
+                        {
+                          "fixed": "8.9.0"
+                        }
+                      ],
+                      "type": "SEMVER"
+                    }
+                  ]
+                }
+              ],
+              "aliases": [
+                "CVE-2026-16729"
+              ],
+              "database_specific": {
+                "cwe_ids": [
+                  "CWE-74"
+                ],
+                "github_reviewed": true,
+                "github_reviewed_at": "2026-08-03T19:30:52Z",
+                "nvd_published_at": "2026-07-29T17:16:51Z",
+                "severity": "MODERATE"
+              },
+              "details": "## Impact\n\nThe `setCookie` function has two attribute injection paths. `validateCookieDomain` does not reject semicolons (`validateCookiePath` already does at 0x3B), so a `domain` value like `example.com; SameSite=None` lands verbatim as `Domain=example.com; SameSite=None`. The `unparsed` array's loop only checks each entry contains `=` and does not sanitize values, so an entry like `X-Custom=val; HttpOnly` lands unchanged, injecting `HttpOnly` without the caller setting `cookie.httpOnly = true`.\n\nApplications that pass user-controlled input to these fields, typically multi-tenant or reverse-proxy servers that scope session cookies to a tenant-supplied domain, can have SameSite CSRF protections bypassed, `Secure` or `HttpOnly` forced or stripped, or the intended SameSite tier overridden.\n\n## Patches\n\nPatched in undici v6.28.0, v7.29.0, and v8.9.0.\n\n## Workarounds\n\n- Sanitize `domain` values against the RFC 1034 letter-digit-hyphen set before passing to `setCookie`.\n- Do not pass user-controlled data to the `unparsed` field.",
+              "id": "GHSA-v3r7-h72x-cjcm",
+              "modified": "2026-08-04T21:26:58.725599541Z",
+              "published": "2026-08-03T19:30:52Z",
+              "references": [
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/nodejs/undici/security/advisories/GHSA-v3r7-h72x-cjcm"
+                },
+                {
+                  "type": "ADVISORY",
+                  "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-16729"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/nodejs/undici/commit/10d93fc332f2c8c161982dec3833201de29891b5"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/nodejs/undici/commit/3bf91ddb493e853957f3a58e155326a668ab8aef"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/nodejs/undici/commit/af7484043ee075a6f216da0ad77e1dac55199235"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://cna.openjsf.org/security-advisories.html"
+                },
+                {
+                  "type": "PACKAGE",
+                  "url": "https://github.com/nodejs/undici"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/nodejs/undici/releases/tag/v6.28.0"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/nodejs/undici/releases/tag/v7.29.0"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://github.com/nodejs/undici/releases/tag/v8.9.0"
+                }
+              ],
+              "related": [
+                "CGA-9jf5-qmm3-5c74"
+              ],
+              "schema_version": "1.7.5",
+              "severity": [
+                {
+                  "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N",
+                  "type": "CVSS_V3"
+                }
+              ],
+              "summary": "undici vulnerable to cookie attribute injection via unsanitized domain and unparsed setCookie fields"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "experimental_config": {
+    "licenses": {
+      "summary": false,
+      "allowlist": null
+    }
+  }
+}

--- a/frontend/scripts/__tests__/osv-report.test.ts
+++ b/frontend/scripts/__tests__/osv-report.test.ts
@@ -1,0 +1,543 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+// Node's URL, not happy-dom's global one: fileURLToPath rejects a DOM URL.
+import { fileURLToPath, URL as NodeURL } from 'node:url'
+// @ts-expect-error -- plain ESM script, no type declarations by design
+import {
+  LABEL,
+  readReport,
+  countReportedPackages,
+  relativeSource,
+  collect,
+  fingerprint,
+  readFingerprint,
+  previousIds,
+  renderBody,
+  run,
+} from '../osv-report.mjs'
+
+/**
+ * Both fixtures are VERBATIM osv-scanner v2.3.8 JSON, not hand-written:
+ *
+ *   osv-findings.json — this repo's own `frontend/package-lock.json` as of
+ *     e52794c~1, re-scanned with the pinned scanner version. The only edit is
+ *     the absolute lockfile path, rewritten to the runner's workspace root so
+ *     the source column is asserted against what CI actually produces.
+ *   osv-clean.json — current `main`'s two lockfiles, which scan clean.
+ *
+ * Hand-built fixtures are what let the original filer assume Go-shaped
+ * advisories; these are the shapes npm really emits (`database_specific.severity`
+ * for the band, `groups[].max_severity` for the score, `aliases` often absent,
+ * one advisory listed once per installed copy of a package).
+ */
+const FINDINGS = fileURLToPath(new NodeURL('./fixtures/osv-findings.json', import.meta.url))
+const CLEAN = fileURLToPath(new NodeURL('./fixtures/osv-clean.json', import.meta.url))
+const EXCEPTIONS = fileURLToPath(new NodeURL('../npm-audit-exceptions.json', import.meta.url))
+const WORKSPACE = '/home/runner/work/terraform-registry-frontend/terraform-registry-frontend'
+
+const NO_EXCEPTIONS = { byAdvisory: new Map(), byPackage: new Map() }
+
+type Call = { name: string; args: Record<string, unknown> }
+
+function mockGithub({ issues = [] as Record<string, unknown>[], labelExists = true, createdNumber = 900 } = {}) {
+  const calls: Call[] = []
+  const record =
+    (name: string, result: unknown = undefined) =>
+    async (args: Record<string, unknown>) => {
+      calls.push({ name, args })
+      return result
+    }
+  const github = {
+    rest: {
+      issues: {
+        listForRepo: record('listForRepo', { data: issues }),
+        create: record('create', { data: { number: createdNumber } }),
+        update: record('update', { data: {} }),
+        createComment: record('createComment', { data: {} }),
+        createLabel: record('createLabel', { data: {} }),
+        getLabel: async (args: Record<string, unknown>) => {
+          calls.push({ name: 'getLabel', args })
+          if (labelExists) return { data: { name: LABEL } }
+          const err: Error & { status?: number } = new Error('Not Found')
+          err.status = 404
+          throw err
+        },
+      },
+    },
+  }
+  return { github, calls, of: (name: string) => calls.filter((c) => c.name === name) }
+}
+
+function mockCore() {
+  const failures: string[] = []
+  const info: string[] = []
+  const summary = {
+    addHeading(this: typeof summary) {
+      return this
+    },
+    addRaw(this: typeof summary) {
+      return this
+    },
+    async write() {},
+  }
+  return {
+    core: {
+      setFailed: (m: string) => failures.push(m),
+      info: (m: string) => info.push(m),
+      summary,
+    },
+    failures,
+    info,
+  }
+}
+
+const CONTEXT = {
+  repo: { owner: 'sethbacon', repo: 'terraform-registry-frontend' },
+  serverUrl: 'https://github.com',
+  runId: 4242,
+  sha: 'abcdef1234567890abcdef1234567890abcdef12',
+}
+
+const RUN_URL = 'https://github.com/sethbacon/terraform-registry-frontend/actions/runs/4242'
+
+function invoke(overrides: Record<string, unknown> = {}) {
+  return {
+    context: CONTEXT,
+    reportPath: FINDINGS,
+    exceptionsPath: EXCEPTIONS,
+    scanOutcome: 'failure',
+    workspace: WORKSPACE,
+    today: '2026-08-13',
+    ...overrides,
+  }
+}
+
+describe('readReport', () => {
+  it('parses a real scanner report', () => {
+    expect(countReportedPackages(readReport(FINDINGS))).toBe(9)
+  })
+
+  it('names the missing file rather than returning an empty report', () => {
+    expect(() => readReport('/nonexistent/osv-results.json')).toThrowError(
+      /could not read \/nonexistent\/osv-results\.json \(ENOENT/,
+    )
+  })
+
+  it('rejects truncated JSON', () => {
+    const truncated = fileURLToPath(new NodeURL('./fixtures/osv-clean.json', import.meta.url))
+    expect(readReport(truncated).results).toEqual([])
+  })
+
+  it('rejects a well-formed JSON document that is not a scanner report', () => {
+    const notAReport = fileURLToPath(new NodeURL('../npm-audit-exceptions.json', import.meta.url))
+    expect(() => readReport(notAReport)).toThrowError(/has no `results` array, so it is not an osv-scanner report/)
+  })
+})
+
+describe('relativeSource', () => {
+  it.each([
+    [`${WORKSPACE}/frontend/package-lock.json`, 'frontend/package-lock.json'],
+    [`${WORKSPACE}/e2e/package-lock.json`, 'e2e/package-lock.json'],
+    ['/elsewhere/package-lock.json', '/elsewhere/package-lock.json'],
+  ])('%s -> %s', (input, expected) => {
+    expect(relativeSource(input, WORKSPACE)).toBe(expected)
+  })
+})
+
+describe('collect', () => {
+  const { tracked, documented } = collect(readReport(FINDINGS), NO_EXCEPTIONS, WORKSPACE)
+
+  it('tracks exactly the high/critical advisories the gate counts', () => {
+    expect(tracked.map((f) => `${f.pkg}@${f.version} ${f.id} ${f.fixed} ${f.status}`)).toEqual([
+      'brace-expansion@1.1.16 GHSA-mh99-v99m-4gvg 1.1.17 fix available',
+      'brace-expansion@1.1.16 GHSA-rgw5-rvv9-x895 1.1.18 fix available',
+      'brace-expansion@5.0.7 GHSA-mh99-v99m-4gvg 5.0.8 fix available',
+      'brace-expansion@5.0.7 GHSA-rgw5-rvv9-x895 5.0.9 fix available',
+      'immutable@3.8.3 GHSA-v56q-mh7h-f735 4.3.9 only a semver-major (breaking) fix is available',
+      'immutable@3.8.3 GHSA-xvcm-6775-5m9r 4.3.9 only a semver-major (breaking) fix is available',
+      'js-yaml@4.3.0 GHSA-5p4m-2wfm-xmqj 4.3.1 fix available',
+      'nanoid@3.3.16 GHSA-2v37-7h3g-55p8 3.3.18 fix available',
+      'react-router@7.18.1 GHSA-qwww-vcr4-c8h2 7.18.2 fix available',
+      'undici@7.28.0 GHSA-4cwx-7wf7-3272 7.29.0 fix available',
+    ])
+    expect(documented).toEqual([])
+  })
+
+  it('carries the fields that make the issue actionable without a workflow log', () => {
+    expect(tracked.find((f) => f.id === 'GHSA-2v37-7h3g-55p8')).toEqual({
+      id: 'GHSA-2v37-7h3g-55p8',
+      aliases: ['CVE-2026-67213'],
+      severity: 'high',
+      cvss: '8.2',
+      pkg: 'nanoid',
+      version: '3.3.16',
+      fixed: '3.3.18',
+      summary: 'nanoid: custom generators can loop indefinitely when size is zero',
+      lockfile: 'frontend/package-lock.json',
+      status: 'fix available',
+    })
+  })
+
+  it('drops the moderate advisories the gate ignores, so issue and gate agree', () => {
+    // dompurify GHSA-55q2-fjhq-7xh7 and postcss GHSA-fxqj-rqcc-2cmp are MODERATE
+    // and present in the fixture; neither is tracked.
+    expect(tracked.map((f) => f.pkg)).not.toContain('dompurify')
+    expect(tracked.map((f) => f.pkg)).not.toContain('postcss')
+  })
+
+  it('moves an advisory to documented-only once it is an accepted risk', () => {
+    const exceptions = {
+      byAdvisory: new Map([['GHSA-2v37-7h3g-55p8', { reason: 'not reachable from the bundle', review_by: '2026-12-01' }]]),
+      byPackage: new Map(),
+    }
+    const out = collect(readReport(FINDINGS), exceptions, WORKSPACE)
+    expect(out.tracked.map((f) => f.id)).not.toContain('GHSA-2v37-7h3g-55p8')
+    expect(out.documented.map((f) => `${f.id} ${f.status} ${f.reason}`)).toEqual([
+      'GHSA-2v37-7h3g-55p8 accepted risk not reachable from the bundle',
+    ])
+  })
+
+  it('reports nothing at all for a clean scan', () => {
+    expect(collect(readReport(CLEAN), NO_EXCEPTIONS, WORKSPACE)).toEqual({ tracked: [], documented: [] })
+  })
+})
+
+describe('fingerprint', () => {
+  const base = [{ id: 'GHSA-a', pkg: 'p', version: '1.0.0', fixed: '1.0.1' }]
+
+  it('is stable for an unchanged finding set', () => {
+    expect(fingerprint(base)).toBe(fingerprint([{ ...base[0] }]))
+  })
+
+  it('changes when an advisory is added', () => {
+    expect(fingerprint([...base, { id: 'GHSA-b', pkg: 'q', version: '2.0.0', fixed: '' }])).not.toBe(fingerprint(base))
+  })
+
+  it('changes when a finding becomes actionable (a fix appears)', () => {
+    expect(fingerprint([{ ...base[0], fixed: '' }])).not.toBe(fingerprint(base))
+  })
+
+  it('round-trips through the issue body marker', () => {
+    const fp = fingerprint(base)
+    expect(readFingerprint(`body text\n<!-- osv-fingerprint: ${fp} -->`)).toBe(fp)
+    expect(readFingerprint('a body with no marker')).toBeNull()
+  })
+})
+
+describe('renderBody', () => {
+  const { tracked, documented } = collect(readReport(FINDINGS), NO_EXCEPTIONS, WORKSPACE)
+  const body = renderBody({
+    tracked,
+    documented,
+    fingerprint: 'deadbeef0000',
+    today: '2026-08-13',
+    runUrl: RUN_URL,
+    sha: CONTEXT.sha,
+  })
+
+  it('counts findings, packages and how many are actionable', () => {
+    expect(body).toContain(
+      '**10 high/critical advisory/advisories across 6 package(s)** — 8 with a non-breaking fix available, 2 without.',
+    )
+  })
+
+  it('renders a row naming advisory, severity, package, version, fix and lockfile', () => {
+    expect(body).toContain(
+      '| [GHSA-2v37-7h3g-55p8](https://osv.dev/GHSA-2v37-7h3g-55p8) | high (8.2) | `nanoid` | `3.3.16` | ' +
+        '`3.3.18` | `frontend/package-lock.json` | fix available |',
+    )
+  })
+
+  it('names the same advisory once per installed copy, with that copy s own fix', () => {
+    expect(body).toContain('| `brace-expansion` | `1.1.16` | `1.1.17` |')
+    expect(body).toContain('| `brace-expansion` | `5.0.7` | `5.0.8` |')
+  })
+
+  it('lists summaries and aliases in the details block', () => {
+    expect(body).toContain(
+      '- **GHSA-2v37-7h3g-55p8** — nanoid: custom generators can loop indefinitely when size is zero ' +
+        '_(aliases: CVE-2026-67213)_',
+    )
+  })
+
+  it('carries the run, commit and fingerprint the next run reads back', () => {
+    expect(body).toContain(`- **Last confirmed:** 2026-08-13 ([run](${RUN_URL}), commit \`abcdef1\`)`)
+    expect(body).toContain('<!-- osv-fingerprint: deadbeef0000 -->')
+    expect(readFingerprint(body)).toBe('deadbeef0000')
+  })
+
+  it('lists accepted risks separately and does not count them', () => {
+    const withAccepted = renderBody({
+      tracked: tracked.slice(0, 1),
+      documented: [{ id: 'GHSA-x', pkg: 'p', version: '1.0.0', reason: 'dev-only', status: 'accepted risk' }],
+      fingerprint: 'aaaa',
+      today: '2026-08-13',
+      runUrl: RUN_URL,
+      sha: CONTEXT.sha,
+    })
+    expect(withAccepted).toContain('<details><summary>1 documented accepted risk(s) — not counted above</summary>')
+    expect(withAccepted).toContain('- GHSA-x — `p@1.0.0` — _dev-only_')
+    expect(withAccepted).toContain('**1 high/critical advisory/advisories across 1 package(s)**')
+  })
+
+  it('lets the next run recover the advisory ids it listed', () => {
+    expect([...previousIds(body)].sort()).toEqual([
+      'GHSA-2v37-7h3g-55p8',
+      'GHSA-4cwx-7wf7-3272',
+      'GHSA-5p4m-2wfm-xmqj',
+      'GHSA-mh99-v99m-4gvg',
+      'GHSA-qwww-vcr4-c8h2',
+      'GHSA-rgw5-rvv9-x895',
+      'GHSA-v56q-mh7h-f735',
+      'GHSA-xvcm-6775-5m9r',
+    ])
+  })
+})
+
+describe('run — unreadable scan output', () => {
+  it('fails loudly instead of reading as clean', async () => {
+    const { github, of } = mockGithub({ issues: [{ number: 5, body: '<!-- osv-fingerprint: aaaaaaaaaaaa -->' }] })
+    const { core, failures } = mockCore()
+
+    const result = await run(invoke({ github, core, reportPath: '/nonexistent/osv-results.json' }))
+
+    expect(result).toBe('failed')
+    expect(failures).toEqual([
+      expect.stringContaining('could not read /nonexistent/osv-results.json (ENOENT'),
+    ])
+    expect(failures[0]).toContain('The scan produced no usable report, so findings could not be triaged.')
+    // Decisive: it must not have closed the live issue.
+    expect(of('update')).toEqual([])
+    expect(of('createComment')).toEqual([])
+  })
+
+  it('fails when the scanner exited non-zero having scanned nothing (network, rate limit)', async () => {
+    const { github, of } = mockGithub({ issues: [{ number: 5, body: 'x' }] })
+    const { core, failures } = mockCore()
+
+    const result = await run(invoke({ github, core, reportPath: CLEAN, scanOutcome: 'failure' }))
+
+    expect(result).toBe('failed')
+    expect(failures).toEqual([
+      'osv-scanner exited non-zero (outcome: failure) and reported no packages at all. ' +
+        'That is a scan failure, not a clean tree; refusing to report clean.',
+    ])
+    expect(of('update')).toEqual([])
+  })
+
+  it('accepts a clean report when the scanner exited zero', async () => {
+    const { github } = mockGithub({ issues: [] })
+    const { core, failures } = mockCore()
+
+    const result = await run(invoke({ github, core, reportPath: CLEAN, scanOutcome: 'success' }))
+
+    expect(result).toBe('noop')
+    expect(failures).toEqual([])
+  })
+})
+
+describe('run — clean scan resolves the tracking issue', () => {
+  it('comments the evidence and closes the open issue', async () => {
+    const { github, of } = mockGithub({ issues: [{ number: 77, body: 'old body' }] })
+    const { core, info } = mockCore()
+
+    const result = await run(invoke({ github, core, reportPath: CLEAN, scanOutcome: 'success' }))
+
+    expect(result).toBe('closed')
+    expect(of('createComment')[0].args).toEqual({
+      owner: 'sethbacon',
+      repo: 'terraform-registry-frontend',
+      issue_number: 77,
+      body: [
+        '**Resolved — OSV-Scanner reported no tracked advisories on 2026-08-13.**',
+        '',
+        `Verified by [this run](${RUN_URL}) against \`${CONTEXT.sha}\`.`,
+        '',
+        'Closing automatically. A future scan with findings will open a new tracking issue.',
+      ].join('\n'),
+    })
+    expect(of('update')[0].args).toEqual({
+      owner: 'sethbacon',
+      repo: 'terraform-registry-frontend',
+      issue_number: 77,
+      state: 'closed',
+      state_reason: 'completed',
+    })
+    expect(info).toContain('Closed #77 — scan reported no tracked advisories.')
+  })
+
+  it('does nothing when there is no open issue to close', async () => {
+    const { github, of } = mockGithub({ issues: [] })
+    const { core, info } = mockCore()
+
+    const result = await run(invoke({ github, core, reportPath: CLEAN, scanOutcome: 'success' }))
+
+    expect(result).toBe('noop')
+    expect(of('update')).toEqual([])
+    expect(of('create')).toEqual([])
+    expect(info).toContain('No tracked advisories and no open OSV issue. Nothing to do.')
+  })
+
+  it('ignores a pull request that carries the label', async () => {
+    const { github, of } = mockGithub({ issues: [{ number: 90, body: 'pr', pull_request: { url: 'x' } }] })
+    const { core } = mockCore()
+
+    const result = await run(invoke({ github, core, reportPath: CLEAN, scanOutcome: 'success' }))
+
+    expect(result).toBe('noop')
+    expect(of('update')).toEqual([])
+  })
+})
+
+describe('run — findings open exactly one issue', () => {
+  let mock: ReturnType<typeof mockGithub>
+
+  beforeEach(() => {
+    mock = mockGithub({ issues: [], createdNumber: 781 })
+  })
+
+  it('looks the issue up by label, not by title', async () => {
+    const { core } = mockCore()
+    await run(invoke({ github: mock.github, core }))
+
+    expect(mock.of('listForRepo')[0].args).toEqual({
+      owner: 'sethbacon',
+      repo: 'terraform-registry-frontend',
+      state: 'open',
+      labels: 'osv-report',
+      per_page: 100,
+    })
+  })
+
+  it('creates the issue with the dedupe label applied', async () => {
+    const { core, info } = mockCore()
+    const result = await run(invoke({ github: mock.github, core }))
+
+    expect(result).toBe('created')
+    const created = mock.of('create')[0].args as { title: string; labels: string[]; body: string }
+    expect(created.title).toBe('OSV-Scanner: vulnerabilities found — 2026-08-13')
+    expect(created.labels).toEqual(['osv-report', 'security', 'dependencies'])
+    expect(created.body).toContain('| [GHSA-qwww-vcr4-c8h2](https://osv.dev/GHSA-qwww-vcr4-c8h2) |')
+    expect(info).toContain('Opened #781 with 10 advisory/advisories.')
+  })
+
+  it('creates the label first when it does not exist, or the next run opens a second issue', async () => {
+    const missing = mockGithub({ issues: [], labelExists: false })
+    const { core, info } = mockCore()
+
+    await run(invoke({ github: missing.github, core }))
+
+    expect(missing.of('createLabel')[0].args).toEqual({
+      owner: 'sethbacon',
+      repo: 'terraform-registry-frontend',
+      name: 'osv-report',
+      color: 'B60205',
+      description: 'Tracking issue maintained by the weekly OSV-Scanner job',
+    })
+    expect(info).toContain("Created missing 'osv-report' label.")
+    // Order matters: the label must exist before the issue that relies on it.
+    const names = missing.calls.map((c) => c.name)
+    expect(names.indexOf('createLabel')).toBeLessThan(names.indexOf('create'))
+  })
+
+  it('propagates a label lookup failure that is not a 404 rather than opening an issue', async () => {
+    const boom = mockGithub({ issues: [] })
+    boom.github.rest.issues.getLabel = async () => {
+      const err: Error & { status?: number } = new Error('server error')
+      err.status = 500
+      throw err
+    }
+    const { core } = mockCore()
+
+    await expect(run(invoke({ github: boom.github, core }))).rejects.toThrowError('server error')
+    expect(boom.of('create')).toEqual([])
+  })
+})
+
+describe('run — an existing issue is updated, never duplicated', () => {
+  const bodyFor = (reportPath: string) => {
+    const { tracked, documented } = collect(readReport(reportPath), NO_EXCEPTIONS, WORKSPACE)
+    return renderBody({
+      tracked,
+      documented,
+      fingerprint: fingerprint(tracked),
+      today: '2026-08-06',
+      runUrl: RUN_URL,
+      sha: CONTEXT.sha,
+    })
+  }
+
+  it('rewrites in place and stays silent when the finding set is unchanged', async () => {
+    const { github, of } = mockGithub({ issues: [{ number: 781, body: bodyFor(FINDINGS) }] })
+    const { core, info } = mockCore()
+
+    const result = await run(invoke({ github, core }))
+
+    expect(result).toBe('refreshed')
+    expect(of('create')).toEqual([])
+    expect(of('createComment')).toEqual([])
+    expect(of('update')).toHaveLength(1)
+    const updated = of('update')[0].args as { issue_number: number; title: string; body: string }
+    expect(updated.issue_number).toBe(781)
+    expect(updated.title).toBe('OSV-Scanner: vulnerabilities found — 2026-08-13')
+    expect(updated.body).toContain('- **Last confirmed:** 2026-08-13')
+    expect(info).toContain('#781 refreshed; finding set unchanged (d131c5e79cf0).')
+  })
+
+  it('comments exactly which advisories were added and removed when the set changes', async () => {
+    const stale = [
+      '## OSV-Scanner Vulnerability Report',
+      '| [GHSA-qwww-vcr4-c8h2](https://osv.dev/GHSA-qwww-vcr4-c8h2) | high | `react-router` | `7.18.1` | | | |',
+      '| [GHSA-0000-0000-0000](https://osv.dev/GHSA-0000-0000-0000) | high | `gone` | `1.0.0` | | | |',
+      '<!-- osv-fingerprint: 000000000000 -->',
+    ].join('\n')
+    const { github, of } = mockGithub({ issues: [{ number: 781, body: stale }] })
+    const { core, info } = mockCore()
+
+    const result = await run(invoke({ github, core }))
+
+    expect(result).toBe('updated')
+    expect(of('create')).toEqual([])
+    const comment = of('createComment')[0].args as { body: string }
+    expect(comment.body).toBe(
+      [
+        // A blank line before and after the bullets: they must render as a
+        // list, not run into the surrounding paragraphs.
+        `**Finding set changed as of 2026-08-13** ([run](${RUN_URL})).`,
+        '',
+        '- Newly reported: `GHSA-mh99-v99m-4gvg`, `GHSA-rgw5-rvv9-x895`, `GHSA-v56q-mh7h-f735`, ' +
+          '`GHSA-xvcm-6775-5m9r`, `GHSA-5p4m-2wfm-xmqj`, `GHSA-2v37-7h3g-55p8`, `GHSA-4cwx-7wf7-3272`',
+        '- No longer reported: `GHSA-0000-0000-0000`',
+        '',
+        'The issue body above has been updated to the current set.',
+        // A blank line before and after the bullets: they must render as a list,
+        // not run into the surrounding paragraphs.
+      ].join('\n'),
+    )
+    expect(info).toContain('#781 updated: +7 / -1.')
+  })
+
+  it('says so when the same advisories changed details — a fix becoming available', async () => {
+    // Same ids as the current report, but recorded when nothing was fixable.
+    const { tracked } = collect(readReport(FINDINGS), NO_EXCEPTIONS, WORKSPACE)
+    const previous = renderBody({
+      tracked: tracked.map((f) => ({ ...f, fixed: '', status: 'no fixed version published' })),
+      documented: [],
+      fingerprint: fingerprint(tracked.map((f) => ({ ...f, fixed: '' }))),
+      today: '2026-08-06',
+      runUrl: RUN_URL,
+      sha: CONTEXT.sha,
+    })
+    const { github, of } = mockGithub({ issues: [{ number: 781, body: previous }] })
+    const { core } = mockCore()
+
+    const result = await run(invoke({ github, core }))
+
+    expect(result).toBe('updated')
+    const comment = of('createComment')[0].args as { body: string }
+    expect(comment.body).toContain(
+      '- Same advisories, changed details (installed or fixed version) — see the table above.',
+    )
+    expect(comment.body).not.toContain('Newly reported')
+    expect(comment.body).not.toContain('No longer reported')
+  })
+})

--- a/frontend/scripts/audit-gate.mjs
+++ b/frontend/scripts/audit-gate.mjs
@@ -42,6 +42,40 @@ import { readFileSync, existsSync, appendFileSync } from 'node:fs'
 
 const BLOCKING_SEVERITIES = new Set(['critical', 'high'])
 
+/** Numeric compare of plain `x.y.z` versions; lockfile versions carry no prerelease tags. */
+export function compareVersions(a, b) {
+  const parts = (v) =>
+    String(v ?? '')
+      .split('.')
+      .map((p) => Number.parseInt(p, 10) || 0)
+  const [x, y] = [parts(a), parts(b)]
+  for (let i = 0; i < Math.max(x.length, y.length); i += 1) {
+    const d = (x[i] ?? 0) - (y[i] ?? 0)
+    if (d !== 0) return d
+  }
+  return 0
+}
+
+/**
+ * The minimal upgrade that clears an advisory: the LOWEST published fixed
+ * version above the installed one.
+ *
+ * An advisory that spans several release lines publishes a fix per line, and
+ * `fixed[0]` is whichever line OSV happens to list first. Real example from
+ * this repo's own history: `brace-expansion@1.1.16` / GHSA-mh99-v99m-4gvg
+ * publishes 1.1.17, 2.1.3, 3.0.3 and 5.0.8; taking the first listed (5.0.8)
+ * made a patch-level fix look like a semver-major, which the gate then reported
+ * as "only a breaking fix is available" and did not block on. Picking the
+ * lowest upgrade names 1.1.17 and blocks, which is correct.
+ *
+ * Falls back to the first published fix when nothing is above the installed
+ * version (an advisory listing only older lines cannot be cleared by upgrading).
+ */
+export function pickFixTarget(fixed, installed) {
+  const upgrades = fixed.filter((v) => compareVersions(v, installed) > 0).sort(compareVersions)
+  return upgrades[0] ?? fixed[0]
+}
+
 export function loadExceptions(path) {
   if (!path || !existsSync(path)) return { byAdvisory: new Map(), byPackage: new Map() }
   const data = JSON.parse(readFileSync(path, 'utf8'))
@@ -91,6 +125,17 @@ export function triageOsv(report, exceptions = { byAdvisory: new Map(), byPackag
     for (const pkg of result?.packages ?? []) {
       const name = pkg?.package?.name ?? '?'
       const installed = pkg?.package?.version ?? '?'
+
+      // osv-scanner reports the qualitative band (HIGH/CRITICAL, used above to
+      // decide what counts) per vulnerability, but the CVSS score only on the
+      // enclosing group. Carried through so osv-report.mjs can print both:
+      // after the high/critical filter the band alone is nearly constant.
+      const cvssById = new Map()
+      for (const group of pkg?.groups ?? []) {
+        if (!group?.max_severity) continue
+        for (const id of group?.ids ?? []) cvssById.set(id, group.max_severity)
+      }
+
       for (const vuln of pkg?.vulnerabilities ?? []) {
         const severity = (vuln?.database_specific?.severity ?? 'HIGH').toLowerCase()
         if (!BLOCKING_SEVERITIES.has(severity)) continue
@@ -107,13 +152,19 @@ export function triageOsv(report, exceptions = { byAdvisory: new Map(), byPackag
         }
 
         const ids = [vuln?.id, ...(vuln?.aliases ?? [])].filter(Boolean)
-        const target = fixed[0]
+        const target = pickFixTarget(fixed, installed)
         const breaking =
           target != null && major(target) != null && major(installed) != null && major(target) !== major(installed)
 
         const entry = {
           package: name,
           severity,
+          // Reporting-only fields (osv-report.mjs); they take no part in the
+          // blocking decision below. `installed` matters because one advisory
+          // can appear twice for two copies of a package at different versions,
+          // one with a non-breaking fix and one without.
+          installed,
+          cvss: cvssById.get(vuln?.id) ?? '',
           advisories: ids,
           titles: [vuln?.summary ?? ''],
           devOnly: false,

--- a/frontend/scripts/osv-report.mjs
+++ b/frontend/scripts/osv-report.mjs
@@ -1,0 +1,367 @@
+#!/usr/bin/env node
+/**
+ * osv-report.mjs — turn an osv-scanner JSON report into ONE tracking issue.
+ *
+ * Ported from terraform-provider-registry's weekly-security.yml (its #108),
+ * which fixed the same class of defect there. The mechanism is identical:
+ *
+ *   - the issue NAMES the advisories (id, severity, package, installed version,
+ *     fixed version, summary, aliases) so it is triageable without opening a
+ *     workflow log;
+ *   - there is exactly ONE tracking issue, found by the `osv-report` LABEL
+ *     rather than by title (the title carries a date, so a title lookup opens a
+ *     new issue every week);
+ *   - an unchanged finding set rewrites the issue in place with no comment
+ *     noise; a changed set comments exactly what was added and removed;
+ *   - a scan with no findings CLOSES the issue, so a fixed vulnerability does
+ *     not leave a permanently open one;
+ *   - an unreadable report FAILS the job instead of reading as "clean" and
+ *     closing a live issue.
+ *
+ * Four things are deliberately NOT ported, because this repository is npm and
+ * the original is Go:
+ *
+ *   1. Reachability. osv-scanner's `experimental_analysis` (`called: false`) is
+ *      produced by Go call-graph analysis only; npm lockfile scans carry no
+ *      such field, so the original's reachability filter would be a branch that
+ *      is always true here. Its PURPOSE — "do not open an issue for something
+ *      nobody can act on" — is served instead by this repo's existing
+ *      actionability triage (audit-gate.mjs), which is what the PR gate and the
+ *      weekly gate already use. Reusing that parser rather than writing a second
+ *      one is the point: the issue and the gate cannot disagree about an
+ *      advisory.
+ *   2. Severity. The original prints `group.max_severity`. For npm that is a
+ *      bare CVSS score, and after the gate's high/critical filter a qualitative
+ *      column alone would be nearly constant, so both are shown: `high (8.2)`.
+ *   3. Lockfile. The original never rendered `source` because Go has one
+ *      module. Here an advisory in `e2e/package-lock.json` never reaches a user
+ *      and one in `frontend/package-lock.json` may, so the lockfile is a column.
+ *   4. Fingerprint. The original hashes id@package@version. This one also hashes
+ *      the fix target, so an advisory that GAINS a non-breaking fix — the moment
+ *      it becomes actionable — notifies instead of being refreshed silently.
+ *
+ * Consumed by .github/workflows/weekly-security.yml via actions/github-script.
+ * Every function below is pure except `run`, which is the only one that touches
+ * the API; see __tests__/osv-report.test.ts.
+ */
+
+import { readFileSync } from 'node:fs'
+import { createHash } from 'node:crypto'
+
+import { triageOsv, loadExceptions } from './audit-gate.mjs'
+
+/** Dedupe key for the tracking issue. A title lookup cannot work: titles carry a date. */
+export const LABEL = 'osv-report'
+
+const FINGERPRINT_RE = /<!-- osv-fingerprint: ([0-9a-f]+) -->/
+const ADVISORY_LINK_RE = /\[((?:GHSA|CVE|GO|OSV|PYSEC|RUSTSEC)-[0-9A-Za-z-]+)\]\(https:\/\/osv\.dev\//g
+
+/**
+ * Reads the scanner's JSON report, refusing anything that is not recognisably
+ * one. A missing, truncated or empty file means the scan died before writing
+ * output; treating that as "no findings" would close a live tracking issue.
+ *
+ * @throws {Error} with a message naming the exact reason, which `run` surfaces
+ *   through `core.setFailed`.
+ */
+export function readReport(path) {
+  let raw
+  try {
+    raw = readFileSync(path, 'utf8')
+  } catch (err) {
+    throw new Error(`could not read ${path} (${err.message})`, { cause: err })
+  }
+  let parsed
+  try {
+    parsed = JSON.parse(raw)
+  } catch (err) {
+    throw new Error(`could not parse ${path} as JSON (${err.message})`, { cause: err })
+  }
+  if (!parsed || !Array.isArray(parsed.results)) {
+    throw new Error(`${path} has no \`results\` array, so it is not an osv-scanner report`)
+  }
+  return parsed
+}
+
+/** Number of scanned packages carrying at least one advisory, across all lockfiles. */
+export function countReportedPackages(report) {
+  let n = 0
+  for (const result of report?.results ?? []) n += (result?.packages ?? []).length
+  return n
+}
+
+/** `/home/runner/work/repo/repo/frontend/package-lock.json` -> `frontend/package-lock.json`. */
+export function relativeSource(source, workspace) {
+  const path = String(source ?? '')
+  if (workspace && path.startsWith(`${workspace}/`)) return path.slice(workspace.length + 1)
+  return path
+}
+
+/**
+ * Splits the scanner report into what the issue tracks and what it only
+ * mentions.
+ *
+ *   tracked    — blocking + advisory: real high/critical findings nobody has
+ *                signed off on. These keep the issue open.
+ *   documented — accepted: listed in npm-audit-exceptions.json with a rationale
+ *                and a review date. Someone already decided about these, so
+ *                they are context and never keep an issue open on their own —
+ *                the same role the original's unreachable findings played.
+ */
+export function collect(report, exceptions, workspace) {
+  const { blocking, advisory, accepted } = triageOsv(report, exceptions)
+
+  const toRow = (entry, status) => ({
+    id: entry.advisories?.[0] ?? '(unknown)',
+    aliases: (entry.advisories ?? []).slice(1),
+    severity: entry.severity ?? '—',
+    cvss: entry.cvss ?? '',
+    pkg: entry.package ?? '(unknown)',
+    version: entry.installed ?? '(unknown)',
+    fixed: entry.fix && typeof entry.fix === 'object' ? entry.fix.version : '',
+    summary: (entry.titles?.[0] ?? '').trim(),
+    lockfile: relativeSource(entry.source, workspace),
+    status,
+  })
+
+  const byPkgThenId = (a, b) => `${a.pkg}${a.version}${a.id}`.localeCompare(`${b.pkg}${b.version}${b.id}`)
+  const tracked = [
+    ...blocking.map((e) => toRow(e, 'fix available')),
+    ...advisory.map((e) => toRow(e, e.why ?? 'not actionable')),
+  ].sort(byPkgThenId)
+  const documented = accepted.map((e) => ({ ...toRow(e, 'accepted risk'), reason: e.reason ?? '' })).sort(byPkgThenId)
+
+  return { tracked, documented }
+}
+
+/**
+ * Stable across runs; changes only when the finding set itself does, so a
+ * persisting set updates the issue quietly instead of commenting every Monday.
+ * The fix target is part of the key on purpose: an advisory that gains a
+ * non-breaking fix has become actionable and is worth a notification.
+ */
+export function fingerprint(tracked) {
+  return createHash('sha256')
+    .update(tracked.map((f) => `${f.id}@${f.pkg}@${f.version}@${f.fixed}`).join(';'))
+    .digest('hex')
+    .slice(0, 12)
+}
+
+export function readFingerprint(body) {
+  return (body ?? '').match(FINGERPRINT_RE)?.[1] ?? null
+}
+
+/** Advisory ids the previous issue body listed, read back out of its table links. */
+export function previousIds(body) {
+  return new Set([...(body ?? '').matchAll(ADVISORY_LINK_RE)].map((m) => m[1]))
+}
+
+export function renderBody({ tracked, documented, fingerprint: fp, today, runUrl, sha }) {
+  const severityCell = (f) => (f.cvss ? `${f.severity} (${f.cvss})` : f.severity)
+  const table = [
+    '| Advisory | Severity | Package | Version | Fixed in | Lockfile | Status |',
+    '| --- | --- | --- | --- | --- | --- | --- |',
+    ...tracked.map(
+      (f) =>
+        `| [${f.id}](https://osv.dev/${f.id}) | ${severityCell(f)} | \`${f.pkg}\` | \`${f.version}\` | ` +
+        `${f.fixed ? `\`${f.fixed}\`` : '—'} | \`${f.lockfile}\` | ${f.status} |`,
+    ),
+  ]
+
+  const details = tracked
+    .filter((f) => f.summary || f.aliases.length)
+    .map((f) => {
+      const alias = f.aliases.length ? ` _(aliases: ${f.aliases.join(', ')})_` : ''
+      return `- **${f.id}** — ${f.summary || 'no summary published'}${alias}`
+    })
+
+  const fixable = tracked.filter((f) => f.status === 'fix available').length
+  const pkgCount = new Set(tracked.map((f) => f.pkg)).size
+
+  return [
+    '## OSV-Scanner Vulnerability Report',
+    '',
+    `**${tracked.length} high/critical advisory/advisories across ${pkgCount} package(s)** — ` +
+      `${fixable} with a non-breaking fix available, ${tracked.length - fixable} without.`,
+    '',
+    `- **Last confirmed:** ${today} ([run](${runUrl}), commit \`${String(sha ?? '').slice(0, 7)}\`)`,
+    '',
+    ...table,
+    '',
+    ...(details.length ? ['<details><summary>Advisory details</summary>', '', ...details, '', '</details>', ''] : []),
+    ...(documented.length
+      ? [
+          `<details><summary>${documented.length} documented accepted risk(s) — not counted above</summary>`,
+          '',
+          ...documented.map(
+            (f) => `- ${f.id} — \`${f.pkg}@${f.version}\`${f.reason ? ` — _${f.reason}_` : ''}`,
+          ),
+          '',
+          '</details>',
+          '',
+        ]
+      : []),
+    'Rows marked **fix available** have a non-breaking upgrade and also fail the weekly job\'s triage gate ' +
+      '(`frontend/scripts/audit-gate.mjs`); upgrade those. The rest have no fix, or only a breaking one — either ' +
+      'wait for upstream or record the decision in `frontend/scripts/npm-audit-exceptions.json` with a rationale ' +
+      'and a review date, which moves them out of this list.',
+    '',
+    'This issue is maintained automatically by the weekly scan: rewritten in place while these findings persist, ' +
+      'and closed once a scan reports none.',
+    '',
+    `<!-- osv-fingerprint: ${fp} -->`,
+  ].join('\n')
+}
+
+/**
+ * @returns {'failed'|'closed'|'noop'|'created'|'refreshed'|'updated'} what the
+ *   run did — asserted exactly by the tests.
+ */
+export async function run({
+  github,
+  context,
+  core,
+  reportPath = 'osv-results.json',
+  exceptionsPath = 'frontend/scripts/npm-audit-exceptions.json',
+  scanOutcome = process.env.OSV_SCAN_OUTCOME ?? '',
+  workspace = process.env.GITHUB_WORKSPACE ?? '',
+  today = new Date().toISOString().slice(0, 10),
+}) {
+  const repo = { owner: context.repo.owner, repo: context.repo.repo }
+  const runUrl = `${context.serverUrl}/${repo.owner}/${repo.repo}/actions/runs/${context.runId}`
+
+  let report
+  try {
+    report = readReport(reportPath)
+  } catch (err) {
+    core.setFailed(`${err.message}. The scan produced no usable report, so findings could not be triaged.`)
+    return 'failed'
+  }
+
+  // osv-scanner exits 0 clean, 1 when it found something, and 127/128 when it
+  // could not scan at all (missing lockfile, network, rate limit) — in which
+  // case it writes an empty report. Non-zero WITH findings is explained; non-zero
+  // WITHOUT any is a scan that did not happen, and must not read as "clean".
+  if (scanOutcome !== 'success' && countReportedPackages(report) === 0) {
+    core.setFailed(
+      `osv-scanner exited non-zero (outcome: ${scanOutcome || 'unknown'}) and reported no packages at all. ` +
+        'That is a scan failure, not a clean tree; refusing to report clean.',
+    )
+    return 'failed'
+  }
+
+  const { tracked, documented } = collect(report, loadExceptions(exceptionsPath), workspace)
+
+  const { data: openIssues } = await github.rest.issues.listForRepo({
+    ...repo,
+    state: 'open',
+    labels: LABEL,
+    per_page: 100,
+  })
+  const existing = openIssues.find((i) => !i.pull_request)
+
+  // ── Nothing tracked: resolve the issue rather than leaving it open forever ──
+  if (tracked.length === 0) {
+    core.summary.addHeading('OSV-Scanner: no tracked advisories', 2)
+    core.summary.addRaw(
+      `No high/critical advisories outside the accepted-risk register. ${documented.length} accepted risk(s).`,
+    )
+    await core.summary.write()
+
+    if (!existing) {
+      core.info('No tracked advisories and no open OSV issue. Nothing to do.')
+      return 'noop'
+    }
+    await github.rest.issues.createComment({
+      ...repo,
+      issue_number: existing.number,
+      // Conditional lines are spread in, not filtered out afterwards: a blank
+      // line here is a markdown paragraph break and must survive.
+      body: [
+        `**Resolved — OSV-Scanner reported no tracked advisories on ${today}.**`,
+        '',
+        `Verified by [this run](${runUrl}) against \`${context.sha}\`.`,
+        ...(documented.length
+          ? [
+              '',
+              `${documented.length} advisory/advisories remain but are recorded as accepted risks in ` +
+                '`frontend/scripts/npm-audit-exceptions.json`, so they are not tracked here.',
+            ]
+          : []),
+        '',
+        'Closing automatically. A future scan with findings will open a new tracking issue.',
+      ].join('\n'),
+    })
+    await github.rest.issues.update({ ...repo, issue_number: existing.number, state: 'closed', state_reason: 'completed' })
+    core.info(`Closed #${existing.number} — scan reported no tracked advisories.`)
+    return 'closed'
+  }
+
+  const fp = fingerprint(tracked)
+  const body = renderBody({ tracked, documented, fingerprint: fp, today, runUrl, sha: context.sha })
+  const title = `OSV-Scanner: vulnerabilities found — ${today}`
+
+  core.summary.addHeading(`OSV-Scanner: ${tracked.length} tracked advisory/advisories`, 2)
+  core.summary.addRaw(body)
+  await core.summary.write()
+
+  if (!existing) {
+    // The label IS the dedupe key. issues.create silently drops a label that
+    // does not exist yet, and the next run would then find nothing and open a
+    // second issue — so make sure it exists before relying on it.
+    try {
+      await github.rest.issues.getLabel({ ...repo, name: LABEL })
+    } catch (err) {
+      if (err.status !== 404) throw err
+      await github.rest.issues.createLabel({
+        ...repo,
+        name: LABEL,
+        color: 'B60205',
+        description: 'Tracking issue maintained by the weekly OSV-Scanner job',
+      })
+      core.info(`Created missing '${LABEL}' label.`)
+    }
+
+    const { data: created } = await github.rest.issues.create({
+      ...repo,
+      title,
+      body,
+      labels: [LABEL, 'security', 'dependencies'],
+    })
+    core.info(`Opened #${created.number} with ${tracked.length} advisory/advisories.`)
+    return 'created'
+  }
+
+  const unchanged = readFingerprint(existing.body) === fp
+  await github.rest.issues.update({ ...repo, issue_number: existing.number, title, body })
+
+  if (unchanged) {
+    core.info(`#${existing.number} refreshed; finding set unchanged (${fp}).`)
+    return 'refreshed'
+  }
+
+  const before = previousIds(existing.body)
+  const now = new Set(tracked.map((f) => f.id))
+  const added = [...now].filter((id) => !before.has(id))
+  const removed = [...before].filter((id) => !now.has(id))
+
+  await github.rest.issues.createComment({
+    ...repo,
+    issue_number: existing.number,
+    body: [
+      `**Finding set changed as of ${today}** ([run](${runUrl})).`,
+      '',
+      ...(added.length ? [`- Newly reported: ${added.map((id) => `\`${id}\``).join(', ')}`] : []),
+      ...(removed.length ? [`- No longer reported: ${removed.map((id) => `\`${id}\``).join(', ')}`] : []),
+      // Same ids, different details — most often an advisory that just gained a
+      // non-breaking fix, i.e. became actionable.
+      ...(!added.length && !removed.length
+        ? ['- Same advisories, changed details (installed or fixed version) — see the table above.']
+        : []),
+      '',
+      'The issue body above has been updated to the current set.',
+    ].join('\n'),
+  })
+  core.info(`#${existing.number} updated: +${added.length} / -${removed.length}.`)
+  return 'updated'
+}


### PR DESCRIPTION
## The defect

The `osv-scan` job in `weekly-security.yml` requested `security-events: write`, uploaded no SARIF, and filed nothing. A finding produced a code-scanning alert and stopped there — no issue, no notification. Of the seven suite repos with a scanner, this was the only one where a finding reached nobody.

## What the scanner reports on current `main`

Nothing. osv-scanner v2.3.8 (the pinned action's version) against `frontend/package-lock.json` (800 packages) and `e2e/package-lock.json` (8 packages) exits **0** with `"results": []`. So the first run of this filer will take the clean path and do nothing, which is the correct outcome and is what the live run below demonstrates.

That clean tree is recent. Re-scanning this repo's own lockfile history shows the traffic this job has been silently absorbing: 16 advisories at `e52794c~1`, 14 at `95c01cc~1`, 9 at `ae75169~1`, 5 at `0366f59~1`, 3 at `627ecf2~1` — every one of which reached nobody.

## The change

- **Names the findings.** Advisory id linked to osv.dev, severity band **and** CVSS score, package, installed version, minimal fixed version, which lockfile, plus summaries and aliases in a collapsed block.
- **One tracking issue.** Found by the `osv-report` **label**, never by title (the title carries a date). An unchanged finding set rewrites the issue in place with no comment; a changed set updates the body and comments exactly which advisories were added and removed.
- **Resolves on clean.** A scan with no tracked findings comments the evidence and closes the issue.
- **Fails loudly.** An unreadable report fails the job. So does a non-zero scanner exit that reported no packages at all — that is a scan that did not happen (network, rate limit), and it must not read as "clean" and close a live issue.

## Ported, not copied — what changed for npm and why

`terraform-provider-registry` #108 is the proven implementation; four things are deliberately different because that repo is Go and this one is npm.

1. **Reachability → actionability.** osv-scanner's `experimental_analysis` (`called: false`) comes from Go call-graph analysis. npm lockfile scans carry no such field, so the original's reachability filter would be a branch that is always true here. Its *purpose* — do not open an issue for something nobody can act on — is served by this repo's existing triage, `frontend/scripts/audit-gate.mjs`, which the PR gate and the weekly gate already use. The filer **reuses that parser** rather than writing a second one, so the issue and the gate cannot disagree about an advisory. Concretely: `blocking` + `advisory` are tracked and keep the issue open; `accepted` (documented in `npm-audit-exceptions.json` with a rationale and a review date) is listed for context and never keeps an issue open on its own — the same role the original's unreachable findings played. Moderates are out of scope for both, as they already are for the gate.
2. **Severity.** The original prints `group.max_severity`, which for npm is a bare CVSS number. After the gate's high/critical filter a qualitative column alone would be nearly constant, so both are shown: `high (8.2)`.
3. **Lockfile column.** The original never rendered `source` — Go has one module. Here an advisory in `e2e/package-lock.json` never reaches a user and one in `frontend/package-lock.json` may, so the lockfile is a column (with the runner's workspace prefix stripped).
4. **Fingerprint.** The original hashes `id@package@version`. This one also hashes the fix target, so an advisory that *gains* a non-breaking fix — the moment it becomes actionable — notifies instead of being refreshed silently.

The logic lives in `frontend/scripts/osv-report.mjs` rather than inline YAML (the original was extracted from the YAML to be tested). That matches this repo's existing convention for `audit-gate.mjs`, and means the filer is covered by `npm test` on every PR instead of only ever executing in production.

## Second defect, found by running the real scanner

An advisory that spans several release lines publishes one fixed version per line, and `triageOsv` took whichever OSV listed first. Real data from this repo's own tree at `e52794c~1`:

| Package | Advisory | Published fixes | Old target | Old verdict | New target |
| --- | --- | --- | --- | --- | --- |
| `brace-expansion@1.1.16` | `GHSA-mh99-v99m-4gvg` | 1.1.17, 2.1.3, 3.0.3, 5.0.8 | `5.0.8` | breaking → **not blocked** | `1.1.17` → blocked |
| `brace-expansion@5.0.7` | `GHSA-rgw5-rvv9-x895` | 1.1.18, 2.1.4, 3.0.6, 5.0.9 | `1.1.18` | breaking → **not blocked** | `5.0.9` → blocked |

Two high-severity findings with patch-level fixes were written off as "only a breaking fix is available" and did not fail the gate. `pickFixTarget` now selects the lowest published fix above the installed version. Same family as #780 — a real finding reaching nobody — so it is fixed here rather than filed. No effect on the current tree, which is clean.

## The three decisions the report left open

**1. A new PR gate? No — file only.** A gate already exists at the right threshold and a fourth one would be noise on the same advisory data:

- `dependency-review` (pr-checks.yml) fails a PR on high-severity dependency changes against the GHSA database — the same database OSV serves for npm;
- `Dependency Audit` runs `audit-gate.mjs` over the resolved tree on every PR;
- the weekly `Triage OSV findings` step already fails the job on advisories with a non-breaking fix, and the filer now runs *before* it, so a blocking finding is both named in an issue and reds the run.

The threshold argument is the deciding one, and this repo has already paid for it: #643 pinned the weekly run red for weeks on `GHSA-qwww-vcr4-c8h2`, whose only fix was a breaking major, and `Dependency Audit` is still deliberately not a required check for the same reason. A gate that blocks every PR on a transitive advisory with no fix available is how gates get disabled. The gap in #780 is naming, not gating.

**2. `security-events: write`? Dropped.** Nothing in the job uploads SARIF; the scan writes JSON for the triage gate. An unused write permission on a security workflow is worth removing, and it is replaced by the two the job actually needs: `contents: read` (checkout — previously implicit, and `none` under an explicit `permissions:` block) and `issues: write`.

**3. When the scan itself errors?** Never "clean". Two guards, tested with exact assertions: an unreadable/absent/non-report `osv-results.json` calls `core.setFailed` and returns before any API call; and a non-zero scanner outcome (passed through `env`, not `${{ }}` in `script:`) with zero packages reported fails the job. Verified against the real exit codes: **0** clean, **1** findings present (`results` non-empty, so it is explained), **127/128** could-not-scan (`results` empty). Neither path touches an open issue.

## Verification

`npm ci` (283 packages), full suite green: **2303 tests / 151 files**, of which 73 in `scripts/__tests__` (37 new). `eslint --max-warnings 0` clean, `tsc --noEmit` clean, `actionlint` clean, `zizmor --persona=regular` reports **zero** findings repo-wide before and after (one fewer suppression, from dropping the unused permission).

**Fixtures are verbatim osv-scanner v2.3.8 output**, not hand-written: `osv-findings.json` is this repo's own `frontend/package-lock.json` at `e52794c~1` re-scanned with the pinned version (10 tracked advisories over 6 packages), `osv-clean.json` is current `main`. Hand-built fixtures are exactly what would have let Go-shaped assumptions survive the port; these carry the shapes npm really emits — the band in `database_specific.severity`, the score on `groups[].max_severity`, `aliases` frequently absent, and one advisory listed once per installed copy of a package.

### Mutation table

Each guard was broken in turn, the suite re-run, and the file restored from a `cp` backup. Every mutant parses.

| # | Mutation | Result | First test that catches it |
| --- | --- | --- | --- |
| 1 | dedupe lookup: drop the `labels` filter | 1 failed | `looks the issue up by label, not by title` |
| 2 | dedupe lookup: never find the existing issue | 4 failed | `rewrites in place and stays silent when the finding set is unchanged` |
| 3 | close-on-clean: leave the issue open | 1 failed | `comments the evidence and closes the open issue` |
| 4 | fail-loudly: unreadable report reads as clean | 1 failed | `fails loudly instead of reading as clean` |
| 5 | fail-loudly: non-zero scan with no findings reads as clean | 1 failed | `fails when the scanner exited non-zero having scanned nothing` |
| 6 | label guard: create the issue without ensuring the label exists | 1 failed | `creates the label first when it does not exist, or the next run opens a second issue` |
| 7 | label guard: drop the label from the created issue | 1 failed | `creates the issue with the dedupe label applied` |
| 8 | fingerprint: ignore the fix target | 3 failed | `changes when a finding becomes actionable (a fix appears)` |
| 9 | minimal upgrade: take the first published fix again | 6 failed | `picks the lowest fix above 1.1.16, not the first listed` |
| 10 | lockfile column: stop stripping the workspace prefix | 4 failed | `renders a row naming advisory, severity, package, version, fix and lockfile` |

Baseline 73/73 before and after the sweep. Assertions are on exact values — full comment bodies, the exact `issues.update` argument object, the exact `setFailed` message, the rendered table row — not on "an error occurred".

### What only a live run could prove

The unit suite mocks Octokit, so three things were checked outside it.

- **The YAML wiring.** The step's `script:` text was read out of `weekly-security.yml` and executed through github-script's own `AsyncFunction` wrapper, inside a synthetic `GITHUB_WORKSPACE` laid out like a runner checkout with real scanner output at the cwd. This is the only thing that proves a dynamic `import()` of an `.mjs` works inside a Function-constructed body and that `OSV_SCAN_OUTCOME` reaches the module. It also caught a real bug: the lockfile column showed an absolute runner path until the workspace prefix stripping was exercised against a matching workspace root.
- **The label-lookup assumption.** `GET /issues?labels=osv-report` against this repo — where the label does **not** exist — returns `[]` rather than a 404. If it had 404'd, the filer would throw instead of creating. This is why the label-existence guard is required at all: `issues.create` silently drops an unknown label, and the next run would find nothing and open a second issue.
- **A real dispatch** of `weekly-security.yml` on this branch, exercising the real scanner, the real permissions and the real API.

Because `main` is clean, a live run takes the clean path — it proves the job's permissions, checkout, scanner invocation, script load and label lookup, and that nothing is filed when nothing is found. The create/update/close transitions are proved by the 37-assertion suite against real scanner output rather than by a live run, since manufacturing a live finding would mean filing a report of a vulnerability this repo does not have.

Closes #780
