### PR TITLE
chore(deps): take @4cloudguru/cloud-suite-ui 0.10.0

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "terraform-registry-frontend",
-  "version": "2.23.1",
+  "version": "2.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "terraform-registry-frontend",
-      "version": "2.23.1",
+      "version": "2.24.0",
       "dependencies": {
-        "@4cloudguru/cloud-suite-ui": "0.9.0",
+        "@4cloudguru/cloud-suite-ui": "0.10.0",
         "@emotion/cache": "^11.14.0",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
@@ -73,9 +73,9 @@
       }
     },
     "node_modules/@4cloudguru/cloud-suite-ui": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@4cloudguru/cloud-suite-ui/-/cloud-suite-ui-0.9.0.tgz",
-      "integrity": "sha512-5N7z3FosJuJjZVHJOhZC9QPHk4dd4WktAblpP6+hHhI0GPZmfe04olwoqm+dO88OQHjeu8VwXvgXOfpM8vJy+Q==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@4cloudguru/cloud-suite-ui/-/cloud-suite-ui-0.10.0.tgz",
+      "integrity": "sha512-zdzh4CqCEthXgg7dVp9xvumtWPjHhYbG7b6e6WFuYU52CG/2XOdHtAsb5PuYl1SW0Qc4LOJZSCzlnudyyAVeuQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=22.0.0 <25"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,7 @@
     "contract:check": "tsx scripts/contract-check.ts"
   },
   "dependencies": {
+    "@4cloudguru/cloud-suite-ui": "0.10.0",
     "@emotion/cache": "^11.14.0",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
@@ -32,7 +33,6 @@
     "@mui/material": "^9.3.1",
     "@mui/material-pigment-css": "^9.3.0",
     "@sentry/react": "^10.70.0",
-    "@4cloudguru/cloud-suite-ui": "0.9.0",
     "@tanstack/react-query": "^5.101.4",
     "@tanstack/react-query-devtools": "^5.101.4",
     "@testing-library/dom": "^10.4.1",


### PR DESCRIPTION
The registry frontend was a release behind its sibling — `terraform-state-manager-frontend` is on **0.10.0**, this repository was on **0.9.0**. Both consume the same shared module, so the drift itself is what's worth closing.

`0.10.0` adds the organization picker and the acting-organization surface (`currentOrganizationId`, `setCurrentOrganization`, `memberships`, `ORGANIZATION_HEADER`, `resolveCurrentOrganization`) for sethbacon/terraform-state-manager-backend#437.

**Nothing here uses them yet, and that's deliberate.** This repository's own organization model is still being settled — a picker wired before that decision would have to be unwired. Everything already consumed is unchanged: the additions are new exports, not altered ones.

## The pin stays exact

`0.10.0`, not `^0.10.0`. It is the **only** exact dependency of thirty-one, so the two suite frontends move together rather than drifting apart on a caret — which is precisely the drift this closes.

## Validated

`tsc --noEmit` clean; full suite green at **2427 tests across 155 files**.

One environment note: this needed node `>=24.15.0` locally. `.npmrc` sets `engine-strict=true` on purpose — the comment cites #547, where the builder image silently ran two majors ahead of `engines` for weeks — and `jsdom@30.0.1` floors there. I installed a compatible node rather than relax the guard or push an unvalidated lockfile. CI pins `node-version: 24`, which resolves current, so CI was never affected.

## Not included: the shared-workflow pins

`release-please` v1.0.0, `signature-replay` v1.9.0, `workflow-hardening`/`workflow-security` v1.6.1, against a current v1.13.0.

**All six suite repos are on exactly those pins**, so bumping only this one would break the `shared-workflow-pin-parity` invariant and fire on the other five. The releases since are additive, and the one that was a real fix — v1.10.1's footer guard — is already pinned estate-wide. That's a coordinated change, not a per-repo one.