### PR TITLE
fix(login): redirect an already-authenticated visitor away from /login (#781)

### DIFF
--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -16,7 +16,7 @@ import {
 import LoginIcon from '@mui/icons-material/Login'
 import { useAuth } from '../contexts/AuthContext'
 import { useThemeMode } from '../contexts/ThemeContext'
-import { useNavigate } from 'react-router-dom'
+import { Navigate, useNavigate } from 'react-router-dom'
 import api from '../services/api'
 import * as devApi from '../services/api/devApi'
 
@@ -51,7 +51,7 @@ function providerSx(p: AuthProvider): Record<string, unknown> | undefined {
 
 const LoginPage: React.FC = () => {
   const { t } = useTranslation()
-  const { login, devLogin, ldapLogin } = useAuth()
+  const { login, devLogin, ldapLogin, isAuthenticated } = useAuth()
   const { productName } = useThemeMode()
   const navigate = useNavigate()
   const [loginError, setLoginError] = React.useState<string | null>(null)
@@ -148,6 +148,33 @@ const LoginPage: React.FC = () => {
   const ssoProviders = providers.filter((p) => p.type !== 'ldap')
   const hasLdap = providers.some((p) => p.type === 'ldap')
   const showNoProvidersAlert = !loading && providers.length === 0 && !isDev
+
+  // Defence in depth after #677 (#781). That issue's cause is fixed — the 401
+  // interceptor no longer tears down a live session on a non-session 401, so a
+  // valid session is no longer bounced here — and this covers the paths nobody
+  // enumerated: if a live session reaches /login by any other route, recognise
+  // it rather than presenting a login form to someone already signed in.
+  //
+  // NOT gated on isLoading, which an earlier draft of this did. The two flags
+  // are independent in cloud-suite-ui (isAuthenticated is `user !== null`;
+  // isLoading is its own state), so they are both true while a live session
+  // refreshes — and `!isLoading && isAuthenticated` would show the login form
+  // to an authenticated user for exactly that window, which is the bug. On the
+  // initial resolve isAuthenticated is false anyway, because it fails closed
+  // there and on error alike, so the gate bought nothing and cost that.
+  //
+  // Destination is '/', matching what this page's own successful logins do, not
+  // the stored returnUrl. That key is CallbackPage's to consume — it carries the
+  // open-redirect validation, and reading it from a second place would either
+  // duplicate that check or skip it, on a value that may be stale from an
+  // earlier bounce.
+  //
+  // <Navigate> rather than a navigate() effect, matching ProtectedRoute: a
+  // route-level redirect belongs in render, and an effect would show the form
+  // for a frame first.
+  if (isAuthenticated) {
+    return <Navigate to="/" replace />
+  }
 
   return (
     <Container maxWidth="sm" sx={{ mx: 'auto' }}>

--- a/frontend/src/pages/__tests__/LoginPage.test.tsx
+++ b/frontend/src/pages/__tests__/LoginPage.test.tsx
@@ -1,13 +1,19 @@
 import { render, screen, waitFor, act } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { MemoryRouter } from 'react-router-dom'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 const mockLogin = vi.fn()
 const mockDevLogin = vi.fn().mockResolvedValue(undefined)
 const mockLdapLogin = vi.fn().mockResolvedValue(undefined)
+const mockAuth = { isAuthenticated: false, isLoading: false }
 vi.mock('../../contexts/AuthContext', () => ({
-  useAuth: () => ({ login: mockLogin, devLogin: mockDevLogin, ldapLogin: mockLdapLogin }),
+  useAuth: () => ({
+    login: mockLogin,
+    devLogin: mockDevLogin,
+    ldapLogin: mockLdapLogin,
+    ...mockAuth,
+  }),
 }))
 
 const mockNavigate = vi.fn()
@@ -59,6 +65,8 @@ function renderLoginPage() {
 
 beforeEach(() => {
   mockGetDevStatus.mockResolvedValue({ dev_mode: false })
+  mockAuth.isAuthenticated = false
+  mockAuth.isLoading = false
   vi.clearAllMocks()
 })
 
@@ -270,5 +278,73 @@ describe('Dev Login gate (#667)', () => {
     renderLoginPage()
     await waitFor(() => expect(mockGetDevStatus).toHaveBeenCalled())
     expect(screen.queryByRole('button', { name: /dev login/i })).not.toBeInTheDocument()
+  })
+})
+
+/**
+ * Defence in depth after #677 (#781). A live session reaching /login should be
+ * recognised, not handed a login form.
+ *
+ * These render through <Routes> rather than asserting on a navigate() spy,
+ * because the guard uses <Navigate> — the same render-time redirect
+ * ProtectedRoute uses — and a spy on useNavigate cannot see it.
+ */
+describe('LoginPage — an already-authenticated visitor (#781)', () => {
+  function renderAtLogin() {
+    return render(
+      <MemoryRouter initialEntries={['/login']}>
+        <Routes>
+          <Route path="/login" element={<LoginPage />} />
+          <Route path="/" element={<div>home</div>} />
+        </Routes>
+      </MemoryRouter>,
+    )
+  }
+
+  it('redirects a resolved, authenticated session away from the form', async () => {
+    mockProviders([{ type: 'oidc', name: 'Corp SSO', id: 'corp' }])
+    mockAuth.isAuthenticated = true
+
+    renderAtLogin()
+
+    expect(await screen.findByText('home')).toBeInTheDocument()
+    expect(screen.queryByText('Terraform Registry')).not.toBeInTheDocument()
+  })
+
+  it('shows the form while the session is still resolving', async () => {
+    // isAuthenticated fails CLOSED — false while resolving and false again if
+    // resolution errored — so the unresolved state needs no separate gate.
+    mockProviders([{ type: 'oidc', name: 'Corp SSO', id: 'corp' }])
+    mockAuth.isAuthenticated = false
+    mockAuth.isLoading = true
+
+    renderAtLogin()
+
+    expect(await screen.findByText('Terraform Registry')).toBeInTheDocument()
+    expect(screen.queryByText('home')).not.toBeInTheDocument()
+  })
+
+  it('redirects a live session that is mid-refresh', async () => {
+    // The two flags are independent: isAuthenticated is `user !== null` and
+    // isLoading is its own state, so both are true while an authenticated
+    // session refreshes. An earlier draft gated on `!isLoading && isAuthenticated`
+    // and would have shown the login form for exactly that window — the bug this
+    // guard exists to prevent, reintroduced by the guard itself.
+    mockProviders([{ type: 'oidc', name: 'Corp SSO', id: 'corp' }])
+    mockAuth.isAuthenticated = true
+    mockAuth.isLoading = true
+
+    renderAtLogin()
+
+    expect(await screen.findByText('home')).toBeInTheDocument()
+  })
+
+  it('shows the form to a visitor who is genuinely signed out', async () => {
+    mockProviders([{ type: 'oidc', name: 'Corp SSO', id: 'corp' }])
+
+    renderAtLogin()
+
+    expect(await screen.findByText('Terraform Registry')).toBeInTheDocument()
+    expect(screen.queryByText('home')).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
Second layer after #677. That issue's cause is fixed — the 401 interceptor no longer tears down a live session on a non-session 401 — so there's no *known* path that lands a signed-in user here. This covers the paths nobody enumerated.

## The interesting part is a gate this does **not** have

My first version read `!isLoading && isAuthenticated`, reasoning that `isAuthenticated` is false while the session resolves, so redirecting then would bounce a signed-out visitor.

Mutation testing said otherwise — removing `!isLoading` changed nothing any test could see. Looking into *why* showed the gate wasn't merely redundant, it was **wrong**:

- In `cloud-suite-ui` the two flags are independent: `isAuthenticated` is `user !== null`, `isLoading` is its own state.
- So **both are true while a live session refreshes**.
- `!isLoading && isAuthenticated` would show the login form for exactly that window — *the bug this guard exists to prevent, reintroduced by the guard itself.*
- And the case the gate was meant to protect never needed it: `isAuthenticated` fails closed on the initial resolve and on error alike.

So the guard is `if (isAuthenticated)`, and there's now a test for the mid-refresh state specifically.

## Destination

`/`, matching this page's own successful logins — not the stored `returnUrl`. That key is `CallbackPage`'s to consume: it carries the open-redirect validation, and reading it from a second place would either duplicate that check or skip it, on a value that may be stale from an earlier bounce.

`<Navigate>` rather than a `navigate()` effect, matching `ProtectedRoute` — a route-level redirect belongs in render, and an effect would flash the form first.

## Tests

The existing mock returned **neither flag**, so the new guard read `undefined` and every test would have passed vacuously. It now carries both and resets per test.

| Mutation | Result |
|---|---|
| guard removed entirely (the reported defect) | caught |
| condition inverted (signed-out visitors bounced) | caught |
| `isLoading` gate reintroduced (mid-refresh regression) | caught |

`src/pages`: 43 files, 922 tests passing. `tsc --noEmit` clean.

Closes #781