### PR TITLE
chore(ci): move breaking-change-footers to v1.16.0

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -222,7 +222,7 @@ jobs:
       # Called as a step, the job keeps its name and the context keeps reporting
       # as "Breaking-change footers survive the squash".
       - name: Count breaking-change declarations across this PR's commits
-        uses: 4cloudguru/shared-workflows/.github/actions/breaking-change-footers@3dac549c7e4fe4a0dc54aaf9ed187b6da2c6eab9 # v1.15.0
+        uses: 4cloudguru/shared-workflows/.github/actions/breaking-change-footers@68cee21133ae19352ee69570a7747838a442b659 # v1.16.0
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
           pr-number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
Moves `breaking-change-footers` to **v1.16.0**, which fixes a gate that has been green on the wrong property in every consumer since v1.15.0.

## What v1.15.0 checked, and what it should have

It asserted a `Release-As` footer **exists**. release-please honours `Release-As` only in the message's **trailer block** — the final paragraph, and only when that paragraph is `Key: Value` lines.

Those differ whenever a branch has more than one commit, which is most branches.

`terraform-state-manager-backend#499` carried `Release-As: 3.14.0`, passed the gate, and produced a release PR for **4.0.0** — because a second commit's body was concatenated after the footer by the squash, and because `Closes #439` sat after it too (no colon, so not a trailer).

## What v1.16.0 checks

It reconstructs the message the squash will produce, takes the final paragraph, and requires `Release-As` to be there among trailers only. The failure message prints that paragraph.

## Worth a look in this repository

Any **multi-commit breaking change** merged since v1.15.0 may have taken a major it did not intend. Checking this repo's tags against its intent is cheap and worth doing once.
