### PR TITLE
fix(ci): make the E2E release gate actually fire on a release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,10 +296,23 @@ jobs:
     name: E2E (gated/manual)
     runs-on: ubuntu-latest
     needs: [lint, typecheck, unit-test-coverage, build, contract-check]
-    # E2E is a required gate: failures block the release pipeline.
+    # E2E is a required gate: failures block the release pipeline. It is
+    # deliberately NOT run on every pull_request — the full multi-browser
+    # suite takes ~12 minutes, so it is scoped to release time plus a
+    # post-merge safety net on main, not every PR.
+    #
+    # 'workflow_call' below can never be true and never gated anything: a
+    # reusable workflow does not see its own invocation as its event_name, it
+    # inherits the CALLER's (release.yml is triggered by a tag `push`, so
+    # that is what this job saw on every release) -- github.ref is inherited
+    # too, and a tag push's ref is refs/tags/vX.Y.Z, which matched none of
+    # the three branches either. So this job silently skipped on every real
+    # release, and the comment above was false the whole time -- confirmed
+    # against three actual release runs (E2E showing skipped in each). See
+    # sethbacon/terraform-registry-backend#883 for what that let through.
     if: >-
-      github.event_name == 'workflow_dispatch' || github.event_name ==
-      'workflow_call' || github.ref == 'refs/heads/main'
+      github.event_name == 'workflow_dispatch' || github.ref ==
+      'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
The comment on this job has said "failures block the release pipeline" since it was written. That was never true.

## The trap

A reusable workflow does not see its own invocation as `github.event_name` — it inherits the CALLER's. `release.yml` is triggered by a tag `push`, not `workflow_call`, and the tag's `ref` is `refs/tags/vX.Y.Z`, which matched neither of the other two branches (`workflow_dispatch`, `refs/heads/main`) either. So the job silently skipped on every real release.

Confirmed against three actual release runs — `31750886940`, `31776364083`, `31820134625` — E2E shows `skipped` in all three, with every job it `needs` (lint, typecheck, build, unit-test-coverage, contract-check) green. So the skip was the `if:` condition itself, not a starved dependency.

## Why this mattered

`terraform-registry-backend#883` — a foreign key aimed at the wrong schema, breaking module publish on any deployment where the identity schema exists — reproduced in this suite for four straight days on direct pushes to `main`. It was never caught before a release, because the release path itself never ran the one test that would have caught it.

## The fix

Detect a release by what one actually looks like from inside this job — `startsWith(github.ref, 'refs/tags/v')` — in place of the `workflow_call` branch, which can never be true for any caller and never gated anything.

`workflow_dispatch` and the direct-push-to-`main` branches are untouched. This job stays deliberately out of the `pull_request` path — the full multi-browser suite takes ~12 minutes and was designed to run at release time, not on every PR (confirmed with the repo owner).

## Verification

YAML parses; `actionlint` clean locally. The tag-push branch cannot be exercised without an actual release — I did not force one to test this. Confirmation is the next real release: E2E should show as executed (not skipped) inside that run, and I will check it.