### PR TITLE
chore(ci): move every shared-workflows pin to v1.14.0

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -222,7 +222,7 @@ jobs:
       # Called as a step, the job keeps its name and the context keeps reporting
       # as "Breaking-change footers survive the squash".
       - name: Count breaking-change declarations across this PR's commits
-        uses: 4cloudguru/shared-workflows/.github/actions/breaking-change-footers@9276df8e0bdb3152e2529ab98c8b99cfb9e22d4b # v1.13.0
+        uses: 4cloudguru/shared-workflows/.github/actions/breaking-change-footers@9ed6d3c988fb075f1023680d92eb4cf5a8e55056 # v1.14.0
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
           pr-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -46,7 +46,7 @@ permissions:
 
 jobs:
   release-please:
-    uses: 4cloudguru/shared-workflows/.github/workflows/release-please.yml@9276df8e0bdb3152e2529ab98c8b99cfb9e22d4b # v1.13.0
+    uses: 4cloudguru/shared-workflows/.github/workflows/release-please.yml@9ed6d3c988fb075f1023680d92eb4cf5a8e55056 # v1.14.0
     # Exactly one secret, named. NOT `secrets: inherit` -- that forwards EVERY
     # secret in this repository to a workflow in another owner's repository,
     # which zizmor flags (secrets-inherit) and which would have been an

--- a/.github/workflows/signature-replay.yml
+++ b/.github/workflows/signature-replay.yml
@@ -49,7 +49,7 @@ concurrency:
 
 jobs:
   replay:
-    uses: 4cloudguru/shared-workflows/.github/workflows/signature-replay.yml@9276df8e0bdb3152e2529ab98c8b99cfb9e22d4b # v1.13.0
+    uses: 4cloudguru/shared-workflows/.github/workflows/signature-replay.yml@9ed6d3c988fb075f1023680d92eb4cf5a8e55056 # v1.14.0
     # Exactly one secret, named. NOT `secrets: inherit`.
     secrets:
       SUITE_READ_APP_KEY: ${{ secrets.SUITE_READ_APP_KEY }}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -32,7 +32,7 @@ concurrency:
 
 jobs:
   workflow-security:
-    uses: 4cloudguru/shared-workflows/.github/workflows/workflow-security.yml@9276df8e0bdb3152e2529ab98c8b99cfb9e22d4b # v1.13.0
+    uses: 4cloudguru/shared-workflows/.github/workflows/workflow-security.yml@9ed6d3c988fb075f1023680d92eb4cf5a8e55056 # v1.14.0
 
   # Second gate, same family: zizmor audits workflow SECURITY, this audits
   # workflow HARDENING -- pins labelled, jobs bounded by a timeout,
@@ -45,6 +45,6 @@ jobs:
   # shared-workflows at that commit, so this repo cannot weaken its own gate by
   # editing a local copy -- there is no local copy.
   workflow-hardening:
-    uses: 4cloudguru/shared-workflows/.github/workflows/workflow-hardening.yml@9276df8e0bdb3152e2529ab98c8b99cfb9e22d4b # v1.13.0
+    uses: 4cloudguru/shared-workflows/.github/workflows/workflow-hardening.yml@9ed6d3c988fb075f1023680d92eb4cf5a8e55056 # v1.14.0
     with:
-      script-ref: 9276df8e0bdb3152e2529ab98c8b99cfb9e22d4b
+      script-ref: 9ed6d3c988fb075f1023680d92eb4cf5a8e55056


### PR DESCRIPTION
chore(ci): move every shared-workflows pin to v1.14.0

Second coordinated pass; v1.13.0 landed a few hours ago and v1.14.0 shipped
today. Three ADO repos had already taken it on signature-replay.yml while
sixteen sat on v1.13.0, so the estate was split again by the same mechanism the
first pass fixed.

v1.14.0 is two commits, and one of them is why this bump is worth making
promptly rather than waiting for Dependabot:

  #26  enforce that script-ref equals the uses: pin beside it
  #27  tell a fork PR apart from a misconfigured repo

`workflow-hardening.yml` declares `script-ref` as required and documented as
"MUST be the same commit this workflow is pinned at". Nothing checked it, and
Dependabot rewrites `uses:` lines while knowing nothing of workflow inputs -- so
its bump moves one and not the other and the resulting PR is green. #26 is the
rule that makes that detectable, and a consumer only gets it when it moves its
own pin. Sitting on v1.13.0 means running without the check that catches the
skew this very file could acquire.

Risk measured rather than assumed. Diffing every artefact from v1.13.0:
go-install, breaking-change-footers, release-please.yml, workflow-hardening.yml,
workflow-security.yml and workflow-security-record.yml are BYTE-IDENTICAL. Only
signature-replay.yml changed (+32), plus the checker script and its tests.

As before this moves the `uses:` pin, the version comment and `script-ref`
together, and asserts afterwards that no v1.13.0 SHA remains anywhere and that
every script-ref equals the workflow-hardening pin in its own file.