### PR TITLE
build(node): pin the builder back to Node 24 and fail on engine mismatch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -90,6 +90,12 @@ updates:
       - docker
     commit-message:
       prefix: "chore(deps)"
+    ignore:
+      # The node builder major is tied to package.json `engines`; Dependabot has
+      # no visibility of that, and #547 silently moved it 24 -> 26. Digest and
+      # minor updates still flow. Raise the major here and in `engines` together.
+      - dependency-name: "node"
+        update-types: ["version-update:semver-major"]
     cooldown:
       default-days: 7
 

--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,1 +1,4 @@
 legacy-peer-deps=true
+# Without this npm only WARNS on an engines mismatch and builds anyway, which is
+# how the builder image silently ran two majors ahead of `engines` for weeks (#547).
+engine-strict=true

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,7 +1,10 @@
 # Multi-stage Dockerfile for Terraform Registry Frontend
 
 # Stage 1: Build the React application
-FROM node:26-alpine@sha256:aadf416b2cdce311a8811ba3f0608a61b77dbf997500e2eafe781b51f6a0b019 AS builder
+# Must stay on the major declared in package.json `engines` (and in
+# @4cloudguru/cloud-suite-ui). .npmrc sets engine-strict=true, so a mismatch
+# fails this build instead of printing an EBADENGINE warning nobody reads.
+FROM node:24-alpine@sha256:d32cdf619f63fe0471182d08996dd516c6275bb5fd31ae06e55a570bd9e1ad43 AS builder
 
 # VITE_MODE controls the Vite build mode.
 # Use "development" to enable the Dev Login button for E2E/staging environments.


### PR DESCRIPTION
`npm ci` in the frontend image has been printing this on every build since 2026-07-12:

```
npm warn EBADENGINE   package: 'terraform-registry-frontend@2.23.1',
npm warn EBADENGINE   required: { node: '>=24.0.0 <25' },
npm warn EBADENGINE   current: { node: 'v26.7.0', npm: '11.19.0' }
```

## How it happened

```
2026-05-22  #312  build(node): upgrade to Node 24 LTS (Krypton)   -> engines <25 + node:24-alpine
2026-07-10  #510  pin builder stage to a digest                   -> still node:24
2026-07-12  #547  bump node from 24-alpine to 26-alpine           <-- two majors, engines untouched
2026-08-18  #808  bump node digest e88a35b -> aadf416             -> digest-only within 26
```

The deliberate "Node 24 LTS" decision in #312 was overwritten by Dependabot's **docker** updater, which bumps image tags across majors with nothing tying it to `engines`. `EBADENGINE` is only a warning unless `engine-strict` is set, so CI stayed green and it went unnoticed for five weeks.

`@4cloudguru/cloud-suite-ui@0.9.1` (the newest published) also declares `>=22.0.0 <25`, so adopting Node 26 is not simply a matter of widening `engines` here -- the shared package would have to be released first.

## Changes

1. **Builder pinned back to `node:24-alpine`**, at the current digest `d32cdf61...` (not the stale July one, so patches come with it).
2. **`engine-strict=true`** in `frontend/.npmrc` -- the mismatch now fails the build instead of warning.
3. **Docker updater ignores node MAJOR bumps.** Digest and minor updates still flow; the major gets raised here and in `engines` together, deliberately.

## Verified locally

Both directions, against this exact lockfile:

| | |
|---|---|
| `npm ci` on `node:24-alpine` + engine-strict | **succeeds** -- Node v24.19.0, 762 packages |
| `npm ci` on `node:26-alpine` + engine-strict | **fails** -- `npm error code EBADENGINE`, exit 1 |

Full `docker build` of this Dockerfile: the builder stage completes (`added 762 packages`, `3896 modules transformed`, `built in 1.44s`). It then failed locally at stage-1's `apk upgrade` with exit 99 -- a network/TLS failure on my machine in a step this PR does not touch, which fails the same way on `main` here. CI has working egress, so that step is expected to pass there.

## Scope note

The runtime image is `nginx`; Node only builds. So this was "built with an undeclared toolchain major", not "running on unsupported Node" -- worth fixing, but it was never a production runtime exposure.
