### PR TITLE
ci: check that release-please can read the commit a PR will create

### DIFF
--- a/.github/commit-message-check/package-lock.json
+++ b/.github/commit-message-check/package-lock.json
@@ -1,0 +1,70 @@
+{
+  "name": "commit-message-check",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "commit-message-check",
+      "version": "0.0.0",
+      "dependencies": {
+        "@conventional-commits/parser": "0.4.1"
+      }
+    },
+    "node_modules/@conventional-commits/parser": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@conventional-commits/parser/-/parser-0.4.1.tgz",
+      "integrity": "sha512-H2ZmUVt6q+KBccXfMBhbBF14NlANeqHTXL4qCL6QGbMzrc4HDXyzWuxPxPNbz71f/5UkR5DrycP5VO9u7crahg==",
+      "license": "ISC",
+      "dependencies": {
+        "unist-util-visit": "^2.0.3",
+        "unist-util-visit-parents": "^3.1.1"
+      }
+    },
+    "node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
+    "node_modules/unist-util-is": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.1.0.tgz",
+      "integrity": "sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.3.tgz",
+      "integrity": "sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^4.0.0",
+        "unist-util-visit-parents": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.1.1.tgz",
+      "integrity": "sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    }
+  }
+}

--- a/.github/commit-message-check/package.json
+++ b/.github/commit-message-check/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "commit-message-check",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Parses the commit a pull request would squash into main, using the parser release-please itself resolves.",
+  "dependencies": {
+    "@conventional-commits/parser": "0.4.1"
+  }
+}

--- a/.github/commit-message-check/verify.mjs
+++ b/.github/commit-message-check/verify.mjs
@@ -1,0 +1,73 @@
+// Fails a pull request whose merge commit release-please would not be able to
+// read. A message its parser rejects is dropped in silence: no changelog entry,
+// no version bump, no BREAKING CHANGE footer, and no later run recovers it.
+import fs from 'node:fs';
+import { parser } from '@conventional-commits/parser';
+
+const commits = fs.readFileSync(process.argv[2] ?? 'commits.ndjson', 'utf8')
+  .split('\n').filter(Boolean).map(line => JSON.parse(line));
+
+// Mirrors this repository's squash settings, COMMIT_OR_PR_TITLE and
+// COMMIT_MESSAGES: a lone commit keeps its own subject and body, otherwise
+// GitHub takes the PR title and lists the commit messages. Merge commits are
+// left out of the body.
+const authored = commits.filter(commit => commit.parents <= 1);
+const source = authored.length ? authored : commits;
+const lone = commits.length === 1;
+const [subject, ...rest] = source[0].message.split('\n');
+const header = `${lone ? subject : process.env.PR_TITLE} (#${process.env.PR_NUMBER})`;
+const body = lone
+  ? rest.join('\n').trim()
+  : source.map(commit => `* ${commit.message}`).join('\n\n');
+const message = body ? `${header}\n\n${body}` : header;
+
+const rejects = text => {
+  try {
+    parser(text);
+    return null;
+  } catch (err) {
+    return err;
+  }
+};
+
+const err = rejects(message);
+if (!err) {
+  console.log(`OK: release-please can read the squash of this PR's ${commits.length} commit(s).`);
+  process.exit(0);
+}
+
+// Re-parse growing prefixes so the report can name the line that breaks it.
+const lines = message.split('\n');
+let culprit = null;
+for (let i = 1; i < lines.length && culprit === null; i++) {
+  if (rejects(lines.slice(0, i + 1).join('\n'))) culprit = lines[i];
+}
+
+const detail = String(err.message).split('\n')[0];
+fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, [
+  '### This PR would merge as a commit release-please cannot read',
+  '',
+  'release-please parses commits with `@conventional-commits/parser`, a strict',
+  'reading of the Conventional Commits grammar. It rejects the message this PR',
+  'would squash into `main`:',
+  '',
+  '```', detail, '```',
+  ...(culprit ? ['', 'The first line it cannot get past:', '', '```', culprit, '```'] : []),
+  '',
+  'A commit it cannot parse contributes nothing: no changelog entry, no version',
+  'bump, and no `BREAKING CHANGE:` footer. release-please logs `commit could not',
+  'be parsed`, reports success, and moves on -- and every later run re-reads the',
+  'same commit and skips it again, so the change never reaches a changelog.',
+  '',
+  'The usual cause is a body line that **starts** with `name(`. The grammar reads',
+  'that as a structured token, so its brackets have to be flat and closed: a line',
+  'opening with `WithArgs(pq.Array(...))` voids the commit, while the same text one',
+  'word further along the line is ordinary prose and parses. Reflow the line so it',
+  'does not begin with the call, or drop the inner brackets.',
+  '',
+  'Fix the commit message on the branch, not the PR description -- this repository',
+  'squashes with `COMMIT_MESSAGES`, so the body comes from the commits themselves.',
+].join('\n') + '\n');
+
+console.log(`::error::release-please cannot parse the commit this PR would create: ${detail}`);
+process.exit(1);

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -126,3 +126,27 @@ updates:
           - "*"
     cooldown:
       default-days: 7
+
+  # ---------------------------------------------------------------------------
+  # npm (.github/commit-message-check: the parser the PR gate shares with
+  # release-please)
+  # ---------------------------------------------------------------------------
+  # The gate is only meaningful while it parses the way release-please does, so
+  # these bumps want checking against release-please's own dependency rather
+  # than merging on green.
+  - package-ecosystem: npm
+    directory: /.github/commit-message-check
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: UTC
+    labels:
+      - dependencies
+      - github-actions
+    commit-message:
+      prefix: "chore(ci)"
+    groups:
+      commit-message-check:
+        patterns:
+          - "*"

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -203,3 +203,55 @@ jobs:
 
           echo "::error::This PR declares $total breaking changes; the squash keeps only the first. See the job summary."
           exit 1
+
+  # ── The merged commit has to be readable by release-please ─────────────
+  # release-please chooses what to release by parsing the commits on main
+  # with a strict reading of the Conventional Commits grammar. A message it
+  # cannot parse is not an error to it: it logs `commit could not be parsed`
+  # at debug level, reports success, and drops the commit. That change then
+  # gets no changelog entry and no version bump, and never will -- every
+  # later run re-reads the same commit and skips it again.
+  #
+  # This is not hypothetical. terraform-state-manager-backend#405, a
+  # dependency migration that cleared seven advisories, merged with a body
+  # line that happened to begin with `WithArgs(pq.Array(...))`. The grammar
+  # reads a line starting with `name(` as a structured token, so its
+  # brackets have to be flat and closed, and nested ones void the whole
+  # commit. The same text one word further along the line is ordinary prose
+  # and parses cleanly. Whether that release got cut came down to where the
+  # paragraph wrapped.
+  #
+  # Its sibling repository made the identical change and released normally,
+  # on the same config and the same action version. Nothing in CI could tell
+  # the two apart, because a PR title check reads only the title and both
+  # titles were correct.
+  release-please-can-read-the-commit:
+    name: release-please can read the merged commit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install the parser release-please uses
+        working-directory: .github/commit-message-check
+        run: npm ci
+
+      - name: Parse the commit this PR would squash into main
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/commits" \
+            --jq '.[] | {sha: .sha, message: .commit.message, parents: (.parents | length)}' \
+            > commits.ndjson
+
+          node .github/commit-message-check/verify.mjs commits.ndjson

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ deployments/certs/
 frontend/vite.config.js
 frontend/vite.config.d.ts
 frontend/*.tsbuildinfo
+
+# Node (CI tooling only, under .github/; the lockfile itself is tracked)
+node_modules/


### PR DESCRIPTION
Adds a job to `pr-checks.yml` that rebuilds the commit this PR would squash into `main` and parses it with the parser release-please actually uses, failing if release-please would not be able to read it.

## Why

`terraform-state-manager-backend#405` — a dependency migration that cleared seven advisories — merged with a correct title, a correct type, and a `deps` section in its release config that maps to `### Dependencies`. No release was cut, and the run reported success:

```
Considering: 11 commits
commit could not be parsed: c9502d6 deps: migrate off lib/pq to jackc/pgx (#405)
No user facing commits found since 9d74a52 - skipping
```

An unparsed commit is lost **permanently** — later runs re-read the same commit and skip it again, so it never reaches a changelog.

## What actually breaks it

`@conventional-commits/parser` reads a body line that **starts** with `name(` as a structured token, so those brackets have to be flat and closed. Measured:

| body text | verdict |
| --- | --- |
| line starts with `WithArgs(pq.Array(...))` | rejected — `unexpected token '(' ... valid tokens [)]` |
| line starts with `s(` | rejected — `unexpected token EOF ... valid tokens [)]` |
| line starts with `foo(bar) here.` | parses |
| **same nested text one word further along the line** | parses |

So that commit failed because of where its paragraph happened to wrap. Its sibling repository made the identical change and released normally, on the same config and the same action version. Nothing in CI could distinguish them: a PR title check reads only the title, and both titles were correct.

## What the job does

Composes the prospective squash message from this repository's own merge settings (`COMMIT_OR_PR_TITLE` + `COMMIT_MESSAGES`), then parses it with `@conventional-commits/parser@0.4.1`, the version release-please resolves. On failure it names the line the parser cannot get past, because the offending text is usually nowhere near the commit type.

The parser is installed with `npm ci` from a lockfile under `.github/`, not by an ad-hoc install, so the whole closure is pinned by integrity hash rather than one package being pinned by version while its two `unist-*` dependencies float. Dependabot watches the directory.

## Verification

The composition was checked against two real merged commits and reproduces both **byte for byte**, including GitHub leaving merge commits out of the body:

| PR | commits | composed == merged | verdict |
| --- | --- | --- | --- |
| `terraform-state-manager-backend#405` | 1 | yes | fails, names the offending line |
| `terraform-registry-backend#910` | 3, one a merge | yes | passes |

It was then proven in CI, both ways, on `terraform-state-manager-backend#407`: a temporary commit whose body line opened with the nested call turned the job red with

```
release-please cannot parse the commit this PR would create: unexpected token '(' at 41:18, valid tokens [)]
```

An earlier probe with the same text placed mid-line passed, which is how the rule above was found.

This is one of 13 identical changes across the repositories that use release-please.
