### PR TITLE
chore(ci): converge every shared-workflow pin on v1.6.1

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -32,7 +32,7 @@ concurrency:
 
 jobs:
   workflow-security:
-    uses: 4cloudguru/shared-workflows/.github/workflows/workflow-security.yml@2279e55c6318846f60f0c8ffcbadbeb9317e5fb5 # v1.0.0
+    uses: 4cloudguru/shared-workflows/.github/workflows/workflow-security.yml@8b7215beac6420881d20d52f9b096edff4238ec9 # v1.6.1
 
   # Second gate, same family: zizmor audits workflow SECURITY, this audits
   # workflow HARDENING -- pins labelled, jobs bounded by a timeout,
@@ -45,6 +45,6 @@ jobs:
   # shared-workflows at that commit, so this repo cannot weaken its own gate by
   # editing a local copy -- there is no local copy.
   workflow-hardening:
-    uses: 4cloudguru/shared-workflows/.github/workflows/workflow-hardening.yml@bc0eaaec5d6f5cf632ef862ff7475da928e32466 # v1.2.0
+    uses: 4cloudguru/shared-workflows/.github/workflows/workflow-hardening.yml@8b7215beac6420881d20d52f9b096edff4238ec9 # v1.6.1
     with:
-      script-ref: bc0eaaec5d6f5cf632ef862ff7475da928e32466
+      script-ref: 8b7215beac6420881d20d52f9b096edff4238ec9


### PR DESCRIPTION
Points every `4cloudguru/shared-workflows` pin at **one** commit — [`v1.6.1`](https://github.com/4cloudguru/shared-workflows/releases/tag/v1.6.1) — with a label that is **true**.

## Why the pins diverged

The shared definitions moved six times today, each release fixing something a caller had exposed:

| release | what it fixed |
| --- | --- |
| v1.1.0 | `go-install` retry — a module-proxy read had failed a required check |
| v1.2.0 | the hardening gate, made portable (ADO per-task check no longer universal) |
| v1.3.0 | matcher fitted to one repo's formatting reported a **false failure** |
| v1.4.0 | actionlint was installed by **curl piped into bash, unverified** |
| v1.5.0 | per-task install found by declaration site, not by one filename |
| v1.6.0 | npm matched **inside quoted strings** — remediation advice read as an install |
| v1.6.1 | checker ran as `.cjs` so it works in `"type": "module"` callers |

Repos adopted mid-stream, so callers ended up spread across four pins. **Pin parity requires every caller of a workflow to agree** — the signature that enforces it reports disagreement, not staleness, because a repo deliberately held back is a decision while N repos disagreeing is drift.

## A mislabel this fixes — one I introduced

Three repos carried `# v1.2.0` on a **v1.5.0** SHA. The generator that wrote the gate block hardcoded the label in its template while the SHA came from a variable, so the two drifted apart the moment the shared repo moved.

That is exactly the defect this programme has been correcting in other repos — `dependency-review-action@a1d282b3` labelled `# v4` when it is v5.0.0 — committed by the tooling doing the correcting.

The label and the SHA now come from **the same pair**, and the script verifies after writing that every `uses:` pin, every `script-ref`, and every label agree. The generator no longer accepts a SHA without being told which release it is.
