### PR TITLE
fix(e2e): grant the dev admin a platform-admin carrier row in the E2E seed

### DIFF
--- a/deployments/create-dev-admin-user.sql
+++ b/deployments/create-dev-admin-user.sql
@@ -5,6 +5,7 @@ DECLARE
     v_user_id uuid;
     v_org_id uuid;
     v_admin_role_template_id uuid;
+    v_granted integer;
 BEGIN
     -- Insert dev admin user
     INSERT INTO users (email, name, oidc_sub)
@@ -38,6 +39,49 @@ BEGIN
            updated_at = NOW()
      WHERE id = 1;
 
+    -- Grant platform-admin through the carrier.
+    --
+    -- Backend migration 000054 (its issue #766) took the `admin` wildcard scope
+    -- off every role template. Platform-admin authority now comes ONLY from a
+    -- `platform_admins` row, resolved per request. The `admin` template above
+    -- still grants organization administration, but it no longer confers
+    -- platform-wide reach and notably no longer implies `audit:read`.
+    --
+    -- That migration backfilled carrier rows for template holders that existed
+    -- WHEN IT RAN. This stack applies migrations to an empty database and seeds
+    -- afterwards, so this user postdates the backfill and inherits nothing from
+    -- it. Without the grant below, dev login succeeds, /admin renders, and every
+    -- platform-scoped read fails -- which is exactly how this surfaced:
+    -- "Audit Logs page (authenticated)" went red while every unauthenticated
+    -- test passed.
+    --
+    -- The audit intent MUST be written in the same transaction. Backend
+    -- migration 000052 puts a DEFERRABLE INITIALLY DEFERRED constraint trigger
+    -- on platform_admins that re-checks at COMMIT for an audit_outbox row
+    -- carrying the same pg_current_xact_id(), subject and action, so a bare
+    -- INSERT aborts this whole script at COMMIT. Deriving the intent from
+    -- RETURNING keeps a re-run from recording a grant it did not make.
+    WITH granted AS (
+        INSERT INTO platform_admins (user_id, note)
+        VALUES (v_user_id, 'granted by deployments/create-dev-admin-user.sql (E2E/dev seed)')
+        ON CONFLICT (user_id) DO NOTHING
+        RETURNING user_id
+    )
+    INSERT INTO audit_outbox (event_id, action, resource_type, resource_id, metadata)
+    SELECT gen_random_uuid(), 'platform_admin.granted', 'platform_admin', g.user_id::text,
+           jsonb_build_object(
+             'target_user_id', g.user_id,
+             'source', 'deployments/create-dev-admin-user.sql',
+             'origin', 'E2E/dev seed')
+      FROM granted g;
+    GET DIAGNOSTICS v_granted = ROW_COUNT;
+
+    IF v_granted > 0 THEN
+        RAISE NOTICE 'Platform-admin carrier row granted to admin@dev.local.';
+    ELSE
+        RAISE NOTICE 'admin@dev.local already holds a platform-admin carrier row; nothing to grant.';
+    END IF;
+
     -- Dev login now uses JWT via POST /api/v1/dev/login (no hardcoded API key needed)
-    RAISE NOTICE 'Dev admin user and org membership with admin role assigned (setup marked completed).';
+    RAISE NOTICE 'Dev admin user, org membership, platform-admin carrier row, and setup completion are in place.';
 END $$;


### PR DESCRIPTION
Fixes the `E2E (gated/manual)` failure on `main` that survived the backend fix and the v4.6.0 release.

## Why the backend fix did not fix this

`sethbacon/terraform-registry-backend#881` corrected `backend/scripts/create-dev-admin-user.sql` and shipped in **v4.6.0**. But the E2E stack mounts **this repo's** copy — `deployments/docker-compose.test.yml`, `seed-db` service, `./create-dev-admin-user.sql` — which is a separate file that was missed. So "Audit Logs page (authenticated)" stayed red after the release while every unauthenticated test passed.

## The underlying cause

Backend migration `000054` (its #766) took the `admin` wildcard scope off every role template; platform-admin authority now comes only from a `platform_admins` row, resolved per request.

`000054` backfilled carrier rows for template holders **that existed when it ran**. This stack applies migrations to an empty database and seeds *afterwards*, so `admin@dev.local` postdates the backfill and inherits nothing from it. The `org_owner` scope set that replaced the wildcard **does not include `audit:read`** — which is why the audit page was the first thing to fail rather than something more obvious.

## Added, not copied

This file also marks setup completed (`system_settings`) so the setup-redirect test passes. Copying the backend's version wholesale would have deleted that. The carrier grant was inserted alongside it, and `setup_completed` is verified to stay `true` across runs.

## Verification

Against `postgres:16` with the real 54-migration chain from `terraform-registry-backend` `origin/main`:

| Seed | Result |
| --- | --- |
| **old** (current `main`) | `carrier_rows=0` — reproduces the failure, exits 0, no error |
| **new**, run 1 | `carrier_rows=1  outbox_intents=1  setup_completed=true` |
| **new**, run 2 | unchanged — "already holds a platform-admin carrier row", no second intent |

The intent is written in the same transaction as a CTE off `RETURNING`, because `000052`'s `DEFERRABLE INITIALLY DEFERRED` constraint trigger aborts the whole script at COMMIT otherwise.

## What this does not fix

**Two near-identical seed scripts now live in two repositories and have already diverged once** — at the cost of a full release cycle to discover, because the backend fix looked verified in isolation. Nothing enforces that they agree. Tracked separately; this PR only unblocks E2E.