### PR TITLE
ci(deps): allow patch/minor updates to @4cloudguru/cloud-suite-ui

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,9 +27,13 @@ updates:
         patterns:
           - "*"
     ignore:
-      # Private, released and version-pinned in lockstep with the suite; not
-      # auto-bumped here (resolved via the registry above only).
+      # Public on npmjs and peer-only (zero runtime deps), so patch/minor can
+      # flow like any other dependency — nothing else would ever surface a fix
+      # in the shared UI here. Majors stay manual because its peerDependencies
+      # pin the react/MUI/react-router ranges this app has to satisfy; a
+      # react-router major already broke this pin once (#643).
       - dependency-name: "@4cloudguru/*"
+        update-types: ["version-update:semver-major"]
       # Major React/MUI bumps require manual migration work.
       - dependency-name: "react"
         update-types: ["version-update:semver-major"]


### PR DESCRIPTION
`@4cloudguru/cloud-suite-ui` is currently ignored outright by the npm updater, so nothing will ever surface an update to it. The stated reason no longer holds.

## The rule says something that is not true any more

```yaml
# Private, released and version-pinned in lockstep with the suite; not
# auto-bumped here (resolved via the registry above only).
- dependency-name: "@4cloudguru/*"
```

- **"Private"** -- it is public on npmjs. The Dockerfile already says so: *"the suite UI dependency is public on npmjs and needs no auth"*.
- **"resolved via the registry above only"** -- there is no `registries:` block in this file. Verified from the lockfile: `resolved` is `https://registry.npmjs.org/...`, and its `integrity` matches the published tarball exactly.

## Why this matters

Nothing else would tell us about an update:

- Dependabot is told to ignore it
- cloud-suite-ui has **no consumer-bump automation** (no dispatch workflow)
- there is **no version-parity check** between this repo and terraform-state-manager-frontend

"Pinned in lockstep with the suite" is therefore a manual process with zero enforcement. Today we sit on 0.9.0 while 0.9.1 is `latest`. That specific gap is harmless -- I diffed both tarballs and only the `version` field in package.json differs, `dist/` is byte-identical (0.9.1 was a CI-only fix) -- but a 0.9.2 carrying a real fix would be just as invisible.

## The change

Narrow the ignore to **majors only**, matching how this same file already treats react, react-dom and MUI:

```yaml
- dependency-name: "@4cloudguru/*"
  update-types: ["version-update:semver-major"]
```

Patch/minor flow; majors stay manual. Majors are the right thing to hold, because the package is **peer-only with zero runtime dependencies** and its `peerDependencies` pin the ranges this app must satisfy:

```
react ^19, react-dom ^19, @mui/* ^9, @emotion/* ^11,
react-router-dom ^6 || ^7, i18next ^24 || ^26, react-i18next ^15 || ^17
```

That coupling is not hypothetical -- weekly-security.yml already documents a react-router major breaking this pin (#643).

## Note

If "lockstep" was meant to keep both frontends on the *same* version at all times, this weakens that, since a patch could land in one repo first. Nothing enforces that today and the two deploy independently, so I do not think it holds -- but it is a release-policy call worth confirming rather than assuming.
