### PR TITLE
feat(auth): publish real organization memberships, and filter audit logs by them

### DIFF
--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,92 +1,164 @@
 // Re-export the shared suite AuthProvider, injecting this app's backend contract.
 // The provider is cookie/`/me`-driven and derives the role template from the primary
-// membership. The registry /me payload exposes a single role_template, so the adapter
-// surfaces it as one synthetic membership. useAuth/SESSION_WARNING_LEAD_MS are
-// re-exported so existing imports keep working.
-import type { ReactNode } from 'react'
+// membership — which, since #795, is a real organization membership rather than a
+// fabricated one. useAuth/SESSION_WARNING_LEAD_MS are re-exported so existing
+// imports keep working; useAuth additionally publishes `memberships` (see below).
+import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from 'react'
 import {
   AuthProvider as SuiteAuthProvider,
-  useAuth,
+  useAuth as useSuiteAuth,
   SESSION_WARNING_LEAD_MS,
   type AuthApi,
+  type AuthContextType,
   type MeResponse,
+  type Membership,
 } from '@4cloudguru/cloud-suite-ui'
 import api from '../services/api'
+import type { AuthMembership } from '../services/api/authApi'
 import { clearAuthStorage } from '../utils/authStorage'
 import { queryClient } from '../queryClient'
-import type { RoleTemplateInfo } from '../types'
-
-// Membership.organization_id/organization_name are required, non-optional
-// strings in the shared package's contract, so the synthetic membership below
-// can't simply omit them. This obviously-fake sentinel (rather than '') is
-// used for both fields so that if a future suite-ui feature (an org switcher,
-// breadcrumbs, etc.) ever renders them, it fails visibly instead of silently
-// showing a blank organization (#622).
-const NO_ORGANIZATION_SENTINEL = '(no organization — registry has a single role_template)'
 
 /**
- * Builds the synthetic single-membership array the shared package's
- * MeResponse contract expects, from this app's single role_template (the
- * registry backend has no real multi-org membership concept). Exported for
- * unit testing.
+ * Maps `/auth/me`'s memberships onto the shared package's `Membership`
+ * contract. Two differences have to be bridged, and both are the reason this
+ * function exists rather than the array being passed through untouched:
+ *
+ *  1. The wire nests the role template under `role_template` (an object, or
+ *     `null`); the shared contract wants it FLAT, as `role_template_name` and
+ *     `role_template_scopes`. Nothing in the contract carries the role's
+ *     display name, so it is dropped here — the provider synthesises
+ *     `roleTemplate.display_name` from `role_template_name` regardless.
+ *  2. `organization_id` and `organization_name` are required, NON-OPTIONAL
+ *     strings in the contract. Until #795 that requirement was met by stamping
+ *     both with a sentinel string (#622) so an org switcher would fail visibly
+ *     rather than render a blank organization. There is nothing left to
+ *     fabricate — the registry backend has had real per-organization
+ *     memberships since backend #719 and `MeHandler` sends them — so the
+ *     requirement is now met honestly, by these two rules:
+ *
+ *     - A membership with no usable `organization_id` is DROPPED. It could not
+ *       be filtered on, granted against, or rendered, and the shared provider
+ *       calls `.localeCompare` on this field while choosing the primary
+ *       membership: one malformed entry would throw inside session resolution,
+ *       which the provider treats as a failed `/me` and signs the user out.
+ *     - An empty `organization_name` falls back to `organization_id`. The
+ *       backend selects it as `COALESCE(o.name, '')`, so a membership whose
+ *       organization row is missing arrives with an empty slug. Showing the id
+ *       is honest and identifies the organization; showing '' reintroduces
+ *       exactly the blank-organization render #622 set its tripwire for.
+ *
+ * Exported for unit testing.
  */
-export function toSyntheticMemberships(
-  roleTemplate: RoleTemplateInfo | null,
-): MeResponse['memberships'] {
-  return roleTemplate
-    ? [
-      {
-        organization_id: NO_ORGANIZATION_SENTINEL,
-        organization_name: NO_ORGANIZATION_SENTINEL,
-        role_template_name: roleTemplate.name,
-        role_template_scopes: roleTemplate.scopes,
-      },
-    ]
-    : []
+export function toSuiteMemberships(memberships: AuthMembership[]): Membership[] {
+  return memberships
+    .filter((m) => typeof m?.organization_id === 'string' && m.organization_id !== '')
+    .map((m) => ({
+      organization_id: m.organization_id,
+      organization_name: m.organization_name || m.organization_id,
+      role_template_name: m.role_template?.name ?? null,
+      role_template_scopes: m.role_template?.scopes ?? [],
+    }))
 }
 
-// On sign-out, also drop the react-query cache so prior-user admin/query data does not
-// linger in memory until a full page reload (a retention gap on shared/kiosk machines).
-function handleClearStorage(): void {
-  clearAuthStorage()
-  queryClient.clear()
-}
-
-const authApi: AuthApi = {
-  getCurrentUser: async (): Promise<MeResponse> => {
-    const r = await api.getCurrentUserWithRole()
-    return {
-      user: r.user,
-      allowed_scopes: r.allowed_scopes,
-      session_expires_at: r.session_expires_at ?? undefined,
-      memberships: toSyntheticMemberships(r.role_template),
-    }
-  },
-  login: (provider) => api.login(provider),
-  // Registry dev/LDAP logins set the HttpOnly auth cookie (plus tfr_csrf) via
-  // Set-Cookie on the response — no token in the body, nothing to persist. The
-  // suite AuthProvider resolves the session via the subsequent /auth/me probe.
-  //
-  // devLogin is dynamically imported (rather than going through the eager `api`
-  // barrel, which deliberately excludes devApi) so this dev-only endpoint stays
-  // out of the production bundle even though AuthContext itself is always
-  // eagerly loaded (#608). LoginPage only calls this from its own
-  // import.meta.env-gated "Dev Login" button.
-  devLogin: () => import('../services/api/devApi').then((devApi) => devApi.devLogin()),
-  ldapLogin: (username, password) => api.ldapLogin(username, password),
-  logout: () => api.logout(),
-  refreshToken: async () => {
-    const r = await api.refreshToken()
-    return { expires_in: r?.expires_in ?? 0 }
-  },
-}
+/**
+ * The real memberships from the most recent successful `/auth/me`.
+ *
+ * The shared provider consumes `MeResponse.memberships` (to pick the primary
+ * role template and to answer `hasScope(scope, organizationId)`) but does not
+ * re-expose the array on its context, so this app publishes it alongside —
+ * see the `useAuth` wrapper below.
+ */
+const MembershipsContext = createContext<Membership[]>([])
 
 export function AuthProvider({ children }: { children: ReactNode }) {
+  const [memberships, setMemberships] = useState<Membership[]>([])
+
+  // On sign-out, also drop the react-query cache so prior-user admin/query data does not
+  // linger in memory until a full page reload (a retention gap on shared/kiosk machines),
+  // and drop the memberships for the same reason: they name the previous user's
+  // organizations. The shared provider calls this on explicit logout AND on every
+  // fail-closed transition (rejected/401 `/me`, lapsed session, malformed response),
+  // i.e. at every moment this array stops being true.
+  //
+  // The `setMemberships([])` is retention only — what CONSUMERS see is already
+  // guaranteed by the isAuthenticated gate in useAuth below, so removing this
+  // line alone breaks no test. It is kept for the same reason as the
+  // queryClient.clear() above it: a signed-out tab should not still be holding
+  // the previous user's data.
+  const handleClearStorage = useCallback(() => {
+    clearAuthStorage()
+    queryClient.clear()
+    setMemberships([])
+  }, [])
+
+  // Memoised with no dependencies so the object identity is stable across renders.
+  // (The shared provider holds `api` in a ref, so this is hygiene rather than a
+  // correctness requirement — but a new object every render would still be a
+  // trap for anyone who later moves it into a dependency array.)
+  const authApi = useMemo<AuthApi>(
+    () => ({
+      getCurrentUser: async (): Promise<MeResponse> => {
+        const r = await api.getCurrentUserWithRole()
+        const suiteMemberships = toSuiteMemberships(r.memberships)
+        setMemberships(suiteMemberships)
+        return {
+          user: r.user,
+          allowed_scopes: r.allowed_scopes,
+          session_expires_at: r.session_expires_at ?? undefined,
+          memberships: suiteMemberships,
+        }
+      },
+      login: (provider) => api.login(provider),
+      // Registry dev/LDAP logins set the HttpOnly auth cookie (plus tfr_csrf) via
+      // Set-Cookie on the response — no token in the body, nothing to persist. The
+      // suite AuthProvider resolves the session via the subsequent /auth/me probe.
+      //
+      // devLogin is dynamically imported (rather than going through the eager `api`
+      // barrel, which deliberately excludes devApi) so this dev-only endpoint stays
+      // out of the production bundle even though AuthContext itself is always
+      // eagerly loaded (#608). LoginPage only calls this from its own
+      // import.meta.env-gated "Dev Login" button.
+      devLogin: () => import('../services/api/devApi').then((devApi) => devApi.devLogin()),
+      ldapLogin: (username, password) => api.ldapLogin(username, password),
+      logout: () => api.logout(),
+      refreshToken: async () => {
+        const r = await api.refreshToken()
+        return { expires_in: r?.expires_in ?? 0 }
+      },
+    }),
+    [],
+  )
+
   return (
-    <SuiteAuthProvider api={authApi} onClearStorage={handleClearStorage}>
-      {children}
-    </SuiteAuthProvider>
+    <MembershipsContext.Provider value={memberships}>
+      <SuiteAuthProvider api={authApi} onClearStorage={handleClearStorage}>
+        {children}
+      </SuiteAuthProvider>
+    </MembershipsContext.Provider>
   )
 }
 
-export { useAuth, SESSION_WARNING_LEAD_MS }
+/** The shared auth context, plus this app's real organization memberships. */
+export type RegistryAuthContextType = AuthContextType & { memberships: Membership[] }
+
+/**
+ * The shared `useAuth`, widened with the memberships the shared context does
+ * not itself expose.
+ *
+ * `memberships` is gated on `isAuthenticated` rather than returned raw. The
+ * adapter above records them the moment `/auth/me` resolves, which is strictly
+ * before the shared provider decides whether to accept that response — so a
+ * `/me` that resolves after a logout (the provider discards it as a stale
+ * generation) would otherwise leave a signed-out session holding a populated
+ * membership list.
+ */
+export function useAuth(): RegistryAuthContextType {
+  const suite = useSuiteAuth()
+  const memberships = useContext(MembershipsContext)
+  return useMemo(
+    () => ({ ...suite, memberships: suite.isAuthenticated ? memberships : [] }),
+    [suite, memberships],
+  )
+}
+
+export { SESSION_WARNING_LEAD_MS }

--- a/frontend/src/contexts/__tests__/AuthContext.test.tsx
+++ b/frontend/src/contexts/__tests__/AuthContext.test.tsx
@@ -1,5 +1,5 @@
 import { render, act, waitFor } from '@testing-library/react'
-import { AuthProvider, useAuth, toSyntheticMemberships } from '../AuthContext'
+import { AuthProvider, useAuth, toSuiteMemberships } from '../AuthContext'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { AUTH_STORAGE_KEYS } from '../../utils/authStorage'
 
@@ -19,9 +19,27 @@ vi.mock('../../services/api', () => ({ default: mockApi }))
 // from the production bundle (#608) — mock that import target too.
 vi.mock('../../services/api/devApi', () => ({ devLogin: () => mockApi.devLogin() }))
 
+// Shaped like MeHandler's actual payload: a nested `role_template` object per
+// membership (nullable), plus the deprecated flat `role_template` back-compat
+// field the endpoint still sends. Since #795 the provider derives everything
+// from `memberships`; the back-compat field is here so the fixture stays
+// faithful to the wire, not because anything reads it.
 const me = {
   user: { id: 'u1', email: 'a@b.c', name: 'Alice' },
   role_template: { name: 'admin', display_name: 'Admin', scopes: ['admin'] },
+  memberships: [
+    {
+      organization_id: 'org-1',
+      organization_name: 'acme',
+      created_at: '2025-01-01T00:00:00Z',
+      role_template: {
+        id: 'rt-1',
+        name: 'admin',
+        display_name: 'Administrator',
+        scopes: ['admin'],
+      },
+    },
+  ],
   allowed_scopes: ['modules:read'],
   session_expires_at: null as string | null,
 }
@@ -152,23 +170,180 @@ describe('AuthProvider', () => {
   })
 })
 
-describe('toSyntheticMemberships (#622)', () => {
-  it('returns an empty array when there is no role template', () => {
-    expect(toSyntheticMemberships(null)).toEqual([])
+// Replaces the toSyntheticMemberships suite that guarded the #622 sentinel.
+// The sentinel existed because the app had no real memberships to publish; it
+// has them now, so the guards move from "the fake value is obviously fake" to
+// "the real value survives the mapping intact and nothing is invented".
+describe('toSuiteMemberships (#795)', () => {
+  it('returns an empty array when there are no memberships', () => {
+    expect(toSuiteMemberships([])).toEqual([])
   })
 
-  it('fills organization_id/organization_name with an obviously-fake sentinel, not blank strings', () => {
-    const [membership] = toSyntheticMemberships({
-      name: 'admin',
-      display_name: 'Administrator',
-      scopes: ['admin'],
-    })
+  it("flattens the handler's NESTED role_template onto the shared contract", () => {
+    // The nested object is what MeHandler emits. The flat role_template_* keys
+    // declared by the backend's admin.MeMembershipEntry struct (and therefore
+    // by swagger.yaml) are never marshalled by any code path — reading those
+    // instead would yield undefined for every role field.
+    const [membership] = toSuiteMemberships([
+      {
+        organization_id: 'org-1',
+        organization_name: 'acme',
+        created_at: '2025-01-01T00:00:00Z',
+        role_template: { id: 'rt-1', name: 'admin', display_name: 'Administrator', scopes: ['a'] },
+      },
+    ])
+    expect(membership.organization_id).toBe('org-1')
+    expect(membership.organization_name).toBe('acme')
     expect(membership.role_template_name).toBe('admin')
-    expect(membership.role_template_scopes).toEqual(['admin'])
-    // Must not silently render blank — a future consumer should notice these
-    // are placeholders, not real organization data.
-    expect(membership.organization_id).not.toBe('')
-    expect(membership.organization_name).not.toBe('')
-    expect(membership.organization_id).toBe(membership.organization_name)
+    expect(membership.role_template_scopes).toEqual(['a'])
+  })
+
+  it('keeps a membership whose role_template is null, with no role name', () => {
+    const [membership] = toSuiteMemberships([
+      {
+        organization_id: 'org-2',
+        organization_name: 'beta',
+        created_at: '2025-01-01T00:00:00Z',
+        role_template: null,
+      },
+    ])
+    // Still a real organization the user belongs to — it must remain
+    // selectable even though it grants no role.
+    expect(membership.organization_id).toBe('org-2')
+    expect(membership.role_template_name).toBeNull()
+    expect(membership.role_template_scopes).toEqual([])
+  })
+
+  it('drops a membership with no usable organization_id', () => {
+    // The shared provider calls organization_id.localeCompare while choosing
+    // the primary membership. One malformed entry would throw inside session
+    // resolution, which the provider treats as a failed /me — i.e. it would
+    // sign the user out.
+    expect(
+      toSuiteMemberships([
+        { organization_id: '', organization_name: 'blank', created_at: '', role_template: null },
+        {
+          organization_id: undefined,
+          organization_name: 'missing',
+          created_at: '',
+          role_template: null,
+        } as unknown as Parameters<typeof toSuiteMemberships>[0][number],
+      ]),
+    ).toEqual([])
+  })
+
+  it('falls back to the organization id when the slug is empty', () => {
+    // organization_name is selected as COALESCE(o.name, '') server-side, so a
+    // membership whose organization row is missing arrives with an empty slug.
+    // Rendering '' is the blank organization #622 set its tripwire for.
+    const [membership] = toSuiteMemberships([
+      { organization_id: 'org-3', organization_name: '', created_at: '', role_template: null },
+    ])
+    expect(membership.organization_name).toBe('org-3')
+  })
+})
+
+describe('memberships reach consumers (#795, the blocker for #779)', () => {
+  it('publishes a two-membership /auth/me as two entries with their real names', async () => {
+    mockApi.getCurrentUserWithRole.mockResolvedValue({
+      ...me,
+      memberships: [
+        {
+          organization_id: 'org-b',
+          organization_name: 'beta',
+          created_at: '2025-01-02T00:00:00Z',
+          role_template: { id: 'rt-2', name: 'viewer', display_name: 'Viewer', scopes: ['read'] },
+        },
+        {
+          organization_id: 'org-a',
+          organization_name: 'acme',
+          created_at: '2025-01-01T00:00:00Z',
+          role_template: { id: 'rt-1', name: 'admin', display_name: 'Admin', scopes: ['admin'] },
+        },
+      ],
+    })
+    await renderAuth()
+    expect(latest.memberships).toHaveLength(2)
+    expect(latest.memberships.map((m) => m.organization_name)).toEqual(['beta', 'acme'])
+    expect(latest.memberships.map((m) => m.organization_id)).toEqual(['org-b', 'org-a'])
+  })
+
+  it('resolves per-organization scopes, which the fabricated membership could not carry', async () => {
+    // hasScope(scope, organizationId) matches on organization_id and reads
+    // that membership's own scopes. Under the sentinel there was exactly one
+    // membership, its id was a fixed placeholder string and its scopes came
+    // from a field the backend does not populate, so this always answered false.
+    mockApi.getCurrentUserWithRole.mockResolvedValue({
+      ...me,
+      memberships: [
+        {
+          organization_id: 'org-a',
+          organization_name: 'acme',
+          created_at: '',
+          role_template: { id: 'rt', name: 'auditor', display_name: 'A', scopes: ['audit:read'] },
+        },
+        {
+          organization_id: 'org-b',
+          organization_name: 'beta',
+          created_at: '',
+          role_template: { id: 'rt', name: 'viewer', display_name: 'V', scopes: ['modules:read'] },
+        },
+      ],
+    })
+    await renderAuth()
+    expect(latest.hasScope('audit:read', 'org-a')).toBe(true)
+    expect(latest.hasScope('audit:read', 'org-b')).toBe(false)
+  })
+
+  it("ignores the deprecated flat role_template: no memberships means no role", async () => {
+    // The back-compat field is still on the wire and still populated. If the
+    // adapter were still deriving a membership from it, roleTemplate would be
+    // non-null here and one fabricated organization would be published.
+    mockApi.getCurrentUserWithRole.mockResolvedValue({ ...me, memberships: [] })
+    await renderAuth()
+    expect(latest.memberships).toEqual([])
+    expect(latest.roleTemplate).toBeNull()
+  })
+
+  it('drops memberships when the session ends', async () => {
+    mockApi.getCurrentUserWithRole.mockResolvedValue(me)
+    await renderAuth()
+    expect(latest.memberships).toHaveLength(1)
+    act(() => latest.logout())
+    // They name the previous user's organizations: they must not outlive the
+    // session any more than the query cache does.
+    expect(latest.memberships).toEqual([])
+  })
+
+  it('publishes no memberships when /me fails', async () => {
+    mockApi.getCurrentUserWithRole.mockRejectedValue(new Error('401'))
+    await renderAuth()
+    expect(latest.memberships).toEqual([])
+  })
+
+  it('does not repopulate memberships from a /me that resolves after logout', async () => {
+    // The adapter records memberships the moment /me resolves, which is
+    // strictly before the shared provider decides whether to accept that
+    // response. The provider discards a response from a superseded generation
+    // (so `user` stays null); without the isAuthenticated gate on the way out,
+    // the discarded response would still leave a signed-out session holding a
+    // populated membership list.
+    let resolveMe: (v: unknown) => void = () => { }
+    mockApi.getCurrentUserWithRole.mockReturnValue(
+      new Promise((resolve) => {
+        resolveMe = resolve
+      }),
+    )
+    render(
+      <AuthProvider>
+        <Consumer />
+      </AuthProvider>,
+    )
+    act(() => latest.logout())
+    await act(async () => {
+      resolveMe(me)
+    })
+    expect(latest.isAuthenticated).toBe(false)
+    expect(latest.memberships).toEqual([])
   })
 })

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -2060,6 +2060,8 @@
       "labelStartDate": "Start Date",
       "labelEndDate": "End Date",
       "labelResourceType": "Resource Type",
+      "labelOrganization": "Organization",
+      "optionAllOrganizations": "All Organizations",
       "labelAction": "Action",
       "labelUserEmail": "User Email",
       "placeholderUserEmail": "Search by email...",
@@ -2072,7 +2074,8 @@
       "emptySubtitle": "Audit log entries appear when users make changes. Adjust the filters above or publish a module to see one.",
       "detailTitle": "Audit Log Detail",
       "close": "Close",
-      "errLoad": "Failed to load audit logs"
+      "errLoad": "Failed to load audit logs",
+      "errNotMember": "You are not a member of that organization"
     },
     "notifications": {
       "pageTitle": "Notifications",

--- a/frontend/src/pages/admin/AuditLogPage.tsx
+++ b/frontend/src/pages/admin/AuditLogPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react'
+import React, { useMemo, useState, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useQuery } from '@tanstack/react-query'
 import {
@@ -34,11 +34,12 @@ import PageHeader from '../../components/PageHeader'
 import StatusAlerts from '../../components/StatusAlerts'
 import PageTitleIcon from '@mui/icons-material/History'
 import api from '../../services/api'
+import { useAuth } from '../../contexts/AuthContext'
 import { useStatusMessage } from '../../hooks/useStatusMessage'
 import { AuditLog } from '../../types'
 import { queryKeys } from '../../services/queryKeys'
 import { usePagination } from '../../hooks/usePagination'
-import { getErrorMessage } from '../../utils/errors'
+import { getErrorMessage, getErrorStatus } from '../../utils/errors'
 
 const RESOURCE_TYPES = [
   { value: '', label: 'All Resource Types' },
@@ -62,9 +63,20 @@ const resourceTypeLabel = (value: string | null | undefined): string => {
   return RESOURCE_TYPES.find((rt) => rt.value === value)?.label ?? value
 }
 
+// The "no organization filter" option value. Empty string rather than a
+// sentinel id: it is the MUI Select's own "nothing selected" value, and it must
+// mean "everything this caller may see" — never "some default organization".
+// Platform admins deliberately read the whole estate here, so defaulting the
+// filter to an organization would quietly hide the rest of it.
+const ALL_ORGANIZATIONS = ''
+
 const AuditLogPage: React.FC = () => {
   const { t } = useTranslation()
   const status = useStatusMessage()
+  // Real per-organization memberships from /auth/me (#795). The options a user
+  // may filter by are exactly the organizations they belong to — which is also
+  // what the backend validates the request against before answering 403.
+  const { memberships } = useAuth()
 
   // Pagination (MUI TablePagination uses 0-based page)
   const { page, rowsPerPage, setPage, handleChangePage, handleChangeRowsPerPage } =
@@ -76,6 +88,7 @@ const AuditLogPage: React.FC = () => {
   const [userEmailFilter, setUserEmailFilter] = useState('')
   const [startDate, setStartDate] = useState('')
   const [endDate, setEndDate] = useState('')
+  const [organizationId, setOrganizationId] = useState(ALL_ORGANIZATIONS)
 
   // Debounced values for text inputs
   const [debouncedAction, setDebouncedAction] = useState('')
@@ -89,14 +102,35 @@ const AuditLogPage: React.FC = () => {
   // Export menu
   const [exportAnchor, setExportAnchor] = useState<null | HTMLElement>(null)
 
+  // THE single description of "what the user is currently looking at".
+  //
+  // Both the table query and both exports build from this object, and nothing
+  // rebuilds the filter list by hand. An export that widens or narrows the
+  // filter the table is showing is not a cosmetic bug: the CSV is compliance
+  // evidence, and one that silently covers a different slice of the estate than
+  // the screen it was taken from is misleading evidence. Keeping one object
+  // makes disagreement impossible rather than merely unlikely.
+  //
+  // Pagination is deliberately NOT part of it — the table shows one page, the
+  // export takes the whole filtered set.
+  const filterParams = useMemo(
+    () => ({
+      ...(resourceType ? { resource_type: resourceType } : {}),
+      ...(debouncedAction ? { action: debouncedAction } : {}),
+      ...(debouncedUserEmail ? { user_email: debouncedUserEmail } : {}),
+      ...(startDate ? { start_date: new Date(startDate).toISOString() } : {}),
+      ...(endDate ? { end_date: new Date(endDate).toISOString() } : {}),
+      // Omitted entirely when unset, so the backend applies the caller's own
+      // scope rather than a requested organization.
+      ...(organizationId ? { organization_id: organizationId } : {}),
+    }),
+    [resourceType, debouncedAction, debouncedUserEmail, startDate, endDate, organizationId],
+  )
+
   const queryParams = {
     page: page + 1,
     per_page: rowsPerPage,
-    ...(resourceType ? { resource_type: resourceType } : {}),
-    ...(debouncedAction ? { action: debouncedAction } : {}),
-    ...(debouncedUserEmail ? { user_email: debouncedUserEmail } : {}),
-    ...(startDate ? { start_date: new Date(startDate).toISOString() } : {}),
-    ...(endDate ? { end_date: new Date(endDate).toISOString() } : {}),
+    ...filterParams,
   }
 
   const {
@@ -104,18 +138,31 @@ const AuditLogPage: React.FC = () => {
     isLoading: loading,
     error: queryError,
   } = useQuery({
-    queryKey: queryKeys.auditLogs.list(queryParams),
+    // The organization is passed to the key separately as well as riding in
+    // queryParams, so switching organizations can never be served the previous
+    // organization's page from cache (#798).
+    queryKey: queryKeys.auditLogs.list(queryParams, organizationId || undefined),
     queryFn: () => api.listAuditLogs(queryParams),
   })
 
   const logs = data?.logs ?? []
   const total = data?.pagination?.total ?? 0
 
+  // The backend answers 403 for an organization the caller is not a member of.
+  // That is a distinct, recoverable condition ("pick a different organization"),
+  // not a load failure, and saying so is what makes it actionable — the generic
+  // message reads like an outage the user can do nothing about.
+  const isNotAMember = (err: unknown): boolean => getErrorStatus(err) === 403
+
   if (queryError && !status.error) {
     // Raw error messages can leak implementation details -- route through the
     // shared getErrorMessage helper, which DEV-gates native Error messages
     // the same way ErrorBoundary.tsx does (#618-class).
-    status.setError(getErrorMessage(queryError, t('admin.auditLog.errLoad')))
+    status.setError(
+      isNotAMember(queryError)
+        ? t('admin.auditLog.errNotMember')
+        : getErrorMessage(queryError, t('admin.auditLog.errLoad')),
+    )
   }
 
   // Debounce text filter changes
@@ -142,6 +189,14 @@ const AuditLogPage: React.FC = () => {
     setPage(0)
   }
 
+  const handleOrganizationChange = (e: SelectChangeEvent) => {
+    setOrganizationId(e.target.value)
+    // A stale 403 from a previously-selected organization must not survive the
+    // change that fixes it.
+    status.setError(null)
+    setPage(0)
+  }
+
   const handleStartDateChange = (value: string) => {
     setStartDate(value)
     setPage(0)
@@ -160,6 +215,7 @@ const AuditLogPage: React.FC = () => {
     setDebouncedUserEmail('')
     setStartDate('')
     setEndDate('')
+    setOrganizationId(ALL_ORGANIZATIONS)
     setPage(0)
   }
 
@@ -168,37 +224,30 @@ const AuditLogPage: React.FC = () => {
     setDetailOpen(true)
   }
 
+  // Both exports re-fetch the SAME filter the table is showing, unpaginated.
+  // Spreading `filterParams` (rather than restating the filters) is what keeps
+  // the exported file and the visible table describing the same slice.
   const handleExportCSV = async () => {
     setExportAnchor(null)
     try {
-      const result = await api.listAuditLogs({
-        per_page: 1000,
-        ...(resourceType ? { resource_type: resourceType } : {}),
-        ...(debouncedAction ? { action: debouncedAction } : {}),
-        ...(debouncedUserEmail ? { user_email: debouncedUserEmail } : {}),
-        ...(startDate ? { start_date: new Date(startDate).toISOString() } : {}),
-        ...(endDate ? { end_date: new Date(endDate).toISOString() } : {}),
-      })
+      const result = await api.listAuditLogs({ per_page: 1000, ...filterParams })
       api.exportAuditLogsCSV(result.logs ?? [])
-    } catch {
-      status.setError('Failed to export audit logs')
+    } catch (err) {
+      status.setError(
+        isNotAMember(err) ? t('admin.auditLog.errNotMember') : 'Failed to export audit logs',
+      )
     }
   }
 
   const handleExportJSON = async () => {
     setExportAnchor(null)
     try {
-      const result = await api.listAuditLogs({
-        per_page: 1000,
-        ...(resourceType ? { resource_type: resourceType } : {}),
-        ...(debouncedAction ? { action: debouncedAction } : {}),
-        ...(debouncedUserEmail ? { user_email: debouncedUserEmail } : {}),
-        ...(startDate ? { start_date: new Date(startDate).toISOString() } : {}),
-        ...(endDate ? { end_date: new Date(endDate).toISOString() } : {}),
-      })
+      const result = await api.listAuditLogs({ per_page: 1000, ...filterParams })
       api.exportAuditLogsJSON(result.logs ?? [])
-    } catch {
-      status.setError('Failed to export audit logs')
+    } catch (err) {
+      status.setError(
+        isNotAMember(err) ? t('admin.auditLog.errNotMember') : 'Failed to export audit logs',
+      )
     }
   }
 
@@ -279,6 +328,44 @@ const AuditLogPage: React.FC = () => {
               ))}
             </Select>
           </FormControl>
+          {/*
+            Rendered only when the caller belongs to at least one organization:
+            the options are their memberships, so with none there is nothing to
+            choose between. Its absence is not a restriction — an unset filter
+            already returns everything the caller may see, which for a platform
+            admin is the whole estate.
+          */}
+          {memberships.length > 0 && (
+            <FormControl size="small" sx={{ minWidth: 200 }}>
+              <InputLabel id="organization-label">
+                {t('admin.auditLog.labelOrganization')}
+              </InputLabel>
+              <Select
+                labelId="organization-label"
+                value={organizationId}
+                label={t('admin.auditLog.labelOrganization')}
+                onChange={handleOrganizationChange}
+                inputProps={{ 'data-testid': 'organization-select' }}
+              >
+                <MenuItem value={ALL_ORGANIZATIONS}>
+                  {t('admin.auditLog.optionAllOrganizations')}
+                </MenuItem>
+                {/*
+                  organization_name is the organization's URL-safe SLUG, which
+                  is all /auth/me sends — the human display name is not on this
+                  payload at all. Shown as-is rather than prettified: inventing
+                  a display name here would make the label disagree with the
+                  one the organizations admin page shows. Surfacing the real
+                  display name is a backend change.
+                */}
+                {memberships.map((m) => (
+                  <MenuItem key={m.organization_id} value={m.organization_id}>
+                    {m.organization_name}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          )}
           <TextField
             label={t('admin.auditLog.labelAction')}
             size="small"

--- a/frontend/src/pages/admin/DashboardPage.tsx
+++ b/frontend/src/pages/admin/DashboardPage.tsx
@@ -862,8 +862,14 @@ const DashboardPage: React.FC = () => {
               <Button
                 variant="outlined"
                 startIcon={<Refresh />}
+                // Invalidate the whole `dashboard` namespace, not `stats()`.
+                // Since #798 the stats key can carry an organization, and
+                // invalidateQueries matches by key PREFIX: `stats()` is
+                // ['dashboard','stats',undefined], which would stop matching
+                // the query the moment anything narrows it to an organization,
+                // silently turning Refresh into a no-op.
                 onClick={() =>
-                  queryClient.invalidateQueries({ queryKey: queryKeys.dashboard.stats() })
+                  queryClient.invalidateQueries({ queryKey: queryKeys.dashboard._def })
                 }
                 disabled={refreshing}
               >

--- a/frontend/src/pages/admin/__tests__/AuditLogPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/AuditLogPage.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { AxiosError } from 'axios'
 
 // ---- Mocks ----
 
@@ -16,6 +17,13 @@ vi.mock('../../../services/api', () => ({
   },
 }))
 
+// The organization filter's options are the caller's real memberships from
+// /auth/me (#795). Mutable so each test can choose the membership set.
+const authState = vi.hoisted(() => ({
+  memberships: [] as Array<{ organization_id: string; organization_name: string }>,
+}))
+vi.mock('../../../contexts/AuthContext', () => ({ useAuth: () => authState }))
+
 import AuditLogPage from '../../admin/AuditLogPage'
 
 // ---- Helpers ----
@@ -28,11 +36,58 @@ function createQueryClient() {
 
 function renderPage() {
   const queryClient = createQueryClient()
-  return render(
-    <QueryClientProvider client={queryClient}>
-      <AuditLogPage />
-    </QueryClientProvider>,
+  return {
+    queryClient,
+    ...render(
+      <QueryClientProvider client={queryClient}>
+        <AuditLogPage />
+      </QueryClientProvider>,
+    ),
+  }
+}
+
+const MEMBERSHIPS = [
+  { organization_id: 'org-a', organization_name: 'acme' },
+  { organization_id: 'org-b', organization_name: 'beta' },
+]
+
+/** Pick out only the filter-bearing keys of a listAuditLogs call. */
+const FILTER_KEYS = [
+  'resource_type',
+  'action',
+  'user_email',
+  'start_date',
+  'end_date',
+  'organization_id',
+] as const
+function filtersOf(params: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(FILTER_KEYS.filter((k) => k in params).map((k) => [k, params[k]]))
+}
+
+/**
+ * A real AxiosError — getErrorStatus() narrows with `instanceof`, so a
+ * duck-typed object would read as status-less and silently take the generic
+ * branch, making the 403 guard below pass for the wrong reason.
+ */
+function forbidden(): AxiosError {
+  return new AxiosError(
+    'Request failed with status code 403',
+    'ERR_BAD_REQUEST',
+    undefined,
+    undefined,
+    {
+      status: 403,
+      statusText: 'Forbidden',
+      headers: {},
+      config: { headers: {} },
+      data: { error: 'Not a member of the requested organization' },
+    } as never,
   )
+}
+
+async function selectOrganization(name: string) {
+  await userEvent.click(screen.getByLabelText('Organization'))
+  await userEvent.click(screen.getByRole('option', { name }))
 }
 
 // ---- Mock data ----
@@ -67,6 +122,7 @@ const fakeLogs = {
 describe('AuditLogPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    authState.memberships = []
   })
 
   it('shows loading spinner while fetching', () => {
@@ -336,5 +392,165 @@ describe('AuditLogPage', () => {
     })
     expect(screen.queryByText('relation "audit_logs" does not exist')).not.toBeInTheDocument()
     vi.unstubAllEnvs()
+  })
+})
+
+// #797. The organization filter is deliberately a FILTER, not a context:
+// unset means "everything this caller may see", which for a platform admin is
+// the whole estate. The backend's own comment is the reason — an audit trail
+// nobody can review across tenants is not much of an audit trail.
+describe('AuditLogPage — organization filter (#797)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    authState.memberships = MEMBERSHIPS
+  })
+
+  it('offers the caller\'s memberships plus an explicit "all organizations" option', async () => {
+    listAuditLogsMock.mockResolvedValue(fakeLogs)
+    renderPage()
+    await waitFor(() => expect(screen.getByText('POST /api/v1/modules')).toBeInTheDocument())
+    await userEvent.click(screen.getByLabelText('Organization'))
+    expect(screen.getByRole('option', { name: 'All Organizations' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'acme' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'beta' })).toBeInTheDocument()
+  })
+
+  it('is hidden when the caller belongs to no organization', async () => {
+    // Nothing to choose between. Its absence is not a restriction: an unset
+    // filter already returns everything the caller may see.
+    authState.memberships = []
+    listAuditLogsMock.mockResolvedValue(fakeLogs)
+    renderPage()
+    await waitFor(() => expect(screen.getByText('POST /api/v1/modules')).toBeInTheDocument())
+    expect(screen.queryByLabelText('Organization')).not.toBeInTheDocument()
+  })
+
+  it('defaults to unset and sends no organization_id', async () => {
+    // The load-bearing assertion of #797: a default organization would silently
+    // hide the rest of the estate from the person auditing it.
+    listAuditLogsMock.mockResolvedValue(fakeLogs)
+    renderPage()
+    await waitFor(() => expect(listAuditLogsMock).toHaveBeenCalled())
+    for (const [params] of listAuditLogsMock.mock.calls) {
+      expect(params).not.toHaveProperty('organization_id')
+    }
+  })
+
+  it('sends organization_id once an organization is chosen', async () => {
+    listAuditLogsMock.mockResolvedValue(fakeLogs)
+    renderPage()
+    await waitFor(() => expect(screen.getByText('POST /api/v1/modules')).toBeInTheDocument())
+    await selectOrganization('beta')
+    await waitFor(() => {
+      expect(listAuditLogsMock).toHaveBeenCalledWith(
+        expect.objectContaining({ organization_id: 'org-b' }),
+      )
+    })
+  })
+
+  it('puts the organization in the react-query cache key, not only in the request', async () => {
+    // #798: if the key cannot name the organization, switching serves the
+    // previous organization's page from cache — instantly, because it is a hit.
+    listAuditLogsMock.mockResolvedValue(fakeLogs)
+    const { queryClient } = renderPage()
+    await waitFor(() => expect(screen.getByText('POST /api/v1/modules')).toBeInTheDocument())
+    await selectOrganization('beta')
+    await waitFor(() => {
+      const keys = queryClient
+        .getQueryCache()
+        .getAll()
+        .map((q) => q.queryKey)
+      // The organization is its own trailing key element, so the key varies by
+      // organization whether or not it also rode along inside `params`.
+      expect(keys.some((k) => k[k.length - 1] === 'org-b')).toBe(true)
+    })
+  })
+
+  it('clears the organization filter on Reset', async () => {
+    listAuditLogsMock.mockResolvedValue(fakeLogs)
+    renderPage()
+    await waitFor(() => expect(screen.getByText('POST /api/v1/modules')).toBeInTheDocument())
+    await selectOrganization('beta')
+    await waitFor(() =>
+      expect(listAuditLogsMock).toHaveBeenCalledWith(
+        expect.objectContaining({ organization_id: 'org-b' }),
+      ),
+    )
+    listAuditLogsMock.mockClear()
+    await userEvent.click(screen.getByRole('button', { name: /^reset$/i }))
+    await waitFor(() => expect(listAuditLogsMock).toHaveBeenCalled())
+    for (const [params] of listAuditLogsMock.mock.calls) {
+      expect(params).not.toHaveProperty('organization_id')
+    }
+  })
+
+  it('reports a 403 as "not a member" rather than a generic load failure', async () => {
+    // Distinct and recoverable — the user can pick another organization. The
+    // generic message reads like an outage they can do nothing about.
+    listAuditLogsMock.mockRejectedValue(forbidden())
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('You are not a member of that organization')).toBeInTheDocument()
+    })
+    expect(screen.queryByText('Failed to load audit logs')).not.toBeInTheDocument()
+  })
+
+  it('reports a 403 from the export as "not a member" too', async () => {
+    listAuditLogsMock.mockResolvedValueOnce(fakeLogs)
+    listAuditLogsMock.mockRejectedValueOnce(forbidden())
+    renderPage()
+    await waitFor(() => expect(screen.getByText('POST /api/v1/modules')).toBeInTheDocument())
+    await userEvent.click(screen.getByRole('button', { name: /export/i }))
+    await userEvent.click(screen.getByText('Export as CSV'))
+    await waitFor(() => {
+      expect(screen.getByText('You are not a member of that organization')).toBeInTheDocument()
+    })
+  })
+})
+
+// The CSV on this page is compliance evidence. An export that covers a
+// different slice of the estate than the table it was taken from is misleading
+// evidence, not a cosmetic bug — in either direction.
+describe('AuditLogPage — exports describe exactly what the table shows (#797)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    authState.memberships = MEMBERSHIPS
+  })
+
+  it.each([
+    ['CSV', 'Export as CSV'],
+    ['JSON', 'Export as JSON'],
+  ])('%s export carries the same filters as the table query', async (_label, menuItem) => {
+    listAuditLogsMock.mockResolvedValue(fakeLogs)
+    renderPage()
+    await waitFor(() => expect(screen.getByText('POST /api/v1/modules')).toBeInTheDocument())
+
+    // Narrow on two independent axes so the comparison cannot pass by both
+    // sides happening to be empty.
+    await userEvent.click(screen.getByLabelText('Resource Type'))
+    await userEvent.click(screen.getByRole('option', { name: 'Module' }))
+    await selectOrganization('beta')
+    await waitFor(() =>
+      expect(listAuditLogsMock).toHaveBeenCalledWith(
+        expect.objectContaining({ organization_id: 'org-b', resource_type: 'module' }),
+      ),
+    )
+
+    const tableCalls = listAuditLogsMock.mock.calls
+    const tableParams = tableCalls[tableCalls.length - 1][0] as Record<string, unknown>
+    listAuditLogsMock.mockClear()
+
+    await userEvent.click(screen.getByRole('button', { name: /export/i }))
+    await userEvent.click(screen.getByText(menuItem))
+    await waitFor(() => expect(listAuditLogsMock).toHaveBeenCalled())
+    const exportParams = listAuditLogsMock.mock.calls[0][0] as Record<string, unknown>
+
+    // Whole filter set, not just the organization: any divergence at all —
+    // a filter the export drops, or one it adds — fails here.
+    expect(filtersOf(exportParams)).toEqual(filtersOf(tableParams))
+    expect(filtersOf(exportParams)).toEqual({ resource_type: 'module', organization_id: 'org-b' })
+    // Pagination is the one deliberate difference: the table shows a page, the
+    // export takes the whole filtered set.
+    expect(exportParams.per_page).toBe(1000)
   })
 })

--- a/frontend/src/services/__tests__/api.test.ts
+++ b/frontend/src/services/__tests__/api.test.ts
@@ -1488,6 +1488,57 @@ describe('ApiClient', () => {
       const result = await client.getCurrentUserWithRole()
       expect(result.role_template).toBeNull()
       expect(result.allowed_scopes).toEqual([])
+      expect(result.memberships).toEqual([])
+    })
+
+    it('getCurrentUserWithRole carries memberships through, nested role_template intact (#795)', async () => {
+      // MeHandler nests the role template under `role_template`; the flat
+      // role_template_* fields declared by admin.MeMembershipEntry (and hence
+      // by swagger.yaml) are never marshalled. This is the shape that must
+      // survive, because the array died here before #795.
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: {
+            user: { id: 'u1' },
+            memberships: [
+              {
+                organization_id: 'org-a',
+                organization_name: 'acme',
+                created_at: '2025-01-01T00:00:00Z',
+                role_template: {
+                  id: 'rt-1',
+                  name: 'auditor',
+                  display_name: 'Auditor',
+                  scopes: ['audit:read'],
+                },
+              },
+              {
+                organization_id: 'org-b',
+                organization_name: 'beta',
+                created_at: '2025-01-02T00:00:00Z',
+                role_template: null,
+              },
+            ],
+          },
+        })
+      const result = await client.getCurrentUserWithRole()
+      expect(result.memberships).toHaveLength(2)
+      expect(result.memberships[0].organization_name).toBe('acme')
+      expect(result.memberships[0].role_template?.scopes).toEqual(['audit:read'])
+      expect(result.memberships[1].role_template).toBeNull()
+    })
+
+    it('getCurrentUserWithRole degrades a non-array memberships to []', async () => {
+      // This array feeds the shared auth provider, which sorts it on
+      // organization_id. A malformed payload must become "no memberships",
+      // not something the provider will try to iterate — a throw there is
+      // treated as a failed /me and signs the user out.
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { user: { id: 'u1' }, memberships: 'not-an-array' },
+        })
+      const result = await client.getCurrentUserWithRole()
+      expect(result.memberships).toEqual([])
     })
 
     // devLogin/getDevStatus/listUsersForImpersonation/impersonateUser are covered
@@ -3277,6 +3328,30 @@ describe('ApiClient', () => {
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/audit-logs', {
         params: { page: 1, per_page: 25, resource_type: 'module' },
       })
+    })
+
+    it('listAuditLogs forwards organization_id (backend #719)', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { logs: [], pagination: {} },
+        })
+      await client.listAuditLogs({ page: 1, organization_id: 'org-a' })
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/admin/audit-logs', {
+        params: { page: 1, organization_id: 'org-a' },
+      })
+    })
+
+    it('listAuditLogs omits organization_id entirely when it is not asked for', async () => {
+      // Absent must mean "everything the caller may see", never a default
+      // organization: a platform admin deliberately reads the whole estate.
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { logs: [], pagination: {} },
+        })
+      await client.listAuditLogs({ page: 1 })
+      const calls = (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mock.calls
+      const [, config] = calls[calls.length - 1]
+      expect(config.params).not.toHaveProperty('organization_id')
     })
 
     it('getAuditLog', async () => {

--- a/frontend/src/services/__tests__/queryKeys.test.ts
+++ b/frontend/src/services/__tests__/queryKeys.test.ts
@@ -106,7 +106,7 @@ describe('queryKeys', () => {
 
   describe('dashboard', () => {
     it('stats key is stable', () => {
-      expect(queryKeys.dashboard.stats()).toEqual(['dashboard', 'stats'])
+      expect(queryKeys.dashboard.stats()).toEqual(['dashboard', 'stats', undefined])
     })
   })
 
@@ -117,12 +117,12 @@ describe('queryKeys', () => {
 
     it('list key includes params', () => {
       const key = queryKeys.users.list({ page: 1, perPage: 20, search: 'john' })
-      expect(key).toEqual(['users', 'list', { page: 1, perPage: 20, search: 'john' }])
+      expect(key).toEqual(['users', 'list', { page: 1, perPage: 20, search: 'john' }, undefined])
     })
 
     it('list key works without params', () => {
       const key = queryKeys.users.list()
-      expect(key).toEqual(['users', 'list', undefined])
+      expect(key).toEqual(['users', 'list', undefined, undefined])
     })
 
     it('detail key includes id', () => {
@@ -192,7 +192,7 @@ describe('queryKeys', () => {
 
     it('list key includes params', () => {
       const params = { action: 'create', resource: 'module' }
-      expect(queryKeys.auditLogs.list(params)).toEqual(['auditLogs', 'list', params])
+      expect(queryKeys.auditLogs.list(params)).toEqual(['auditLogs', 'list', params, undefined])
     })
   })
 
@@ -222,7 +222,7 @@ describe('queryKeys', () => {
 
   describe('mirrors', () => {
     it('list key is stable', () => {
-      expect(queryKeys.mirrors.list()).toEqual(['mirrors', 'list'])
+      expect(queryKeys.mirrors.list()).toEqual(['mirrors', 'list', undefined])
     })
 
     it('providers key includes mirrorId', () => {
@@ -254,11 +254,12 @@ describe('queryKeys', () => {
         'approvals',
         'list',
         { status: 'pending' },
+        undefined,
       ])
     })
 
     it('list key works without params', () => {
-      expect(queryKeys.approvals.list()).toEqual(['approvals', 'list', undefined])
+      expect(queryKeys.approvals.list()).toEqual(['approvals', 'list', undefined, undefined])
     })
   })
 
@@ -325,6 +326,44 @@ describe('queryKeys', () => {
       const a = queryKeys.advisories.adminList('binary')
       const b = queryKeys.advisories.adminList('provider')
       expect(a).not.toEqual(b)
+    })
+  })
+
+  // #798. React Query serves a cached entry whenever the key matches, so a key
+  // that cannot name an organization hands the previous organization's rows to
+  // the next one — instantly, because it is a cache hit, and only self-correcting
+  // once the entry goes stale.
+  //
+  // Table-driven over EVERY organization-scoped axis rather than just the ones
+  // #798 widened: the four that already took an organization are the reference
+  // shape, and including them means a future narrowing of any of them fails here
+  // too. Each entry's other arguments are held constant, so the only thing that
+  // can vary the key is the organization.
+  describe('organization-parameterised cache keys (#798)', () => {
+    const axes: Array<[string, (organizationId?: string) => readonly unknown[]]> = [
+      // Widened by #798.
+      ['auditLogs.list', (org) => queryKeys.auditLogs.list({ page: 1 }, org)],
+      ['users.list', (org) => queryKeys.users.list({ page: 1 }, org)],
+      ['mirrors.list', (org) => queryKeys.mirrors.list(org)],
+      ['approvals.list', (org) => queryKeys.approvals.list({ status: 'pending' }, org)],
+      ['versionApprovals.list', (org) => queryKeys.versionApprovals.list({ type: 'module' }, org)],
+      ['versionApprovals.pendingCount', (org) => queryKeys.versionApprovals.pendingCount(org)],
+      ['dashboard.stats', (org) => queryKeys.dashboard.stats(org)],
+      // Already organization-parameterised before #798 — the reference shape.
+      ['apiKeys.list', (org) => queryKeys.apiKeys.list(org)],
+      ['scmProviders.list', (org) => queryKeys.scmProviders.list(org)],
+      ['policies.list', (org) => queryKeys.policies.list(org)],
+      ['quotas.list', (org) => queryKeys.quotas.list(org)],
+    ]
+
+    it.each(axes)('%s serves a distinct cache entry per organization', (_name, key) => {
+      expect(key('org-a')).not.toEqual(key('org-b'))
+    })
+
+    it.each(axes)('%s distinguishes "no organization" from a chosen one', (_name, key) => {
+      // "All organizations" is its own result set — everything the caller may
+      // see — not a synonym for whichever organization was picked last.
+      expect(key(undefined)).not.toEqual(key('org-a'))
     })
   })
 

--- a/frontend/src/services/api/auditApi.ts
+++ b/frontend/src/services/api/auditApi.ts
@@ -15,6 +15,16 @@ export async function listAuditLogs(opts?: {
   user_email?: string
   start_date?: string
   end_date?: string
+  /**
+   * Narrow the trail to one organization (backend #719). OMIT IT — do not pass
+   * a "default" organization — to get everything the caller may see. That
+   * distinction is the endpoint's design, not an accident: a platform admin
+   * deliberately reads the whole estate unfiltered, because an audit trail
+   * nobody can review across tenants is not much of an audit trail. The
+   * backend validates the requested id against the caller's resolved scope and
+   * answers 403 for an organization they are not a member of.
+   */
+  organization_id?: string
 }): Promise<AuditLogListResponse> {
   const response = await http.get<AuditLogListResponse>('/api/v1/admin/audit-logs', {
     params: opts,

--- a/frontend/src/services/api/authApi.ts
+++ b/frontend/src/services/api/authApi.ts
@@ -66,9 +66,44 @@ export async function getCurrentUser(): Promise<User> {
   return response.data.user
 }
 
+/**
+ * One organization membership exactly as `GET /api/v1/auth/me` emits it.
+ *
+ * This is typed against the HANDLER (`MeHandler`, backend
+ * `internal/api/admin/auth.go`), which builds the payload with `gin.H` and
+ * nests the role template under a single `role_template` key that is
+ * explicitly `null` when the membership carries no role.
+ *
+ * It is deliberately NOT typed against the backend's `admin.MeResponse` /
+ * `admin.MeMembershipEntry` structs, which declare FLAT `role_template_id` /
+ * `role_template_name` / `role_template_display_name` / `role_template_scopes`
+ * fields. Those structs are referenced by nothing but the handler's swagger
+ * annotation — no code path ever marshals them — so `backend/docs/swagger.yaml`
+ * documents a membership shape that no client has ever received. Trusting it
+ * here would silently produce `undefined` for every role field.
+ *
+ * `organization_name` is the organization's URL-safe SLUG (`o.name`). The human
+ * display name (`o.display_name`) is not sent by this endpoint at all; adding
+ * it is a backend change, not something to synthesise here.
+ */
+export interface AuthMembership {
+  organization_id: string
+  organization_name: string
+  created_at: string
+  role_template: RoleTemplateInfo | null
+}
+
 export async function getCurrentUserWithRole(): Promise<{
   user: User
+  /**
+   * The endpoint's deprecated back-compat convenience field: the role template
+   * of `Memberships[0]`, carrying only `name`/`display_name` and no scopes.
+   * Surfaced here because the endpoint sends it, but nothing consumes it —
+   * `AuthContext` derives the display role from `memberships` below, which is
+   * the same information per-organization and with scopes attached.
+   */
   role_template: RoleTemplateInfo | null
+  memberships: AuthMembership[]
   allowed_scopes: string[]
   session_expires_at: string | null
 }> {
@@ -76,6 +111,11 @@ export async function getCurrentUserWithRole(): Promise<{
   return {
     user: response.data.user,
     role_template: response.data.role_template || null,
+    // Array.isArray rather than `|| []`: this array now feeds the shared auth
+    // provider, which sorts it on `organization_id`. A non-array (or absent)
+    // `memberships` must degrade to "no memberships", not to a value the
+    // provider will try to iterate.
+    memberships: Array.isArray(response.data.memberships) ? response.data.memberships : [],
     allowed_scopes: response.data.allowed_scopes || [],
     session_expires_at: response.data.session_expires_at || null,
   }

--- a/frontend/src/services/queryKeys.ts
+++ b/frontend/src/services/queryKeys.ts
@@ -41,12 +41,26 @@ export const queryKeys = {
   },
   dashboard: {
     _def: ['dashboard'] as const,
-    stats: () => [...queryKeys.dashboard._def, 'stats'] as const,
+    // ORGANIZATION-PARAMETERISED (#798). The payload is already tenant-derived:
+    // the backend scopes every panel by the caller's resolved organization
+    // scope rather than by a requested id, so today every caller passes
+    // undefined and the key is unchanged. It takes the argument anyway because
+    // the day a picker narrows the dashboard, a key that cannot express the
+    // narrowing serves the previous organization's counts from cache.
+    stats: (organizationId?: string) =>
+      [...queryKeys.dashboard._def, 'stats', organizationId] as const,
   },
   users: {
     _def: ['users'] as const,
-    list: (params?: { page?: number; perPage?: number; search?: string }) =>
-      [...queryKeys.users._def, 'list', params] as const,
+    // ORGANIZATION-PARAMETERISED (#798). Users are listed with their
+    // memberships and are filtered server-side by the caller's organization
+    // scope, so a narrowed list is a different list. The organization is a
+    // separate argument rather than a `params` member so the key varies by
+    // organization whether or not a caller remembered to put it in `params`.
+    list: (
+      params?: { page?: number; perPage?: number; search?: string },
+      organizationId?: string,
+    ) => [...queryKeys.users._def, 'list', params, organizationId] as const,
     detail: (id: string) => [...queryKeys.users._def, 'detail', id] as const,
   },
   organizations: {
@@ -69,8 +83,14 @@ export const queryKeys = {
   },
   auditLogs: {
     _def: ['auditLogs'] as const,
-    list: (params?: Record<string, unknown>) =>
-      [...queryKeys.auditLogs._def, 'list', params] as const,
+    // ORGANIZATION-PARAMETERISED (#798). The backend has accepted
+    // `?organization_id=` since backend #719 and validates it against the
+    // caller's scope, so two organizations are genuinely two result sets.
+    // `organizationId` is passed separately from `params` (which also carries
+    // it on the wire) so the key is org-varying by construction, not by a
+    // caller's discipline.
+    list: (params?: Record<string, unknown>, organizationId?: string) =>
+      [...queryKeys.auditLogs._def, 'list', params, organizationId] as const,
   },
   storageConfigs: {
     _def: ['storageConfigs'] as const,
@@ -84,7 +104,14 @@ export const queryKeys = {
   },
   mirrors: {
     _def: ['mirrors'] as const,
-    list: () => [...queryKeys.mirrors._def, 'list'] as const,
+    // ORGANIZATION-PARAMETERISED (#798). Mirror configs carry an
+    // `organization_id` and `listMirrors` already accepts one as a request
+    // parameter — the key was the only part of the path that could not
+    // express it.
+    list: (organizationId?: string) =>
+      [...queryKeys.mirrors._def, 'list', organizationId] as const,
+    // Deliberately global: a mirror's provider inventory is addressed by
+    // mirror id, which is itself already organization-scoped.
     providers: (mirrorId: string) => [...queryKeys.mirrors._def, 'providers', mirrorId] as const,
   },
   roles: {
@@ -97,7 +124,11 @@ export const queryKeys = {
   },
   approvals: {
     _def: ['approvals'] as const,
-    list: (params?: { status?: string }) => [...queryKeys.approvals._def, 'list', params] as const,
+    // ORGANIZATION-PARAMETERISED (#798). Approval queues are per-organization
+    // work lists; showing one organization's pending items under another's
+    // heading is the failure mode this widening exists to prevent.
+    list: (params?: { status?: string }, organizationId?: string) =>
+      [...queryKeys.approvals._def, 'list', params, organizationId] as const,
   },
   policies: {
     _def: ['policies'] as const,
@@ -133,9 +164,17 @@ export const queryKeys = {
   },
   versionApprovals: {
     _def: ['versionApprovals'] as const,
-    list: (params?: { type?: string; config_id?: string; status?: string }) =>
-      [...queryKeys.versionApprovals._def, 'list', params] as const,
-    pendingCount: () => [...queryKeys.versionApprovals._def, 'pendingCount'] as const,
+    // ORGANIZATION-PARAMETERISED (#798), for the same reason as `approvals`:
+    // the rows are the organization's pending version promotions.
+    list: (
+      params?: { type?: string; config_id?: string; status?: string },
+      organizationId?: string,
+    ) => [...queryKeys.versionApprovals._def, 'list', params, organizationId] as const,
+    // ORGANIZATION-PARAMETERISED (#798). This count is rendered as a nav badge
+    // beside the list above; a badge that keeps the previous organization's
+    // number is the same defect, one pixel smaller.
+    pendingCount: (organizationId?: string) =>
+      [...queryKeys.versionApprovals._def, 'pendingCount', organizationId] as const,
     events: (id: string) => [...queryKeys.versionApprovals._def, 'events', id] as const,
   },
   scanner: {


### PR DESCRIPTION
Closes #795. Closes #797. Closes #798.

The groundwork the organization picker (#779) is blocked on. The picker itself is **not** here.

The backend has emitted real per-organization memberships on `/auth/me` since backend #719. The frontend discarded them at the HTTP boundary and rebuilt one fabricated membership stamped with a sentinel, so the picker had nothing real to render.

## 1. Carry real memberships end to end (#795)

`getCurrentUserWithRole` now returns `memberships`, typed against what `MeHandler` actually emits: a **nested**, nullable `role_template` object. It is deliberately not typed against `admin.MeResponse` / `admin.MeMembershipEntry`, whose flat `role_template_*` fields are referenced by nothing but the handler's swagger annotation and are never marshalled — `backend/docs/swagger.yaml` documents a membership shape no client has ever received.

`AuthContext` publishes the real array; `toSyntheticMemberships` and `NO_ORGANIZATION_SENTINEL` are gone, and the "the registry backend has no real multi-org membership concept" comment is corrected rather than deleted.

**The shared contract is satisfied honestly, not with a placeholder.** `Membership.organization_id` / `organization_name` are still required non-optional strings — the reason the sentinel existed. So:

- a membership with no usable `organization_id` is **dropped** — the shared provider calls `.localeCompare` on that field while choosing the primary membership, so one malformed entry throws inside session resolution, which the provider treats as a failed `/me` and signs the user out;
- an empty `organization_name` falls back to the id. The backend selects it as `COALESCE(o.name, '')`, so a membership whose organization row is missing arrives with an empty slug — rendering `''` is exactly the blank organization #622's tripwire was set for.

`organization_name` is the URL-safe **slug** (`o.name`); the display name is not on this payload at all, and is not invented here.

### The shared package does not expose memberships

`@4cloudguru/cloud-suite-ui@0.9.0`'s `AuthContextType` has no `memberships` field. The provider consumes `MeResponse.memberships` (to pick the primary role template and answer `hasScope(scope, organizationId)`) and keeps it in its own state, but never re-exports it — so handing the provider the real array is necessary and **not sufficient** for #795's acceptance criterion. This app therefore publishes the array on a local context and `useAuth` returns the shared context widened with it. Every existing `useAuth` consumer and every `vi.mock('.../AuthContext')` in the suite is unaffected.

They are gated on `isAuthenticated`: the adapter records memberships the moment `/me` resolves, which is strictly before the provider decides whether to accept that response, so a `/me` resolving after a logout would otherwise leave a signed-out session holding a populated membership list.

### Behaviour change

`useAuth().roleTemplate` is now derived by the shared provider from the real memberships — lowest `organization_id` carrying a role — instead of from `/me`'s deprecated back-compat `role_template` (which is `Memberships[0]`, i.e. database row order). Its `scopes` are populated for the first time, and `hasScope(scope, organizationId)` resolves against real per-organization scopes instead of always answering false. Only `APIKeysPage`'s informational alert reads `roleTemplate`.

## 2. Organization-parameterise the cache keys (#798)

`auditLogs`, `users`, `mirrors`, `approvals`, `versionApprovals` and `dashboard.stats` now take an organization in the same position `apiKeys.list` already did, each with the decision recorded in a comment. `versionApprovals.pendingCount` is widened alongside its list — it is the same defect one pixel smaller (a nav badge holding the previous organization's count).

Every existing caller passes nothing, so only the key shape changes. One consequence needed fixing in the same change: Dashboard's Refresh button invalidated `queryKeys.dashboard.stats()`, and `invalidateQueries` matches by **prefix** — `['dashboard','stats',undefined]` stops matching the moment anything narrows the query to an organization, silently turning Refresh into a no-op. It now invalidates the `dashboard` namespace.

For the `params`-shaped keys the organization is a separate argument rather than a `params` member, so the key varies by organization *by construction* rather than by a caller remembering to include it.

## 3. Filter audit logs by organization (#797)

`listAuditLogs` accepts `organization_id`; `AuditLogPage` surfaces it as an optional filter sourced from the caller's memberships, defaulting to unset, hidden entirely when the caller belongs to no organization.

**Unset means everything the caller may see — never a default organization.** Platform admins deliberately read the whole estate here; a default would quietly hide most of it from the person auditing it. A 403 is reported as "You are not a member of that organization" rather than a load failure, on both the table query and the exports, because it is distinct and recoverable.

**The exports and the table now agree by construction.** Both build from one `filterParams` object instead of restating the filter list; the previous hand-rolled duplication is exactly how a filtered table ends up beside an unfiltered CSV. A test compares the whole filter set of the export call against the table call and fails on divergence in **either** direction (M10a widens, M10b narrows).

## Verification

Full suite green, `eslint --max-warnings 0` clean, `tsc --noEmit` clean.

Every new guard was mutation-verified — the change reverted in the shipped file, the suite re-run, the failure confirmed, the change restored:

| # | Mutation | Test that failed |
| --- | --- | --- |
| M1 | `getCurrentUserWithRole` returns `memberships: []` | carries memberships through, nested role_template intact |
| M2 | `Array.isArray(...)` → `... \|\| []` | degrades a non-array memberships to [] |
| M3 | Drop the malformed-membership filter | drops a membership with no usable organization_id |
| M4 | Drop the empty-slug fallback | falls back to the organization id when the slug is empty |
| M5 | Drop the `isAuthenticated` gate in `useAuth` | does not repopulate memberships from a /me that resolves after logout |
| M6 | Drop `setMemberships([])` from `onClearStorage` **alone** | *nothing* — see note below |
| M6b | Drop that **and** the gate | drops memberships when the session ends (+ M5's test) |
| M7 | `auditLogs.list` stops taking an organization | 3 key tests + puts the organization in the react-query cache key |
| M8 | Drop `organization_id` from `filterParams` | 4 tests (request, reset, both exports) |
| M9 | Default the filter to the first membership | defaults to unset and sends no organization_id |
| M10a | Export re-states the filters by hand, missing the newest one | CSV export carries the same filters as the table query |
| M10b | Export adds a filter the table does not have | JSON export carries the same filters as the table query |
| M11 | Drop the 403 branch on the table query | reports a 403 as "not a member" rather than a generic load failure |
| M12 | Reset stops clearing the organization | clears the organization filter on Reset |
| M13 | Always render the organization filter | is hidden when the caller belongs to no organization |
| M14 | `dashboard.stats` stops taking an organization | 3 key tests |

**M6 is reported as inert on purpose.** Clearing the memberships state on sign-out is retention hygiene only — what consumers see is already guaranteed by the gate M5 covers, so removing that line alone kills no test. It is kept for the same reason as the `queryClient.clear()` beside it (a signed-out tab should not still hold the previous user's data) and the code says so, rather than presenting itself as a guard.

The `queryKeys` guard is table-driven over **all eleven** organization-scoped axes, including the four that already took an organization, so a future narrowing of any of them fails here too. Each axis is asserted twice: two organizations differ, and "no organization" differs from a chosen one — the second is what proves the argument actually lands in the key.

The 403 tests construct a real `AxiosError`; `getErrorStatus` narrows with `instanceof`, so a duck-typed object would read as status-less and take the generic branch, passing for the wrong reason.

## Things the brief got slightly wrong, found while doing this

- **`listAuditLogs` already forwarded `organization_id` at runtime.** It spreads `opts` straight into `params`, so only the TypeScript type forbade it. That change is type-level: reverting it fails `tsc`, not a test.
- **`queryKeys.auditLogs.list(params)` already varied on anything inside `params`.** Putting `organization_id` there would have varied the key. The explicit second argument is still added per #798, because it makes the variance structural rather than dependent on the caller.
- **The app was not membership-blind overall.** `useDefaultOrgMembership` fetches `GET /api/v1/users/me/memberships` and already backs the organization pickers in APIKeysPage, SCMProvidersPage and ModuleUploadPage, plus HomePage's primary-org lookup. `/auth/me`'s memberships were discarded; a second endpoint was carrying the real ones. Consolidating those four onto `useAuth().memberships` (one fewer round-trip, one source of truth) is left for #779 to decide, not done here.

## Not in scope

No picker, no dropdown, no persisted organization context. `useDefaultOrgMembership` and its consumers are untouched. `format:check` still fails on these files exactly as it does on `main` (#782) — nothing was reformatted, so the diff is only the change.
