### PR TITLE
docs: complete the suite-package inventory, and stop it drifting again (#603)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,4 +1,5 @@
 <!-- markdownlint-disable MD013 -->
+
 # Architecture
 
 This document describes the frontend architecture for the Terraform Registry, covering component hierarchy, routing, data fetching, authentication, and state management.
@@ -89,28 +90,28 @@ Routes are defined in `App.tsx`. The app uses React Router v6 with the following
 
 All admin routes are lazy-loaded and wrapped in `<ProtectedRoute requiredScope="...">`.
 
-| Path                       | Component              | Required Scope       |
-| -------------------------- | ---------------------- | -------------------- |
-| `/admin`                   | `DashboardPage`        | (authenticated)      |
-| `/admin/users`             | `UsersPage`            | `users:read`         |
-| `/admin/organizations`     | `OrganizationsPage`    | `organizations:read` |
-| `/admin/roles`             | `RolesPage`            | `users:read`         |
-| `/admin/apikeys`           | `APIKeysPage`          | (authenticated)      |
-| `/admin/upload`            | redirect → `/admin/upload/module` | —         |
-| `/admin/upload/module`     | `ModuleUploadPage`     | `modules:write`      |
-| `/admin/upload/provider`   | `ProviderUploadPage`   | `providers:write`    |
-| `/admin/scm-providers`     | `SCMProvidersPage`     | `scm:read`           |
-| `/admin/mirrors`           | `MirrorsPage`          | `mirrors:read`       |
-| `/admin/terraform-mirror`  | `TerraformMirrorPage`  | `mirrors:read`       |
-| `/admin/storage`           | `StoragePage`          | `admin`              |
-| `/admin/approvals`         | `ApprovalsPage`        | `mirrors:read`       |
-| `/admin/version-approvals` | `VersionApprovalsPage` | `mirrors:read`       |
-| `/admin/policies`          | `MirrorPoliciesPage`   | `admin`              |
-| `/admin/oidc`              | `OIDCSettingsPage`     | `admin`              |
-| `/admin/scim`              | `SCIMProvisioningPage` | `admin`              |
-| `/admin/mtls`              | `MTLSPage`             | `admin`              |
-| `/admin/audit-logs`        | `AuditLogPage`         | `audit:read`         |
-| `/admin/security-scanning` | `SecurityScanningPage` | `admin`              |
+| Path                       | Component                         | Required Scope       |
+| -------------------------- | --------------------------------- | -------------------- |
+| `/admin`                   | `DashboardPage`                   | (authenticated)      |
+| `/admin/users`             | `UsersPage`                       | `users:read`         |
+| `/admin/organizations`     | `OrganizationsPage`               | `organizations:read` |
+| `/admin/roles`             | `RolesPage`                       | `users:read`         |
+| `/admin/apikeys`           | `APIKeysPage`                     | (authenticated)      |
+| `/admin/upload`            | redirect → `/admin/upload/module` | —                    |
+| `/admin/upload/module`     | `ModuleUploadPage`                | `modules:write`      |
+| `/admin/upload/provider`   | `ProviderUploadPage`              | `providers:write`    |
+| `/admin/scm-providers`     | `SCMProvidersPage`                | `scm:read`           |
+| `/admin/mirrors`           | `MirrorsPage`                     | `mirrors:read`       |
+| `/admin/terraform-mirror`  | `TerraformMirrorPage`             | `mirrors:read`       |
+| `/admin/storage`           | `StoragePage`                     | `admin`              |
+| `/admin/approvals`         | `ApprovalsPage`                   | `mirrors:read`       |
+| `/admin/version-approvals` | `VersionApprovalsPage`            | `mirrors:read`       |
+| `/admin/policies`          | `MirrorPoliciesPage`              | `admin`              |
+| `/admin/oidc`              | `OIDCSettingsPage`                | `admin`              |
+| `/admin/scim`              | `SCIMProvisioningPage`            | `admin`              |
+| `/admin/mtls`              | `MTLSPage`                        | `admin`              |
+| `/admin/audit-logs`        | `AuditLogPage`                    | `audit:read`         |
+| `/admin/security-scanning` | `SecurityScanningPage`            | `admin`              |
 
 `ProtectedRoute` checks `useAuth()` for authentication and scope. If loading, it shows a spinner. If unauthenticated, it redirects to `/login`. If the required scope is missing (and the user does not have `admin`), it shows "Access Denied".
 
@@ -188,8 +189,8 @@ The `QueryClient` is configured in `App.tsx`:
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      staleTime: 30_000,       // Data considered fresh for 30 seconds
-      retry: 1,                // One retry on failure
+      staleTime: 30_000, // Data considered fresh for 30 seconds
+      retry: 1, // One retry on failure
       refetchOnWindowFocus: false,
     },
   },
@@ -394,41 +395,58 @@ auth/session provider and is treated as load-bearing security code).
 
 The following local files are thin wrappers or re-exports around it:
 
-| Local file                     | Wraps / re-exports from the package                                 |
-| ------------------------------ | ------------------------------------------------------------------- |
-| `contexts/AuthContext.tsx`     | `AuthProvider`, `useAuth` (session lifecycle, expiry, scopes)       |
-| `contexts/ConsentContext.tsx`  | `ConsentProvider`, `useConsent` (GDPR consent preferences)          |
-| `contexts/ThemeContext.tsx`    | `SuiteThemeProvider`, `useThemeMode` (light/dark, RTL, whitelabel)  |
-| `components/Layout.tsx`        | `SuiteLayout` (sidebar/topbar app shell)                            |
-| `components/Page.tsx`          | `Page` + `PageProps`                                                |
-| `components/PageHeader.tsx`    | `PageHeader` + `PageHeaderProps`                                    |
-| `components/DashboardCard.tsx` | `DashboardCard` + `DashboardCardProps`                              |
-| `components/ConsentBanner.tsx` | `ConsentBanner`                                                     |
-| `components/SuiteSwitcher.tsx` | `SuiteSwitcher` (cross-app switcher)                                |
-| `navigation.tsx`               | `NavItem` / `NavGroup` types for the sidebar config                 |
+| Local file                     | Wraps / re-exports from the package                                |
+| ------------------------------ | ------------------------------------------------------------------ |
+| `contexts/AuthContext.tsx`     | `AuthProvider`, `useAuth` (session lifecycle, expiry, scopes)      |
+| `contexts/ConsentContext.tsx`  | `ConsentProvider`, `useConsent` (GDPR consent preferences)         |
+| `contexts/ThemeContext.tsx`    | `SuiteThemeProvider`, `useThemeMode` (light/dark, RTL, whitelabel) |
+| `components/Layout.tsx`        | `SuiteLayout` (sidebar/topbar app shell)                           |
+| `components/Page.tsx`          | `Page` + `PageProps`                                               |
+| `components/PageHeader.tsx`    | `PageHeader` + `PageHeaderProps`                                   |
+| `components/DashboardCard.tsx` | `DashboardCard` + `DashboardCardProps`                             |
+| `components/ConsentBanner.tsx` | `ConsentBanner`                                                    |
+| `components/SuiteSwitcher.tsx` | `SuiteSwitcher` (cross-app switcher)                               |
+| `navigation.tsx`               | `NavItem` / `NavGroup` types for the sidebar config                |
+
+These files are not wrappers — they **consume** the package's components and
+types directly, adding this app's own data fetching and policy around them:
+
+| Local file                           | Consumes from the package                                                                           |
+| ------------------------------------ | --------------------------------------------------------------------------------------------------- |
+| `pages/admin/APIKeysPage.tsx`        | `ApiKeyExpirySettingsCard`, `ApiKeyExpirySettingsInput`                                             |
+| `pages/admin/NotificationsPage.tsx`  | `NotificationChannelsSection`, `NotificationChannelTypeOption`                                      |
+| `pages/admin/BrandingPage.tsx`       | `BrandingSettingsCard`, `UIThemeConfig`                                                             |
+| `pages/setup/steps/BrandingStep.tsx` | `BrandingSettingsCard`, `UIThemeConfig` — the setup-wizard counterpart of the admin page above      |
+| `services/api/themeApi.ts`           | `UIThemeConfig` (type only)                                                                         |
+| `utils/externalUrl.ts`               | `isSafeUrl`, composed with this app's scheme narrowing and origin allowlist rather than re-exported |
+
+`routeScopes.ts` and `services/errorReporting.ts` mention the package in
+comments but import nothing from it, so they are deliberately absent from both
+tables. `suitePackageDocumented.test.ts` keeps these lists in step with the
+imports themselves.
 
 ## Shared Components
 
-| Component                | Purpose                                                                        |
-| ------------------------ | ------------------------------------------------------------------------------ |
-| `Layout`                 | App shell with collapsible sidebar, topbar, and `<Outlet />` for nested routes |
-| `ProtectedRoute`         | Auth guard checking authentication and scope                                   |
-| `ErrorBoundary`          | Catches render errors with fallback UI                                         |
-| `RegistryItemCard`       | Card component for module/provider search results                              |
-| `MarkdownRenderer`       | Renders markdown content (README files) with GFM and HTML sanitization         |
-| `SecurityScanPanel`      | Displays security scan results for a module version                            |
-| `VersionDetailsPanel`    | Shows version metadata, inputs/outputs, dependencies                           |
-| `WebhookEventsPanel`     | Collapsible panel showing SCM webhook events                                   |
-| `ProviderDetailHeader`   | Breadcrumbs, title, version selector and manage actions for a provider        |
-| `ProviderUsageExample`   | `required_providers` snippet with copy-source action                          |
-| `ProviderPlatformsTable` | OS/arch build matrix with copyable SHA256 sums                                |
-| `ProviderInfoPanel`      | Provider sidebar card (namespace, latest version, repo/changelog links)       |
-| `ProviderVersionDetailsPanel` | Provider version sidebar card with deprecation status and actions        |
-| `TerraformBinaryDetailHeader` | Breadcrumbs, title, tool chip and mirror-URL hint for a binary mirror     |
-| `TerraformBinaryVersionsTable` | Synced-version table for a binary mirror (or its empty state)           |
-| `TerraformBinaryVersionRow` | One version row with expandable platform detail; exports `getChangelogUrl` |
-| `TerraformBinaryPlatformRows` | Lazily loaded OS/arch rows with SHA256 / GPG verification state          |
-| `RepositoryBrowser`      | SCM repository picker with branch/tag selection                                |
-| `StorageMigrationWizard` | Multi-step dialog for storage backend migration                                |
-| `ProviderIcon`           | Renders provider brand icons from simple-icons                                 |
-| `HelpPanel`              | Slide-out contextual help panel                                                |
+| Component                      | Purpose                                                                        |
+| ------------------------------ | ------------------------------------------------------------------------------ |
+| `Layout`                       | App shell with collapsible sidebar, topbar, and `<Outlet />` for nested routes |
+| `ProtectedRoute`               | Auth guard checking authentication and scope                                   |
+| `ErrorBoundary`                | Catches render errors with fallback UI                                         |
+| `RegistryItemCard`             | Card component for module/provider search results                              |
+| `MarkdownRenderer`             | Renders markdown content (README files) with GFM and HTML sanitization         |
+| `SecurityScanPanel`            | Displays security scan results for a module version                            |
+| `VersionDetailsPanel`          | Shows version metadata, inputs/outputs, dependencies                           |
+| `WebhookEventsPanel`           | Collapsible panel showing SCM webhook events                                   |
+| `ProviderDetailHeader`         | Breadcrumbs, title, version selector and manage actions for a provider         |
+| `ProviderUsageExample`         | `required_providers` snippet with copy-source action                           |
+| `ProviderPlatformsTable`       | OS/arch build matrix with copyable SHA256 sums                                 |
+| `ProviderInfoPanel`            | Provider sidebar card (namespace, latest version, repo/changelog links)        |
+| `ProviderVersionDetailsPanel`  | Provider version sidebar card with deprecation status and actions              |
+| `TerraformBinaryDetailHeader`  | Breadcrumbs, title, tool chip and mirror-URL hint for a binary mirror          |
+| `TerraformBinaryVersionsTable` | Synced-version table for a binary mirror (or its empty state)                  |
+| `TerraformBinaryVersionRow`    | One version row with expandable platform detail; exports `getChangelogUrl`     |
+| `TerraformBinaryPlatformRows`  | Lazily loaded OS/arch rows with SHA256 / GPG verification state                |
+| `RepositoryBrowser`            | SCM repository picker with branch/tag selection                                |
+| `StorageMigrationWizard`       | Multi-step dialog for storage backend migration                                |
+| `ProviderIcon`                 | Renders provider brand icons from simple-icons                                 |
+| `HelpPanel`                    | Slide-out contextual help panel                                                |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,5 +1,4 @@
 <!-- markdownlint-disable MD013 -->
-
 # Architecture
 
 This document describes the frontend architecture for the Terraform Registry, covering component hierarchy, routing, data fetching, authentication, and state management.
@@ -90,28 +89,28 @@ Routes are defined in `App.tsx`. The app uses React Router v6 with the following
 
 All admin routes are lazy-loaded and wrapped in `<ProtectedRoute requiredScope="...">`.
 
-| Path                       | Component                         | Required Scope       |
-| -------------------------- | --------------------------------- | -------------------- |
-| `/admin`                   | `DashboardPage`                   | (authenticated)      |
-| `/admin/users`             | `UsersPage`                       | `users:read`         |
-| `/admin/organizations`     | `OrganizationsPage`               | `organizations:read` |
-| `/admin/roles`             | `RolesPage`                       | `users:read`         |
-| `/admin/apikeys`           | `APIKeysPage`                     | (authenticated)      |
-| `/admin/upload`            | redirect → `/admin/upload/module` | —                    |
-| `/admin/upload/module`     | `ModuleUploadPage`                | `modules:write`      |
-| `/admin/upload/provider`   | `ProviderUploadPage`              | `providers:write`    |
-| `/admin/scm-providers`     | `SCMProvidersPage`                | `scm:read`           |
-| `/admin/mirrors`           | `MirrorsPage`                     | `mirrors:read`       |
-| `/admin/terraform-mirror`  | `TerraformMirrorPage`             | `mirrors:read`       |
-| `/admin/storage`           | `StoragePage`                     | `admin`              |
-| `/admin/approvals`         | `ApprovalsPage`                   | `mirrors:read`       |
-| `/admin/version-approvals` | `VersionApprovalsPage`            | `mirrors:read`       |
-| `/admin/policies`          | `MirrorPoliciesPage`              | `admin`              |
-| `/admin/oidc`              | `OIDCSettingsPage`                | `admin`              |
-| `/admin/scim`              | `SCIMProvisioningPage`            | `admin`              |
-| `/admin/mtls`              | `MTLSPage`                        | `admin`              |
-| `/admin/audit-logs`        | `AuditLogPage`                    | `audit:read`         |
-| `/admin/security-scanning` | `SecurityScanningPage`            | `admin`              |
+| Path                       | Component              | Required Scope       |
+| -------------------------- | ---------------------- | -------------------- |
+| `/admin`                   | `DashboardPage`        | (authenticated)      |
+| `/admin/users`             | `UsersPage`            | `users:read`         |
+| `/admin/organizations`     | `OrganizationsPage`    | `organizations:read` |
+| `/admin/roles`             | `RolesPage`            | `users:read`         |
+| `/admin/apikeys`           | `APIKeysPage`          | (authenticated)      |
+| `/admin/upload`            | redirect → `/admin/upload/module` | —         |
+| `/admin/upload/module`     | `ModuleUploadPage`     | `modules:write`      |
+| `/admin/upload/provider`   | `ProviderUploadPage`   | `providers:write`    |
+| `/admin/scm-providers`     | `SCMProvidersPage`     | `scm:read`           |
+| `/admin/mirrors`           | `MirrorsPage`          | `mirrors:read`       |
+| `/admin/terraform-mirror`  | `TerraformMirrorPage`  | `mirrors:read`       |
+| `/admin/storage`           | `StoragePage`          | `admin`              |
+| `/admin/approvals`         | `ApprovalsPage`        | `mirrors:read`       |
+| `/admin/version-approvals` | `VersionApprovalsPage` | `mirrors:read`       |
+| `/admin/policies`          | `MirrorPoliciesPage`   | `admin`              |
+| `/admin/oidc`              | `OIDCSettingsPage`     | `admin`              |
+| `/admin/scim`              | `SCIMProvisioningPage` | `admin`              |
+| `/admin/mtls`              | `MTLSPage`             | `admin`              |
+| `/admin/audit-logs`        | `AuditLogPage`         | `audit:read`         |
+| `/admin/security-scanning` | `SecurityScanningPage` | `admin`              |
 
 `ProtectedRoute` checks `useAuth()` for authentication and scope. If loading, it shows a spinner. If unauthenticated, it redirects to `/login`. If the required scope is missing (and the user does not have `admin`), it shows "Access Denied".
 
@@ -189,8 +188,8 @@ The `QueryClient` is configured in `App.tsx`:
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      staleTime: 30_000, // Data considered fresh for 30 seconds
-      retry: 1, // One retry on failure
+      staleTime: 30_000,       // Data considered fresh for 30 seconds
+      retry: 1,                // One retry on failure
       refetchOnWindowFocus: false,
     },
   },
@@ -395,18 +394,18 @@ auth/session provider and is treated as load-bearing security code).
 
 The following local files are thin wrappers or re-exports around it:
 
-| Local file                     | Wraps / re-exports from the package                                |
-| ------------------------------ | ------------------------------------------------------------------ |
-| `contexts/AuthContext.tsx`     | `AuthProvider`, `useAuth` (session lifecycle, expiry, scopes)      |
-| `contexts/ConsentContext.tsx`  | `ConsentProvider`, `useConsent` (GDPR consent preferences)         |
-| `contexts/ThemeContext.tsx`    | `SuiteThemeProvider`, `useThemeMode` (light/dark, RTL, whitelabel) |
-| `components/Layout.tsx`        | `SuiteLayout` (sidebar/topbar app shell)                           |
-| `components/Page.tsx`          | `Page` + `PageProps`                                               |
-| `components/PageHeader.tsx`    | `PageHeader` + `PageHeaderProps`                                   |
-| `components/DashboardCard.tsx` | `DashboardCard` + `DashboardCardProps`                             |
-| `components/ConsentBanner.tsx` | `ConsentBanner`                                                    |
-| `components/SuiteSwitcher.tsx` | `SuiteSwitcher` (cross-app switcher)                               |
-| `navigation.tsx`               | `NavItem` / `NavGroup` types for the sidebar config                |
+| Local file                     | Wraps / re-exports from the package                                 |
+| ------------------------------ | ------------------------------------------------------------------- |
+| `contexts/AuthContext.tsx`     | `AuthProvider`, `useAuth` (session lifecycle, expiry, scopes)       |
+| `contexts/ConsentContext.tsx`  | `ConsentProvider`, `useConsent` (GDPR consent preferences)          |
+| `contexts/ThemeContext.tsx`    | `SuiteThemeProvider`, `useThemeMode` (light/dark, RTL, whitelabel)  |
+| `components/Layout.tsx`        | `SuiteLayout` (sidebar/topbar app shell)                            |
+| `components/Page.tsx`          | `Page` + `PageProps`                                                |
+| `components/PageHeader.tsx`    | `PageHeader` + `PageHeaderProps`                                    |
+| `components/DashboardCard.tsx` | `DashboardCard` + `DashboardCardProps`                              |
+| `components/ConsentBanner.tsx` | `ConsentBanner`                                                     |
+| `components/SuiteSwitcher.tsx` | `SuiteSwitcher` (cross-app switcher)                                |
+| `navigation.tsx`               | `NavItem` / `NavGroup` types for the sidebar config                 |
 
 These files are not wrappers — they **consume** the package's components and
 types directly, adding this app's own data fetching and policy around them:
@@ -427,26 +426,26 @@ imports themselves.
 
 ## Shared Components
 
-| Component                      | Purpose                                                                        |
-| ------------------------------ | ------------------------------------------------------------------------------ |
-| `Layout`                       | App shell with collapsible sidebar, topbar, and `<Outlet />` for nested routes |
-| `ProtectedRoute`               | Auth guard checking authentication and scope                                   |
-| `ErrorBoundary`                | Catches render errors with fallback UI                                         |
-| `RegistryItemCard`             | Card component for module/provider search results                              |
-| `MarkdownRenderer`             | Renders markdown content (README files) with GFM and HTML sanitization         |
-| `SecurityScanPanel`            | Displays security scan results for a module version                            |
-| `VersionDetailsPanel`          | Shows version metadata, inputs/outputs, dependencies                           |
-| `WebhookEventsPanel`           | Collapsible panel showing SCM webhook events                                   |
-| `ProviderDetailHeader`         | Breadcrumbs, title, version selector and manage actions for a provider         |
-| `ProviderUsageExample`         | `required_providers` snippet with copy-source action                           |
-| `ProviderPlatformsTable`       | OS/arch build matrix with copyable SHA256 sums                                 |
-| `ProviderInfoPanel`            | Provider sidebar card (namespace, latest version, repo/changelog links)        |
-| `ProviderVersionDetailsPanel`  | Provider version sidebar card with deprecation status and actions              |
-| `TerraformBinaryDetailHeader`  | Breadcrumbs, title, tool chip and mirror-URL hint for a binary mirror          |
-| `TerraformBinaryVersionsTable` | Synced-version table for a binary mirror (or its empty state)                  |
-| `TerraformBinaryVersionRow`    | One version row with expandable platform detail; exports `getChangelogUrl`     |
-| `TerraformBinaryPlatformRows`  | Lazily loaded OS/arch rows with SHA256 / GPG verification state                |
-| `RepositoryBrowser`            | SCM repository picker with branch/tag selection                                |
-| `StorageMigrationWizard`       | Multi-step dialog for storage backend migration                                |
-| `ProviderIcon`                 | Renders provider brand icons from simple-icons                                 |
-| `HelpPanel`                    | Slide-out contextual help panel                                                |
+| Component                | Purpose                                                                        |
+| ------------------------ | ------------------------------------------------------------------------------ |
+| `Layout`                 | App shell with collapsible sidebar, topbar, and `<Outlet />` for nested routes |
+| `ProtectedRoute`         | Auth guard checking authentication and scope                                   |
+| `ErrorBoundary`          | Catches render errors with fallback UI                                         |
+| `RegistryItemCard`       | Card component for module/provider search results                              |
+| `MarkdownRenderer`       | Renders markdown content (README files) with GFM and HTML sanitization         |
+| `SecurityScanPanel`      | Displays security scan results for a module version                            |
+| `VersionDetailsPanel`    | Shows version metadata, inputs/outputs, dependencies                           |
+| `WebhookEventsPanel`     | Collapsible panel showing SCM webhook events                                   |
+| `ProviderDetailHeader`   | Breadcrumbs, title, version selector and manage actions for a provider        |
+| `ProviderUsageExample`   | `required_providers` snippet with copy-source action                          |
+| `ProviderPlatformsTable` | OS/arch build matrix with copyable SHA256 sums                                |
+| `ProviderInfoPanel`      | Provider sidebar card (namespace, latest version, repo/changelog links)       |
+| `ProviderVersionDetailsPanel` | Provider version sidebar card with deprecation status and actions        |
+| `TerraformBinaryDetailHeader` | Breadcrumbs, title, tool chip and mirror-URL hint for a binary mirror     |
+| `TerraformBinaryVersionsTable` | Synced-version table for a binary mirror (or its empty state)           |
+| `TerraformBinaryVersionRow` | One version row with expandable platform detail; exports `getChangelogUrl` |
+| `TerraformBinaryPlatformRows` | Lazily loaded OS/arch rows with SHA256 / GPG verification state          |
+| `RepositoryBrowser`      | SCM repository picker with branch/tag selection                                |
+| `StorageMigrationWizard` | Multi-step dialog for storage backend migration                                |
+| `ProviderIcon`           | Renders provider brand icons from simple-icons                                 |
+| `HelpPanel`              | Slide-out contextual help panel                                                |

--- a/frontend/src/__tests__/suitePackageDocumented.test.ts
+++ b/frontend/src/__tests__/suitePackageDocumented.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+// Read rather than imported with `?raw`: ARCHITECTURE.md sits at the repo root,
+// one level above this Vite project, and Vite denies module ids outside it.
+const architecture = readFileSync(resolve(process.cwd(), '../ARCHITECTURE.md'), 'utf8')
+
+/**
+ * ARCHITECTURE.md's two suite-package tables have to name every local file that
+ * imports from `@4cloudguru/cloud-suite-ui` (#603).
+ *
+ * The tables were written by hand and then six files started importing from the
+ * package without being added, which is the normal fate of a hand-maintained
+ * inventory. Rewriting them once fixes today; deriving the check from the
+ * imports themselves is what stops it recurring.
+ *
+ * A grep for the package NAME would not do: `routeScopes.ts` and
+ * `services/errorReporting.ts` mention it in prose comments while importing
+ * nothing from it, and counting those would demand rows for files that belong
+ * in neither table. The match is on an import statement.
+ *
+ * The check is one-directional on purpose. It fails when an importer is
+ * undocumented; it does not fail when a documented file stops importing,
+ * because both tables carry explanatory rows and prose that are worth keeping
+ * even so. Deletion is the cheaper error to notice by reading.
+ */
+
+const sources = import.meta.glob('../**/*.{ts,tsx}', {
+  query: '?raw',
+  import: 'default',
+  eager: true,
+}) as Record<string, string>
+
+const PACKAGE = '@4cloudguru/cloud-suite-ui'
+
+/** True only for a real import statement, not a mention in a comment. */
+function importsPackage(source: string): boolean {
+  return new RegExp(`(?:^|\\n)\\s*import[^;]*?from\\s*['"]${PACKAGE}['"]`).test(source)
+}
+
+function importers(): string[] {
+  return Object.entries(sources)
+    .filter(([path]) => !path.includes('__tests__') && !path.includes('.test.'))
+    .filter(([, source]) => importsPackage(source))
+    .map(([path]) => path.replace(/^\.\.\//, ''))
+    .sort()
+}
+
+describe('ARCHITECTURE.md documents every suite-package importer (#603)', () => {
+  it('finds importers to check', () => {
+    // Positive control: a rotted glob or regex finds nothing, and every
+    // assertion below passes over an empty set — a clean tree and a blind
+    // check produce the same green.
+    expect(importers().length).toBeGreaterThan(5)
+  })
+
+  it.each(importers())('%s appears in ARCHITECTURE.md', (file) => {
+    expect(architecture).toContain(file)
+  })
+
+  it('does not count a file that only names the package in a comment', () => {
+    expect(importsPackage(`// see ${PACKAGE} for the contract\nexport const x = 1`)).toBe(false)
+    expect(importsPackage(`import { isSafeUrl } from '${PACKAGE}'`)).toBe(true)
+  })
+})

--- a/frontend/src/__tests__/suitePackageDocumented.test.ts
+++ b/frontend/src/__tests__/suitePackageDocumented.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect } from 'vitest'
-import { readFileSync } from 'node:fs'
-import { resolve } from 'node:path'
-
-// Read rather than imported with `?raw`: ARCHITECTURE.md sits at the repo root,
-// one level above this Vite project, and Vite denies module ids outside it.
-const architecture = readFileSync(resolve(process.cwd(), '../ARCHITECTURE.md'), 'utf8')
+// ARCHITECTURE.md sits at the repo root, one level above this Vite project, so
+// vitest.config.ts extends server.fs.allow to reach it. Imported rather than
+// read through node:fs because tsconfig.json covers src/ without node types,
+// and pulling them in for one doc check would widen what the whole app may
+// call.
+import architecture from '../../../ARCHITECTURE.md?raw'
 
 /**
  * ARCHITECTURE.md's two suite-package tables have to name every local file that

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -23,6 +23,14 @@ export default defineConfig({
       '@': resolve(__dirname, './src'),
     },
   },
+  server: {
+    fs: {
+      // suitePackageDocumented.test.ts (#603) asserts against ARCHITECTURE.md,
+      // which lives at the repo root — outside this Vite project, and therefore
+      // denied by default.
+      allow: [resolve(__dirname, '..')],
+    },
+  },
   test: {
     environment: 'happy-dom',
     setupFiles: './src/setupTests.ts',


### PR DESCRIPTION
## The gap

ARCHITECTURE.md listed **ten** local files as wrapping or re-exporting `@4cloudguru/cloud-suite-ui`. **Six more** import from it and were never added: `APIKeysPage`, `NotificationsPage`, `BrandingPage`, `BrandingStep`, `themeApi.ts`, `externalUrl.ts`.

## Why a second table

None of the six is a wrapper. They **consume** the package's components and types, adding this app's own data fetching and policy — `externalUrl.ts` composes `isSafeUrl` with a scheme narrowing and an origin allowlist rather than re-exporting it.

Filing them under *"thin wrappers or re-exports"* would have completed the inventory by making its own description false.

`routeScopes.ts` and `services/errorReporting.ts` name the package in **prose comments** and import nothing from it. They're called out as deliberately absent, so the next reader doesn't add them back.

## The part that matters

Rewriting the tables fixes today. A hand-maintained inventory drifts again by the same mechanism that produced this issue — so the check is derived from the imports themselves: every file whose source contains an `import ... from '@4cloudguru/cloud-suite-ui'` must appear in ARCHITECTURE.md.

Matching on the package **name** would have been wrong here, and instructively so: it would demand rows for the two comment-only mentions, i.e. it would fail on files that belong in neither table.

It's **one-directional** on purpose — it fails when an importer is undocumented, not when a documented file stops importing. Both tables carry prose worth keeping, and a stale row is the cheaper error to catch by reading.

| Mutation | Result |
|---|---|
| a row deleted (the original #603 defect) | caught |
| the whole consumer table removed | caught |
| a new importer nobody documented | caught |

Its first assertion is a positive control: a rotted glob or regex finds nothing, and every `it.each` would pass over an empty set — a clean tree and a blind check look identical otherwise.

**Refs #603** — this is the documentation half of that issue: *"there is no single place that documents the full contract surface the app relies on"*. The issue's main recommendation — routing these imports through a local facade module so upgrades have one place to absorb breaking changes — is **not** addressed here, so #603 stays open.
