### PR TITLE
ci: count breaking-change declarations the way release-please counts them

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -143,6 +143,27 @@ jobs:
   # dropped in silence: the change ships with no changelog entry, no upgrade
   # note, and nothing failing to say so.
   #
+  # WHAT COUNTS is release-please's rule, not the spec's, and the two spellings
+  # of the token are NOT symmetric there. Verified against release-please
+  # 17.11.1's own parser rather than its documentation: `BREAKING CHANGE:`, with
+  # a space, is read only at the START of a line, while the hyphenated spelling
+  # is ALSO matched by an unanchored regex over the commit body -- mid-sentence,
+  # indented, inside a fenced code block, even inside a longer word -- with the
+  # remainder of that line taken as the description.
+  #
+  # This guard used to count only line-anchored matches, so it UNDER-counted
+  # against release-please and passed commits release-please treats as breaking.
+  # abacdb5 in azure-pipelines-terraform, the commit that ADDED the guard there,
+  # is the case: a sentence in its body NAMING the hyphenated spelling made
+  # release-please propose a MAJOR bump over 1.14.4 with a changelog entry
+  # reading "` spelling". The guard counted it 0.
+  #
+  # So the count below is release-please's count -- no more, and no less, since a
+  # guard that rejects legitimate prose is one people route around and then
+  # delete. On top of it the guard rejects a hyphenated token found off the start
+  # of a line at all: that is never a declaration anybody WROTE, and it always
+  # buys a major version bump nobody asked for.
+  #
   # This is not hypothetical. terraform-registry-backend v4.0.0 shipped two
   # undocumented breaking changes this way -- including one that breaks CI
   # tokens -- and terraform-state-manager-backend 3.1.0 lost three before the
@@ -195,14 +216,47 @@ jobs:
 
           total=0
           report=""
+          strays=0
+          stray_report=""
           while IFS= read -r line; do
             [ -n "$line" ] || continue
             sha=$(jq -r '.sha' <<<"$line")
             msg=$(jq -r '.msg' <<<"$line")
             subject=$(head -n1 <<<"$msg")
 
-            # Spec allows both spellings of the footer token.
-            footers=$(grep -cE '^BREAKING[ -]CHANGE:' <<<"$msg" || true)
+            # release-please recognises the two spellings of the token by
+            # DIFFERENT rules, and they are not interchangeable. Verified
+            # against release-please 17.11.1's own parser rather than its docs:
+            #
+            #   `BREAKING CHANGE:`, with a space, counts only where the
+            #   Conventional Commits grammar sees a footer -- at the START of a
+            #   line, with no leading whitespace. Mid-sentence or indented it is
+            #   prose, and release-please ignores it.
+            #
+            #   The hyphenated spelling counts EVERYWHERE. release-please's
+            #   postProcessCommits runs an UNANCHORED regex over the commit body
+            #   and takes the rest of the matching line as the description, so it
+            #   fires mid-sentence, indented, inside a fenced code block, and
+            #   even inside a longer word such as NON-BREAKING-CHANGE:.
+            #
+            # Both are read out of the BODY, so the same token in the subject
+            # line is not a declaration.
+            #
+            # Counting only line-anchored matches is what let abacdb5 through:
+            # a sentence NAMING the hyphenated spelling was read as a real
+            # declaration, and release-please proposed a MAJOR bump whose
+            # changelog entry was the remainder of that sentence.
+            body=$(tail -n +2 <<<"$msg")
+            spaced=$(grep -cE '^BREAKING CHANGE:' <<<"$body" || true)
+            # Occurrences, not lines. The squash concatenates every body into one
+            # and that regex is not global, so a second match on the same line is
+            # dropped exactly as surely as one in a later commit.
+            hyphenated=$(grep -oF 'BREAKING-CHANGE:' <<<"$body" | grep -c '' || true)
+            anchored=$(grep -cE '^BREAKING-CHANGE:' <<<"$body" || true)
+            # A hyphenated token anywhere but the start of a line is a
+            # declaration nobody WROTE and release-please acts on regardless.
+            stray=$((hyphenated - anchored))
+            footers=$((spaced + hyphenated))
             if [ "$footers" -gt 0 ]; then
               # A footer wins over the header's `!`, so they are not additive.
               n="$footers"
@@ -215,12 +269,41 @@ jobs:
             if [ "$n" -gt 0 ]; then
               report="${report}  ${sha}  ${n} declaration(s)  ${subject}"$'\n'
             fi
+            if [ "$stray" -gt 0 ]; then
+              strays=$((strays + stray))
+              stray_report="${stray_report}  ${sha}  ${stray} off the start of a line  ${subject}"$'\n'
+            fi
             total=$((total + n))
           done < commits.ndjson
 
           echo "Breaking-change declarations in this PR: $total"
           if [ -n "$report" ]; then
             printf 'Where they are:\n%s' "$report"
+          fi
+
+          if [ "$strays" -gt 0 ]; then
+            printf 'Not written as a footer:\n%s' "$stray_report"
+            {
+              echo "### A breaking change nobody declared"
+              echo
+              echo "This pull request carries **$strays** hyphenated breaking-change"
+              echo "token(s) somewhere other than the start of a line. release-please"
+              echo "matches that spelling ANYWHERE in a commit body -- mid-sentence,"
+              echo "indented, inside a fenced code block -- and takes the rest of the"
+              echo "line as the description. Prose that merely NAMES the token therefore"
+              echo "forces a MAJOR version bump and writes a changelog entry out of the"
+              echo "remainder of the sentence."
+              echo
+              echo '```'
+              printf '%s' "$stray_report"
+              echo '```'
+              echo
+              echo "To write ABOUT the token, drop the colon, or use the spaced spelling,"
+              echo "which release-please reads only at the start of a line. To declare a"
+              echo "real breaking change, put the footer at the start of its own line."
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::error::This PR has $strays breaking-change token(s) off the start of a line; release-please reads each one as a declaration. See the job summary."
+            exit 1
           fi
 
           if [ "$total" -le 1 ]; then

--- a/frontend/scripts/__tests__/breaking-change-footers.test.ts
+++ b/frontend/scripts/__tests__/breaking-change-footers.test.ts
@@ -156,12 +156,79 @@ function runGuard(commits: string[], stubDir: string = binDir): GuardRun {
   }
 }
 
+// The verbatim body of sethbacon/azure-pipelines-terraform@abacdb5 -- the
+// commit that ADDED that repository's copy of this guard. One sentence in it
+// NAMES the hyphenated spelling of the token, mid-line, as prose describing
+// what the guard detects. release-please read that as a real declaration, took
+// the remainder of the line as the description, and proposed 2.0.0 over a
+// 1.14.4 release whose honest successor was 1.14.5 -- with a changelog entry
+// reading "` spelling". The guard, counting only line-anchored matches, said 0.
+//
+// It is load bearing that this is the WHOLE body and not just that sentence: it
+// also names the SPACED spelling mid-line, which release-please does not read.
+// The only count that is right for it is 1.
+const ABACDB5_BODY = [
+  "ci: count breaking-change declarations across the commits being squashed (#974)",
+  "",
+  "This repo squash-merges with `squash_merge_commit_message=COMMIT_MESSAGES`",
+  "(re-verified on the live repo), so every commit body in a PR is concatenated",
+  "into ONE merge commit -- and release-please keeps only the FIRST",
+  "`BREAKING CHANGE:` footer of that commit, reading a `!` marker only from its",
+  "header. A second declaration anywhere in the PR is dropped in silence: no",
+  "changelog entry, no upgrade note, and nothing failing to say so.",
+  "terraform-registry-backend v4.0.0 shipped two undocumented breaking changes",
+  "exactly this way, and it reaches further from here: this extension publishes to",
+  "the VS Marketplace, where the release notes are a pipeline author's only signal",
+  "that a task changed incompatibly, and ADO agents cache tasks by Major.Minor.",
+  "",
+  "Five other suite repos carry this guard; the two ADO extensions did not. The",
+  "only `BREAKING` matches here were prose inside",
+  "`.github/commit-message-check/verify.mjs`, which parses the SINGLE message this",
+  "PR would squash and asks whether release-please can read it at all -- it never",
+  "counts declarations across the set being concatenated. The two are the halves of",
+  "one pair and neither subsumes the other: a perfectly parseable squash can still",
+  "swallow a second footer, and a single-footer PR can still be unparseable.",
+  "",
+  "Ported from `azure-pipelines-release-docs`, which took it from",
+  "`terraform-registry-backend` and added the self-test. The self-test EXTRACTS the",
+  "bash out of pr-checks.yml rather than copying it -- a copy drifts from the thing",
+  "it claims to prove, which is the same defect one level up -- and runs it against",
+  "fixture commit histories with `gh` stubbed. It runs in the already-required",
+  "`Lint GitHub Actions` job, so the proof blocks a merge from the day it lands.",
+  "",
+  "Mutation-proved against the committed workflow, each rejection asserted by name:",
+  "two footers, two `!` headers, three footers and the `BREAKING-CHANGE:` spelling",
+  "are rejected; the single-declaration, no-declaration, many-clean-commits,",
+  "prose-mention and footer-plus-`!`-in-one-commit shapes pass untouched. Five",
+  "mutations of the guard were each seen failing the test: dropping the hyphen",
+  "spelling, making the footer and `!` additive, raising the threshold to 2,",
+  "renaming the job (the vacuity contract), and dropping `set -euo pipefail`.",
+  "",
+  "That last one is a case the source implementation could not see, so this port",
+  "adds it: without `set -euo pipefail` a failed `gh api` leaves an empty commit",
+  "list behind and the job reports \"declarations in this PR: 0\" and goes green. The",
+  "new `gh-unavailable` case stubs a failing `gh` and requires the guard to fail",
+  "closed.",
+  "",
+  "No task.json touched, and no existing job renamed or split.",
+  "",
+  "BRANCH PROTECTION: this adds one NEW context, `Breaking-change footers survive",
+  "the squash`, which has to be added to main's required checks by hand. Until then",
+  "the job reports on every PR without blocking one -- the same state as",
+  "`release-please can read the merged commit`, the other half of the pair.",
+  "",
+  "Closes #966",
+].join('\n')
+
 const FOOTER = 'BREAKING CHANGE: the module detail route moved'
 
 describe('the guard is the one in the workflow', () => {
   it('extracts a real script, not an empty match that would pass every case below', () => {
     expect(guard.split('\n').length).toBeGreaterThan(20)
-    expect(guard).toMatch(/BREAKING\[ -\]CHANGE:/)
+    // Both halves of the rule, because they are different rules: the spaced
+    // spelling counts only at the start of a line, the hyphenated one anywhere.
+    expect(guard).toContain("grep -cE '^BREAKING CHANGE:'")
+    expect(guard).toContain("grep -oF 'BREAKING-CHANGE:'")
     expect(guard).toContain('gh api --paginate')
   })
 })
@@ -195,9 +262,31 @@ describe('pull requests it must not obstruct', () => {
     expect(status).toBe(0)
   })
 
-  it('treats a mid-line mention as prose rather than a footer', () => {
-    const { status, output } = runGuard(['docs: explain that a BREAKING CHANGE: footer is kept only once'])
+  // CORRECTED. This case used to assert that ANY mid-line mention is prose, and
+  // it pinned a model release-please does not implement. Only the SPACED spelling
+  // is ignored mid-line; the hyphenated one is matched anywhere, and asserting
+  // otherwise is exactly what let abacdb5 through -- that body is rejected below.
+  // What survives here is the half that is true, and it has to survive: a guard
+  // that failed a sentence release-please reads as prose would be routed around
+  // and then deleted.
+  //
+  // The mention is in the BODY. The old fixture was a single-line message, so it
+  // never exercised the body at all.
+  it('treats a mid-line mention of the SPACED spelling as prose, as release-please does', () => {
+    const { status, output } = runGuard([
+      'docs: explain the footer rule\n\nA line that merely says BREAKING CHANGE: in the middle of a\nsentence is prose, and release-please never reads it as a footer.',
+    ])
     expect(output).toContain('declarations in this PR: 0')
+    expect(status).toBe(0)
+  })
+
+  // The hyphenated spelling written as a real footer IS a real declaration, and
+  // one of them is what the squash can carry. Rejecting it would be the
+  // over-count mirror of the bug this change fixes, and an over-counting guard
+  // gets bypassed and then deleted just as surely as a blind one.
+  it('passes a single hyphenated footer, which is a legitimate declaration', () => {
+    const { status, output } = runGuard(['feat: rework the module detail route\n\nBREAKING-CHANGE: the input is no longer optional'])
+    expect(output).toContain('declarations in this PR: 1')
     expect(status).toBe(0)
   })
 })
@@ -249,6 +338,35 @@ describe('pull requests whose squash would drop a declaration', () => {
     expect(status).not.toBe(0)
     expect(output).toContain('declares 3 breaking changes')
     expect(summary).toContain('The other 2 would ship with no changelog entry')
+  })
+  // THE regression, and the reason this file changed. abacdb5 is the commit that
+  // ADDED this guard in azure-pipelines-terraform; a sentence in its body naming
+  // the hyphenated spelling was read by release-please as a declaration, which
+  // proposed 2.0.0 over 1.14.4 with a changelog entry reading "` spelling". The
+  // guard counted it 0 and passed it.
+  //
+  // The count asserted here is 1, and that number is load bearing in BOTH
+  // directions: 0 is the under-count that shipped, and 2 is what merely
+  // un-anchoring the old expression would give, because this body also names the
+  // spaced spelling mid-line and release-please does not read that.
+  it('rejects abacdb5, the accidental declaration that got through', () => {
+    const { status, output, summary } = runGuard([ABACDB5_BODY])
+    expect(status).not.toBe(0)
+    expect(output).toContain('declarations in this PR: 1')
+    expect(output).toContain('off the start of a line')
+    expect(summary).toContain('A breaking change nobody declared')
+  })
+
+  // Two of them in one PR: two notes, and the squash keeps one. This is the shape
+  // the old `prose-mention` assertion declared acceptable.
+  it('rejects two mid-line mentions, which are two declarations', () => {
+    const { status, output } = runGuard([
+      'docs: describe the footer rule\n\nprose naming BREAKING-CHANGE: once',
+      'docs: describe it again\n\nmore prose naming BREAKING-CHANGE: twice',
+    ])
+    expect(status).not.toBe(0)
+    expect(output).toContain('declarations in this PR: 2')
+    expect(output).toContain('off the start of a line')
   })
 })
 


### PR DESCRIPTION
## The bug

The `Breaking-change footers survive the squash` guard counted declarations with
a **line-anchored** expression. release-please does not. The guard therefore
under-counted against the tool it exists to model, and passed commits
release-please treats as breaking.

The case is `abacdb5` in `sethbacon/azure-pipelines-terraform` — *the commit that
added the guard there*. Every repository carrying this guard counts the same
way, so every one is open to the same false major bump. Its body contains, as prose describing what the guard detects, a sentence
naming the hyphenated spelling of the token mid-line. release-please matched it,
took the remainder of the sentence as the description, and proposed **2.0.0** over
a 1.14.4 release whose honest successor was 1.14.5 — with a changelog entry
reading `` * ` spelling``.

| | count on `abacdb5` |
|---|---|
| the old guard (line-anchored) | **0** |
| release-please | **1** |
| naive un-anchoring of the old expression | **2** |

Only one of those is right.

## The rule release-please actually applies

Established by running **release-please 17.11.1's own parser** over the real
commit body, not from documentation. The two spellings are read by *different*
rules:

- **`BREAKING CHANGE:` (space)** — a footer only where the Conventional Commits
  grammar sees one: at the **start of a line**, no leading whitespace.
  Mid-sentence or indented it is prose and release-please ignores it. Blank-line
  separation is **not** required.
- **`BREAKING-CHANGE:` (hyphen)** — read by that grammar **and, additionally**, by
  release-please's own `postProcessCommits`, whose regex
  (`/BREAKING-CHANGE:\s*(.*)/`) is **unanchored over the commit body**. It counts
  **anywhere**: mid-sentence, indented, inside a fenced code block, even inside a
  longer word such as `NON-BREAKING-CHANGE:`. It takes the rest of that line as
  the description, and only the **first** match in a body survives.
- Both are read from the **body**, so the same token in the subject line is not a
  declaration. Both are case-sensitive and both require the colon.

## The corrected pattern

```bash
body=$(tail -n +2 <<<"$msg")
spaced=$(grep -cE '^BREAKING CHANGE:' <<<"$body" || true)
hyphenated=$(grep -oF 'BREAKING-CHANGE:' <<<"$body" | grep -c '' || true)
anchored=$(grep -cE '^BREAKING-CHANGE:' <<<"$body" || true)
stray=$((hyphenated - anchored))
footers=$((spaced + hyphenated))
```

Occurrences, not lines: the squash concatenates every body into one and that
regex is not global, so a second match on one line is lost as surely as one in a
later commit.

A differential test against release-please's own parser over **14 shapes** agrees
on every one. The old expression disagreed on three, all under-counts.

## A second failure mode, same job, same context name

`abacdb5` declared **exactly one** breaking change by release-please's reckoning,
so the "more than one" rule would never have caught it however well it counted.
The guard now also rejects a **hyphenated token found off the start of a line**
on its own. Such a token is never a declaration anyone *wrote*, and it always
buys a major version bump nobody asked for. The job summary says how to write
about the token without declaring one.

## What `prose-mention` now asserts, and why

It used to assert that **any** mid-line mention is prose. That pinned a model
release-please does not implement, and it is the assertion that let `abacdb5`
through.

It now asserts the half that is **true**: a sentence naming the **spaced**
spelling mid-line declares nothing, and the guard must not fire on it. That half
has to survive — over-counting is its own failure, because a guard that rejects
legitimate prose gets routed around and then deleted. The fixture also now
carries a real **body**; the old one was a subject-only message that never
exercised the body at all.

The other half is pinned by the new rejections.

## Mutation evidence

Every mutation was applied to the committed workflow and seen **failing** the
self-test:

| mutation | detected by |
|---|---|
| revert the hyphenated count to the line-anchored form | `abacdb5-accidental-declaration` |
| un-anchor the **spaced** count instead (over-count → 2) | `abacdb5-accidental-declaration` |
| delete the off-the-start-of-a-line check | `abacdb5-accidental-declaration` |
| raise the threshold to 2 | `two-footers` |
| drop `set -euo pipefail` | `gh-unavailable` |
| rename the job | vacuity contract |

A clean tree passes; every pre-existing must-not-obstruct and rejection shape
still behaves.

## Safety

- No job renamed or split, no job or step added. Only the body of an existing
  `run:` block changed, so the `harden-runner` step and its
  `# hardening-exception: egress-audit` comment are untouched and the shared
  hardening gate sees no new surface. `actionlint` is clean.
- **This PR's own commit message is parse-safe**: it never writes the hyphenated
  token at a position release-please parses, and it was verified by running
  release-please's own parser over the exact message — `breaking=0, notes=0` —
  and by running this very guard over it (`declarations in this PR: 0`).
