### PR TITLE
chore(ci): require a Release-As beside a declared breaking change

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -222,7 +222,7 @@ jobs:
       # Called as a step, the job keeps its name and the context keeps reporting
       # as "Breaking-change footers survive the squash".
       - name: Count breaking-change declarations across this PR's commits
-        uses: 4cloudguru/shared-workflows/.github/actions/breaking-change-footers@9ed6d3c988fb075f1023680d92eb4cf5a8e55056 # v1.14.0
+        uses: 4cloudguru/shared-workflows/.github/actions/breaking-change-footers@3dac549c7e4fe4a0dc54aaf9ed187b6da2c6eab9 # v1.15.0
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
           pr-number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
Bumps the `breaking-change-footers` action to **v1.15.0**, which adds a requirement: a pull request declaring a breaking change must also carry a `Release-As:` footer naming the version to cut.

## Why

Under conventional versioning a `BREAKING CHANGE` footer bumps the **major**. For an application nothing imports, that announces a redesign nobody did — terraform-registry-backend went 3.5.2 to 4.0.0 in an afternoon that way, which is what put `always-bump-minor` into the two Go backends.

That flag turns out to be symmetric: it caps majors **and** lifts every `fix:`-only release to a minor. So the cap moves from the configuration to the commit — a `Release-As:` footer, decided per release — and this is what stops it being forgotten on the release it mattered for.

## What changes here

Nothing, until you declare a breaking change. Then CI asks for:

```text
BREAKING CHANGE: ...what an operator must do...

Release-As: <current-major>.<current-minor + 1>.0
```

**If a major is genuinely intended**, say so in the PR and either set `require-release-as: "false"` on that step for the merge, or cut the release manually.

Line-anchored, matching how release-please actually reads the footer — accepting one CI can see but the parser would not is how a PR passes and still cuts a major.

Upstream: 4cloudguru/shared-workflows#30 — 26 assertions, mutation-verified.
