### PR TITLE
chore(ci): normalise the Dependabot updater conventions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -106,6 +106,10 @@ updates:
   # ---------------------------------------------------------------------------
   # GitHub Actions
   # ---------------------------------------------------------------------------
+    groups:
+      docker-dependencies:
+        patterns:
+          - '*'
   - package-ecosystem: github-actions
     directory: /
     schedule:
@@ -119,7 +123,7 @@ updates:
       - dependencies
       - github-actions
     commit-message:
-      prefix: "chore(ci)"
+      prefix: "chore(deps)"
     groups:
       github-actions-dependencies:
         patterns:
@@ -145,7 +149,7 @@ updates:
       - dependencies
       - github-actions
     commit-message:
-      prefix: "chore(ci)"
+      prefix: "chore(deps)"
     groups:
       commit-message-check:
         patterns:


### PR DESCRIPTION
chore(ci): normalise the Dependabot updater conventions

`.github/dependabot.yml` cannot be shared -- it must live in each repository's
own `.github/`, there is no `uses:`-style include for it, and it is not one of
the files an org-level `.github` repository supplies defaults for. Every
convention in it is therefore duplicated 19 times by construction, and it had
drifted:

  commit-message.prefix     SIX variants (chore, chore(ci), chore(deps), deps,
                            ci(deps), build(deps)) plus two stanzas with none
  schedule                  a 36/36 split between bare `weekly` and
                            `weekly monday 09:00 UTC`
  open-pull-requests-limit  18 stanzas overriding the platform default
  groups                    11 stanzas with none, so one PR per dependency

Normalised to `chore(deps)`, `weekly monday 09:00 UTC`, no explicit
open-pull-requests-limit, and a group on every stanza.

NOT normalised, deliberately: the 16 groups that select by `dependency-type:
development` or `update-types: [minor, patch]` rather than `patterns`. Those are
NARROWER than `patterns: ["*"]`; rewriting them to a wildcard would widen what
they batch. The invariant is that a stanza groups its pull requests, not that it
groups them by pattern.

Also untouched: directories and `ignore` rules. 14 of 21 distinct directories
appear in exactly one repository and 33 of 72 stanzas carry repo-specific ignore
policy, so that half is irreducibly local -- centralising it would trade visible
duplication for the harder-to-see drift this estate already documents.

Changing the prefix is changelog-safe: no release-please config in the estate
declares changelog-sections for `ci`, `deps` or `chore`.

Rewritten with ruamel so comments survive; verified per repo that the file still
parses and the comment count is unchanged.