### PR TITLE
ci(replay): check out azure-pipelines-release-docs

### DIFF
--- a/.github/workflows/signature-replay.yml
+++ b/.github/workflows/signature-replay.yml
@@ -196,6 +196,20 @@ jobs:
             persist-credentials: false,
           }
 
+      # The THIRD ADO extension, and today a scaffold: it has no Tasks/ tree, so
+      # scope.json gives it a signature-free kind and no `ado-extension`
+      # signature is pointed at an empty task surface (that would be exit 2, and
+      # exit 2 is could-not-run, never clean). It is in SIGNATURE_SCOPE all the
+      # same, and in scope.json but absent here is exit 2 for the whole job
+      # rather than a quieter run.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          {
+            repository: sethbacon/azure-pipelines-release-docs,
+            path: suite/azure-pipelines-release-docs,
+            persist-credentials: false,
+          }
+
       # Overwrite this repo's sibling copy with the commit under test, so the
       # replay reads the PR's code and not origin/main's. Guarded because
       # `github.event.repository` is absent on schedule events — the path would


### PR DESCRIPTION
## What

Adds one `actions/checkout` step for `sethbacon/azure-pipelines-release-docs` at
`suite/azure-pipelines-release-docs`.

## Why now, and why this half first

`release-docs-ext` is being added to `SIGNATURE_SCOPE` in
sethbacon/security-orchestration#55. `load_scope` raises a `GateError` when a
scoped repo's path is not a directory, and the replay contract is explicit that
**exit 2 is could-not-run, which must never be read as clean** — so the required
`replay` check goes red in every host the instant `scope.json` names a repo the
host does not check out.

This is a distributed migration across the estate, and the order is fixed:

1. **every host's checkout lands first** — this PR. An extra checked-out
   directory that `scope.json` does not list is harmless and ignored, so merging
   this on its own changes nothing about what the gate concludes.
2. **`scope.json` lands last** — sethbacon/security-orchestration#55.

Getting it backwards blocks every PR in the estate at once. It has happened
twice, most recently when `pipeline-task-ado` went into scope ahead of the host
checkouts.

## Why the step was copied rather than templated

The new step is a copy of **this file's own** `azure-pipelines-packer` step, so
it inherits this repo's action SHA pin, its version comment and its mapping
style (flow vs block, and key order). One block templated across every host
would not survive contact: `azure-pipelines-terraform` pins
`actions/checkout` v6.0.3 where the rest pin v7.0.1, and a SHA whose trailing
version comment disagrees is exactly what zizmor's `ref-version-mismatch` audit
fires on.

## Verification

`scope.json` and all 18 copies of `signature-replay.yml` (this repo's, the 15
other hosts', the central copy and the onboarding template) were parsed with a
real YAML parser and asserted to agree: the set of `suite/` checkout paths
equals the scoped-repo set, every checkout carries `persist-credentials: false`,
no path or slug is duplicated, and the only token-bearing checkout in the
checkout job is the private `sethbacon/security-orchestration`. The checker was
falsified first — dropping a repo, duplicating a block, removing a
`persist-credentials`, putting a token on a public checkout and pointing a path
at the wrong slug each reddened only its own assertion, and the unmutated files
passed.

No AI attribution; no repo settings touched.
