### PR TITLE
fix(nginx): raise the proxy body limit above the application file limit (#766)

### DIFF
--- a/frontend/nginx-ecs.conf.template
+++ b/frontend/nginx-ecs.conf.template
@@ -105,7 +105,7 @@ server {
     sub_filter '__CSP_NONCE__' '$csp_nonce';
 
     # Upload size limit (matches backend: 100MB modules, 500MB providers)
-    client_max_body_size 500m;
+    client_max_body_size 512m;
 
     # SPA fallback - serve index.html for all non-file requests
     location / {

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -132,7 +132,7 @@ server {
     sub_filter '__CSP_NONCE__' '$csp_nonce';
 
     # Upload size limit (matches backend: 100MB modules, 500MB providers)
-    client_max_body_size 500m;
+    client_max_body_size 512m;
 
     # SPA fallback - serve index.html for all non-file requests
     location / {

--- a/frontend/src/__tests__/nginxBodySize.test.ts
+++ b/frontend/src/__tests__/nginxBodySize.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest'
+import nginxConf from '../../nginx.conf?raw'
+import nginxEcsConf from '../../nginx-ecs.conf.template?raw'
+import { PROVIDER_MAX_BYTES } from '../components/FileDropZone'
+
+/**
+ * The proxy body limit must sit ABOVE the application's file limit (#766).
+ *
+ * `client_max_body_size` bounds the request BODY, not the file. A multipart
+ * upload adds boundary delimiters, per-part `Content-Disposition` and
+ * `Content-Type` headers and CRLFs on top of the archive, so a file of exactly
+ * PROVIDER_MAX_BYTES produces a body a few hundred bytes larger. With the proxy
+ * set to exactly 500m — "provisioned to match", as the old comment put it —
+ * that upload passed the client-side check and the backend's own limit, and
+ * then died at the edge with a bare 413 that names no cause.
+ *
+ * Equality is the bug, so `toBeGreaterThan` is the assertion. Three values in
+ * three files have to stay ordered, and every one of them can be edited without
+ * the others: the two configs have drifted before (the HSTS note in the ECS
+ * template records it), and #672 was the application constants drifting from
+ * each other.
+ *
+ * This is a STATIC check. It cannot prove nginx enforces the value — that needs
+ * a container, which #691 tracks — but the ordering is what the bug was.
+ */
+
+const CONFIGS: [string, string][] = [
+  ['nginx.conf', nginxConf],
+  ['nginx-ecs.conf.template', nginxEcsConf],
+]
+
+/** nginx size suffixes: bare bytes, `k`/`K` kibibytes, `m`/`M` mebibytes. */
+const UNIT_BYTES: Record<string, number> = {
+  '': 1,
+  k: 1024,
+  m: 1024 * 1024,
+}
+
+function bodyLimitBytes(conf: string): number | null {
+  // Ignore commented-out directives: a `#`-prefixed limit is not in force, and
+  // reading one would let a real limit be deleted without this test noticing.
+  const uncommented = conf.replace(/#[^\n]*/g, '')
+  const match = uncommented.match(/client_max_body_size\s+(\d+)([kKmM]?)\s*;/)
+  if (!match) return null
+  return Number(match[1]) * UNIT_BYTES[match[2].toLowerCase()]
+}
+
+describe('nginx client_max_body_size (#766)', () => {
+  it.each(CONFIGS)('%s declares a body limit', (_name, conf) => {
+    // Positive control. If the directive is renamed or the regex rots,
+    // bodyLimitBytes returns null and every comparison below would be skipped
+    // rather than failed — a guard that stopped looking, reporting green.
+    expect(bodyLimitBytes(conf)).not.toBeNull()
+  })
+
+  it.each(CONFIGS)('%s sits above the application file limit', (_name, conf) => {
+    expect(bodyLimitBytes(conf)!).toBeGreaterThan(PROVIDER_MAX_BYTES)
+  })
+
+  it('both configs agree', () => {
+    expect(bodyLimitBytes(nginxConf)).toBe(bodyLimitBytes(nginxEcsConf))
+  })
+
+  it('does not read a commented-out directive as the limit', () => {
+    expect(bodyLimitBytes('# client_max_body_size 999m;')).toBeNull()
+  })
+
+  it('parses each nginx size suffix', () => {
+    expect(bodyLimitBytes('client_max_body_size 512m;')).toBe(512 * 1024 * 1024)
+    expect(bodyLimitBytes('client_max_body_size 64k;')).toBe(64 * 1024)
+    expect(bodyLimitBytes('client_max_body_size 1048576;')).toBe(1048576)
+  })
+})

--- a/frontend/src/components/FileDropZone.tsx
+++ b/frontend/src/components/FileDropZone.tsx
@@ -18,8 +18,16 @@ export const HARD_MAX_BYTES = 100 * 1024 * 1024 // 100MB
 /**
  * Cap for provider archives, mirroring `MaxProviderBinarySize` in the backend's
  * `internal/api/providers/upload.go`, which rejects anything larger with
- * "provider binary too large". The edge proxy is provisioned to match
- * (`client_max_body_size 500m` in nginx.conf and nginx-ecs.conf.template).
+ * "provider binary too large".
+ *
+ * The edge proxy is deliberately provisioned ABOVE this, not equal to it
+ * (#766). `client_max_body_size` bounds the REQUEST BODY, and a multipart
+ * upload carries boundary delimiters, per-part headers and CRLFs on top of the
+ * file — so a 500MB archive produces a body slightly over 500MB, and a proxy
+ * set to exactly 500m rejected it with a bare 413 before the backend could
+ * explain why. The proxy limit is a coarse DoS guard; this constant and the
+ * backend's are the authoritative caps, and they are the ones that return a
+ * useful error. nginxBodySize.test.ts pins the ordering.
  */
 export const PROVIDER_MAX_BYTES = 500 * 1024 * 1024 // 500MB
 


### PR DESCRIPTION
## The bug is the equality

`client_max_body_size` bounds the **request body**, not the file. A multipart upload adds boundary delimiters, per-part `Content-Disposition`/`Content-Type` headers and CRLFs on top of the archive — so a provider `.zip` of exactly 500MB produces a body a few hundred bytes *larger*.

With the proxy at exactly `500m` — *"provisioned to match"*, as `FileDropZone.tsx` put it — that upload passed the client-side check **and** the backend's `MaxProviderBinarySize` check, then died at the edge with a bare 413 that names no cause.

## The fix

Both configs to `512m`, which is the issue's preferred option: the proxy limit is a coarse DoS guard, and leaving the application constants authoritative keeps the *useful* error. `512` rather than the issue's example `502` only because it's the round binary figure and the headroom costs nothing.

The stale comment claiming the proxy matches is corrected — it's what made the equality look intentional.

## The test pins the ordering, not the value

Equality is what broke, so the assertion is `toBeGreaterThan`. Three numbers in three files have to stay in step and each can be edited without the others — the two configs have drifted before (the HSTS note in the ECS template records it), and #672 was the application constants drifting from each other.

The first assertion is a **positive control**: a renamed directive or a rotted regex returns `null`, and every comparison after it would be silently skipped rather than failed.

| Mutation | Result |
|---|---|
| `nginx.conf` back to `500m` (the original bug) | caught |
| ECS template back to `500m` | caught |
| the two configs drift apart | caught |
| directive commented out entirely | caught |
| application constant raised to meet the proxy | caught |

Full suite: **156 files, 2434 tests, all passing.**

Static check only — it can't prove nginx enforces the value (that needs a container, tracked by #691), but the ordering is what the bug was.

Closes #766