### PR TITLE
ci(replay): check out pipeline-task-ado alongside its scope entry

### DIFF
--- a/.github/workflows/signature-replay.yml
+++ b/.github/workflows/signature-replay.yml
@@ -139,6 +139,18 @@ jobs:
           persist-credentials: false
           repository: 4cloudguru/pipeline-task-core
           path: suite/pipeline-task-core
+      # The SECOND shared destination package, added to SIGNATURE_SCOPE in 2026-08.
+      # The two ADO extensions are splitting their duplicated modules across two
+      # packages rather than one: pipeline-task-core stays platform-agnostic (it
+      # imports neither azure-pipelines-task-lib nor undici) and pipeline-task-ado
+      # takes the code that must name Azure DevOps. Nothing consumes it yet, which
+      # is not a reason to leave it out -- in scope.json and absent here is exit 2
+      # for the whole job, not a quieter run.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          repository: 4cloudguru/pipeline-task-ado
+          path: suite/pipeline-task-ado
       # The GitHub-Actions family plus the drift payload contract they share with
       # the ADO TerraformDriftReport task. In SIGNATURE_SCOPE and absent here is
       # exit 2 for the whole job, not a quieter run. Note drift-contract is owned


### PR DESCRIPTION
## Why

`sethbacon/security-orchestration#42` registered `@4cloudguru/pipeline-task-ado`
in `SIGNATURE_SCOPE`, but the host workflows were never given a matching
checkout. `load_scope()` raises a `GateError` for any scoped repo whose
directory is not a directory, and the replay contract reads **exit 2 as
could-not-run, never as clean** — so the merge-blocking `replay` job in this
repo gate-errors on every PR until this lands:

```
GATE ERROR: repos in SIGNATURE_SCOPE are not checked out, so no signature can
run against them:
  pipeline-task-ado -> .../suite/pipeline-task-ado
```

Reproduced locally against the merged `scope.json` with the pre-change checkout
set (exit 2), and again with the checkout added (exit 0). This repo is red right
now; it is one of 14 in the same state.

## What

One `actions/checkout` step, cloned verbatim from this repo's own
`pipeline-task-core` checkout so it keeps the local flow-vs-block mapping style
and the same pinned action SHA. Additions only, no other file touched.

`scope.json`'s `dir` is a contract with the `path:` basename here, which is what
`--repos-root suite` resolves against.

## Verification

A YAML-parsing checker asserts, for every host in the estate: the set of
`suite/` checkouts equals the scoped-repo set from `scope.json` (excluding the
templated self-checkout, which is deliberate); no duplicates;
`persist-credentials: false` on every checkout; and exactly one token-bearing
checkout, for the private `security-orchestration`. All 15 hosts pass with this
change; 14 failed without it.

The checker was falsified before being trusted — dropping a repo, duplicating a
block, removing a `persist-credentials`, and putting a token on a public
checkout each reddened only its own assertion, and the unmutated file passed.

Nothing consumes the package yet. It is in scope so check 2 can read it, and
because code leaving an audited extension arrives there.
