### PR TITLE
fix(ci): give translation PRs the CI every other PR gets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,21 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/setup-frontend
 
+      # Runs before the ESLint pass, and from the repository root rather than frontend/.
+      #
+      # PREVENTIVE layer: it stops a CI-skip directive reaching a workflow or action file
+      # at all. Deliberately not the only layer -- it is a check, and the directive it
+      # looks for is the thing that stops checks running, so a PR already carrying one in
+      # its head commit skips this job along with every other. The suppression-immune half
+      # lives in pr-ci-presence.yml, on a schedule, where no commit message can reach it.
+      #
+      # Needs frontend/node_modules, so it runs after setup-frontend: the scanner parses
+      # the YAML and tests resolved string values, because four different spellings of the
+      # same directive all resolve to the live one while defeating a source-text regex.
+      # Without the parser it exits 2 rather than reporting clean.
+      - name: No CI-skip directives in workflow or action files
+        run: node scripts/check-workflow-ci-skip.mjs
+
       - name: Lint
         working-directory: frontend
         run: npm run lint

--- a/.github/workflows/pr-ci-presence.yml
+++ b/.github/workflows/pr-ci-presence.yml
@@ -1,0 +1,84 @@
+---
+# Every open pull request must actually have CI attached to it.
+#
+# WHY THIS IS NOT A PULL_REQUEST WORKFLOW
+# ---------------------------------------
+# The condition being detected -- "no workflow ran for this PR" -- is precisely the
+# condition that stops a pull_request-triggered workflow from running. A CI-skip directive
+# on a branch's head commit suppresses `push` and `pull_request` runs alike, so an
+# assertion carried by either event is inert in exactly the case it exists to catch. It
+# would sit at "Expected - waiting for status" alongside the checks it was meant to be
+# vouching for.
+#
+# GitHub's skip keywords apply to `push` and `pull_request` only. `schedule` therefore
+# cannot be suppressed by anything written in a commit message, which is the property this
+# guard needs and the reason it is the trigger here.
+#
+# `pull_request_target` was the other candidate and was rejected twice over: the
+# documentation does not settle whether the skip keywords apply to it, and building the
+# only load-bearing guard on an unverified assumption is how the original defect survived
+# for seventeen pull requests; and it runs with a base-context write token, a hazard the
+# workflow-security gate in this repository exists to keep out.
+#
+# COST OF THIS CHOICE, STATED PLAINLY
+# -----------------------------------
+# A scheduled auditor is detective, not preventive: it reports after the fact and a PR
+# merged inside the interval can still slip past. That gap is covered from the other side
+# by translate.yml, which asserts on its own PR in the run that opens it, and by
+# scripts/check-workflow-ci-skip.mjs, which is a required check and stops the directive
+# reaching a workflow file in the first place. Three layers, because each one alone has a
+# hole the other two do not.
+#
+# A failing scheduled run notifies the account that last modified this file. Note also
+# that GitHub disables scheduled workflows in a repository with 60 days of no activity;
+# the workflow_dispatch trigger is here so it can always be run on demand.
+
+name: PR CI presence
+
+"on":
+  schedule:
+    # Every 30 minutes. Frequent enough to catch a PR before a same-session merge,
+    # infrequent enough not to spend the API budget.
+    - cron: "*/30 * * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-ci-presence
+  cancel-in-progress: true
+
+jobs:
+  pr-ci-presence:
+    name: Open PRs have checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      # hardening-exception: egress-audit — this job calls the GitHub API; harden-runner
+      #   has never run in this repository, so no endpoint baseline exists and a block
+      #   policy written without one fails closed on its first run; audit is what
+      #   produces that list
+      - name: Harden the runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+
+      # No npm install: the script uses only the Node standard library and global fetch,
+      # so it cannot be broken by a dependency change, and it runs identically here and
+      # on a developer's machine.
+      - name: Assert every open PR has check runs
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          # Minutes a head commit may exist with no checks before that counts as a
+          # failure, rather than as a run that simply has not started yet.
+          GRACE_MINUTES: "15"
+        run: node scripts/assert-pr-checks-present.mjs

--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -65,6 +65,7 @@ jobs:
           DEEPL_API_KEY: ${{ secrets.DEEPL_API_KEY }}
 
       - name: Create PR with translations
+        id: cpr
         # v8.1.1
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
@@ -78,5 +79,31 @@ jobs:
             - [ ] Spot-check a few strings in each language for accuracy
             - [ ] No English source strings appear verbatim in non-English files
             - [ ] Interpolation tokens (`{{name}}`) are preserved correctly
-          commit-message: "chore(i18n): update translations [skip ci]"
+          # NO CI-skip directive here, and never again. GitHub honours one on a
+          # branch HEAD COMMIT for both the push and the pull_request event, and
+          # create-pull-request never rewrites that head commit, so the suppression
+          # lasted the entire life of every PR this workflow opened. Seventeen of
+          # twenty-seven merged with no gate having inspected them.
+          #
+          # Removing it cannot loop: this job triggers on pushes that touch
+          # frontend/src/locales/en/translation.json, and scripts/translate.mjs only
+          # ever writes the non-English bundles and scripts/.translation-hashes.json.
+          # Merging its own PR therefore does not re-trigger it. The recursion the
+          # directive appeared to guard against was never possible.
+          #
+          # scripts/check-workflow-ci-skip.mjs fails CI if it comes back, in any
+          # spelling: it tests the resolved YAML value, not the source text.
+          commit-message: "chore(i18n): update translations"
           delete-branch: true
+
+      # Zero-latency half of the guard. The scheduled auditor in pr-ci-presence.yml is
+      # the suppression-immune backstop, but it runs on a cadence and these PRs are
+      # sometimes merged within the hour. This asserts, in the run that opens the PR,
+      # that checks actually attached to it -- and this job is reachable, because it is
+      # triggered by a human push to main rather than by the bot commit under test.
+      - name: Assert the translation PR has checks
+        if: steps.cpr.outputs.pull-request-number != ''
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
+        run: node scripts/assert-pr-checks-present.mjs --pr "$PR_NUMBER" --wait 10

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -354,6 +354,69 @@ Once `DEEPL_API_KEY` is configured, the workflow:
 - Translates new/changed keys for every supported locale via DeepL.
 - Opens a PR (`i18n/auto-translate`) titled `i18n: update translations` for review.
 
+### Translation PRs must have CI attached
+
+`translate.yml` used to commit with a **CI-skip directive** in its message. GitHub honours one
+on a branch's **head commit** for both the `push` and the `pull_request` event, and
+`create-pull-request` never rewrites that head commit — so every PR the workflow opened was
+born with zero real check runs, branch protection sat at "Expected — waiting for status", and
+the only way to land it was an override of a PR no gate had inspected. **Seventeen of the
+twenty-seven merged translation PRs went in that way.**
+
+The natural experiment is on the branch itself: PR #849, head carrying the directive, has one
+check run — `Auto-merge Dependabot`, conclusion `skipped`. PR #822, whose head is a
+`Merge branch 'main'` commit written by the **Update branch** button and carrying no directive,
+has twenty-one. Same branch, same token, same triggers; the commit message is the only variable.
+
+Three layers keep it fixed, because each one alone has a hole the other two cover:
+
+| Layer | Where | Catches |
+|---|---|---|
+| `scripts/check-workflow-ci-skip.mjs` | step in the required **Lint** check | the directive reaching any workflow or action file |
+| `scripts/assert-pr-checks-present.mjs` | `.github/workflows/pr-ci-presence.yml`, on a **schedule** | any open PR with no checks, whatever the cause |
+| the same script, `--pr` mode | last step of `translate.yml` | the translation PR itself, with no scheduler latency |
+
+The scheduled auditor is the load-bearing one. A guard for *"no checks ran"* that is itself a
+check cannot fire in the one situation it exists to detect — the suppression that hides the CI
+hides the guard with it. GitHub's skip keywords apply to `push` and `pull_request` only, so
+`schedule` is the trigger a commit message cannot reach.
+
+The static scanner runs **two passes**. Pass 1 reads raw text. Pass 2 parses the YAML and tests
+the **resolved string values** — what GitHub itself reads — because YAML has many spellings for
+one string and all of these resolve to the live directive while defeating a source-text regex:
+
+```yaml
+commit-message: "... [skip\x20ci]"      # hex escape for the space
+commit-message: "... [skip\u0020ci]"    # unicode escape for the space
+commit-message: "... \x5Bskip ci]"      # hex escape for the opening bracket
+commit-message: "... [skip \
+  ci]"                                  # double-quoted line continuation
+```
+
+The last is the instructive case: whitespace-normalising the whole file closes the `>-` folded
+scalar **only**, because a line continuation leaves a literal backslash between the words that
+survives normalisation. Testing the resolved value closes all of them at once. Pass 1 is kept
+because comments do not survive parsing and an unparseable file still gets read; a directive
+must evade **both**.
+
+The scanner enumerates **every YAML file under `.github`**, recursively, plus any `action.yml`
+elsewhere — not just `.github/workflows/*.yml`. `.github/dependabot.yml` has a `commit-message:`
+key of its own, and a composite action can `git commit` in a `run:` block. It then cross-checks
+what it read against an independent enumeration and exits non-zero if the two disagree, because
+a walk that quietly narrows goes green over the files it stopped reading.
+
+Run them locally:
+
+```bash
+node scripts/check-workflow-ci-skip.mjs
+GITHUB_REPOSITORY=sethbacon/terraform-registry-frontend \
+  node scripts/assert-pr-checks-present.mjs
+```
+
+Never re-add a skip directive to a commit message. If a workflow needs to avoid re-triggering
+itself, express that as a `paths:` or `branches:` filter on the trigger, where it is visible
+and reviewable.
+
 ---
 
 ## Pull Request Process

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -60,6 +60,7 @@
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.4",
         "happy-dom": "^20.9.0",
+        "js-yaml": "^4.2.0",
         "jsdom": "^30.0.1",
         "prettier": "^3.9.6",
         "rollup-plugin-visualizer": "^7.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -72,6 +72,7 @@
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.4",
     "happy-dom": "^20.9.0",
+    "js-yaml": "^4.2.0",
     "jsdom": "^30.0.1",
     "prettier": "^3.9.6",
     "rollup-plugin-visualizer": "^7.1.1",

--- a/scripts/assert-pr-checks-present.mjs
+++ b/scripts/assert-pr-checks-present.mjs
@@ -1,0 +1,215 @@
+#!/usr/bin/env node
+/**
+ * Assert that pull requests actually have CI attached to them.
+ *
+ * THE HOLE THIS EXISTS TO FILL
+ * ----------------------------
+ * The natural place to detect "this PR ran no checks" is a check. That guard cannot
+ * possibly fire, because the condition it detects is the condition that stops it running.
+ * A CI-skip directive on a branch's head commit suppresses `push` AND `pull_request`
+ * workflow runs alike, so a `pull_request`-triggered assertion is suppressed by the very
+ * thing it is looking for. It is not merely unreliable, it is inert exactly when needed.
+ *
+ * So the assertion has to be driven by an event that a commit message cannot suppress.
+ * GitHub's skip keywords apply to `push` and `pull_request` only. This script is therefore
+ * driven by `schedule` (see .github/workflows/pr-ci-presence.yml), which no commit message
+ * can suppress, and additionally called in-band by translate.yml straight after it opens a
+ * PR, to remove the scheduler's latency for the one producer known to have caused this.
+ *
+ * `pull_request_target` was considered as the immune trigger and rejected: whether the skip
+ * keywords apply to it is not something the documentation settles, and building the only
+ * load-bearing guard on an unverified assumption is how the original bug survived. It also
+ * runs with a base-context token, which is a hazard this repository's workflow-security gate
+ * exists to keep out.
+ *
+ * BLIND VERSUS CLEAN
+ * ------------------
+ * "No PR is missing its checks" and "I cannot see check runs at all" produce the same
+ * silence. Before trusting any zero, this script proves it can observe a non-zero: it walks
+ * back the default branch until it finds a commit that DOES have check runs. If it cannot
+ * find one, it exits 2 (blind) rather than 0 (clean).
+ *
+ * Usage:
+ *   node scripts/assert-pr-checks-present.mjs                  audit every open PR
+ *   node scripts/assert-pr-checks-present.mjs --pr 123         audit one PR, poll for it
+ *   node scripts/assert-pr-checks-present.mjs --pr 123 --wait 0   audit one PR, no polling
+ *
+ * Env: GITHUB_REPOSITORY (owner/repo), GITHUB_TOKEN (optional; only raises the rate limit --
+ * check runs and statuses are world-readable on a public repository, so this guard cannot be
+ * blinded by narrowing a token).
+ *
+ * Exit codes: 0 clean, 1 a PR has no checks, 2 the guard could not see (blind / bad input).
+ */
+
+const API = 'https://api.github.com';
+
+function arg(name, fallback = null) {
+  const i = process.argv.indexOf(name);
+  return i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : fallback;
+}
+
+const REPO = process.env.GITHUB_REPOSITORY || arg('--repo');
+const GRACE_MIN = Number(process.env.GRACE_MINUTES || arg('--grace', '15'));
+const PR_ONLY = arg('--pr');
+const WAIT_MIN = Number(arg('--wait', PR_ONLY ? '10' : '0'));
+
+if (!REPO || !REPO.includes('/')) {
+  console.error('ERROR: set GITHUB_REPOSITORY (owner/repo) or pass --repo owner/repo');
+  process.exit(2);
+}
+
+async function gh(path) {
+  const headers = { Accept: 'application/vnd.github+json', 'User-Agent': 'pr-ci-presence' };
+  if (process.env.GITHUB_TOKEN) headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+  const res = await fetch(`${API}${path}`, { headers });
+  if (!res.ok) {
+    // An API failure is NOT an empty result. Treating it as one is how a guard goes quietly
+    // green over a universe it never managed to read.
+    throw new Error(`GitHub API ${res.status} ${res.statusText} for ${path}`);
+  }
+  return res.json();
+}
+
+/** check-runs + commit statuses on one SHA. */
+async function coverage(sha) {
+  const [checks, status] = await Promise.all([
+    gh(`/repos/${REPO}/commits/${sha}/check-runs?per_page=1`),
+    gh(`/repos/${REPO}/commits/${sha}/status`),
+  ]);
+  return { checkRuns: checks.total_count ?? 0, statuses: status.total_count ?? 0 };
+}
+
+/**
+ * Prove the check-runs axis is observable at all. Without this, a permanently broken
+ * reader reports every PR as fine.
+ */
+async function proveNotBlind(defaultBranch) {
+  const commits = await gh(`/repos/${REPO}/commits?sha=${defaultBranch}&per_page=30`);
+  if (!Array.isArray(commits) || commits.length === 0) {
+    console.error(`ERROR: no commits enumerated on ${defaultBranch} -- cannot self-verify.`);
+    process.exit(2);
+  }
+  for (const c of commits) {
+    const { checkRuns, statuses } = await coverage(c.sha);
+    if (checkRuns > 0 || statuses > 0) {
+      console.log(
+        `vision check: ${c.sha.slice(0, 8)} on ${defaultBranch} has ` +
+          `${checkRuns} check run(s) / ${statuses} status(es) -- the guard can see checks`
+      );
+      return;
+    }
+  }
+  console.error(
+    `ERROR: none of the last ${commits.length} commits on ${defaultBranch} has a single ` +
+      'check run or status.\nThis guard cannot distinguish "every PR is covered" from ' +
+      '"I am unable to observe checks", so it refuses to report clean.'
+  );
+  process.exit(2);
+}
+
+const ageMinutes = (iso) => (Date.now() - new Date(iso).getTime()) / 60000;
+
+async function evaluate(pr) {
+  const sha = pr.head.sha;
+  const commit = await gh(`/repos/${REPO}/commits/${sha}`);
+  const committedAt = commit.commit.committer?.date || commit.commit.author?.date;
+  const { checkRuns, statuses } = await coverage(sha);
+  return {
+    number: pr.number,
+    title: pr.title,
+    sha,
+    checkRuns,
+    statuses,
+    ageMin: ageMinutes(committedAt),
+    covered: checkRuns > 0 || statuses > 0,
+  };
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function main() {
+  const repo = await gh(`/repos/${REPO}`);
+  const defaultBranch = repo.default_branch;
+
+  await proveNotBlind(defaultBranch);
+
+  let prs;
+  if (PR_ONLY) {
+    prs = [await gh(`/repos/${REPO}/pulls/${PR_ONLY}`)];
+  } else {
+    prs = await gh(`/repos/${REPO}/pulls?state=open&base=${defaultBranch}&per_page=100`);
+  }
+
+  // Say the size out loud. A run that inspected nothing must not read like a run that
+  // inspected everything and approved it.
+  console.log(`inspecting ${prs.length} pull request(s) against ${defaultBranch}`);
+  if (prs.length === 0) {
+    console.log('no open pull requests -- nothing to assert');
+    return 0;
+  }
+
+  const deadline = Date.now() + WAIT_MIN * 60000;
+  const POLL_SECONDS = 30;
+  let results = [];
+  for (;;) {
+    results = [];
+    for (const pr of prs) results.push(await evaluate(pr));
+
+    const uncovered = results.filter((r) => !r.covered);
+    if (uncovered.length === 0) break;
+    if (Date.now() >= deadline) break;
+
+    console.log(
+      `  ${uncovered.length} PR(s) still without checks; re-checking in ` +
+        `${POLL_SECONDS}s (up to ${WAIT_MIN}m)`
+    );
+    await sleep(POLL_SECONDS * 1000);
+  }
+
+  for (const r of results) {
+    const mark = r.covered ? 'ok  ' : 'NONE';
+    console.log(
+      `  ${mark} #${r.number} ${r.sha.slice(0, 8)} checks=${r.checkRuns} ` +
+        `statuses=${r.statuses} age=${r.ageMin.toFixed(0)}m  ${r.title}`
+    );
+  }
+
+  // When asked about one specific PR, waiting it out and still seeing nothing IS the failure;
+  // the grace window has already been spent in the polling loop.
+  const failing = PR_ONLY
+    ? results.filter((r) => !r.covered)
+    : results.filter((r) => !r.covered && r.ageMin >= GRACE_MIN);
+
+  if (failing.length > 0) {
+    console.error('\nPull requests with NO check runs and NO commit statuses:\n');
+    for (const r of failing) {
+      console.error(`  #${r.number}  ${r.sha}  (head is ${r.ageMin.toFixed(0)} minutes old)`);
+      console.error(`    https://github.com/${REPO}/pull/${r.number}`);
+    }
+    console.error(`
+Nothing has inspected these branches. Branch protection will show every required
+context as "Expected - waiting for status" indefinitely, which can only be cleared
+by an admin override -- a merge no gate has ever seen.
+
+The usual cause is a CI-skip directive in the head commit's message, which suppresses
+push and pull_request workflow runs alike. Check with:
+
+  gh api repos/${REPO}/commits/<sha> --jq .commit.message
+
+scripts/check-workflow-ci-skip.mjs rejects that directive in workflow files. If the
+message is clean, look instead at the workflow triggers and their branch filters.
+`);
+    return 1;
+  }
+
+  console.log('\nevery inspected pull request has CI attached');
+  return 0;
+}
+
+main().then(
+  (code) => process.exit(code),
+  (err) => {
+    console.error(`ERROR: ${err.message}`);
+    process.exit(2);
+  }
+);

--- a/scripts/check-workflow-ci-skip.mjs
+++ b/scripts/check-workflow-ci-skip.mjs
@@ -1,0 +1,445 @@
+#!/usr/bin/env node
+/**
+ * Reject CI-skip directives in workflow and composite-action files.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * `translate.yml` shipped `commit-message: "chore(i18n): update translations [skip ci]"`
+ * from the day it was written. GitHub honours the skip directive on the HEAD COMMIT of a
+ * branch for BOTH `push` and `pull_request` events, so every PR that workflow opened was
+ * born with zero check runs and zero commit statuses -- not red, not pending, absent.
+ * Branch protection showed "Expected - waiting for status" forever and seventeen of those PRs
+ * were merged without a single real gate ever executing. The natural experiment is on the
+ * branch itself: PR 849, whose head commit carries the directive, has one check run, and it
+ * is `Auto-merge Dependabot` with conclusion `skipped`. PR 822, whose head is a
+ * `Merge branch 'main'` commit written by the Update branch button and carrying no
+ * directive, has twenty-one. Same branch, same token, same triggers.
+ *
+ * The head commit of a `create-pull-request` branch never changes, so the suppression is
+ * permanent for the life of the PR.
+ *
+ * HOW THIS SCANS -- TWO PASSES, NEITHER SUFFICIENT ALONE
+ * -----------------------------------------------------
+ * The first version of this guard matched the RAW SOURCE TEXT only. That is not enough,
+ * because YAML has more than one spelling for the same string. All four of these parse to
+ * exactly `chore(i18n): update translations [skip ci]` and all four defeated a source-text
+ * regex:
+ *
+ *   commit-message: "... [skip\x20ci]"       <- hex escape for the space
+ *   commit-message: "... [skip\u0020ci]"     <- unicode escape for the space
+ *   commit-message: "... \x5Bskip ci]"       <- hex escape for the opening bracket
+ *   commit-message: "... [skip \<newline>ci]" <- double-quoted line continuation
+ *
+ * The fourth is the instructive one. A whitespace-normalising whole-file pass was believed
+ * to close the multi-line axis; it closes the `>-` folded scalar only. A line continuation
+ * leaves a literal backslash between the words, which survives normalisation and breaks
+ * `\s+`. Chasing spellings one at a time is unwinnable -- there is always a fifth.
+ *
+ * So the load-bearing pass is PASS 2: parse the YAML and test the RESOLVED STRING VALUES,
+ * which is what GitHub itself reads. Every present and future spelling of the same string
+ * collapses to one value, and one comparison covers them all.
+ *
+ * PASS 1 (raw text) is kept, because it is not a subset of pass 2:
+ *
+ *   - Comments are absent from parsed YAML. A directive in a comment is harmless today but
+ *     is one uncomment away from live, and a guard that cannot see it has a blind axis.
+ *   - A file that fails to parse still gets read.
+ *
+ * PASS 2 is not a subset of pass 1 either: it sees through escapes, continuations and folds.
+ * A directive has to evade BOTH to land. The union is the guard.
+ *
+ * KNOWN LIMIT: a directive assembled at runtime -- `commit-message: "x ${{ env.MSG }}"` --
+ * is invisible to any static scan, in either pass. That case is covered by the runtime
+ * auditor in scripts/assert-pr-checks-present.mjs, which observes the PR after it exists.
+ */
+
+import { readFileSync, readdirSync, existsSync, statSync } from 'node:fs';
+import { join, relative, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// GitHub's documented skip directives, as of the "Skipping workflow runs" page:
+// [skip ci] [ci skip] [no ci] [skip actions] [actions skip] and ***NO_CI***.
+// Matching is case-insensitive and tolerant of internal whitespace -- deliberately WIDER
+// than GitHub's own literal substring match, because over-reporting a directive costs one
+// review comment and under-reporting it costs an unverified merge.
+const BRACKETED =
+  /\[\s*(?:skip\s+ci|ci\s+skip|no\s+ci|skip\s+actions|actions\s+skip)\s*\]/gi;
+const STARRED = /\*\*\*\s*NO_CI\s*\*\*\*/gi;
+
+// Raise this when the repository gains workflows. NEVER lower it to make a red run green:
+// a shrinking sweep is the failure this floor exists to catch. A guard that enumerates
+// nothing reports exactly what a clean repository reports.
+const MIN_SCANNED_FILES = 11;
+
+/** Every match in one blob of text, as {text, index}. */
+function findAll(text) {
+  const hits = [];
+  for (const re of [BRACKETED, STARRED]) {
+    re.lastIndex = 0;
+    let m;
+    while ((m = re.exec(text)) !== null) hits.push({ text: m[0], index: m.index });
+  }
+  return hits.sort((a, b) => a.index - b.index);
+}
+
+/**
+ * PASS 1 -- raw source text. Returns [{where, text}].
+ *
+ * Deliberately NOT comment-stripped: a correct YAML comment stripper has to know that `#`
+ * inside a quoted scalar is not a comment, and a naive one truncates
+ * `commit-message: "chore: fix #123 [skip ci]"` at the `#` and reports the file clean.
+ * A directive sitting in a real comment fails here too; that is the price of having no
+ * blind axis, and the error message says so.
+ *
+ * The whitespace-normalised whole-file sub-pass catches a `>-` folded scalar, which YAML
+ * folds back into `[skip ci]` but which no per-line regex can see.
+ */
+export function scanRaw(source) {
+  const found = [];
+  source.split('\n').forEach((line, i) => {
+    for (const hit of findAll(line)) found.push({ where: `line ${i + 1}`, text: hit.text });
+  });
+
+  const perLineCount = found.length;
+  const wholeFile = findAll(source.replace(/\s+/g, ' '));
+  if (wholeFile.length > perLineCount) {
+    for (const hit of wholeFile.slice(perLineCount)) {
+      found.push({ where: 'folded across lines', text: hit.text.replace(/\s+/g, ' ') });
+    }
+  }
+  return found;
+}
+
+/**
+ * Walk a parsed YAML value, yielding every string it contains -- values AND keys -- with
+ * the path where it was found. Keys are included because a directive can hide in one:
+ * `run:` blocks, `env:` names and `with:` inputs are all just strings to the parser.
+ */
+function* walkStrings(node, path = '$') {
+  if (typeof node === 'string') {
+    yield { path, value: node };
+    return;
+  }
+  if (Array.isArray(node)) {
+    for (let i = 0; i < node.length; i += 1) yield* walkStrings(node[i], `${path}[${i}]`);
+    return;
+  }
+  if (node && typeof node === 'object') {
+    for (const [k, v] of Object.entries(node)) {
+      if (typeof k === 'string') yield { path: `${path}.${k} (key)`, value: k };
+      yield* walkStrings(v, `${path}.${k}`);
+    }
+  }
+}
+
+/**
+ * PASS 2 -- resolved YAML string values. Returns {hits, parsed}.
+ *
+ * `parsed: false` means the file could not be parsed, so pass 2 could NOT verify it.
+ * Callers must treat that as "unverified", never as "clean".
+ */
+export function scanResolved(source, yaml) {
+  const docs = [];
+  try {
+    yaml.loadAll(source, (d) => docs.push(d));
+  } catch {
+    return { hits: [], parsed: false };
+  }
+  const hits = [];
+  for (const doc of docs) {
+    for (const { path, value } of walkStrings(doc)) {
+      for (const hit of findAll(value)) {
+        hits.push({ where: `resolved value at ${path}`, text: hit.text });
+      }
+    }
+  }
+  return { hits, parsed: true };
+}
+
+/**
+ * Union of both passes, de-duplicated by the directive text so a plainly-written directive
+ * -- which both passes see -- is reported once, with every place it was observed.
+ */
+export function scanSource(source, yaml) {
+  const raw = scanRaw(source);
+  const resolved = yaml ? scanResolved(source, yaml) : { hits: [], parsed: null };
+
+  const byText = new Map();
+  for (const hit of [...raw, ...resolved.hits]) {
+    const key = hit.text.toLowerCase().replace(/\s+/g, ' ');
+    if (!byText.has(key)) byText.set(key, { text: hit.text, where: [] });
+    byText.get(key).where.push(hit.where);
+  }
+  return { violations: [...byText.values()], parsed: resolved.parsed };
+}
+
+/**
+ * The parser is load-bearing: without it pass 2 cannot run and the guard is back to being
+ * a source-text regex that four known spellings walk straight past. Resolve it explicitly
+ * rather than trusting ambient resolution -- js-yaml is a declared devDependency of
+ * frontend/, and this script runs from the repository root, so a bare specifier would not
+ * resolve. Returns null if unavailable; the caller must exit non-zero, never report clean.
+ */
+async function loadYamlParser(repoRoot) {
+  const candidates = [
+    join(repoRoot, 'frontend', 'node_modules', 'js-yaml', 'dist', 'js-yaml.mjs'),
+    join(repoRoot, 'node_modules', 'js-yaml', 'dist', 'js-yaml.mjs'),
+  ];
+  for (const path of candidates) {
+    if (!existsSync(path)) continue;
+    try {
+      const mod = await import(`file://${path}`);
+      const yaml = mod.default ?? mod;
+      if (typeof yaml.loadAll === 'function') return yaml;
+    } catch {
+      /* try the next candidate */
+    }
+  }
+  return null;
+}
+
+/**
+ * Every YAML file under .github, recursively, plus any composite action elsewhere in the
+ * tree. Recursive-and-unfiltered under .github is deliberate: the previous version listed
+ * `.github/workflows/*.yml` only and never once read
+ * `.github/actions/setup-frontend/action.yml` or `.github/dependabot.yml` -- and
+ * dependabot.yml has a `commit-message:` key of its very own. Enumerating the whole
+ * directory means a new workflow, action or config cannot be silently missed by a walk
+ * that was never taught about it.
+ */
+export function enumerateFiles(repoRoot) {
+  const files = [];
+  const isYaml = (f) => f.endsWith('.yml') || f.endsWith('.yaml');
+
+  const walk = (dir, { yamlOnly }) => {
+    if (!existsSync(dir)) return;
+    for (const entry of readdirSync(dir).sort()) {
+      if (entry === 'node_modules' || entry === '.git' || entry === 'dist') continue;
+      const full = join(dir, entry);
+      if (statSync(full).isDirectory()) {
+        walk(full, { yamlOnly });
+      } else if (yamlOnly ? isYaml(entry) : entry === 'action.yml' || entry === 'action.yaml') {
+        files.push(full);
+      }
+    }
+  };
+
+  walk(join(repoRoot, '.github'), { yamlOnly: true });
+  // Composite actions living outside .github are still actions.
+  const before = new Set(files);
+  walk(repoRoot, { yamlOnly: false });
+  return [...new Set([...before, ...files])].sort();
+}
+
+/**
+ * Independently re-enumerate every YAML file under .github and assert the scanned set
+ * covers it. This is deliberately a SECOND, dumber implementation than enumerateFiles:
+ * a walk that quietly narrows -- back to `.github/workflows/*.yml`, as the first version
+ * of this guard did, never once reading `.github/actions/setup-frontend/action.yml` or
+ * `.github/dependabot.yml` -- produces a clean run and a green check. Comparing the set
+ * that was READ against the set that EXISTS is the only thing that tells a blind sweep
+ * from an honest one.
+ */
+function coverageGaps(repoRoot, scanned) {
+  const expected = [];
+  const stack = [join(repoRoot, '.github')];
+  while (stack.length > 0) {
+    const dir = stack.pop();
+    if (!existsSync(dir)) continue;
+    for (const entry of readdirSync(dir)) {
+      const full = join(dir, entry);
+      if (statSync(full).isDirectory()) stack.push(full);
+      else if (entry.endsWith('.yml') || entry.endsWith('.yaml')) expected.push(full);
+    }
+  }
+  const seen = new Set(scanned);
+  return { gaps: expected.filter((f) => !seen.has(f)).sort(), expectedCount: expected.length };
+}
+
+function selfTest(yaml) {
+  const must = [
+    ['bare', 'commit-message: chore: x [skip ci]'],
+    ['double-quoted', 'commit-message: "chore: x [skip ci]"'],
+    ['single-quoted', "commit-message: 'chore: x [skip ci]'"],
+    ['uppercase', 'commit-message: "x [SKIP CI]"'],
+    ['mixed case', 'commit-message: "x [Skip Ci]"'],
+    ['extra space', 'commit-message: "x [skip   ci]"'],
+    ['tab inside', 'commit-message: "x [skip\tci]"'],
+    ['ci skip', 'commit-message: "x [ci skip]"'],
+    ['no ci', 'commit-message: "x [no ci]"'],
+    ['skip actions', 'commit-message: "x [skip actions]"'],
+    ['actions skip', 'commit-message: "x [actions skip]"'],
+    ['starred', 'commit-message: "x ***NO_CI***"'],
+    ['in a run block', '  run: git commit -m "chore: x [skip ci]"'],
+    ['in an env value', '  env:\n    MSG: "release [ci skip]"'],
+    // The blind axis a `#`-truncating comment stripper would create.
+    ['after a # inside a string', 'commit-message: "chore: fix #123 [skip ci]"'],
+    // The blind axis a per-line regex would create. Both passes catch this one.
+    ['folded across lines', 'commit-message: >-\n  chore: x [skip\n  ci]'],
+    // The four spellings that a source-text regex resolves to `[skip ci]` and misses.
+    // Each is caught by pass 2 ONLY -- deleting the resolved pass makes all four go dark.
+    ['hex-escaped space', 'commit-message: "chore: x [skip\\x20ci]"'],
+    ['unicode-escaped space', 'commit-message: "chore: x [skip\\u0020ci]"'],
+    ['hex-escaped bracket', 'commit-message: "chore: x \\x5Bskip ci]"'],
+    ['line continuation', 'commit-message: "chore: x [skip \\\n  ci]"'],
+    // A directive in a block scalar, which no escape trick needs.
+    ['literal block scalar', 'commit-message: |\n  chore: x\n  [skip ci]'],
+    // Key position, not value position.
+    ['in a key', '"[skip ci]": true'],
+  ];
+  const mustNot = [
+    ['no brackets', 'commit-message: "we do not skip ci here"'],
+    ['no space', 'commit-message: "x [skipci]"'],
+    ['different word', 'commit-message: "x [skipped ci]"'],
+    ['trailing content in bracket', 'commit-message: "x [skip ci and more]"'],
+    ['ordinary workflow line', '  run: npm run lint'],
+    ['a real workflow', 'name: CI\non: [push]\njobs:\n  a:\n    runs-on: ubuntu-latest'],
+  ];
+
+  let bad = 0;
+  let resolvedOnly = 0;
+  for (const [label, src] of must) {
+    if (scanSource(src, yaml).violations.length === 0) {
+      console.error(`  self-test MISS  (should have been caught): ${label}`);
+      bad += 1;
+    } else if (scanRaw(src).length === 0) {
+      // Proves pass 2 is doing work no source-text regex can do.
+      resolvedOnly += 1;
+    }
+  }
+  for (const [label, src] of mustNot) {
+    if (scanSource(src, yaml).violations.length !== 0) {
+      console.error(`  self-test FALSE POSITIVE: ${label}`);
+      bad += 1;
+    }
+  }
+
+  // A resolved pass that catches nothing the raw pass missed is a resolved pass that is
+  // not running. Assert it earns its place, so silently breaking it cannot read as green.
+  if (resolvedOnly < 4) {
+    console.error(
+      `  self-test FAILED: the resolved-YAML pass caught ${resolvedOnly} case(s) the raw ` +
+        'pass missed, expected at least 4. Pass 2 is not doing its job.',
+    );
+    bad += 1;
+  }
+
+  if (bad > 0) {
+    console.error(`\nself-test FAILED: ${bad} case(s). The scanner is not trustworthy.`);
+    return false;
+  }
+  console.log(
+    `self-test passed: ${must.length} caught (${resolvedOnly} only by the resolved-YAML ` +
+      `pass), ${mustNot.length} correctly ignored`,
+  );
+  return true;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const rootArg = args.find((a) => a.startsWith('--root='));
+  const repoRoot = rootArg
+    ? rootArg.slice('--root='.length)
+    : fileURLToPath(new URL('..', import.meta.url));
+
+  const yaml = await loadYamlParser(repoRoot);
+  if (!yaml) {
+    console.error('ERROR: could not load the js-yaml parser -- the resolved-value pass cannot run.');
+    console.error(
+      'Without it this guard is a source-text regex, and four known spellings of the same\n' +
+        'directive walk straight past a source-text regex. Run `npm ci` in frontend/ first.\n' +
+        'A guard that cannot see is not a guard that found nothing.',
+    );
+    process.exit(2);
+  }
+
+  // The scanner has to prove it can see a directive before its silence means anything.
+  // A regex that matches nothing looks exactly like a repository with nothing to find.
+  if (!selfTest(yaml)) process.exit(2);
+  if (args.includes('--self-test-only')) return;
+
+  const files = enumerateFiles(repoRoot);
+
+  // An empty or shrinking sweep is the bug class this guard exists to close. Green over
+  // nothing is not green.
+  if (files.length === 0) {
+    console.error(`ERROR: no workflow or action files found under ${repoRoot} -- nothing was scanned.`);
+    console.error('A guard that enumerates an empty universe cannot report anything.');
+    process.exit(2);
+  }
+  if (files.length < MIN_SCANNED_FILES) {
+    console.error(
+      `ERROR: scanned ${files.length} file(s), floor is ${MIN_SCANNED_FILES}. ` +
+        'The sweep shrank; the walk is broken or files moved out from under it.',
+    );
+    for (const f of files) console.error(`  enumerated: ${relative(repoRoot, f)}`);
+    process.exit(2);
+  }
+
+  // Cross-check the walk against an independent enumeration. A narrowed walk exits 2 here
+  // rather than reporting clean over the files it stopped reading.
+  const { gaps, expectedCount } = coverageGaps(repoRoot, files);
+  if (gaps.length > 0) {
+    console.error(
+      `ERROR: the walk read ${files.length} file(s) but ${expectedCount} YAML file(s) exist ` +
+        'under .github. These were never scanned:',
+    );
+    for (const f of gaps) console.error(`  ${relative(repoRoot, f).split(sep).join('/')}`);
+    console.error('\nA guard is only as wide as the set it enumerates.');
+    process.exit(2);
+  }
+
+  // Print the enumerated set. A blind axis and a clean one produce identical exit codes,
+  // so the only way to tell them apart is to say out loud what was actually read.
+  console.log(`scanned ${files.length} workflow/action file(s):`);
+  for (const f of files) console.log(`  ${relative(repoRoot, f).split(sep).join('/')}`);
+
+  const violations = [];
+  const unparseable = [];
+  for (const file of files) {
+    const rel = relative(repoRoot, file).split(sep).join('/');
+    const { violations: hits, parsed } = scanSource(readFileSync(file, 'utf8'), yaml);
+    if (parsed === false) unparseable.push(rel);
+    for (const hit of hits) violations.push({ file: rel, ...hit });
+  }
+
+  // A file pass 2 could not read is UNVERIFIED, not clean.
+  if (unparseable.length > 0) {
+    console.error('\nERROR: these files could not be parsed as YAML, so the resolved-value');
+    console.error('pass could not verify them. Unverified is not clean:\n');
+    for (const f of unparseable) console.error(`  ${f}`);
+    process.exit(2);
+  }
+
+  if (violations.length > 0) {
+    console.error('\nCI-skip directive found:\n');
+    for (const v of violations) {
+      console.error(`  ${v.file}  ->  ${v.text}`);
+      for (const w of v.where) console.error(`      seen at: ${w}`);
+    }
+    console.error(`
+A CI-skip directive in a commit message suppresses workflow runs for BOTH the
+push and the pull_request event. A pull request whose head commit carries one is
+created with zero check runs -- branch protection sits at "Expected - waiting for
+status" and the only way to land it is an admin override of a PR that no gate has
+ever inspected. That is how seventeen translation PRs merged unverified.
+
+If the intent was to avoid a loop, express it as a path or branch filter on the
+workflow's trigger, which is visible and reviewable, not as a directive hidden in
+a commit message.
+
+This scan reads both the raw text and the parsed YAML, and does not exempt
+comments, so writing the directive in a comment fails too. Refer to it in prose
+instead.
+`);
+    process.exit(1);
+  }
+
+  console.log('\nno CI-skip directives found');
+}
+
+// Only run when executed directly, so tests can import the scanning functions without
+// the module scanning the repository as an import side effect.
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  await main();
+}


### PR DESCRIPTION
The defect fixed in `terraform-state-manager-frontend#387` is live here too, **verbatim**, and has been since `translate.yml` was written. Filed as a separate PR, branched from this repo's `origin/main` — not stacked.

## The defect

`.github/workflows/translate.yml:81` carried a CI-skip directive in its `commit-message`. GitHub honours one on a branch's **head commit** for both the `push` and the `pull_request` event, and `create-pull-request` never rewrites that head commit — so suppression lasted each PR's entire life. Branch protection sat at "Expected — waiting for status" and the only way to land one was an override of a PR that no gate had inspected.

**17 of the 27 merged translation PRs went in that way** (measured per head SHA via `check-runs` and `status`):

| PR | head | check runs | statuses |
|---|---|---:|---:|
| #849 | `2923d304` | **1** | 0 |
| #822 | `29a7a2de` | 21 | 0 |
| #801 | `148daa98` | **1** | 0 |
| #790 | `c888a2a6` | 31 | 0 |
| #642, #592, #585, #572, #555, #458, #455, #448, #439, #433, #361, #357, #351, #348, #346 | — | **0** | 0 |

#849's single check run is `Auto-merge Dependabot` with conclusion **`skipped`** — not a gate at all.

The natural experiment is on the branch itself, same token and same triggers, one variable:

| head commit on `i18n/auto-translate` | checks |
|---|---:|
| `chore(i18n): update translations` + directive | **1**, and it is skipped |
| `Merge branch 'main' into i18n/auto-translate` (Update branch button) | **21** |

## The fix — three layers

| Layer | Trigger | Hole it has | Covered by |
|---|---|---|---|
| `scripts/check-workflow-ci-skip.mjs`, step in required **Lint** | `pull_request` | suppressed by the very directive it hunts | layer 2 |
| `pr-ci-presence.yml` → `assert-pr-checks-present.mjs` | **`schedule`** | detective, cadence latency | layers 1 and 3 |
| same script, `--pr` mode, last step of `translate.yml` | `push` to main | only the one producer | layers 1 and 2 |

A guard for *"no checks ran"* that is itself a check **cannot fire in the one condition it detects**. Skip keywords apply to `push` and `pull_request` only, so `schedule` is the trigger a commit message cannot reach. `pull_request_target` was rejected: the docs do not settle whether skip keywords apply to it, and it carries a base-context write token.

## The scanner tests the resolved YAML value, not the source text

Ported already-hardened. A source-text regex loses this race — all of these parse to a string byte-identical to the live directive:

| spelling | source-text scanner | this scanner |
|---|---|---|
| hex escape for the space — `[skip\x20ci]` | **exit 0** | exit 1 |
| unicode escape for the space | **exit 0** | exit 1 |
| hex escape for the bracket — `\x5Bskip ci]` | **exit 0** | exit 1 |
| line continuation — `[skip \` + newline + `ci]` | **exit 0** | exit 1 |

The last one is why whitespace-normalising the file is not enough: that closes the `>-` folded-scalar axis only, because a continuation leaves a literal backslash between the words which survives normalisation. Testing the resolved value closes all of them, and the fifth nobody has thought of.

The raw-text pass is kept — comments do not survive parsing, and an unparseable file still gets read. Neither pass subsumes the other; a directive must evade both.

The walk covers **every YAML file under `.github`** recursively plus any `action.yml` (14 files, printed by name each run), not one directory glob. `.github/dependabot.yml` **has a `commit-message:` key of its own**, and a composite action can `git commit` in a `run:` block. Two floors: a minimum file count, and an **independent second enumeration** cross-checked against what was read.

`js-yaml` reached the guard only transitively via `swagger-ui-react`. Now an explicit `devDependency`; the lock records the direct dependency only, the resolved package set is unchanged and `js-yaml` stays at 4.3.1. If the parser cannot load, the guard **exits 2**, never clean.

## Mutation table

Each mutation confirmed **applied** (non-empty diff) and **compiling** (`node --check`) before its result was read.

| Mutation | Result |
|---|---|
| Original directive restored to `translate.yml` | exit 1 at `translate.yml:96`; exit 0 once removed |
| 4 escape spellings, source-text scanner | **exit 0 — bypass** (all resolve live) |
| 4 escape spellings, this scanner | exit 1 |
| Directive into `dependabot.yml` / `action.yml`, narrow walk | **exit 0 — blind** |
| Directive into `dependabot.yml` / `action.yml`, this scanner | exit 1 |
| Delete the resolved pass | exit 2 |
| Break parser loading | exit 2 |
| Narrow the walk while staying above the floor | exit 2, names `.github/actions/setup-frontend/action.yml` |

The auditor was also run live against this repository before porting: vision check found 17 check runs on `main`, inspected the open PR, exit 0.

## Are the already-merged translations correct?

**Yes — no live bug.** Nothing had ever verified them, so they were audited directly: all 10 bundles, **2133 English keys**, and every locale has all 2133. 0 parse failures, 0 duplicate keys under a raw brace-depth scan, 0 missing keys, 0 extra keys, 0 interpolation-token mismatches, 0 type mismatches. The content shipped sound; only the verification was absent.

## Gates

`tsc --noEmit` clean · `eslint --max-warnings 0` clean · `prettier --check` clean · `actionlint 1.7.12` clean · **2455 tests pass**.

One note: `npm install` cannot re-resolve this lock on Node 24.14 because the already-locked `jsdom@30.0.1` requires `^24.15.0` and `.npmrc` sets `engine-strict=true`. That is **pre-existing** — it reproduces on a pristine checkout with no change applied — which is why the two dependency lines were hand-edited rather than regenerated. `npm ci` verified green, 764 packages.
