### PR TITLE
chore(ci): pick up report and log redaction in the shared signature-replay

### DIFF
--- a/.github/workflows/signature-replay.yml
+++ b/.github/workflows/signature-replay.yml
@@ -49,7 +49,7 @@ concurrency:
 
 jobs:
   replay:
-    uses: 4cloudguru/shared-workflows/.github/workflows/signature-replay.yml@f5d5c746c3d8baa5b66674057ec1d6ebd34c30d2 # v1.8.0
+    uses: 4cloudguru/shared-workflows/.github/workflows/signature-replay.yml@0a0281d388c7f84057e2681bcf62bec217b94542 # v1.9.0
     # Exactly one secret, named. NOT `secrets: inherit`.
     secrets:
       SUITE_READ_APP_KEY: ${{ secrets.SUITE_READ_APP_KEY }}


### PR DESCRIPTION
v1.8.0 → **v1.9.0**. The shared signature-replay now **redacts its report and its log** before publishing either.

## What this repository has been publishing

`replay.py` produces a per-issue map of the estate's **known-defective, not-yet-fixed** sites across fifteen repositories, derived from a ledger in the **private** `security-orchestration` repo.

This repository is **public**. Actions artifacts inherit **repository** read access, and there is no per-artifact ACL. The step log is public too, and `replay.py`'s human render prints every `REGRESSED` and `UNADDRESSED` site to stdout.

Measured on the pilot run: **243 sites across 92 lists** were in the raw artifact.

## Both surfaces, or neither

Redacting only the artifact would move the same data from one world-readable surface to another. So stdout is captured to a file rather than printed, and only the redacted render is echoed. Verified on the pilot: **zero** `REGRESSED`/`UNADDRESSED` lines reached the public log.

## What survives

`signature_id`, `ran_in`, `skipped`, `caveats`, per-set **counts**, `failed`, `exit`.

A green `replay` is worth nothing until you can see which signatures ran and what they **skipped** — a signature that enumerated nothing exits clean and looks exactly like one that enumerated everything and found nothing. That evidence is kept in full.

## It fails closed, and it does not change the verdict

A report the redactor cannot redact safely **exits 1 and fails the job** rather than publishing an unredacted one. The replay's own exit code still decides the check.

The redactor lives in `security-orchestration` beside `replay.py`, with a nine-case mutation self-test in that repo's harness. No caller needs a copy.
