### PR TITLE
fix(e2e): ensureMirroringExpanded collapsed the group it was meant to open

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -82,6 +82,12 @@ export default defineConfig({
         {
           name: 'webkit',
           use: { ...devices['Desktop Safari'] },
+          // WebKit is the slowest engine here and runs four workers deep in CI,
+          // where a first paint can exceed the 5s global expect timeout on an
+          // otherwise correct page. This raises the assertion budget for THIS
+          // project only, so chromium and firefox keep the tighter bound and a
+          // genuine regression there still shows up as one.
+          expect: { timeout: 15_000 },
         },
       ]
       : []),

--- a/e2e/tests/admin.spec.ts
+++ b/e2e/tests/admin.spec.ts
@@ -397,17 +397,33 @@ test.describe('Admin: SCM Providers', () => {
 });
 
 test.describe('Admin: Sidebar Navigation', () => {
-  // Helper: expand the MIRRORING nav group by clicking its header if collapsed
+  // Helper: expand the MIRRORING nav group, idempotently.
+  //
+  // The previous version sampled `link.isVisible()` to decide whether the group
+  // was already open. isVisible() reports the CURRENT state and does NOT wait --
+  // its `timeout` option does not make it retry -- so on a slow first paint it
+  // answers "not visible" for a group that is already EXPANDED, and the click
+  // below then COLLAPSES it. The 10s assertion in the caller can never recover
+  // from that, because the group is now shut. It only misfires when the paint
+  // loses the race, which is why it failed on webkit (the slowest engine, four
+  // workers deep) and passed everywhere else.
+  //
+  // So: actually wait for the link before concluding it is absent, and after
+  // clicking wait for the link itself rather than guessing an animation duration.
   async function ensureMirroringExpanded(page: Page) {
-    // If Approvals link is already visible, nothing to do
     const link = page.locator('a', { hasText: /^Approvals$/ });
-    const isVisible = await link.isVisible({ timeout: 2_000 }).catch(() => false);
-    if (isVisible) return;
-    // Click the MIRRORING group header to expand it
+    const alreadyOpen = await link
+      .waitFor({ state: 'visible', timeout: 5_000 })
+      .then(() => true)
+      .catch(() => false);
+    if (alreadyOpen) return;
+
     const header = page.locator('[class*="MuiListItemButton"]', { hasText: /^MIRRORING$/i });
-    if (await header.isVisible({ timeout: 2_000 }).catch(() => false)) {
+    if (await header.isVisible().catch(() => false)) {
       await header.click();
-      await page.waitForTimeout(300); // allow collapse animation
+      // Wait for the thing the caller needs, not for a fixed 300ms that is a
+      // guess about an animation on the fastest engine.
+      await link.waitFor({ state: 'visible', timeout: 10_000 }).catch(() => {});
     }
   }
 


### PR DESCRIPTION
The webkit E2E failures on `main` are a **logic bug**, not slowness alone.

```ts
const isVisible = await link.isVisible({ timeout: 2_000 }).catch(() => false);
if (isVisible) return;
...
header.click()          // ← collapses an already-open group
```

`locator.isVisible()` reports the **current** state and does **not** wait — its `timeout` option does not make it retry. So on a slow first paint it answers *"not visible"* for a nav group that is already **expanded**, and the click that follows **collapses** it. The caller's 10s assertion can never recover, because the group is now shut.

## Why webkit only

It misfires only when the paint loses the race. In the failing run, chromium and firefox passed the *same assertions against the same backend* while webkit failed — the slowest engine, four workers deep. Same-run, same-data, one-engine-only is what said "race in the test", not "missing data in the app".

That accounts for 3 of the 4 failures (`Approvals`, `Mirror Policies`, and its retry).

## The fix

Wait for the link before concluding it is absent, and after clicking wait for **the link itself** rather than a fixed `300ms` guess about an animation. That makes the helper idempotent, which is what its name always claimed.

## The fourth failure is different

`providers.spec.ts:14` is a plain visibility assertion with the global **5s** expect timeout — a genuine first-paint cost on the slowest engine under four-way parallelism, not a defect. WebKit now gets **15s**, scoped to that project only, so chromium and firefox keep the tighter bound and a real regression there still surfaces as one.

## Context for anyone reading a failed run

`maxFailures: 1` — a single flake ends the whole run and the remaining tests never report. So "4 failures" understates how much did not get to execute.

This job is **`E2E (gated/manual)` and is not a required context**, so this has been eroding confidence rather than blocking merges. Across the last six `main` runs it went failure / success / failure / success / success / success.

## Verification

I have not run the full suite (it needs the compose stack). `playwright test --list` parses cleanly — 26 tests in `admin.spec.ts`, and with `CI=1` all three projects enumerate 177 tests each, so the config change is valid for every project. The behavioural claim rests on `isVisible()`'s documented non-waiting semantics plus the same-run engine split in the failing job.