### PR TITLE
fix(admin): read has_more itself, not the presence of the object around it

### DIFF
--- a/frontend/src/services/__tests__/api.test.ts
+++ b/frontend/src/services/__tests__/api.test.ts
@@ -2093,10 +2093,33 @@ describe('ApiClient', () => {
       expect((await client.listOrganizations()).total).toBe(0)
     })
 
-    // A backend predating #893 sends no pagination at all. A full page is then
-    // the only available evidence of a possible next one — the weaker signal,
-    // which is why it is the fallback and not the rule.
-    it('falls back to the row count when the server sends no pagination', async () => {
+    // The shape a backend predating #893 ACTUALLY sent: a pagination object was
+    // always present, it simply had no `has_more` inside it. So a guard on the
+    // object's presence never fires here — it takes the "server knows" branch
+    // and yields undefined, which the non-optional `has_more` type cannot catch.
+    // Reading the field itself is what makes this case answerable at all.
+    it('reports not-more when a pre-#893 backend sends pagination without has_more', async () => {
+      const client = await getApiClient()
+        ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          data: {
+            organizations: Array.from({ length: 2 }, (_, i) => ({
+              id: `o${i}`, name: `org${i}`, display_name: `Org ${i}`, created_at: '', updated_at: '',
+            })),
+            // A full page, and a total that says more exist. Neither is consulted:
+            // guessing from either is the defect #893 built has_more to retire.
+            pagination: { page: 1, per_page: 2, total: 5 },
+          },
+        })
+      const result = await client.listOrganizations(1, 2)
+      expect(result.hasMore).toBe(false)
+      expect(result.total).toBe(5)
+    })
+
+    // Defence in depth for a response with no pagination at all. Unknown reads
+    // as "nothing follows" rather than as a row-count guess dressed up as an
+    // answer, and total stays null — never 0, which would claim the deployment
+    // has no organizations.
+    it('reports not-more when the server sends no pagination object', async () => {
       const client = await getApiClient()
         ; (mockAxiosInstance.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
           data: {
@@ -2106,9 +2129,7 @@ describe('ApiClient', () => {
           },
         })
       const result = await client.listOrganizations(1, 2)
-      expect(result.hasMore).toBe(true)
-      // Uncounted, because there was no pagination object to count from — not
-      // zero, which would claim the deployment has no organizations.
+      expect(result.hasMore).toBe(false)
       expect(result.total).toBeNull()
     })
 

--- a/frontend/src/services/api/organizationsApi.ts
+++ b/frontend/src/services/api/organizationsApi.ts
@@ -54,11 +54,17 @@ export interface OrganizationPage {
   /**
    * Whether more organizations exist beyond this page.
    *
-   * Taken from the server's exact `has_more` when present. The fallback covers
-   * a backend predating #893, which emitted no pagination at all: there, a
-   * completely full page is the only available evidence of a possible next one.
-   * It is the weaker signal by construction — which is why it is the fallback
-   * and not the rule.
+   * The server's `has_more` and nothing else. There is deliberately no row-count
+   * fallback: counting rows cannot distinguish "the last page happened to be
+   * full" from "another page follows", which is wrong for every list whose
+   * length is a multiple of the page size — the guess this field exists to
+   * replace (backend #893).
+   *
+   * A backend predating #893 always sent a `pagination` object too; it simply
+   * had no `has_more` inside it. So guarding on the object's presence would
+   * silently yield `undefined` there rather than falling back, and the type
+   * would not catch it. Absent or non-boolean therefore reads as false: unknown
+   * is reported as "nothing follows", never as a guess dressed up as an answer.
    */
   hasMore: boolean
   /** Total across all pages, or null when this endpoint does not count. */
@@ -83,14 +89,14 @@ function transformOrganization(org: Record<string, unknown>): Organization {
   }
 }
 
-function toPage(data: ListOrganizationsResponse, perPage: number): OrganizationPage {
+function toPage(data: ListOrganizationsResponse): OrganizationPage {
   const organizations = (data.organizations || []).map((org: Record<string, unknown>) =>
     transformOrganization(org),
   )
   const pagination = data.pagination
   return {
     organizations,
-    hasMore: pagination ? pagination.has_more : organizations.length >= perPage,
+    hasMore: pagination?.has_more === true,
     total: pagination ? (pagination.total ?? null) : null,
   }
 }
@@ -110,7 +116,7 @@ export async function listOrganizations(page = 1, perPage = 20): Promise<Organiz
   const response = await http.get<ListOrganizationsResponse>('/api/v1/organizations', {
     params: { page, per_page: perPage },
   })
-  return toPage(response.data, perPage)
+  return toPage(response.data)
 }
 
 export async function searchOrganizations(
@@ -123,7 +129,7 @@ export async function searchOrganizations(
   })
   // This axis has no counting query, so `total` is null and `has_more` comes
   // from the server probing one row past the page.
-  return toPage(response.data, perPage)
+  return toPage(response.data)
 }
 
 export async function getOrganization(id: string): Promise<Organization> {


### PR DESCRIPTION
PR #805 landed the right change with one line resting on an unverified claim about the sibling backend — the same class of error it was fixing.

## The premise that was wrong

`toPage` guards on `pagination ?`, with a comment saying the fallback covers "a backend predating #893, which emitted no pagination at all".

Checked against backend source at `2f3f833^`:

- `ListOrganizationsHandler` emitted `pagination: {page, per_page, total}`
- `SearchOrganizationsHandler` emitted `pagination: {page, per_page}`

`pagination` was **always** present. Only `has_more` was missing.

## What that costs

Guarding on the object never selects the fallback against any real backend version. Against a genuine pre-#893 backend it takes the server-knows branch and yields `undefined` — and `PaginationMeta.has_more` is declared non-optional `boolean`, so TypeScript does not catch it.

The existing test could not see this because it synthesises a response with no `pagination` object at all, a shape no backend has ever sent.

## The change

`hasMore: pagination?.has_more === true` — read the field, not the object around it. Absent or non-boolean reads as false: unknown is reported as "nothing follows" rather than as a row-count guess dressed up as an answer, which is the guess `has_more` exists to retire.

`toPage` no longer needs `perPage`; both call sites drop it.

## Verification

Replaced the unreachable-shape test with the shape that actually existed (`pagination` present, `has_more` absent, a full page and a `total` that both suggest more — neither consulted), plus one for a wholly absent `pagination`.

Mutation-verified: restoring `pagination ? pagination.has_more : false` fails with `expected undefined to be false`. 272 tests pass, `tsc --noEmit` and lint clean.