### PR TITLE
chore(deps): give every Dependabot updater a 7-day cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -150,3 +150,8 @@ updates:
       commit-message-check:
         patterns:
           - "*"
+    # zizmor dependabot-cooldown: the implicit default is 3 days and the audit
+    # requires 7. Security updates are exempt from cooldown, so this delays
+    # feature bumps and not fixes.
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
chore(deps): give every Dependabot updater a 7-day cooldown

zizmor's `dependabot-cooldown` audit requires 7 days; an updater with no
`cooldown:` takes GitHub's implicit default of 3.

The honest size of this: it is 3 days -> 7, not 0 -> 7. There IS already a
cooldown, shorter than the threshold. Security updates are exempt from cooldown
entirely, so this delays feature bumps and not fixes.

Estate-wide sweep rather than one repo at a time: 19 stanzas across 12
repositories had no cooldown, against 53 that already carried exactly
`default-days: 7`. Every ecosystem involved (npm, github-actions, gomod) already
uses cooldown elsewhere in the estate, so support is established rather than
assumed.