### PR TITLE
fix(admin): read the server has_more instead of guessing from the row count

### DIFF
--- a/frontend/src/components/OrganizationFilter.tsx
+++ b/frontend/src/components/OrganizationFilter.tsx
@@ -6,18 +6,15 @@ import api from '../services/api'
 import { useAuth } from '../contexts/AuthContext'
 import { useDebounce } from '../hooks/useDebounce'
 import { queryKeys } from '../services/queryKeys'
+import { ORGANIZATION_PAGE_MAX } from '../services/api/organizationsApi'
 
 /**
- * The largest page `GET /api/v1/organizations` will actually honour.
+ * The page this picker asks for: the largest the endpoint serves.
  *
- * `ListOrganizationsHandler` resets an out-of-range `per_page` to the DEFAULT
- * rather than clamping it to the maximum, so asking for 200 returns 20 — worse
- * than asking for 100 (backend #893, still open; verified unfixed against
- * backend main). 100 is inside the accepted range and is therefore the largest
- * page that does not silently shrink. `OIDCSettingsPage` asking for 200 and
- * receiving 20 is the same bug's other victim.
+ * Re-exported from the API module rather than restated, so the number bounding
+ * the request and the number the endpoint enforces cannot drift apart.
  */
-export const ORGANIZATION_PAGE_SIZE = 100
+export const ORGANIZATION_PAGE_SIZE = ORGANIZATION_PAGE_MAX
 
 /** Debounce for the server-side organization search, in milliseconds. */
 const SEARCH_DEBOUNCE_MS = 300
@@ -74,9 +71,9 @@ export interface OrganizationFilterProps {
  * present a list that is quietly incomplete — an administrator scrolling for an
  * organization that is simply not in the first page has no way to tell that
  * from it not existing. So: a searchable Autocomplete whose typing hits
- * `/organizations/search` server-side, plus an explicit notice when a full page
- * comes back. The list may still be partial; what it may not be is SILENTLY
- * partial.
+ * `/organizations/search` server-side, plus an explicit notice driven by the
+ * server's exact `has_more`. The list may still be partial; what it may not be
+ * is SILENTLY partial.
  */
 const OrganizationFilter: React.FC<OrganizationFilterProps> = ({ value, onChange, label }) => {
   const { t } = useTranslation()
@@ -95,13 +92,13 @@ const OrganizationFilter: React.FC<OrganizationFilterProps> = ({ value, onChange
   // below, because VISIBILITY is decided from it: driving visibility off the
   // currently-displayed options would make the picker vanish mid-typing the
   // moment a search narrowed to a single match.
-  const { data: baseline = [] } = useQuery({
+  const { data: baseline } = useQuery({
     queryKey: queryKeys.organizations.list({ page: 1, perPage: ORGANIZATION_PAGE_SIZE }),
     queryFn: () => api.listOrganizations(1, ORGANIZATION_PAGE_SIZE),
     enabled: isPlatformAdmin,
   })
 
-  const { data: searched = [] } = useQuery({
+  const { data: searched } = useQuery({
     queryKey: queryKeys.organizations.list({
       page: 1,
       perPage: ORGANIZATION_PAGE_SIZE,
@@ -116,20 +113,29 @@ const OrganizationFilter: React.FC<OrganizationFilterProps> = ({ value, onChange
     [memberships],
   )
 
+  // The page currently on screen: the search results once the user has typed,
+  // the unsearched first page otherwise.
+  const shown = search ? searched : baseline
+
   const adminOptions = useMemo<OrganizationOption[]>(
-    () => (search ? searched : baseline).map((o) => ({ id: o.id, label: o.name })),
-    [search, searched, baseline],
+    () => (shown?.organizations ?? []).map((o) => ({ id: o.id, label: o.name })),
+    [shown],
   )
 
   const options = isPlatformAdmin ? adminOptions : membershipOptions
 
-  // A page that came back exactly full is the only evidence available that
-  // there may be more: `listOrganizations` discards the `pagination` object the
-  // backend does send, so the true total never reaches this component (also
-  // backend #893). Saying "there may be more, narrow it" on a full page is the
-  // honest reading of the only signal there is.
-  const mayBeTruncated =
-    isPlatformAdmin && (search ? searched : baseline).length >= ORGANIZATION_PAGE_SIZE
+  // Whether to tell the administrator that organizations exist beyond the ones
+  // on offer.
+  //
+  // Reads the server's `has_more`, which is EXACT — false if and only if
+  // nothing follows this page — rather than re-deriving completeness from the
+  // row count (backend #893). The count heuristic this replaces ("the page came
+  // back full") is wrong for every list whose length is an exact multiple of
+  // the page size: a deployment with precisely 100 organizations would be told
+  // to keep searching for a 101st that does not exist. On the search axis it
+  // was not merely imprecise but unavailable, since that axis cannot count at
+  // all; the server now probes one row past the page to answer honestly.
+  const mayBeTruncated = isPlatformAdmin && (shown?.hasMore ?? false)
 
   /**
    * Shown only when there is a choice to make: more than one organization to
@@ -144,7 +150,9 @@ const OrganizationFilter: React.FC<OrganizationFilterProps> = ({ value, onChange
    * carrier-only administrator (zero memberships, every organization) would
    * never see it.
    */
-  const visible = isPlatformAdmin ? baseline.length > 1 : membershipOptions.length > 1
+  const visible = isPlatformAdmin
+    ? (baseline?.organizations.length ?? 0) > 1
+    : membershipOptions.length > 1
 
   // A deep-linked ?org= naming an organization outside the loaded page still
   // has to render as itself. Synthesising the missing option keeps the URL

--- a/frontend/src/components/__tests__/OrganizationFilter.test.tsx
+++ b/frontend/src/components/__tests__/OrganizationFilter.test.tsx
@@ -48,13 +48,25 @@ const organization = (id: string, name: string) => ({
 const organizations = (n: number) =>
   Array.from({ length: n }, (_, i) => organization(`org-${i}`, `slug-${i}`))
 
+/**
+ * One page as the API layer now returns it. `hasMore` is the SERVER's exact
+ * answer, so the tests set it independently of the row count — which is the
+ * whole point of backend #893, and what makes "a full page that is the last
+ * page" expressible at all.
+ */
+const page = (orgs: ReturnType<typeof organization>[], hasMore = false, total: number | null = null) => ({
+  organizations: orgs,
+  hasMore,
+  total,
+})
+
 describe('OrganizationFilter', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockAllowedScopes = []
     mockMemberships = []
-    listOrganizationsMock.mockResolvedValue([])
-    searchOrganizationsMock.mockResolvedValue([])
+    listOrganizationsMock.mockResolvedValue(page([]))
+    searchOrganizationsMock.mockResolvedValue(page([]))
   })
 
   // ── Visibility ────────────────────────────────────────────────────────────
@@ -90,10 +102,7 @@ describe('OrganizationFilter', () => {
   it('is shown to a platform admin with no memberships at all', async () => {
     mockAllowedScopes = ['admin']
     mockMemberships = []
-    listOrganizationsMock.mockResolvedValue([
-      organization('org-1', 'acme'),
-      organization('org-2', 'globex'),
-    ])
+    listOrganizationsMock.mockResolvedValue(page([organization('org-1', 'acme'), organization('org-2', 'globex')]))
     renderFilter()
     await waitFor(() => {
       expect(screen.getByTestId('organization-filter-input')).toBeInTheDocument()
@@ -103,11 +112,13 @@ describe('OrganizationFilter', () => {
   it('offers a platform admin every organization, not just their memberships', async () => {
     mockAllowedScopes = ['admin']
     mockMemberships = [membership('org-1', 'acme')]
-    listOrganizationsMock.mockResolvedValue([
-      organization('org-1', 'acme'),
-      organization('org-2', 'globex'),
-      organization('org-3', 'initech'),
-    ])
+    listOrganizationsMock.mockResolvedValue(
+      page([
+        organization('org-1', 'acme'),
+        organization('org-2', 'globex'),
+        organization('org-3', 'initech'),
+      ]),
+    )
     renderFilter()
     const input = await screen.findByTestId('organization-filter-input')
     await userEvent.click(input)
@@ -124,7 +135,7 @@ describe('OrganizationFilter', () => {
 
   it('is hidden from a platform admin when the deployment has only one organization', async () => {
     mockAllowedScopes = ['admin']
-    listOrganizationsMock.mockResolvedValue([organization('org-1', 'acme')])
+    listOrganizationsMock.mockResolvedValue(page([organization('org-1', 'acme')]))
     renderFilter()
     await waitFor(() => expect(listOrganizationsMock).toHaveBeenCalled())
     expect(screen.queryByTestId('organization-filter-input')).not.toBeInTheDocument()
@@ -137,26 +148,49 @@ describe('OrganizationFilter', () => {
   // returns fewer rows, not more. 100 is the largest page that does not shrink.
   it('asks for the largest page the backend actually honours', async () => {
     mockAllowedScopes = ['admin']
-    listOrganizationsMock.mockResolvedValue(organizations(2))
+    listOrganizationsMock.mockResolvedValue(page(organizations(2)))
     renderFilter()
     await waitFor(() => expect(listOrganizationsMock).toHaveBeenCalledWith(1, 100))
     expect(ORGANIZATION_PAGE_SIZE).toBe(100)
     expect(ORGANIZATION_PAGE_SIZE).toBeLessThanOrEqual(100)
   })
 
-  it('says so when the organization list may be incomplete', async () => {
+  it('says so when the server reports more organizations beyond this page', async () => {
     mockAllowedScopes = ['admin']
-    listOrganizationsMock.mockResolvedValue(organizations(ORGANIZATION_PAGE_SIZE))
+    listOrganizationsMock.mockResolvedValue(page(organizations(ORGANIZATION_PAGE_SIZE), true, 137))
     renderFilter()
     expect(await screen.findByTestId('organization-filter-truncated')).toBeInTheDocument()
   })
 
   it('does not claim truncation when the whole list fits in one page', async () => {
     mockAllowedScopes = ['admin']
-    listOrganizationsMock.mockResolvedValue(organizations(ORGANIZATION_PAGE_SIZE - 1))
+    listOrganizationsMock.mockResolvedValue(page(organizations(ORGANIZATION_PAGE_SIZE - 1), false, 99))
     renderFilter()
     await screen.findByTestId('organization-filter-input')
     expect(screen.queryByTestId('organization-filter-truncated')).not.toBeInTheDocument()
+  })
+
+  // The case the old row-count heuristic got WRONG, and the reason this now
+  // reads the server's flag: a page that is completely full and is nonetheless
+  // the last one. Counting rows would tell the administrator to keep searching
+  // for a 101st organization that does not exist.
+  it('does not claim truncation on a full page that is the last page', async () => {
+    mockAllowedScopes = ['admin']
+    listOrganizationsMock.mockResolvedValue(
+      page(organizations(ORGANIZATION_PAGE_SIZE), false, ORGANIZATION_PAGE_SIZE),
+    )
+    renderFilter()
+    await screen.findByTestId('organization-filter-input')
+    expect(screen.queryByTestId('organization-filter-truncated')).not.toBeInTheDocument()
+  })
+
+  // And the converse: a SHORT page the server says is not the end. The row
+  // count would call this complete; only the flag knows better.
+  it('says so on a short page the server reports as incomplete', async () => {
+    mockAllowedScopes = ['admin']
+    listOrganizationsMock.mockResolvedValue(page(organizations(3), true, null))
+    renderFilter()
+    expect(await screen.findByTestId('organization-filter-truncated')).toBeInTheDocument()
   })
 
   // What makes the truncation survivable: an organization outside the first
@@ -164,8 +198,8 @@ describe('OrganizationFilter', () => {
   // filtering the page already in hand.
   it('searches the server for a platform admin rather than filtering one page', async () => {
     mockAllowedScopes = ['admin']
-    listOrganizationsMock.mockResolvedValue(organizations(ORGANIZATION_PAGE_SIZE))
-    searchOrganizationsMock.mockResolvedValue([organization('org-999', 'faraway')])
+    listOrganizationsMock.mockResolvedValue(page(organizations(ORGANIZATION_PAGE_SIZE), true, 137))
+    searchOrganizationsMock.mockResolvedValue(page([organization('org-999', 'faraway')]))
     renderFilter()
     const input = await screen.findByTestId('organization-filter-input')
     await userEvent.type(input, 'faraway')
@@ -212,7 +246,7 @@ describe('OrganizationFilter', () => {
   // filtered is the worst of both: narrowed data, no visible cause.
   it('renders a deep-linked organization that is not in the loaded page', async () => {
     mockAllowedScopes = ['admin']
-    listOrganizationsMock.mockResolvedValue(organizations(3))
+    listOrganizationsMock.mockResolvedValue(page(organizations(3)))
     renderFilter({ value: 'org-outside-the-page' })
     await waitFor(() => {
       expect(screen.getByTestId('organization-filter-input')).toHaveValue('org-outside-the-page')

--- a/frontend/src/pages/admin/OIDCSettingsPage.tsx
+++ b/frontend/src/pages/admin/OIDCSettingsPage.tsx
@@ -49,6 +49,7 @@ import type {
   IdentityGroupMappings,
 } from '../../types'
 import { queryKeys } from '../../services/queryKeys'
+import { ORGANIZATION_PAGE_MAX } from '../../services/api/organizationsApi'
 import { getErrorMessage } from '../../utils/errors'
 
 // Available roles that can be assigned to mapped groups — must match system role template names
@@ -142,7 +143,12 @@ const OIDCSettingsPage: React.FC = () => {
   const loadOrgs = async () => {
     setOrgLoading(true)
     try {
-      const orgs: Organization[] = await api.listOrganizations(1, 200)
+      // Asks for the endpoint's maximum: this form offers every organization
+      // as a mapping target. It used to ask for 200 and be silently served 20,
+      // because an over-large per_page was reset to the default rather than
+      // clamped (backend #893).
+      const page = await api.listOrganizations(1, ORGANIZATION_PAGE_MAX)
+      const orgs: Organization[] = page.organizations
       setOrgOptions(orgs.map((o) => o.name))
     } catch {
       setOrgOptions([])

--- a/frontend/src/pages/admin/OrganizationsPage.tsx
+++ b/frontend/src/pages/admin/OrganizationsPage.tsx
@@ -94,8 +94,8 @@ const OrganizationsPage: React.FC = () => {
   } = useQuery<Organization[]>({
     queryKey: queryKeys.organizations.list(),
     queryFn: async () => {
-      const orgs = await api.listOrganizations()
-      return orgs || []
+      const page = await api.listOrganizations()
+      return page.organizations
     },
   })
 

--- a/frontend/src/pages/admin/UsersPage.tsx
+++ b/frontend/src/pages/admin/UsersPage.tsx
@@ -180,8 +180,8 @@ const UsersPage: React.FC = () => {
   const loadOrganizations = async () => {
     try {
       setOrgsLoading(true)
-      const orgs = await api.listOrganizations()
-      setOrganizations(orgs || [])
+      const page = await api.listOrganizations()
+      setOrganizations(page.organizations)
     } catch (err) {
       console.error('Failed to load organizations:', err)
       // No getErrorMessage() call here (list load just resets local state), so

--- a/frontend/src/pages/admin/__tests__/ApprovalsPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/ApprovalsPage.test.tsx
@@ -16,8 +16,9 @@ vi.mock('../../../services/api', () => ({
     // The organization picker sources a platform admin's options from these.
     // Empty keeps it hidden, so these tests exercise the page's own filtering
     // rather than the picker's (covered in OrganizationFilter.test.tsx).
-    listOrganizations: () => Promise.resolve([]),
-    searchOrganizations: () => Promise.resolve([]),
+    listOrganizations: () => Promise.resolve({ organizations: [], hasMore: false, total: 0 }),
+    searchOrganizations: () =>
+      Promise.resolve({ organizations: [], hasMore: false, total: null }),
   },
 }))
 

--- a/frontend/src/pages/admin/__tests__/OIDCSettingsPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/OIDCSettingsPage.test.tsx
@@ -32,6 +32,13 @@ vi.mock('../../../services/api', () => ({
   },
 }))
 
+/** One page of organizations, as the API layer returns it since backend #893. */
+const orgPage = (organizations: unknown[], hasMore = false, total: number | null = null) => ({
+  organizations,
+  hasMore,
+  total,
+})
+
 import OIDCSettingsPage from '../OIDCSettingsPage'
 
 function renderWithProviders(ui: React.ReactElement) {
@@ -80,7 +87,7 @@ const fakeOrgs: Organization[] = [
 describe('OIDCSettingsPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    listOrganizationsMock.mockResolvedValue(fakeOrgs)
+    listOrganizationsMock.mockResolvedValue(orgPage(fakeOrgs))
   })
 
   it('shows loading spinner while fetching', () => {

--- a/frontend/src/pages/admin/__tests__/OrganizationsPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/OrganizationsPage.test.tsx
@@ -30,6 +30,13 @@ vi.mock('../../../services/api', () => ({
   },
 }))
 
+/** One page of organizations, as the API layer returns it since backend #893. */
+const orgPage = (organizations: unknown[], hasMore = false, total: number | null = null) => ({
+  organizations,
+  hasMore,
+  total,
+})
+
 let mockAllowedScopes: string[] = ['admin']
 
 vi.mock('../../../contexts/AuthContext', () => ({
@@ -94,7 +101,7 @@ describe('OrganizationsPage', () => {
   })
 
   it('renders heading and description after load', async () => {
-    listOrganizationsMock.mockResolvedValue(fakeOrgs)
+    listOrganizationsMock.mockResolvedValue(orgPage(fakeOrgs))
     renderPage()
     await waitFor(() => {
       expect(screen.getByText('Organizations')).toBeInTheDocument()
@@ -103,7 +110,7 @@ describe('OrganizationsPage', () => {
   })
 
   it('shows org table with data', async () => {
-    listOrganizationsMock.mockResolvedValue(fakeOrgs)
+    listOrganizationsMock.mockResolvedValue(orgPage(fakeOrgs))
     renderPage()
     await waitFor(() => {
       expect(screen.getByText('acme-corp')).toBeInTheDocument()
@@ -118,7 +125,7 @@ describe('OrganizationsPage', () => {
   })
 
   it('shows Add Organization button', async () => {
-    listOrganizationsMock.mockResolvedValue(fakeOrgs)
+    listOrganizationsMock.mockResolvedValue(orgPage(fakeOrgs))
     renderPage()
     await waitFor(() => {
       expect(screen.getByText('Add Organization')).toBeInTheDocument()
@@ -126,7 +133,7 @@ describe('OrganizationsPage', () => {
   })
 
   it('shows empty state when no organizations exist', async () => {
-    listOrganizationsMock.mockResolvedValue([])
+    listOrganizationsMock.mockResolvedValue(orgPage([]))
     renderPage()
     await waitFor(() => {
       expect(screen.getByText('No organizations found')).toBeInTheDocument()
@@ -144,7 +151,7 @@ describe('OrganizationsPage', () => {
   })
 
   it('opens Add Organization dialog', async () => {
-    listOrganizationsMock.mockResolvedValue(fakeOrgs)
+    listOrganizationsMock.mockResolvedValue(orgPage(fakeOrgs))
     renderPage()
     await waitFor(() => expect(screen.getByText('acme-corp')).toBeInTheDocument())
     await userEvent.click(screen.getByRole('button', { name: /add organization/i }))
@@ -152,7 +159,7 @@ describe('OrganizationsPage', () => {
   })
 
   it('opens Edit Organization dialog', async () => {
-    listOrganizationsMock.mockResolvedValue(fakeOrgs)
+    listOrganizationsMock.mockResolvedValue(orgPage(fakeOrgs))
     renderPage()
     await waitFor(() => expect(screen.getByText('acme-corp')).toBeInTheDocument())
     const editBtns = screen.getAllByRole('button', { name: /edit organization/i })
@@ -161,7 +168,7 @@ describe('OrganizationsPage', () => {
   })
 
   it('opens Delete confirmation dialog', async () => {
-    listOrganizationsMock.mockResolvedValue(fakeOrgs)
+    listOrganizationsMock.mockResolvedValue(orgPage(fakeOrgs))
     renderPage()
     await waitFor(() => expect(screen.getByText('acme-corp')).toBeInTheDocument())
     const delBtns = screen.getAllByRole('button', { name: /delete organization/i })
@@ -170,7 +177,7 @@ describe('OrganizationsPage', () => {
   })
 
   it('opens View Members dialog and loads members', async () => {
-    listOrganizationsMock.mockResolvedValue(fakeOrgs)
+    listOrganizationsMock.mockResolvedValue(orgPage(fakeOrgs))
     listOrganizationMembersMock.mockResolvedValue([
       {
         user_id: 'u1',
@@ -193,7 +200,7 @@ describe('OrganizationsPage', () => {
   })
 
   it('creates a new organization via the Add dialog', async () => {
-    listOrganizationsMock.mockResolvedValue(fakeOrgs)
+    listOrganizationsMock.mockResolvedValue(orgPage(fakeOrgs))
     createOrganizationMock.mockResolvedValue({ id: 'new', name: 'newco' })
     renderPage()
     await waitFor(() => expect(screen.getByText('acme-corp')).toBeInTheDocument())
@@ -209,7 +216,7 @@ describe('OrganizationsPage', () => {
   })
 
   it('shows "No organizations found" and allows creation from empty state', async () => {
-    listOrganizationsMock.mockResolvedValue([])
+    listOrganizationsMock.mockResolvedValue(orgPage([]))
     renderPage()
     await waitFor(() => expect(screen.getByText('No organizations found')).toBeInTheDocument())
     await userEvent.click(screen.getByRole('button', { name: /create first organization/i }))
@@ -217,7 +224,7 @@ describe('OrganizationsPage', () => {
   })
 
   it('cancels the Add Organization dialog', async () => {
-    listOrganizationsMock.mockResolvedValue(fakeOrgs)
+    listOrganizationsMock.mockResolvedValue(orgPage(fakeOrgs))
     renderPage()
     await waitFor(() => expect(screen.getByText('acme-corp')).toBeInTheDocument())
     await userEvent.click(screen.getByRole('button', { name: /add organization/i }))
@@ -227,7 +234,7 @@ describe('OrganizationsPage', () => {
   })
 
   it('saves edits via the Edit Organization dialog', async () => {
-    listOrganizationsMock.mockResolvedValue(fakeOrgs)
+    listOrganizationsMock.mockResolvedValue(orgPage(fakeOrgs))
     updateOrganizationMock.mockResolvedValue({})
     renderPage()
     await waitFor(() => expect(screen.getByText('acme-corp')).toBeInTheDocument())
@@ -248,7 +255,7 @@ describe('OrganizationsPage', () => {
 
   it('clearing the IdP binding sends an explicit empty string, not null', async () => {
     // The backend only clears on idp_type === ""; null is silently ignored (#538).
-    listOrganizationsMock.mockResolvedValue(fakeOrgs)
+    listOrganizationsMock.mockResolvedValue(orgPage(fakeOrgs))
     updateOrganizationMock.mockResolvedValue({})
     renderPage()
     await waitFor(() => expect(screen.getByText('acme-corp')).toBeInTheDocument())
@@ -267,7 +274,7 @@ describe('OrganizationsPage', () => {
   })
 
   it('deletes an organization via Delete confirmation dialog', async () => {
-    listOrganizationsMock.mockResolvedValue(fakeOrgs)
+    listOrganizationsMock.mockResolvedValue(orgPage(fakeOrgs))
     deleteOrganizationMock.mockResolvedValue({})
     renderPage()
     await waitFor(() => expect(screen.getByText('acme-corp')).toBeInTheDocument())
@@ -280,7 +287,7 @@ describe('OrganizationsPage', () => {
   })
 
   it('cancels the Delete confirmation dialog', async () => {
-    listOrganizationsMock.mockResolvedValue(fakeOrgs)
+    listOrganizationsMock.mockResolvedValue(orgPage(fakeOrgs))
     renderPage()
     await waitFor(() => expect(screen.getByText('acme-corp')).toBeInTheDocument())
     const delBtns = screen.getAllByRole('button', { name: /delete organization/i })
@@ -292,7 +299,7 @@ describe('OrganizationsPage', () => {
   })
 
   it('closes Members dialog via Close button', async () => {
-    listOrganizationsMock.mockResolvedValue(fakeOrgs)
+    listOrganizationsMock.mockResolvedValue(orgPage(fakeOrgs))
     listOrganizationMembersMock.mockResolvedValue([])
     listRoleTemplatesMock.mockResolvedValue([])
     renderPage()
@@ -308,7 +315,7 @@ describe('OrganizationsPage', () => {
   })
 
   it('opens Add Member dialog from Members dialog', async () => {
-    listOrganizationsMock.mockResolvedValue(fakeOrgs)
+    listOrganizationsMock.mockResolvedValue(orgPage(fakeOrgs))
     listOrganizationMembersMock.mockResolvedValue([])
     listRoleTemplatesMock.mockResolvedValue([
       { id: 'rt-admin', name: 'admin', display_name: 'Administrator', description: 'Full access' },
@@ -329,7 +336,7 @@ describe('OrganizationsPage', () => {
   })
 
   it('cancels Add Member dialog', async () => {
-    listOrganizationsMock.mockResolvedValue(fakeOrgs)
+    listOrganizationsMock.mockResolvedValue(orgPage(fakeOrgs))
     listOrganizationMembersMock.mockResolvedValue([])
     listRoleTemplatesMock.mockResolvedValue([])
     listUsersMock.mockResolvedValue({ users: [] })
@@ -349,7 +356,7 @@ describe('OrganizationsPage', () => {
   })
 
   it('renders existing members in Members dialog', async () => {
-    listOrganizationsMock.mockResolvedValue(fakeOrgs)
+    listOrganizationsMock.mockResolvedValue(orgPage(fakeOrgs))
     listOrganizationMembersMock.mockResolvedValue([
       {
         user_id: 'u1',
@@ -372,7 +379,7 @@ describe('OrganizationsPage', () => {
   })
 
   it('removes a member via Remove member button', async () => {
-    listOrganizationsMock.mockResolvedValue(fakeOrgs)
+    listOrganizationsMock.mockResolvedValue(orgPage(fakeOrgs))
     listOrganizationMembersMock.mockResolvedValue([
       {
         user_id: 'u1',
@@ -399,7 +406,7 @@ describe('OrganizationsPage', () => {
   // ── Phase 2: Identity Provider fields ─────────────────────────────────────
   it('shows Identity Provider column with IdP chip', async () => {
     const orgsWithIdp = [{ ...fakeOrgs[0], idp_type: 'saml', idp_name: 'Okta' }, { ...fakeOrgs[1] }]
-    listOrganizationsMock.mockResolvedValue(orgsWithIdp)
+    listOrganizationsMock.mockResolvedValue(orgPage(orgsWithIdp))
     renderPage()
     await waitFor(() => expect(screen.getByText('acme-corp')).toBeInTheDocument())
     expect(screen.getByText('Identity Provider')).toBeInTheDocument()
@@ -408,7 +415,7 @@ describe('OrganizationsPage', () => {
 
   it('shows IdP chip without name when idp_name is empty', async () => {
     const orgsWithIdp = [{ ...fakeOrgs[0], idp_type: 'ldap', idp_name: null }]
-    listOrganizationsMock.mockResolvedValue(orgsWithIdp)
+    listOrganizationsMock.mockResolvedValue(orgPage(orgsWithIdp))
     renderPage()
     await waitFor(() => expect(screen.getByText('acme-corp')).toBeInTheDocument())
     expect(screen.getByText('LDAP')).toBeInTheDocument()
@@ -417,7 +424,7 @@ describe('OrganizationsPage', () => {
   // ── Rename tests ──────────────────────────────────────────────────────────
 
   it('includes name in update payload when org name is changed', async () => {
-    listOrganizationsMock.mockResolvedValue(fakeOrgs)
+    listOrganizationsMock.mockResolvedValue(orgPage(fakeOrgs))
     updateOrganizationMock.mockResolvedValue({})
     renderPage()
     await waitFor(() => expect(screen.getByText('acme-corp')).toBeInTheDocument())
@@ -441,7 +448,7 @@ describe('OrganizationsPage', () => {
   })
 
   it('shows rename cascade warning when name is changed to a valid value', async () => {
-    listOrganizationsMock.mockResolvedValue(fakeOrgs)
+    listOrganizationsMock.mockResolvedValue(orgPage(fakeOrgs))
     renderPage()
     await waitFor(() => expect(screen.getByText('acme-corp')).toBeInTheDocument())
     const editBtns = screen.getAllByRole('button', { name: /edit organization/i })
@@ -460,7 +467,7 @@ describe('OrganizationsPage', () => {
   })
 
   it('does not include name in update payload when name is unchanged', async () => {
-    listOrganizationsMock.mockResolvedValue(fakeOrgs)
+    listOrganizationsMock.mockResolvedValue(orgPage(fakeOrgs))
     updateOrganizationMock.mockResolvedValue({})
     renderPage()
     await waitFor(() => expect(screen.getByText('acme-corp')).toBeInTheDocument())
@@ -490,7 +497,7 @@ describe('OrganizationsPage', () => {
 
   it('shows member-management UI for the canonical organizations:write scope', async () => {
     mockAllowedScopes = ['organizations:write']
-    listOrganizationsMock.mockResolvedValue(fakeOrgs)
+    listOrganizationsMock.mockResolvedValue(orgPage(fakeOrgs))
     listOrganizationMembersMock.mockResolvedValue([aliceMember])
     listRoleTemplatesMock.mockResolvedValue([
       { id: 'rt-admin', name: 'admin', display_name: 'Administrator' },
@@ -505,7 +512,7 @@ describe('OrganizationsPage', () => {
 
   it('hides member-management UI for the organizations:read scope', async () => {
     mockAllowedScopes = ['organizations:read']
-    listOrganizationsMock.mockResolvedValue(fakeOrgs)
+    listOrganizationsMock.mockResolvedValue(orgPage(fakeOrgs))
     listOrganizationMembersMock.mockResolvedValue([aliceMember])
     listRoleTemplatesMock.mockResolvedValue([
       { id: 'rt-admin', name: 'admin', display_name: 'Administrator' },
@@ -522,7 +529,7 @@ describe('OrganizationsPage', () => {
 
   it('hides Add/Edit/Delete organization controls for the organizations:read scope', async () => {
     mockAllowedScopes = ['organizations:read']
-    listOrganizationsMock.mockResolvedValue(fakeOrgs)
+    listOrganizationsMock.mockResolvedValue(orgPage(fakeOrgs))
     renderPage()
     await waitFor(() => expect(screen.getByText('acme-corp')).toBeInTheDocument())
 
@@ -535,7 +542,7 @@ describe('OrganizationsPage', () => {
 
   it('shows Add/Edit/Delete organization controls for the canonical organizations:write scope', async () => {
     mockAllowedScopes = ['organizations:write']
-    listOrganizationsMock.mockResolvedValue(fakeOrgs)
+    listOrganizationsMock.mockResolvedValue(orgPage(fakeOrgs))
     renderPage()
     await waitFor(() => expect(screen.getByText('acme-corp')).toBeInTheDocument())
 
@@ -545,7 +552,7 @@ describe('OrganizationsPage', () => {
   })
 
   it('blocks save and shows field error when name format is invalid', async () => {
-    listOrganizationsMock.mockResolvedValue(fakeOrgs)
+    listOrganizationsMock.mockResolvedValue(orgPage(fakeOrgs))
     renderPage()
     await waitFor(() => expect(screen.getByText('acme-corp')).toBeInTheDocument())
 
@@ -570,7 +577,7 @@ describe('OrganizationsPage', () => {
   // Regression guard (#623): a failed members load only reset local state via
   // console.error before this fix -- it must also reach the app's telemetry pipeline.
   it('reports a failed members load to telemetry', async () => {
-    listOrganizationsMock.mockResolvedValue(fakeOrgs)
+    listOrganizationsMock.mockResolvedValue(orgPage(fakeOrgs))
     const loadError = new Error('members load failed')
     listOrganizationMembersMock.mockRejectedValue(loadError)
     listRoleTemplatesMock.mockResolvedValue([])

--- a/frontend/src/pages/admin/__tests__/UsersPage.test.tsx
+++ b/frontend/src/pages/admin/__tests__/UsersPage.test.tsx
@@ -38,6 +38,13 @@ vi.mock('../../../services/api', () => ({
   },
 }))
 
+/** One page of organizations, as the API layer returns it since backend #893. */
+const orgPage = (organizations: unknown[], hasMore = false, total: number | null = null) => ({
+  organizations,
+  hasMore,
+  total,
+})
+
 // Default to admin scope so existing tests pass; individual tests can override.
 const useAuthMock = vi.fn(() => ({
   allowedScopes: ['admin'],
@@ -213,7 +220,7 @@ describe('UsersPage', () => {
   it('opens Add User dialog when Add User is clicked', async () => {
     listUsersMock.mockResolvedValue(fakeUsersResponse)
     getUserMembershipsMock.mockResolvedValue([])
-    listOrganizationsMock.mockResolvedValue(fakeOrganizations)
+    listOrganizationsMock.mockResolvedValue(orgPage(fakeOrganizations))
     listRoleTemplatesMock.mockResolvedValue(fakeRoleTemplates)
     renderPage()
     await waitFor(() => expect(screen.getByText('Alice Smith')).toBeInTheDocument())
@@ -224,7 +231,7 @@ describe('UsersPage', () => {
   it('opens Edit User dialog when row edit is clicked', async () => {
     listUsersMock.mockResolvedValue(fakeUsersResponse)
     getUserMembershipsMock.mockResolvedValue([fakeMembership])
-    listOrganizationsMock.mockResolvedValue(fakeOrganizations)
+    listOrganizationsMock.mockResolvedValue(orgPage(fakeOrganizations))
     listRoleTemplatesMock.mockResolvedValue(fakeRoleTemplates)
     renderPage()
     await waitFor(() => expect(screen.getByText('Alice Smith')).toBeInTheDocument())
@@ -257,7 +264,7 @@ describe('UsersPage', () => {
   it('creates a user via Add User dialog', async () => {
     listUsersMock.mockResolvedValue(fakeUsersResponse)
     getUserMembershipsMock.mockResolvedValue([])
-    listOrganizationsMock.mockResolvedValue(fakeOrganizations)
+    listOrganizationsMock.mockResolvedValue(orgPage(fakeOrganizations))
     listRoleTemplatesMock.mockResolvedValue(fakeRoleTemplates)
     createUserMock.mockResolvedValue({ id: 'u-new', email: 'c@example.com', name: 'Carol' })
     renderPage()
@@ -276,7 +283,7 @@ describe('UsersPage', () => {
   it('saves an edited user via Edit User dialog', async () => {
     listUsersMock.mockResolvedValue(fakeUsersResponse)
     getUserMembershipsMock.mockResolvedValue([fakeMembership])
-    listOrganizationsMock.mockResolvedValue(fakeOrganizations)
+    listOrganizationsMock.mockResolvedValue(orgPage(fakeOrganizations))
     listRoleTemplatesMock.mockResolvedValue(fakeRoleTemplates)
     updateUserMock.mockResolvedValue({})
     renderPage()
@@ -296,7 +303,7 @@ describe('UsersPage', () => {
   it('cancels Add User dialog', async () => {
     listUsersMock.mockResolvedValue(fakeUsersResponse)
     getUserMembershipsMock.mockResolvedValue([])
-    listOrganizationsMock.mockResolvedValue(fakeOrganizations)
+    listOrganizationsMock.mockResolvedValue(orgPage(fakeOrganizations))
     listRoleTemplatesMock.mockResolvedValue(fakeRoleTemplates)
     renderPage()
     await waitFor(() => expect(screen.getByText('Alice Smith')).toBeInTheDocument())
@@ -323,7 +330,7 @@ describe('UsersPage', () => {
   it('removes a membership in Edit User dialog', async () => {
     listUsersMock.mockResolvedValue(fakeUsersResponse)
     getUserMembershipsMock.mockResolvedValue([fakeMembership])
-    listOrganizationsMock.mockResolvedValue(fakeOrganizations)
+    listOrganizationsMock.mockResolvedValue(orgPage(fakeOrganizations))
     listRoleTemplatesMock.mockResolvedValue(fakeRoleTemplates)
     removeOrganizationMemberMock.mockResolvedValue({})
     renderPage()
@@ -339,7 +346,7 @@ describe('UsersPage', () => {
   it('shows error alert when create user fails', async () => {
     listUsersMock.mockResolvedValue(fakeUsersResponse)
     getUserMembershipsMock.mockResolvedValue([])
-    listOrganizationsMock.mockResolvedValue(fakeOrganizations)
+    listOrganizationsMock.mockResolvedValue(orgPage(fakeOrganizations))
     listRoleTemplatesMock.mockResolvedValue(fakeRoleTemplates)
     createUserMock.mockRejectedValue(new Error('boom'))
     renderPage()
@@ -376,7 +383,7 @@ describe('UsersPage', () => {
   it('reports a failed role templates load to telemetry', async () => {
     listUsersMock.mockResolvedValue(fakeUsersResponse)
     getUserMembershipsMock.mockResolvedValue([])
-    listOrganizationsMock.mockResolvedValue(fakeOrganizations)
+    listOrganizationsMock.mockResolvedValue(orgPage(fakeOrganizations))
     const loadError = new Error('role templates load failed')
     listRoleTemplatesMock.mockRejectedValue(loadError)
     renderPage()
@@ -392,7 +399,7 @@ describe('UsersPage', () => {
   it('reports a failed "add user to organization" to telemetry', async () => {
     listUsersMock.mockResolvedValue(fakeUsersResponse)
     getUserMembershipsMock.mockResolvedValue([])
-    listOrganizationsMock.mockResolvedValue(fakeOrganizations)
+    listOrganizationsMock.mockResolvedValue(orgPage(fakeOrganizations))
     listRoleTemplatesMock.mockResolvedValue(fakeRoleTemplates)
     createUserMock.mockResolvedValue({ id: 'u-new', email: 'c@example.com', name: 'Carol' })
     const addMemberError = new Error('add member failed')

--- a/frontend/src/services/__tests__/api.test.ts
+++ b/frontend/src/services/__tests__/api.test.ts
@@ -2035,11 +2035,81 @@ describe('ApiClient', () => {
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/organizations', {
         params: { page: 1, per_page: 20 },
       })
-      expect(result).toHaveLength(1)
+      expect(result.organizations).toHaveLength(1)
       // The transform must pass the IdP binding through — dropping it made the
       // binding invisible and un-clearable in the admin UI (#538).
-      expect(result[0].idp_type).toBe('saml')
-      expect(result[0].idp_name).toBe('corp-idp')
+      expect(result.organizations[0].idp_type).toBe('saml')
+      expect(result.organizations[0].idp_name).toBe('corp-idp')
+    })
+
+    // ── The page window (backend #893) ──────────────────────────────────────
+    //
+    // Discarding `pagination` is what let the organization pickers render a
+    // truncated list with nothing to say it was truncated.
+
+    it('carries the server has_more through rather than re-deriving it', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: {
+            organizations: [{ id: 'o1', name: 'org1', display_name: 'Org 1', created_at: '', updated_at: '' }],
+            pagination: { page: 1, per_page: 100, has_more: true, total: 137 },
+          },
+        })
+      const result = await client.listOrganizations(1, 100)
+      expect(result.hasMore).toBe(true)
+      expect(result.total).toBe(137)
+    })
+
+    // The count heuristic this replaces is wrong for exactly this shape: a page
+    // that is completely full but is nonetheless the last one. Trusting the row
+    // count would tell the user to keep searching for rows that do not exist.
+    it('reports a full but final page as complete', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: {
+            organizations: Array.from({ length: 3 }, (_, i) => ({
+              id: `o${i}`, name: `org${i}`, display_name: `Org ${i}`, created_at: '', updated_at: '',
+            })),
+            pagination: { page: 1, per_page: 3, has_more: false, total: 3 },
+          },
+        })
+      const result = await client.listOrganizations(1, 3)
+      expect(result.organizations).toHaveLength(3)
+      expect(result.hasMore).toBe(false)
+    })
+
+    // null ("this axis does not count") and 0 ("none matched") are different
+    // answers and must not collapse into one.
+    it('keeps an uncounted total distinct from a zero total', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { organizations: [], pagination: { page: 1, per_page: 20, has_more: false, total: null } },
+        })
+      expect((await client.listOrganizations()).total).toBeNull()
+
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: { organizations: [], pagination: { page: 1, per_page: 20, has_more: false, total: 0 } },
+        })
+      expect((await client.listOrganizations()).total).toBe(0)
+    })
+
+    // A backend predating #893 sends no pagination at all. A full page is then
+    // the only available evidence of a possible next one — the weaker signal,
+    // which is why it is the fallback and not the rule.
+    it('falls back to the row count when the server sends no pagination', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: {
+            organizations: Array.from({ length: 2 }, (_, i) => ({
+              id: `o${i}`, name: `org${i}`, display_name: `Org ${i}`, created_at: '', updated_at: '',
+            })),
+          },
+        })
+      const result = await client.listOrganizations(1, 2)
+      expect(result.hasMore).toBe(true)
+      // Uncounted, because there was no pagination object to count from — not
+      // zero, which would claim the deployment has no organizations.
+      expect(result.total).toBeNull()
     })
 
     it('searchOrganizations', async () => {
@@ -2055,7 +2125,7 @@ describe('ApiClient', () => {
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/v1/organizations/search', {
         params: { q: 'org', page: 1, per_page: 10 },
       })
-      expect(result).toHaveLength(1)
+      expect(result.organizations).toHaveLength(1)
     })
 
     it('getOrganization', async () => {

--- a/frontend/src/services/api/organizationsApi.ts
+++ b/frontend/src/services/api/organizationsApi.ts
@@ -5,9 +5,64 @@ import { http, encodeSegment } from './http'
 import { sanitizeServerErrorMessage } from '../../utils/errors'
 import type { Organization, OrganizationMemberWithUser } from '../../types'
 
+/**
+ * The largest `per_page` the organization list/search endpoints serve.
+ *
+ * Since backend #893 an over-large `per_page` clamps to this maximum; it used
+ * to be RESET to the default of 20, so asking for 200 returned fewer rows than
+ * asking for 50. Defined here, beside the requests it bounds, so the pages that
+ * want "as many as possible" name one number rather than each picking their own.
+ */
+export const ORGANIZATION_PAGE_MAX = 100
+
+/**
+ * The page window the admin list endpoints return alongside their rows
+ * (swagger: admin.PaginationMeta), added by backend #893.
+ */
+export interface PaginationMeta {
+  page: number
+  per_page: number
+  /**
+   * Whether any rows follow this page. **False if and only if this is the end
+   * of the list**, on every endpoint emitting this shape — including the search
+   * axes, which cannot count and derive it by fetching one row past the page.
+   *
+   * This is the field to read. Do NOT re-derive completeness from the row
+   * count: "the page came back full" is wrong for every list whose length is an
+   * exact multiple of the page size, which reports a phantom extra page.
+   */
+  has_more: boolean
+  /**
+   * Total matching rows across all pages, or **null when the endpoint does not
+   * count** — the search axes have no counting query and send null.
+   *
+   * Deliberately nullable rather than absent: `null` ("not counted") and `0`
+   * ("none matched") are different answers and must not be collapsed.
+   */
+  total: number | null
+}
+
 /** Wire shape of the list/search organizations endpoints (swagger: admin.ListOrganizationsResponse). */
 interface ListOrganizationsResponse {
   organizations?: Record<string, unknown>[]
+  pagination?: PaginationMeta
+}
+
+/** One page of organizations, plus whether anything follows it. */
+export interface OrganizationPage {
+  organizations: Organization[]
+  /**
+   * Whether more organizations exist beyond this page.
+   *
+   * Taken from the server's exact `has_more` when present. The fallback covers
+   * a backend predating #893, which emitted no pagination at all: there, a
+   * completely full page is the only available evidence of a possible next one.
+   * It is the weaker signal by construction — which is why it is the fallback
+   * and not the rule.
+   */
+  hasMore: boolean
+  /** Total across all pages, or null when this endpoint does not count. */
+  total: number | null
 }
 
 // Helper to transform organization from API format to frontend format
@@ -28,25 +83,47 @@ function transformOrganization(org: Record<string, unknown>): Organization {
   }
 }
 
+function toPage(data: ListOrganizationsResponse, perPage: number): OrganizationPage {
+  const organizations = (data.organizations || []).map((org: Record<string, unknown>) =>
+    transformOrganization(org),
+  )
+  const pagination = data.pagination
+  return {
+    organizations,
+    hasMore: pagination ? pagination.has_more : organizations.length >= perPage,
+    total: pagination ? (pagination.total ?? null) : null,
+  }
+}
+
 // Organizations
-export async function listOrganizations(page = 1, perPage = 20): Promise<Organization[]> {
+/**
+ * One page of organizations.
+ *
+ * Returns the page window as well as the rows: discarding it is what let the
+ * organization pickers render a truncated list with nothing to say it was
+ * truncated (backend #893). There is deliberately ONE function per endpoint
+ * rather than a bare-array convenience beside a paged one — two accessors for
+ * one question is how the caller that forgets to ask about completeness gets
+ * written.
+ */
+export async function listOrganizations(page = 1, perPage = 20): Promise<OrganizationPage> {
   const response = await http.get<ListOrganizationsResponse>('/api/v1/organizations', {
     params: { page, per_page: perPage },
   })
-  const orgs = response.data.organizations || []
-  return orgs.map((org: Record<string, unknown>) => transformOrganization(org))
+  return toPage(response.data, perPage)
 }
 
 export async function searchOrganizations(
   query: string,
   page = 1,
   perPage = 20,
-): Promise<Organization[]> {
+): Promise<OrganizationPage> {
   const response = await http.get<ListOrganizationsResponse>('/api/v1/organizations/search', {
     params: { q: query, page, per_page: perPage },
   })
-  const orgs = response.data.organizations || []
-  return orgs.map((org: Record<string, unknown>) => transformOrganization(org))
+  // This axis has no counting query, so `total` is null and `has_more` comes
+  // from the server probing one row past the page.
+  return toPage(response.data, perPage)
 }
 
 export async function getOrganization(id: string): Promise<Organization> {


### PR DESCRIPTION
Follow-up to #803 (which closed #779), now that backend #893 has landed as `2f3f833`.

#803 shipped the organization picker against a backend that could not say whether a list was complete, so it inferred completeness from the row count and said so in a comment. `GET /api/v1/organizations` now answers the question directly, and the client was still throwing the answer away.

## What changed

**`organizationsApi.ts` no longer discards `pagination`.** That discard was the real blocker behind "must not present a silently incomplete list": the backend has always sent a `total` the client dropped on the floor, and now sends `has_more` too.

`listOrganizations` / `searchOrganizations` return `{ organizations, hasMore, total }` instead of a bare array. There is deliberately **one function per endpoint** rather than a paged accessor beside a bare-array convenience — two accessors for one question is how the caller that forgets to ask about completeness gets written, which is the same reasoning that removed the second membership client in #803.

**The picker reads `has_more` instead of guessing.** The heuristic it replaces — "the page came back exactly full" — is not merely imprecise, it is **wrong for every list whose length is an exact multiple of the page size**. A deployment with precisely 100 organizations was told to keep searching for a 101st that does not exist. And on the search axis the count carried no information at all, because that axis cannot count; the server now probes one row past the page to answer honestly.

**`total` distinguishes null from zero.** It is a pointer without `omitempty`, so "this axis does not count" (`null`, both search axes) stays distinguishable from "none matched" (`0`). Collapsing them is the same class of silence the field exists to end, so `toPage` preserves it.

**A fallback for a pre-#893 backend is kept and labelled as the weaker signal.** If no `pagination` object arrives at all, the row count is the only available evidence — which is exactly the situation #803 shipped into. It is the fallback, not the rule, and the comment says which is which.

**`ORGANIZATION_PAGE_MAX` now lives beside the requests it bounds** (`organizationsApi.ts`) rather than in the component, so the number bounding the request and the number the endpoint enforces cannot drift apart. `OrganizationFilter` re-exports it under its existing name; `OIDCSettingsPage` imports it.

**`OIDCSettingsPage` stops asking for 200.** It asked for 200 precisely to get every organization and was silently served 20 — the frontend victim named in #893. It now asks for the maximum and receives up to 100. `OrganizationsPage` and `UsersPage` destructure `.organizations`; neither gained pagination UI, which is a separate piece of work and not claimed here.

## A scoped boundary, checked rather than assumed

`has_more` is on the **admin** pagination shape only. `/v1/modules/search` and `/v1/providers/search` keep their `meta{limit,offset,total}`, where completeness is derivable but by hand. Nothing here touches those, and `PaginationMeta` is deliberately typed against the admin shape rather than presented as a universal envelope.

## Verification

Full suite **154 files / 2415 tests** green (+6 net). `eslint --max-warnings 0` clean, `tsc --noEmit` clean. Nothing reformatted, so `format:check` fails exactly as on `main` (#782).

Every new guard mutation-verified — behaviour reverted in the shipped file, suite re-run, failure confirmed, change restored:

| # | Mutation | Test that failed |
| --- | --- | --- |
| N1 | Discard the server's `has_more` (always "complete") | carries the server has_more through; falls back to the row count |
| N2 | **Re-derive `has_more` from the row count even when the server sent it** | carries the server has_more through; **reports a full but final page as complete** |
| N3 | Collapse an uncounted `total` into `0` | keeps an uncounted total distinct from a zero total |
| N4 | Drop the pre-#893 fallback | falls back to the row count when the server sends no pagination |
| N5 | **Picker re-derives truncation from the row count** | **does not claim truncation on a full page that is the last page**; says so on a short page the server reports as incomplete |
| N6 | Picker never reports truncation | says so when the server reports more beyond this page; says so on a short page |
| N7 | Lower `ORGANIZATION_PAGE_MAX` below what the endpoint serves | asks for the largest page the backend honours; server search |

**N2 and N5 are the ones that matter.** They are the only mutations that distinguish "reads the server's flag" from "counts the rows", and they are pinned from both directions:

- a **full page that is the last page** — the row count says "more", the server says "done";
- a **short page that is not the last page** — the row count says "done", the server says "more".

Both were unexpressible against #803's heuristic, which is why they are new tests rather than adjustments to old ones.

The two page-shape mutations that were previously reported as inert-by-omission are now covered: nothing in this change is kept without a test that fails when it is removed.

## Process note

My first mutation run reported five spurious `PATTERN-NOT-FOUND` results because the script restored files with `git checkout --` while my work was still **uncommitted** — so the first restore reverted the change under test rather than just the mutation. Committing first fixed it, and the table above is from the clean re-run. Worth recording since the same script will be reused: mutation-verify from a committed tree, or the harness silently tests `main`.
